### PR TITLE
Update display controls layers in the WebGUI

### DIFF
--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -20,6 +20,7 @@ set(WEB_ASSET_FILES
     src/ui-utils.js
     src/checkbox-tree-model.js
     src/vis-tree.js
+    src/modal.js
     src/websocket-manager.js
     src/websocket-tile-layer.js
     src/display-controls.js
@@ -55,6 +56,7 @@ add_custom_command(
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ui-utils.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/checkbox-tree-model.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/vis-tree.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/modal.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/websocket-manager.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/websocket-tile-layer.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/display-controls.js

--- a/src/web/src/color.h
+++ b/src/web/src/color.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace web {
 
 struct Color
@@ -14,6 +16,22 @@ struct Color
 
   Color lighter(double factor = 1.5) const;
   Color darken(double factor = 0.5) const;
+};
+
+// Per-layer fill pattern, mirroring gui::DisplayControls' kBrushPatterns so the
+// Qt GUI and the web viewer share one pattern index over the wire and in
+// persisted state.  Order MUST match the GUI's brush list:
+// {NoBrush, Solid} {Hor, Ver} {Cross, DiagCross} {FDiag, BDiag}.
+enum class FillPattern : uint8_t
+{
+  kNone = 0,    // outline only (Qt::NoBrush)
+  kSolid,       // Qt::SolidPattern
+  kHorizontal,  // Qt::HorPattern
+  kVertical,    // Qt::VerPattern
+  kCross,       // Qt::CrossPattern
+  kDiagCross,   // Qt::DiagCrossPattern
+  kFDiag,       // Qt::FDiagPattern
+  kBDiag,       // Qt::BDiagPattern
 };
 
 }  // namespace web

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -118,18 +118,26 @@ export function populateDisplayControls(app, visibility, selectability,
                 = new Set(JSON.parse(decodeURIComponent(raw)));
         }
     } catch (_) { /* ignore */ }
-    try {
-        const raw = getCookie('or_layer_patterns');
-        if (raw) savedLayerPatterns = JSON.parse(decodeURIComponent(raw));
-    } catch (_) { /* ignore */ }
-    try {
-        const raw = getCookie('or_layer_colors');
-        if (raw) savedLayerColors = JSON.parse(decodeURIComponent(raw));
-    } catch (_) { /* ignore */ }
-    try {
-        const raw = getCookie('or_layer_opacity');
-        if (raw) savedLayerOpacity = JSON.parse(decodeURIComponent(raw));
-    } catch (_) { /* ignore */ }
+    // Parse a cookie expected to hold a JSON object ({name: value}).  Guards
+    // against a corrupted/tampered cookie whose JSON is valid but not an object
+    // (e.g. "null" or a number) — using that directly would later throw in
+    // buildLayerSpec (hasOwnProperty.call(null, ...) / writing to a primitive).
+    const parseCookieObject = (name) => {
+        try {
+            const raw = getCookie(name);
+            if (raw) {
+                const parsed = JSON.parse(decodeURIComponent(raw));
+                if (parsed && typeof parsed === 'object'
+                    && !Array.isArray(parsed)) {
+                    return parsed;
+                }
+            }
+        } catch (_) { /* ignore */ }
+        return {};
+    };
+    savedLayerPatterns = parseCookieObject('or_layer_patterns');
+    savedLayerColors = parseCookieObject('or_layer_colors');
+    savedLayerOpacity = parseCookieObject('or_layer_opacity');
 
     // Global counter so each layer (across the whole hierarchy) gets a unique
     // z-index and palette slot regardless of which chiplet it belongs to.
