### PR TITLE
grt: add regression test for incremental deleted-net handling in CUGR

### DIFF
--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -175,7 +175,7 @@ set_infinite_cap(bool infinite_capacity)
 {
   getGlobalRouter()->setInfiniteCapacity(infinite_capacity);
 }
-// NOTE: Debug-only. Not part of the public incremental API.
+
 void
 add_dirty_net(odb::dbNet* net)
 {

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -179,7 +179,9 @@ set_infinite_cap(bool infinite_capacity)
 void
 add_dirty_net(odb::dbNet* net)
 {
-  getGlobalRouter()->addDirtyNet(net);
+  if (net != nullptr) {
+    getGlobalRouter()->addDirtyNet(net);
+  }
 }
 
 void

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -177,6 +177,12 @@ set_infinite_cap(bool infinite_capacity)
 }
 // NOTE: Debug-only. Not part of the public incremental API.
 void
+add_dirty_net(odb::dbNet* net)
+{
+  getGlobalRouter()->addDirtyNet(net);
+}
+
+void
 update_cugr_net(odb::dbNet* net)
 {
   getGlobalRouter()->updateCUGRNet(net);

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -34,6 +34,7 @@ TESTS = [
     "gcd_cugr",
     "gcd_flute",
     "increase_capacity1",
+    "incremental_deleted_net",
     "incremental_update_net",
     "infinite_cap",
     "inst_pin_out_of_die",

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -3,9 +3,9 @@ or_integration_tests(
   TESTS
     bus_route
     clock_route
+    clock_route_alpha
     clock_route_cugr
     clock_route_cugr2
-    clock_route_alpha
     clock_route_error1
     clock_route_error2
     colocated_pins
@@ -31,6 +31,7 @@ or_integration_tests(
     gcd_cugr
     gcd_flute
     increase_capacity1
+    incremental_deleted_net
     incremental_update_net
     infinite_cap
     inst_pin_out_of_die
@@ -77,12 +78,12 @@ or_integration_tests(
     repair_antennas2
     repair_antennas3
     repair_antennas4
+    repair_antennas_allow_congestion
     repair_antennas_error1
     repair_antennas_error2
+    repair_antennas_from_odb
     repair_antennas_only_diodes
     repair_antennas_only_jumpers
-    repair_antennas_allow_congestion
-    repair_antennas_from_odb
     report_wire_length1
     report_wire_length2
     report_wire_length3
@@ -112,7 +113,7 @@ or_integration_tests(
     congestion_report_file_cugr
     snapshot_batched_bus_route
     snapshot_batched_incremental_state
-    snapshot_batched_smoke
     snapshot_batched_single_thread_smoke
+    snapshot_batched_smoke
     thread_count_reports
 )

--- a/src/grt/test/incremental_deleted_net.ok
+++ b/src/grt/test/incremental_deleted_net.ok
@@ -1,0 +1,68 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: top
+[INFO ODB-0130]     Created 2 pins.
+[INFO ODB-0131]     Created 4 components and 16 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 8 connections.
+[INFO ODB-0133]     Created 5 nets and 8 connections.
+[INFO GRT-0020] Min routing layer: metal2
+[INFO GRT-0021] Max routing layer: metal8
+[INFO GRT-0022] Global adjustment: 50%
+[INFO GRT-0023] Grid origin: (0, 0)
+[INFO GRT-0088] Layer metal1  Track-Pitch = 0.1400  line-2-Via Pitch: 0.1350
+[INFO GRT-0088] Layer metal2  Track-Pitch = 0.1900  line-2-Via Pitch: 0.1400
+[INFO GRT-0088] Layer metal3  Track-Pitch = 0.1400  line-2-Via Pitch: 0.1400
+[INFO GRT-0088] Layer metal4  Track-Pitch = 0.2800  line-2-Via Pitch: 0.2800
+[INFO GRT-0088] Layer metal5  Track-Pitch = 0.2800  line-2-Via Pitch: 0.2800
+[INFO GRT-0088] Layer metal6  Track-Pitch = 0.2800  line-2-Via Pitch: 0.2800
+[INFO GRT-0088] Layer metal7  Track-Pitch = 0.8000  line-2-Via Pitch: 0.8000
+[INFO GRT-0088] Layer metal8  Track-Pitch = 0.8000  line-2-Via Pitch: 0.8000
+[INFO GRT-0003] Macros: 0
+[INFO GRT-0004] Blockages: 0
+[INFO GRT-0019] Found 0 clock nets.
+[INFO GRT-0001] Minimum degree: 2
+[INFO GRT-0002] Maximum degree: 2
+Design statistics
+Nets:                5
+Special nets:        0
+Routing layers:      8
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal          0             0          0.00%
+metal2     Vertical         4208           842          79.99%
+metal3     Horizontal       5712          1714          69.99%
+metal4     Vertical         2848          1424          50.00%
+metal5     Horizontal       2864          1432          50.00%
+metal6     Vertical         2848          1424          50.00%
+metal7     Horizontal        992           496          50.00%
+metal8     Vertical          992           496          50.00%
+---------------------------------------------------------------
+
+Stage 1: Pattern routing.
+Routing statistics
+Wire length:           709
+Total via count:       28
+Total congestion:      0
+Min resource:          1.5
+Bottleneck:            (6, 0, 0)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
+---------------------------------------------------------------------------------------
+metal1               0             0            0.00%             0 /  0 /  0
+metal2             842             0            0.00%             0 /  0 /  0
+metal3            1714            27            1.58%             0 /  0 /  0
+metal4            1424            12            0.84%             0 /  0 /  0
+metal5            1432             0            0.00%             0 /  0 /  0
+metal6            1424             8            0.56%             0 /  0 /  0
+metal7             496             0            0.00%             0 /  0 /  0
+metal8             496             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total             7828            47            0.60%             0 /  0 /  0
+
+[INFO GRT-0018] Total wirelength: 319 um
+[INFO GRT-0014] Routed nets: 5
+Summary 1 / 1 (100% pass)
+pass

--- a/src/grt/test/incremental_deleted_net.tcl
+++ b/src/grt/test/incremental_deleted_net.tcl
@@ -15,7 +15,7 @@ set_routing_layers -signal metal2-metal8 -clock metal3-metal8
 global_route -verbose -use_cugr
 
 # c. Call global_route -start_incremental
-global_route -start_incremental
+global_route -start_incremental -use_cugr
 
 set block [ord::get_db_block]
 set n2_net [$block findNet "n2"]
@@ -51,7 +51,7 @@ odb::dbNet_destroy $n_extra_net
 grt::add_dirty_net $n2_net
 
 # g. Call global_route -end_incremental
-global_route -end_incremental
+global_route -end_incremental -use_cugr
 
 # h. Write guides to a result file
 set guide_file [make_result_file "incremental_deleted_net.guide"]

--- a/src/grt/test/incremental_deleted_net.tcl
+++ b/src/grt/test/incremental_deleted_net.tcl
@@ -25,7 +25,7 @@ set n_extra_net [odb::dbNet_create $block "n_extra"]
 set db [ord::get_db]
 set master [$db findMaster "BUF_X1"]
 if { $master == "NULL" } {
-    utl::error GRT 9999 "Failed to create n_extra net"
+  utl::error GRT 9999 "Failed to find BUF_X1 master"
 }
 set b_extra [odb::dbInst_create $block $master "b_extra"]
 
@@ -43,7 +43,7 @@ odb::dbITerm_connect $b_extra_z $n_extra_net
 
 # e. Remove that buffer so the intermediate net is deleted
 $b1_a disconnect
-odb::dbITerm_connect $b1_a $n2_net   ;# reconnect b1/A back to original n2
+odb::dbITerm_connect $b1_a $n2_net ;# reconnect b1/A back to original n2
 odb::dbInst_destroy $b_extra
 odb::dbNet_destroy $n_extra_net
 

--- a/src/grt/test/incremental_deleted_net.tcl
+++ b/src/grt/test/incremental_deleted_net.tcl
@@ -1,0 +1,68 @@
+# Test deleted net handling in CUGR incremental routing.
+# a. Read a small LEF/DEF
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def remove_buffers1.def
+
+set_global_routing_layer_adjustment metal2 0.8
+set_global_routing_layer_adjustment metal3 0.7
+set_global_routing_layer_adjustment * 0.5
+
+set_routing_layers -signal metal2-metal8 -clock metal3-metal8
+
+# b. Run global_route with -router cugr to get a baseline full route
+global_route -verbose -use_cugr
+
+# c. Call global_route -start_incremental
+global_route -start_incremental
+
+set block [ord::get_db_block]
+set n2_net [$block findNet "n2"]
+
+# d. Insert a buffer manually using ODB API (creates intermediate net n_extra)
+set n_extra_net [odb::dbNet_create $block "n_extra"]
+set db [ord::get_db]
+set master [$db findMaster "BUF_X1"]
+if { $master == "NULL" } {
+    utl::error GRT 9999 "Failed to create n_extra net"
+}
+set b_extra [odb::dbInst_create $block $master "b_extra"]
+
+# Disconnect b1/A from n2 and connect to n_extra (b_extra output)
+set b1 [$block findInst "b1"]
+set b1_a [$b1 findITerm "A"]
+$b1_a disconnect
+odb::dbITerm_connect $b1_a $n_extra_net
+
+# Connect b_extra: input from n2, output to n_extra
+set b_extra_a [$b_extra findITerm "A"]
+set b_extra_z [$b_extra findITerm "Z"]
+odb::dbITerm_connect $b_extra_a $n2_net
+odb::dbITerm_connect $b_extra_z $n_extra_net
+
+# e. Remove that buffer so the intermediate net is deleted
+$b1_a disconnect
+odb::dbITerm_connect $b1_a $n2_net   ;# reconnect b1/A back to original n2
+odb::dbInst_destroy $b_extra
+odb::dbNet_destroy $n_extra_net
+
+# f. Mark the affected nets dirty
+grt::add_dirty_net $n2_net
+
+# g. Call global_route -end_incremental
+global_route -end_incremental
+
+# h. Write guides to a result file
+set guide_file [make_result_file "incremental_deleted_net.guide"]
+write_guides $guide_file
+
+# i. Assert the deleted intermediate net name does NOT appear in the guide file
+check "n_extra net (deleted) does NOT have routing guides" {
+  set fh [open $guide_file r]
+  set content [read $fh]
+  close $fh
+  expr { [string first "n_extra" $content] == -1 }
+} 1
+
+exit_summary


### PR DESCRIPTION
### Summary
Adds a regression test for the deleted-net handling in CUGR incremental
routing that was merged in #10578 .

### Changes
- `src/grt/test/incremental_deleted_net.tcl` — new regression test that:
  - Routes a small design (`remove_buffers1.def`) with CUGR
  - Enters incremental mode
  - Manually inserts a buffer via ODB API, creating an intermediate net `n_extra`
  - Deletes the buffer and `n_extra`, restoring the original connectivity
  - Marks `n2` dirty and ends the incremental session
  - Asserts `n_extra` is absent from the final routing guides
- `src/grt/src/GlobalRouter.i` — exposes `GlobalRouter::addDirtyNet` to Tcl
  as `grt::add_dirty_net` for use in tests
- `src/grt/test/CMakeLists.txt` — adds the new test and re-sorts all entries
  alphabetically
- `src/grt/test/incremental_deleted_net.ok` — golden reference log

### Testing
Verified locally:

```
sparsh@ext-sparsh:~/OpenROAD/build$ ctest -R incremental_deleted_net -V
UpdateCTestConfiguration  from :/home/sparsh/OpenROAD/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/sparsh/OpenROAD/build/DartConfiguration.tcl
Test project /home/sparsh/OpenROAD/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 7198
    Start 7198: grt.incremental_deleted_net.tcl

7198: Test command: /usr/bin/bash "/home/sparsh/OpenROAD/test/regression_test.sh"
7198: Working Directory: /home/sparsh/OpenROAD/src/grt/test
7198: Environment variables: 
7198:  OPENROAD_EXE=/home/sparsh/OpenROAD/build/bin/openroad
7198:  TEST_NAME=incremental_deleted_net
7198:  TEST_EXT=tcl
7198:  TEST_TYPE=tcl
7198:  TEST_CHECK_LOG=True
7198:  TEST_CHECK_PASSFAIL=False
7198: Test timeout computed to be: 10000000
7198: Directory: /home/sparsh/OpenROAD/src/grt/test
7198: Results Directory: results
7198: Command: /home/sparsh/OpenROAD/build/bin/openroad -no_splash -no_init -exit incremental_deleted_net.tcl
7198: [INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
7198: [INFO ODB-0128] Design: top
7198: [INFO ODB-0130]     Created 2 pins.
7198: [INFO ODB-0131]     Created 4 components and 16 component-terminals.
7198: [INFO ODB-0132]     Created 2 special nets and 8 connections.
7198: [INFO ODB-0133]     Created 5 nets and 8 connections.
7198: [INFO GRT-0020] Min routing layer: metal2
7198: [INFO GRT-0021] Max routing layer: metal8
7198: [INFO GRT-0022] Global adjustment: 50%
7198: [INFO GRT-0023] Grid origin: (0, 0)
7198: [INFO GRT-0088] Layer metal1  Track-Pitch = 0.1400  line-2-Via Pitch: 0.1350
7198: [INFO GRT-0088] Layer metal2  Track-Pitch = 0.1900  line-2-Via Pitch: 0.1400
7198: [INFO GRT-0088] Layer metal3  Track-Pitch = 0.1400  line-2-Via Pitch: 0.1400
7198: [INFO GRT-0088] Layer metal4  Track-Pitch = 0.2800  line-2-Via Pitch: 0.2800
7198: [INFO GRT-0088] Layer metal5  Track-Pitch = 0.2800  line-2-Via Pitch: 0.2800
7198: [INFO GRT-0088] Layer metal6  Track-Pitch = 0.2800  line-2-Via Pitch: 0.2800
7198: [INFO GRT-0088] Layer metal7  Track-Pitch = 0.8000  line-2-Via Pitch: 0.8000
7198: [INFO GRT-0088] Layer metal8  Track-Pitch = 0.8000  line-2-Via Pitch: 0.8000
7198: [INFO GRT-0003] Macros: 0
7198: [INFO GRT-0004] Blockages: 0
7198: [INFO GRT-0019] Found 0 clock nets.
7198: [INFO GRT-0001] Minimum degree: 2
7198: [INFO GRT-0002] Maximum degree: 2
7198: Design statistics
7198: Nets:                5
7198: Special nets:        0
7198: Routing layers:      8
7198: 
7198: [INFO GRT-0053] Routing resources analysis:
7198:           Routing      Original      Derated      Resource
7198: Layer     Direction    Resources     Resources    Reduction (%)
7198: ---------------------------------------------------------------
7198: metal1     Horizontal          0             0          0.00%
7198: metal2     Vertical         4208           842          79.99%
7198: metal3     Horizontal       5712          1714          69.99%
7198: metal4     Vertical         2848          1424          50.00%
7198: metal5     Horizontal       2864          1432          50.00%
7198: metal6     Vertical         2848          1424          50.00%
7198: metal7     Horizontal        992           496          50.00%
7198: metal8     Vertical          992           496          50.00%
7198: ---------------------------------------------------------------
7198: 
7198: Stage 1: Pattern routing.
7198: Routing statistics
7198: Wire length:           709
7198: Total via count:       28
7198: Total congestion:      0
7198: Min resource:          1.5
7198: Bottleneck:            (6, 0, 0)
7198: 
7198: [INFO GRT-0096] Final congestion report:
7198: Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
7198: ---------------------------------------------------------------------------------------
7198: metal1               0             0            0.00%             0 /  0 /  0
7198: metal2             842             0            0.00%             0 /  0 /  0
7198: metal3            1714            27            1.58%             0 /  0 /  0
7198: metal4            1424            12            0.84%             0 /  0 /  0
7198: metal5            1432             0            0.00%             0 /  0 /  0
7198: metal6            1424             8            0.56%             0 /  0 /  0
7198: metal7             496             0            0.00%             0 /  0 /  0
7198: metal8             496             0            0.00%             0 /  0 /  0
7198: ---------------------------------------------------------------------------------------
7198: Total             7828            47            0.60%             0 /  0 /  0
7198: 
7198: [INFO GRT-0018] Total wirelength: 319 um
7198: [INFO GRT-0014] Routed nets: 5
7198: Summary 1 / 1 (100% pass)
7198: pass
7198: Exitcode:  0
7198: Diff:      results/incremental_deleted_net-tcl.diff
1/1 Test #7198: grt.incremental_deleted_net.tcl ...   Passed    0.21 sec

The following tests passed:
        grt.incremental_deleted_net.tcl

100% tests passed, 0 tests failed out of 1

Label Time Summary:
IntegrationTest tcl grt log_compare    =   0.21 sec*proc (1 test)

Total Test time (real) =   0.40 sec
```