@@ -546,7 +554,7 @@ export function populateDisplayControls(app, visibility, selectability,
 
         const { dialog, close } = createModalDialog(`
             <div class="modal-dialog layer-config-dialog">
-            <h3>Layer Config — ${node.data.name}</h3>
+            <h3 id="lc-title"></h3>
             <div class="layer-config-row">
                 <label for="lc-color">Color</label>
                 <input type="color" id="lc-color" value="${rgbToHex(curColor)}">
@@ -566,6 +574,11 @@ export function populateDisplayControls(app, visibility, selectability,
                 <button id="lc-ok" class="primary">OK</button>
             </div>
             </div>`);
+
+        // Set the title via textContent (not HTML interpolation) so a layer
+        // name from the design can't inject markup.
+        dialog.querySelector('#lc-title').textContent
+            = 'Layer Config — ' + node.data.name;
 
         const colorInput = dialog.querySelector('#lc-color');
         const patternSelect = dialog.querySelector('#lc-pattern');

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -6,6 +6,7 @@
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
 import { VisTree } from './vis-tree.js';
 import { getCookie, setCookie } from './theme.js';
+import { createModalDialog } from './modal.js';
 
 // Compute a Set of layer indices around `center` within [0, count).
 // `lower` layers below and `upper` layers above are included.
@@ -97,6 +98,15 @@ export function populateDisplayControls(app, visibility, selectability,
     // Restore saved hidden-layers and non-selectable-layers sets.
     let savedHiddenLayers = new Set();
     let savedNonSelectableLayers = new Set();
+    // Per-layer fill pattern, keyed by tech-layer name (like color, a pattern
+    // is a property of the layer, so it is shared across chiplets).  Maps
+    // layer name → FillPattern index; absent means solid.
+    let savedLayerPatterns = {};
+    // Per-layer color overrides ({name: [r,g,b]}) and opacity ({name: 0..1}),
+    // keyed by tech-layer name like the pattern map.  Set via the Layer Config
+    // dialog.
+    let savedLayerColors = {};
+    let savedLayerOpacity = {};
     try {
         const raw = getCookie('or_hidden_layers');
         if (raw) savedHiddenLayers = new Set(JSON.parse(decodeURIComponent(raw)));
@@ -107,6 +117,18 @@ export function populateDisplayControls(app, visibility, selectability,
             savedNonSelectableLayers
                 = new Set(JSON.parse(decodeURIComponent(raw)));
         }
+    } catch (_) { /* ignore */ }
+    try {
+        const raw = getCookie('or_layer_patterns');
+        if (raw) savedLayerPatterns = JSON.parse(decodeURIComponent(raw));
+    } catch (_) { /* ignore */ }
+    try {
+        const raw = getCookie('or_layer_colors');
+        if (raw) savedLayerColors = JSON.parse(decodeURIComponent(raw));
+    } catch (_) { /* ignore */ }
+    try {
+        const raw = getCookie('or_layer_opacity');
+        if (raw) savedLayerOpacity = JSON.parse(decodeURIComponent(raw));
     } catch (_) { /* ignore */ }
 
     // Global counter so each layer (across the whole hierarchy) gets a unique
@@ -128,9 +150,21 @@ export function populateDisplayControls(app, visibility, selectability,
                 const name = layerObj.name || layerObj;
                 const slot = nextLayerSlot++;
                 const zIndex = slot + 3;
+                // Default to 1 (solid); a stored 0 (outline-only) must survive.
+                const pattern = Object.prototype.hasOwnProperty.call(
+                    savedLayerPatterns, name) ? (savedLayerPatterns[name] | 0) : 1;
+                // Color override (RGB array) and opacity from the Layer Config
+                // dialog, if previously set.  Color falls back to the server
+                // default; opacity to 0.7.
+                const colorOverride = Array.isArray(savedLayerColors[name])
+                    ? savedLayerColors[name] : null;
+                const opacity = (typeof savedLayerOpacity[name] === 'number')
+                    ? savedLayerOpacity[name] : 0.7;
                 const layer = new WebSocketTileLayer(app.websocketManager, name, {
-                    opacity: 0.7,
+                    opacity: opacity,
                     zIndex: zIndex,
+                    fillPattern: pattern,
+                    fillColor: colorOverride,
                 });
 
                 const id = `${parentId}/${name}`;
@@ -148,7 +182,11 @@ export function populateDisplayControls(app, visibility, selectability,
                 layerIds.push(id);
                 children.push({
                     id,
-                    data: { name, layer, color: layerObj.color, colorIndex: slot, nodeId: id },
+                    data: { name, layer,
+                            color: colorOverride || layerObj.color,
+                            serverColor: layerObj.color,
+                            colorIndex: slot, nodeId: id, pattern,
+                            opacity },
                     checked: visible,
                 });
             });
@@ -178,14 +216,24 @@ export function populateDisplayControls(app, visibility, selectability,
         layerSpec = {
             id: 'layers_parent',
             children: techData.layers.map((name, index) => {
+                // Mirror the hierarchy path so saved per-layer pattern/color/
+                // opacity (or_layer_*) also apply on this old-backend fallback.
+                const pattern = Object.prototype.hasOwnProperty.call(
+                    savedLayerPatterns, name) ? (savedLayerPatterns[name] | 0) : 1;
+                const colorOverride = Array.isArray(savedLayerColors[name])
+                    ? savedLayerColors[name] : null;
+                const opacity = (typeof savedLayerOpacity[name] === 'number')
+                    ? savedLayerOpacity[name] : 0.7;
                 const layer = new WebSocketTileLayer(app.websocketManager, name, {
-                    opacity: 0.7,
+                    opacity: opacity,
                     zIndex: index + 3,
+                    fillPattern: pattern,
+                    fillColor: colorOverride,
                 });
 
                 const id = `layers_parent/${name}`;
                 layer._nodeId = id;
-                
+
                 const visible = !savedHiddenLayers.has(id);
                 if (visible) {
                     layer.addTo(app.map);
@@ -195,8 +243,15 @@ export function populateDisplayControls(app, visibility, selectability,
                 app.allLayers.push(layer);
                 leafletLayers.push(layer);
 
+                const serverColor = (techData.layer_colors
+                    && techData.layer_colors[index]) || null;
                 layerIds.push(id);
-                return { id, data: { name, layer, colorIndex: index, nodeId: id }, checked: visible };
+                return { id, data: { name, layer,
+                                     color: colorOverride || serverColor,
+                                     serverColor,
+                                     colorIndex: index, nodeId: id, pattern,
+                                     opacity },
+                         checked: visible };
             }),
         };
     }
@@ -391,6 +446,144 @@ export function populateDisplayControls(app, visibility, selectability,
         { label: 'Show layer range \u2191',   fn: (i) => layerRangeSet(i, 0, 1, n) },
     ];
 
+    // Fill patterns offered in the Layer Config dialog.  `value` is the
+    // FillPattern index (see color.h) sent to the server with each tile request.
+    const fillPatternItems = [
+        { label: 'Solid',             value: 1 },
+        { label: 'Horizontal',        value: 2 },
+        { label: 'Vertical',          value: 3 },
+        { label: 'Cross',             value: 4 },
+        { label: 'Diagonal cross',    value: 5 },
+        { label: 'Forward diagonal',  value: 6 },
+        { label: 'Backward diagonal', value: 7 },
+        { label: 'None (outline)',    value: 0 },
+    ];
+
+    // Apply a fill pattern to a layer node: re-render its tiles and persist
+    // the choice (keyed by layer name) to the or_layer_patterns cookie.
+    function applyLayerPattern(node, value) {
+        node.data.pattern = value;
+        if (node.data.layer && node.data.layer.setFillPattern) {
+            node.data.layer.setFillPattern(value);
+        }
+        if (value === 1 || value === undefined) {
+            delete savedLayerPatterns[node.data.name];  // solid is the default
+        } else {
+            savedLayerPatterns[node.data.name] = value;
+        }
+        setCookie('or_layer_patterns',
+                  encodeURIComponent(JSON.stringify(savedLayerPatterns)));
+    }
+
+    // RGB array ⇄ "#rrggbb" hex helpers for the <input type="color"> control.
+    function rgbToHex(rgb) {
+        const h = (v) => Math.max(0, Math.min(255, v | 0))
+            .toString(16).padStart(2, '0');
+        return `#${h(rgb[0])}${h(rgb[1])}${h(rgb[2])}`;
+    }
+    function hexToRgb(hex) {
+        const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+        return m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)]
+                 : [200, 200, 200];
+    }
+
+    // Apply a color override (RGB array) to a layer node: update the swatch,
+    // re-render its tiles, and persist to the or_layer_colors cookie.
+    function applyLayerColor(node, rgb) {
+        node.data.color = rgb;
+        if (node.colorSwatch) {
+            node.colorSwatch.style.backgroundColor
+                = `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`;
+        }
+        // If the chosen color matches the server default, clear the override so
+        // the layer reverts to getLayerColorMap and the choice doesn't get
+        // pinned in the (global, name-keyed) cookie across designs/sessions.
+        const def = node.data.serverColor;
+        const isDefault = Array.isArray(def) && def[0] === rgb[0]
+            && def[1] === rgb[1] && def[2] === rgb[2];
+        if (node.data.layer && node.data.layer.setFillColor) {
+            node.data.layer.setFillColor(isDefault ? null : rgb);
+        }
+        if (isDefault) {
+            delete savedLayerColors[node.data.name];
+        } else {
+            savedLayerColors[node.data.name] = rgb;
+        }
+        setCookie('or_layer_colors',
+                  encodeURIComponent(JSON.stringify(savedLayerColors)));
+    }
+
+    // Apply a layer opacity (0..1) client-side via Leaflet and persist it.
+    function applyLayerOpacity(node, value) {
+        node.data.opacity = value;
+        if (node.data.layer && node.data.layer.setOpacity) {
+            node.data.layer.setOpacity(value);
+        }
+        if (value === 0.7) {
+            delete savedLayerOpacity[node.data.name];  // 0.7 is the default
+        } else {
+            savedLayerOpacity[node.data.name] = value;
+        }
+        setCookie('or_layer_opacity',
+                  encodeURIComponent(JSON.stringify(savedLayerOpacity)));
+    }
+
+    // Modal "Layer Config" dialog (color + fill pattern + opacity), mirroring
+    // the Qt GUI's DisplayColorDialog.  Opened by double-clicking the swatch.
+    // Uses the shared createModalDialog lifecycle (overlay/Escape/backdrop).
+    function showLayerConfigDialog(node) {
+        const curColor = Array.isArray(node.data.color)
+            ? node.data.color : [200, 200, 200];
+        const curPattern = (node.data.pattern == null)
+            ? 1 : (node.data.pattern | 0);
+        const curOpacity = (typeof node.data.opacity === 'number')
+            ? node.data.opacity : 0.7;
+
+        const patternOptions = fillPatternItems.map(
+            (p) => `<option value="${p.value}"`
+                + (p.value === curPattern ? ' selected' : '')
+                + `>${p.label}</option>`).join('');
+
+        const { dialog, close } = createModalDialog(`
+            <div class="modal-dialog layer-config-dialog">
+            <h3>Layer Config — ${node.data.name}</h3>
+            <div class="layer-config-row">
+                <label for="lc-color">Color</label>
+                <input type="color" id="lc-color" value="${rgbToHex(curColor)}">
+            </div>
+            <div class="layer-config-row">
+                <label for="lc-pattern">Fill pattern</label>
+                <select id="lc-pattern">${patternOptions}</select>
+            </div>
+            <div class="layer-config-row">
+                <label for="lc-opacity">Opacity</label>
+                <input type="range" id="lc-opacity" min="0" max="100"
+                       value="${Math.round(curOpacity * 100)}">
+                <span id="lc-opacity-val">${Math.round(curOpacity * 100)}%</span>
+            </div>
+            <div class="modal-buttons">
+                <button id="lc-cancel">Cancel</button>
+                <button id="lc-ok" class="primary">OK</button>
+            </div>
+            </div>`);
+
+        const colorInput = dialog.querySelector('#lc-color');
+        const patternSelect = dialog.querySelector('#lc-pattern');
+        const opacityInput = dialog.querySelector('#lc-opacity');
+        const opacityVal = dialog.querySelector('#lc-opacity-val');
+        opacityInput.addEventListener('input', () => {
+            opacityVal.textContent = opacityInput.value + '%';
+        });
+
+        dialog.querySelector('#lc-cancel').addEventListener('click', close);
+        dialog.querySelector('#lc-ok').addEventListener('click', () => {
+            applyLayerColor(node, hexToRgb(colorInput.value));
+            applyLayerPattern(node, parseInt(patternSelect.value, 10));
+            applyLayerOpacity(node, (parseInt(opacityInput.value, 10) || 0) / 100);
+            close();
+        });
+    }
+
     document.addEventListener('click', (e) => {
         if (!contextMenu.contains(e.target)) hideContextMenu();
     });
@@ -434,11 +627,22 @@ export function populateDisplayControls(app, visibility, selectability,
             colorSwatch.className = 'layer-color';
             const c = node.data.color || (techData.layer_colors && techData.layer_colors[index]) || fallbackLayerPalette[index % fallbackLayerPalette.length];
             colorSwatch.style.backgroundColor = `rgb(${c[0]},${c[1]},${c[2]})`;
+            colorSwatch.style.cursor = 'pointer';
+            colorSwatch.title = 'Double-click to configure layer';
+            node.colorSwatch = colorSwatch;  // so applyLayerColor can update it
+            // Double-click the swatch to open the Layer Config dialog (color,
+            // fill pattern, opacity) — mirrors the Qt GUI DisplayColorDialog.
+            colorSwatch.addEventListener('dblclick', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                showLayerConfigDialog(node);
+            });
             label.appendChild(colorSwatch);
 
             label.appendChild(document.createTextNode(name));
 
-            // Setup context menu for layer
+            // Setup context menu for layer (visibility ranges; fill pattern now
+            // lives in the Layer Config dialog).
             label.addEventListener('contextmenu', (e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -886,6 +1090,7 @@ export function populateDisplayControls(app, visibility, selectability,
         { key: 'placement_blockages', label: 'Placement' },
         { key: 'routing_obstructions', label: 'Routing' },
     ]});
+    visTree.add({ key: 'fills', label: 'Metal Fill' });
     if (techData.sites && techData.sites.length > 0) {
         visTree.add({ label: 'Rows', visKey: 'rows', addSelectable: true,
             children: techData.sites.map(name => ({

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -189,6 +189,8 @@ const visibility = {
     // Blockages
     placement_blockages: true,
     routing_obstructions: true,
+    // Metal fill (dbFill) — on by default; toggle in the Blockages group.
+    fills: true,
     // Rows (off by default, matching GUI)
     rows: false,
     // Tracks (off by default, matching GUI)

--- a/src/web/src/menu-bar.js
+++ b/src/web/src/menu-bar.js
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+import { createModalDialog } from './modal.js';
+
 // Creates a menu bar in #menu-bar and returns keyboard shortcut bindings.
 export function createMenuBar(app) {
     const menus = [
@@ -157,10 +159,7 @@ export function createMenuBar(app) {
 
 function showPathDialog(app, title, tclCmd) {
     const isSave = tclCmd === 'write_db';
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-
-    overlay.innerHTML = `
+    const { overlay, close } = createModalDialog(`
         <div class="modal-dialog file-browser-dialog">
             <h3>${title}</h3>
             <div class="fb-breadcrumb"></div>
@@ -172,9 +171,7 @@ function showPathDialog(app, title, tclCmd) {
                 <button class="cancel">Cancel</button>
                 <button class="primary ok" disabled>${isSave ? 'Save' : 'Open'}</button>
             </div>
-        </div>`;
-
-    document.body.appendChild(overlay);
+        </div>`);
 
     const breadcrumb = overlay.querySelector('.fb-breadcrumb');
     const fileList = overlay.querySelector('.fb-file-list');
@@ -184,10 +181,6 @@ function showPathDialog(app, title, tclCmd) {
     const cancelBtn = overlay.querySelector('.cancel');
     let currentPath = '';
     let selectedEntry = null;
-
-    function close() {
-        overlay.remove();
-    }
 
     function updateOkState() {
         const val = pathInput.value.trim();
@@ -366,7 +359,7 @@ function showPathDialog(app, title, tclCmd) {
     });
     okBtn.addEventListener('click', submit);
     cancelBtn.addEventListener('click', close);
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+    // Escape and backdrop-click dismissal are handled by createModalDialog.
 
     // Start browsing from server's cwd
     navigate('');

--- a/src/web/src/modal.js
+++ b/src/web/src/modal.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+// Shared modal-dialog lifecycle: overlay creation, Escape-to-close (document
+// level, removed on close), and backdrop-click dismissal.  Callers supply the
+// inner HTML (expected to contain a `.modal-dialog` element) and wire their own
+// OK/Cancel buttons via the returned `dialog`/`close`.
+
+export function createModalDialog(innerHtml) {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.innerHTML = innerHtml;
+
+    function onKeydown(e) {
+        if (e.key === 'Escape') {
+            close();
+        }
+    }
+    function close() {
+        document.removeEventListener('keydown', onKeydown);
+        overlay.remove();
+    }
+
+    document.body.appendChild(overlay);
+    overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) {
+            close();
+        }
+    });
+    document.addEventListener('keydown', onKeydown);
+
+    return { overlay, dialog: overlay.querySelector('.modal-dialog'), close };
+}

--- a/src/web/src/search.cpp
+++ b/src/web/src/search.cpp
@@ -1328,16 +1328,19 @@ Search::SnapResult Search::searchNearestEdge(
         }
       }
 
-      // Fills.
-      for (auto* fill : searchFills(block,
-                                    layer,
-                                    search_box.xMin(),
-                                    search_box.yMin(),
-                                    search_box.xMax(),
-                                    search_box.yMax())) {
-        odb::Rect fill_rect;
-        fill->getRect(fill_rect);
-        check_rect(fill_rect);
+      // Fills.  Gated by vis.fills to stay consistent with the render path
+      // (don't let edge-snapping target fills the user has hidden).
+      if (vis.fills) {
+        for (auto* fill : searchFills(block,
+                                      layer,
+                                      search_box.xMin(),
+                                      search_box.yMin(),
+                                      search_box.xMax(),
+                                      search_box.yMax())) {
+          odb::Rect fill_rect;
+          fill->getRect(fill_rect);
+          check_rect(fill_rect);
+        }
       }
 
       // Obstructions.

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -303,6 +303,33 @@ html, body {
     cursor: default;
 }
 
+/* Layer Config dialog */
+.layer-config-dialog .layer-config-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 8px 0;
+}
+.layer-config-dialog .layer-config-row label {
+    flex: 0 0 90px;
+}
+.layer-config-dialog select,
+.layer-config-dialog input[type="range"] {
+    flex: 1;
+}
+.layer-config-dialog input[type="color"] {
+    width: 48px;
+    height: 24px;
+    padding: 0;
+    border: 1px solid var(--border-strong);
+    background: var(--bg-main);
+    cursor: pointer;
+}
+.layer-config-dialog #lc-opacity-val {
+    flex: 0 0 40px;
+    text-align: right;
+}
+
 /* File browser dialog */
 .file-browser-dialog {
     min-width: 520px;

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -759,11 +759,9 @@ inline int posMod(const int v, const int m)
 // left empty; callers draw the outline separately).  Evaluated in global
 // coordinates so hatch lines line up across adjacent tiles.
 //
-// Called per interior pixel, but every call site guards with
-// `pattern != kSolid`, so the overwhelmingly common solid fill pays nothing;
-// only hatch/cross/diagonal fills (rare, user-selected) pay the modulo.  Kept
-// as a single inlinable predicate rather than per-pattern specialized loops to
-// avoid duplicating the scanline/rect rasterizers.
+// Call sites unswitch the loop on the (loop-invariant) pattern, so the common
+// solid fill never reaches here; only hatch/cross/diagonal fills (rare,
+// user-selected) call this, once per interior pixel.
 inline bool patternMask(const web::FillPattern pattern,
                         const int gx,
                         const int gy)
@@ -883,15 +881,26 @@ void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
           kTileSizeInPixel, static_cast<int>(std::ceil(x_intercepts[k + 1])));
       const int draw_y = 255 - iy;
       const int gy = px_origin_y + draw_y;
-      for (int ix = ix_min; ix < ix_max; ++ix) {
-        if (pattern != FillPattern::kSolid
-            && !patternMask(pattern, px_origin_x + ix, gy)) {
-          continue;
+      // Unswitch the loop on the (loop-invariant) pattern: the common solid
+      // fill avoids the per-pixel pattern test entirely.
+      if (pattern == FillPattern::kSolid) {
+        for (int ix = ix_min; ix < ix_max; ++ix) {
+          if (blend) {
+            blendPixel(image, ix, draw_y, color);
+          } else {
+            setPixel(image, ix, draw_y, color);
+          }
         }
-        if (blend) {
-          blendPixel(image, ix, draw_y, color);
-        } else {
-          setPixel(image, ix, draw_y, color);
+      } else {
+        for (int ix = ix_min; ix < ix_max; ++ix) {
+          if (!patternMask(pattern, px_origin_x + ix, gy)) {
+            continue;
+          }
+          if (blend) {
+            blendPixel(image, ix, draw_y, color);
+          } else {
+            setPixel(image, ix, draw_y, color);
+          }
         }
       }
     }
@@ -3774,15 +3783,24 @@ void TileGenerator::drawFilledRect(std::vector<unsigned char>& buffer,
     return;
   }
 
-  for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
-    const int draw_y = (255 - iy);
-    const int gy = px_origin_y + draw_y;
-    for (int ix = rect.xMin(); ix < rect.xMax(); ++ix) {
-      if (pattern != FillPattern::kSolid
-          && !patternMask(pattern, px_origin_x + ix, gy)) {
-        continue;
+  // Unswitch the loop on the (loop-invariant) pattern: the common solid fill
+  // avoids the per-pixel pattern test entirely.
+  if (pattern == FillPattern::kSolid) {
+    for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
+      const int draw_y = (255 - iy);
+      for (int ix = rect.xMin(); ix < rect.xMax(); ++ix) {
+        setPixel(buffer, ix, draw_y, color);
       }
-      setPixel(buffer, ix, draw_y, color);
+    }
+  } else {
+    for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
+      const int draw_y = (255 - iy);
+      const int gy = px_origin_y + draw_y;
+      for (int ix = rect.xMin(); ix < rect.xMax(); ++ix) {
+        if (patternMask(pattern, px_origin_x + ix, gy)) {
+          setPixel(buffer, ix, draw_y, color);
+        }
+      }
     }
   }
 }

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -115,6 +115,7 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
     {"inst_pins",          &TileVisibility::inst_pins,          true},
     {"inst_pin_names",     &TileVisibility::inst_pin_names,     true},
     {"blockages",              &TileVisibility::blockages,              true},
+    {"fills",                  &TileVisibility::fills,                  true},
     {"placement_blockages",    &TileVisibility::placement_blockages,    true},
     {"routing_obstructions",   &TileVisibility::routing_obstructions,   true},
     {"rows",                   &TileVisibility::rows,                   false},
@@ -132,6 +133,36 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
   // fall back to the per-field default when a flag is omitted.
   for (const auto& f : kFields) {
     this->*(f.field) = jsonOr<bool>(json, f.key, f.default_val);
+  }
+
+  // Per-layer fill pattern (index into FillPattern, mirroring the GUI brush
+  // order).  Clamp out-of-range values to solid so a bad payload can't index
+  // past the enum.
+  {
+    const int64_t p = jsonOr<int64_t>(
+        json, "pattern", static_cast<int64_t>(FillPattern::kSolid));
+    constexpr int64_t kMaxPattern = static_cast<int64_t>(FillPattern::kBDiag);
+    fill_pattern = (p >= 0 && p <= kMaxPattern) ? static_cast<FillPattern>(p)
+                                                : FillPattern::kSolid;
+  }
+
+  // Per-layer color override, sent as [r, g, b] (0-255).  Absent ⇒ fall back
+  // to the server's getLayerColorMap.  Alpha is not sent; it is taken from the
+  // resolved layer color at render time.
+  has_layer_color = false;
+  if (auto it = json.find("layer_color");
+      it != json.end() && it->value().is_array()) {
+    const auto& arr = it->value().as_array();
+    if (arr.size() >= 3) {
+      auto channel = [](const boost::json::value& v) -> unsigned char {
+        const int64_t c = v.is_int64() ? v.as_int64() : 0;
+        return static_cast<unsigned char>(std::clamp<int64_t>(c, 0, 255));
+      };
+      layer_color.r = channel(arr[0]);
+      layer_color.g = channel(arr[1]);
+      layer_color.b = channel(arr[2]);
+      has_layer_color = true;
+    }
   }
 
   // Bound the visibility-filter sizes so a malformed/oversized payload
@@ -709,12 +740,68 @@ void TileGenerator::setPixel(std::vector<unsigned char>& image,
   image[index + 3] = c.a;
 }
 
+namespace {
+
+// Fixed screen-space geometry of the hatch patterns, in pixels.  Independent
+// of zoom so the pattern density looks the same at every level, mirroring how
+// Qt brushes paint in device space rather than world space.
+constexpr int kFillPatternSpacing = 6;    // distance between hatch lines
+constexpr int kFillPatternLineWidth = 1;  // hatch line thickness
+
+// Always-positive modulo so the diagonal masks behave for negative (gx-gy).
+inline int posMod(const int v, const int m)
+{
+  return ((v % m) + m) % m;
+}
+
+// Returns whether the interior pixel at GLOBAL pixel coordinate (gx, gy)
+// belongs to the pattern's painted set.  kNone always returns false (interior
+// left empty; callers draw the outline separately).  Evaluated in global
+// coordinates so hatch lines line up across adjacent tiles.
+//
+// Called per interior pixel, but every call site guards with
+// `pattern != kSolid`, so the overwhelmingly common solid fill pays nothing;
+// only hatch/cross/diagonal fills (rare, user-selected) pay the modulo.  Kept
+// as a single inlinable predicate rather than per-pattern specialized loops to
+// avoid duplicating the scanline/rect rasterizers.
+inline bool patternMask(const web::FillPattern pattern,
+                        const int gx,
+                        const int gy)
+{
+  constexpr int kS = kFillPatternSpacing;
+  constexpr int kW = kFillPatternLineWidth;
+  switch (pattern) {
+    case web::FillPattern::kSolid:
+      return true;
+    case web::FillPattern::kNone:
+      return false;
+    case web::FillPattern::kHorizontal:
+      return posMod(gy, kS) < kW;
+    case web::FillPattern::kVertical:
+      return posMod(gx, kS) < kW;
+    case web::FillPattern::kCross:
+      return posMod(gy, kS) < kW || posMod(gx, kS) < kW;
+    case web::FillPattern::kFDiag:
+      return posMod(gx + gy, kS) < kW;
+    case web::FillPattern::kBDiag:
+      return posMod(gx - gy, kS) < kW;
+    case web::FillPattern::kDiagCross:
+      return posMod(gx + gy, kS) < kW || posMod(gx - gy, kS) < kW;
+  }
+  return true;
+}
+
+}  // namespace
+
 void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
                                 const odb::Polygon& poly,
                                 const odb::Rect& dbu_tile,
                                 const double scale,
                                 const Color& color,
-                                const bool blend) const
+                                const bool blend,
+                                const FillPattern pattern,
+                                const int px_origin_x,
+                                const int px_origin_y) const
 {
   const auto& points = poly.getPoints();
   const int n = static_cast<int>(points.size());
@@ -727,6 +814,40 @@ void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
   for (int i = 0; i < n; ++i) {
     px[i] = (points[i].x() - dbu_tile.xMin()) * scale;
     py[i] = (points[i].y() - dbu_tile.yMin()) * scale;
+  }
+
+  // kNone: paint only the polygon outline, leaving the interior empty.
+  // Walk each edge with Bresenham so the outline honors `blend` (drawLine is
+  // opaque setPixel only); matters if a blended caller ever requests kNone.
+  if (pattern == FillPattern::kNone) {
+    for (int i = 0, j = n - 1; i < n; j = i++) {
+      int x0 = static_cast<int>(px[j]), y0 = 255 - static_cast<int>(py[j]);
+      const int x1 = static_cast<int>(px[i]),
+                y1 = 255 - static_cast<int>(py[i]);
+      const int dx = std::abs(x1 - x0), dy = -std::abs(y1 - y0);
+      const int sx = x0 < x1 ? 1 : -1, sy = y0 < y1 ? 1 : -1;
+      int err = dx + dy;
+      while (true) {
+        if (blend) {
+          blendPixel(image, x0, y0, color);
+        } else {
+          setPixel(image, x0, y0, color);
+        }
+        if (x0 == x1 && y0 == y1) {
+          break;
+        }
+        const int e2 = 2 * err;
+        if (e2 >= dy) {
+          err += dy;
+          x0 += sx;
+        }
+        if (e2 <= dx) {
+          err += dx;
+          y0 += sy;
+        }
+      }
+    }
+    return;
   }
 
   // Compute pixel bounding box, clamped to tile.
@@ -761,7 +882,12 @@ void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
       const int ix_max = std::min(
           kTileSizeInPixel, static_cast<int>(std::ceil(x_intercepts[k + 1])));
       const int draw_y = 255 - iy;
+      const int gy = px_origin_y + draw_y;
       for (int ix = ix_min; ix < ix_max; ++ix) {
+        if (pattern != FillPattern::kSolid
+            && !patternMask(pattern, px_origin_x + ix, gy)) {
+          continue;
+        }
         if (blend) {
           blendPixel(image, ix, draw_y, color);
         } else {
@@ -1516,6 +1642,13 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
   // Determine our tile's bounding box in dbu coordinates.
   const double num_tiles_at_zoom = pow(2, z);
   if (x >= 0 && y >= 0 && x < num_tiles_at_zoom && y < num_tiles_at_zoom) {
+    // Top-left pixel of this tile in the zoom level's global pixel grid,
+    // captured before the Y flip below (which converts to DBU-up tile
+    // coordinates).  Used so the layer fill pattern stays continuous across
+    // tile seams — see fillPolygon/drawFilledRect.
+    const int px_origin_x = x * kTileSizeInPixel;
+    const int px_origin_y = y * kTileSizeInPixel;
+    const FillPattern fill_pattern = vis.fill_pattern;
     y = num_tiles_at_zoom - 1 - y;  // flip
     const odb::Rect full_bounds = getBounds();
     // Guard against an empty/invalid design footprint.  Without this,
@@ -1665,7 +1798,26 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
           color = it->second;
         }
       }
+      // Per-request color override (from the Layer Config dialog): take the
+      // user's RGB but keep the resolved layer alpha so transparency stays
+      // consistent with the default look.
+      if (vis.has_layer_color) {
+        color.r = vis.layer_color.r;
+        color.g = vis.layer_color.g;
+        color.b = vis.layer_color.b;
+      }
       const Color obs_color = color.lighter();
+
+      // For non-routing layers (implant/masterslice/overlap/…), the master and
+      // block "obstruction" geometry IS the layer's own geometry, so draw it in
+      // the layer color (like the Qt GUI's drawInstanceShapes/drawObstructions
+      // which use the layer brush) instead of the faint obstruction shade used
+      // for routing-layer blockages.
+      const bool layer_is_routing
+          = tech_layer
+            && (tech_layer->getRoutingLevel() > 0
+                || tech_layer->getType() == odb::dbTechLayerType::CUT);
+      const Color obs_fill = layer_is_routing ? obs_color : color;
 
       // Special "_modules" layer: draw filled module-colored rectangles
       const bool modules_layer
@@ -2099,7 +2251,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 }
                 odb::Polygon poly = poly_obs->getPolygon();
                 inst->getTransform().apply(poly);
-                fillPolygon(image_buffer, poly, dbu_tile, scale, obs_color);
+                fillPolygon(image_buffer,
+                            poly,
+                            dbu_tile,
+                            scale,
+                            obs_fill,
+                            /*blend=*/false,
+                            fill_pattern,
+                            px_origin_x,
+                            px_origin_y);
               }
               for (odb::dbBox* obs : master->getObstructions(false)) {
                 if (tech_layer && obs->getTechLayer() != tech_layer) {
@@ -2113,7 +2273,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 const odb::Rect overlap = box.intersect(dbu_tile);
                 const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
 
-                drawFilledRect(image_buffer, draw, obs_color);
+                drawFilledRect(image_buffer,
+                               draw,
+                               obs_fill,
+                               fill_pattern,
+                               px_origin_x,
+                               px_origin_y);
               }
             }
 
@@ -2126,7 +2291,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                     }
                     odb::Polygon poly = poly_geom->getPolygon();
                     inst->getTransform().apply(poly);
-                    fillPolygon(image_buffer, poly, dbu_tile, scale, color);
+                    fillPolygon(image_buffer,
+                                poly,
+                                dbu_tile,
+                                scale,
+                                color,
+                                /*blend=*/false,
+                                fill_pattern,
+                                px_origin_x,
+                                px_origin_y);
                   }
                   for (odb::dbBox* geom : mpin->getGeometry(false)) {
                     if (tech_layer && geom->getTechLayer() != tech_layer) {
@@ -2140,7 +2313,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                     const odb::Rect overlap = box.intersect(dbu_tile);
                     const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
 
-                    drawFilledRect(image_buffer, draw, color);
+                    drawFilledRect(image_buffer,
+                                   draw,
+                                   color,
+                                   fill_pattern,
+                                   px_origin_x,
+                                   px_origin_y);
                   }
                 }
               }
@@ -2261,7 +2439,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             const odb::Rect overlap = box.intersect(dbu_tile);
             const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
 
-            drawFilledRect(image_buffer, draw, color);
+            drawFilledRect(image_buffer,
+                           draw,
+                           color,
+                           fill_pattern,
+                           px_origin_x,
+                           px_origin_y);
           }
         }
 
@@ -2287,7 +2470,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               continue;
             }
             const odb::Polygon& poly = std::get<1>(shape);
-            fillPolygon(image_buffer, poly, dbu_tile, scale, color);
+            fillPolygon(image_buffer,
+                        poly,
+                        dbu_tile,
+                        scale,
+                        color,
+                        /*blend=*/false,
+                        fill_pattern,
+                        px_origin_x,
+                        px_origin_y);
           }
         }
 
@@ -2331,7 +2522,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               }
               const odb::Rect overlap = box.intersect(dbu_tile);
               const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
-              drawFilledRect(image_buffer, draw, color);
+              drawFilledRect(image_buffer,
+                             draw,
+                             color,
+                             fill_pattern,
+                             px_origin_x,
+                             px_origin_y);
             }
           }
         }
@@ -2385,7 +2581,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 }
                 const odb::Rect overlap = box.intersect(dbu_tile);
                 const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
-                drawFilledRect(image_buffer, draw, color);
+                drawFilledRect(image_buffer,
+                               draw,
+                               color,
+                               fill_pattern,
+                               px_origin_x,
+                               px_origin_y);
               }
             }
           }
@@ -2419,8 +2620,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
           }
         }
 
-        // Draw routing obstructions (dbObstruction) on per-layer tiles.
-        // Same diagonal white hash lines.
+        // Draw block obstructions (dbObstruction) on per-layer tiles, gated by
+        // routing_obstructions for every layer (preserves the prior toggle
+        // semantics).  Only the RENDER differs by layer type: routing/cut →
+        // diagonal white hash (routing blockage); non-routing (implant/other) →
+        // the obstruction IS the layer geometry, so fill in the layer color +
+        // pattern.
         if (!instances_only && tech_layer && vis.routing_obstructions) {
           const Color hash_color{.r = 255, .g = 255, .b = 255, .a = 180};
           constexpr int kPixelPeriod = 20;
@@ -2438,6 +2643,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             }
             const odb::Rect overlap = box.intersect(dbu_tile);
             const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
+            if (!layer_is_routing) {
+              drawFilledRect(image_buffer,
+                             draw,
+                             color,
+                             fill_pattern,
+                             px_origin_x,
+                             px_origin_y);
+              continue;
+            }
             const int ox = (int) (dbu_x_min * scale);
             const int oy = (int) (dbu_y_min * scale);
             for (int iy = draw.yMin(); iy < draw.yMax(); ++iy) {
@@ -2447,6 +2661,34 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 }
               }
             }
+          }
+        }
+
+        // Draw metal fill (dbFill) on per-layer tiles, in the layer color +
+        // pattern.  Indexed by Search but not drawn elsewhere; the GUI draws
+        // these in drawLayer via searchFills.  Skip the rtree query (and its
+        // first-use index build) entirely when the design has no fills.
+        if (!instances_only && tech_layer && vis.fills
+            && !block->getFills().empty()) {
+          for (odb::dbFill* fill : search_->searchFills(block,
+                                                        tech_layer,
+                                                        dbu_x_min,
+                                                        dbu_y_min,
+                                                        dbu_x_max,
+                                                        dbu_y_max)) {
+            odb::Rect box;
+            fill->getRect(box);
+            if (!box.overlaps(dbu_tile)) {
+              continue;
+            }
+            const odb::Rect overlap = box.intersect(dbu_tile);
+            const odb::Rect draw = toPixels(scale, overlap, dbu_tile);
+            drawFilledRect(image_buffer,
+                           draw,
+                           color,
+                           fill_pattern,
+                           px_origin_x,
+                           px_origin_y);
           }
         }
 
@@ -3514,11 +3756,32 @@ void TileGenerator::blendPixel(std::vector<unsigned char>& image,
 
 void TileGenerator::drawFilledRect(std::vector<unsigned char>& buffer,
                                    const odb::Rect& rect,
-                                   const Color& color) const
+                                   const Color& color,
+                                   const FillPattern pattern,
+                                   const int px_origin_x,
+                                   const int px_origin_y) const
 {
-  for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
+  // kNone: paint only the rectangle border, leaving the interior empty.
+  if (pattern == FillPattern::kNone) {
     for (int ix = rect.xMin(); ix < rect.xMax(); ++ix) {
-      const int draw_y = (255 - iy);
+      setPixel(buffer, ix, 255 - rect.yMin(), color);
+      setPixel(buffer, ix, 255 - (rect.yMax() - 1), color);
+    }
+    for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
+      setPixel(buffer, rect.xMin(), 255 - iy, color);
+      setPixel(buffer, rect.xMax() - 1, 255 - iy, color);
+    }
+    return;
+  }
+
+  for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
+    const int draw_y = (255 - iy);
+    const int gy = px_origin_y + draw_y;
+    for (int ix = rect.xMin(); ix < rect.xMax(); ++ix) {
+      if (pattern != FillPattern::kSolid
+          && !patternMask(pattern, px_origin_x + ix, gy)) {
+        continue;
+      }
       setPixel(buffer, ix, draw_y, color);
     }
   }
@@ -3948,29 +4211,42 @@ boost::json::object buildLayerHierarchy(
   json_node["type"] = (node.inst == nullptr) ? "block" : "instance";
   json_node["path"] = node.path;
 
+  // Group layers by type, mirroring gui::DisplayControls::addTech:
+  // routing/cut form the main "Layers" group, IMPLANT and everything else
+  // (masterslice, overlap, …) get their own folders so the web tree reaches
+  // structural parity with the Qt GUI.  NOTE: implant/other geometry is not
+  // yet indexed by Search (which serves routing/special-net shapes), so those
+  // category tiles may render empty until the search index is extended; the
+  // tree entries are emitted regardless so the categories are visible.
   boost::json::array layers_arr;
   boost::json::array backside_layers_arr;
+  boost::json::array implant_layers_arr;
+  boost::json::array other_layers_arr;
   if (node.chip) {
     if (odb::dbTech* tech = node.chip->getTech()) {
       const auto& layer_colors = gen.getLayerColorMap(tech);
       for (odb::dbTechLayer* layer : tech->getLayers()) {
-        if (layer->getRoutingLevel() > 0
-            || layer->getType() == odb::dbTechLayerType::CUT) {
-          boost::json::object layer_obj;
-          layer_obj["name"] = layer->getName();
-          Color c{.r = 200, .g = 200, .b = 200, .a = 180};
-          auto it = layer_colors.find(layer);
-          if (it != layer_colors.end()) {
-            c = it->second;
-          }
-          layer_obj["color"] = boost::json::array{static_cast<int>(c.r),
-                                                  static_cast<int>(c.g),
-                                                  static_cast<int>(c.b)};
+        boost::json::object layer_obj;
+        layer_obj["name"] = layer->getName();
+        Color c{.r = 200, .g = 200, .b = 200, .a = 180};
+        auto it = layer_colors.find(layer);
+        if (it != layer_colors.end()) {
+          c = it->second;
+        }
+        layer_obj["color"] = boost::json::array{static_cast<int>(c.r),
+                                                static_cast<int>(c.g),
+                                                static_cast<int>(c.b)};
+        const odb::dbTechLayerType type = layer->getType();
+        if (layer->getRoutingLevel() > 0 || type == odb::dbTechLayerType::CUT) {
           if (layer->isBackside()) {
             backside_layers_arr.emplace_back(std::move(layer_obj));
           } else {
             layers_arr.emplace_back(std::move(layer_obj));
           }
+        } else if (type == odb::dbTechLayerType::IMPLANT) {
+          implant_layers_arr.emplace_back(std::move(layer_obj));
+        } else {
+          other_layers_arr.emplace_back(std::move(layer_obj));
         }
       }
     }
@@ -3985,14 +4261,24 @@ boost::json::object buildLayerHierarchy(
           buildLayerHierarchy(*child, children_by_parent, gen));
     }
   }
-  if (!backside_layers_arr.empty()) {
-    boost::json::object backside_node;
-    backside_node["name"] = "Backside";
-    backside_node["type"] = "category";
-    backside_node["layers"] = std::move(backside_layers_arr);
-    backside_node["instances"] = boost::json::array{};
-    instances_arr.emplace_back(std::move(backside_node));
-  }
+  // Emit a "category" folder node (Backside / Implant / Other) holding the
+  // grouped layers.  Category nodes carry no chiplet path, so the frontend
+  // treats them as pure UI folders (see buildLayerSpec).
+  auto add_category
+      = [&instances_arr](const char* name, boost::json::array&& layers) {
+          if (layers.empty()) {
+            return;
+          }
+          boost::json::object cat_node;
+          cat_node["name"] = name;
+          cat_node["type"] = "category";
+          cat_node["layers"] = std::move(layers);
+          cat_node["instances"] = boost::json::array{};
+          instances_arr.emplace_back(std::move(cat_node));
+        };
+  add_category("Backside", std::move(backside_layers_arr));
+  add_category("Implant", std::move(implant_layers_arr));
+  add_category("Other", std::move(other_layers_arr));
   json_node["instances"] = std::move(instances_arr);
 
   return json_node;

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -183,6 +183,11 @@ struct TileVisibility
   bool pin_names = true;          // BTerm name labels on _pins layer
   bool blockages = true;
 
+  // Metal fill (dbFill) shapes.  Indexed by Search but only rasterized when
+  // this is on.  Defaults true so fill geometry is visible without a dedicated
+  // UI toggle (a toggle mirroring the GUI's off-by-default is a follow-up).
+  bool fills = true;
+
   // Instance sub-shapes
   bool inst_names = true;      // Instance name labels on _instances layer
   bool inst_pins = true;       // ITerm (cell pin) shapes on tech layers
@@ -202,6 +207,19 @@ struct TileVisibility
   // Tracks (off by default, matching GUI)
   bool tracks_pref = false;
   bool tracks_non_pref = false;
+
+  // Per-layer fill pattern for the active layer's shapes.  A tile request
+  // carries exactly one layer, so a single pattern per request suffices.
+  // Defaults to solid, matching the Qt GUI default brush.
+  FillPattern fill_pattern = FillPattern::kSolid;
+
+  // Per-layer color override for the active layer.  Like fill_pattern, a tile
+  // request carries one layer, so a single color suffices.  When
+  // has_layer_color is false the server falls back to getLayerColorMap.  Only
+  // RGB is sent by the client (the user picks via an <input type="color">);
+  // the alpha is preserved from the resolved layer color at render time.
+  Color layer_color{};
+  bool has_layer_color = false;
 
   // Debug
   bool debug = false;
@@ -515,16 +533,28 @@ class TileGenerator
                             const odb::Rect& rect,
                             const odb::Rect& dbu_tile);
 
+  // `pattern` masks which interior pixels are drawn (hatch/cross/diag); for
+  // kNone only the outline is drawn.  `px_origin_x/y` is the tile's top-left
+  // pixel in the zoom level's global pixel grid (tile_col*256, tile_row*256);
+  // the pattern mask is evaluated in those global coordinates so hatch lines
+  // stay continuous across tile boundaries.  Defaults keep every existing
+  // caller (highlights, pins, modules) on a plain solid fill.
   void fillPolygon(std::vector<unsigned char>& image,
                    const odb::Polygon& poly,
                    const odb::Rect& dbu_tile,
                    double scale,
                    const Color& color,
-                   bool blend = false) const;
+                   bool blend = false,
+                   FillPattern pattern = FillPattern::kSolid,
+                   int px_origin_x = 0,
+                   int px_origin_y = 0) const;
 
   void drawFilledRect(std::vector<unsigned char>& buffer,
                       const odb::Rect& rect,
-                      const Color& color) const;
+                      const Color& color,
+                      FillPattern pattern = FillPattern::kSolid,
+                      int px_origin_x = 0,
+                      int px_origin_y = 0) const;
 
   static void blendPixel(std::vector<unsigned char>& image,
                          int x,

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -20,7 +20,7 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
     // Tiles don't actually use selectability for rendering, but we
     // send it on every request so the wire schema stays uniform with
     // selectAt requests.
-    function buildTileRequest(coords, layerName) {
+    function buildTileRequest(coords, layerName, fillPattern, fillColor) {
         const vf = {};
         for (const [k, v] of Object.entries(visibility)) {
             vf[k] = !!v;
@@ -36,10 +36,18 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
             z: coords.z,
             x: coords.x,
             y: coords.y,
+            // Per-layer fill pattern index (see FillPattern in color.h):
+            // 1 = solid (default), 0 = kNone/outline-only, 2.. = hatch styles.
+            pattern: fillPattern | 0,
             visible_layers: visibleLayers ? [...visibleLayers] : [],
             selectable_layers: selectableLayers ? [...selectableLayers] : [],
             ...vf,
         };
+        // Per-layer color override (RGB) from the Layer Config dialog.  Omitted
+        // when unset so the server uses its default getLayerColorMap color.
+        if (Array.isArray(fillColor) && fillColor.length >= 3) {
+            req.layer_color = [fillColor[0] | 0, fillColor[1] | 0, fillColor[2] | 0];
+        }
         if (app && app.visibleChiplets instanceof Set) {
             req.visible_chiplets = [...app.visibleChiplets];
         }
@@ -49,7 +57,31 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
         initialize: function(websocketManager, layerName, options) {
             this._websocketManager = websocketManager;
             this._layerName = layerName;
+            // Per-layer fill pattern index (FillPattern in color.h).  Defaults
+            // to 1 (solid) — note 0 means "outline only" (kNone), so we must
+            // not let an absent option collapse to 0.
+            this._fillPattern = (options && options.fillPattern != null)
+                ? (options.fillPattern | 0)
+                : 1;
+            // Per-layer color override (RGB array) or null to use the server
+            // default color.
+            this._fillColor = (options && Array.isArray(options.fillColor))
+                ? options.fillColor
+                : null;
             L.GridLayer.prototype.initialize.call(this, options);
+        },
+
+        // Change the layer's fill pattern and re-render its tiles in place.
+        setFillPattern: function(fillPattern) {
+            this._fillPattern = fillPattern | 0;
+            this.refreshTiles();
+        },
+
+        // Change the layer's color override (RGB array, or null to reset to
+        // the server default) and re-render its tiles in place.
+        setFillColor: function(rgb) {
+            this._fillColor = Array.isArray(rgb) ? rgb : null;
+            this.refreshTiles();
         },
 
         createTile: function(coords, done) {
@@ -81,7 +113,8 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
             tile._websocketRequestId = this._websocketManager.nextId;
 
             this._websocketManager.request(
-                buildTileRequest(coords, this._layerName)
+                buildTileRequest(coords, this._layerName, this._fillPattern,
+                                 this._fillColor)
             ).then(data => {
                 if (typeof data === 'string') {
                     tile.src = data;  // data URI from cache
@@ -115,7 +148,8 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
                 tile._websocketRequestId = this._websocketManager.nextId;
 
                 this._websocketManager.request(
-                    buildTileRequest(coords, this._layerName)
+                    buildTileRequest(coords, this._layerName, this._fillPattern,
+                                     this._fillColor)
                 ).then(data => {
                     if (tile.src && tile.src.startsWith('blob:')) {
                         URL.revokeObjectURL(tile.src);


### PR DESCRIPTION
Addresses a portion of https://github.com/The-OpenROAD-Project/OpenROAD/issues/10619

Three blocks of functionality, all in OpenROAD's src/web module, closing gaps from table 2.2 ("Display controls — layers") and related areas:

Fill pattern per layer + Implant/Other categorization (❌/🟡 gaps in table 2.2)
"Layer Config" dialog (color + pattern + opacity) — parity with the GUI's DisplayColorDialog
Geometry rasterization for implant/other + fills (dbFill) — ensuring these layers do not render empty