### PR TITLE
web: add net fanout histogram to charts widget

### DIFF
--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -41,11 +41,24 @@ export function hitTestColumn(bars, chartArea, mx, my) {
     return null;
 }
 
+// Map a count to a [0,1] vertical fraction.  Log mode uses log10(c+1) so a
+// count of 0 maps to 0 and the fraction is monotonic over all integers.
+function countFraction(count, yMax, logY) {
+    if (logY) {
+        return Math.log10(count + 1) / Math.log10(yMax + 1);
+    }
+    return count / yMax;
+}
+
 // Pure layout computation — extracted for testability.
-export function computeHistogramLayout(histogramData, canvasWidth, canvasHeight) {
+// `opts.logY` switches the Y axis to a log scale (useful for highly skewed
+// distributions like net fanout).
+export function computeHistogramLayout(histogramData, canvasWidth, canvasHeight,
+                                       opts = {}) {
+    const logY = !!opts.logY;
     const bins = histogramData?.bins;
     if (!bins || bins.length === 0) {
-        return { bars: [], yMax: 0, yTicks: [], chartArea: null };
+        return { bars: [], yMax: 0, yTicks: [], chartArea: null, logY };
     }
 
     const chartLeft = kLeftMargin;
@@ -56,7 +69,7 @@ export function computeHistogramLayout(histogramData, canvasWidth, canvasHeight)
     const chartHeight = chartBottom - chartTop;
 
     if (chartWidth <= 0 || chartHeight <= 0) {
-        return { bars: [], yMax: 0, yTicks: [], chartArea: null };
+        return { bars: [], yMax: 0, yTicks: [], chartArea: null, logY };
     }
 
     const chartArea = { left: chartLeft, right: chartRight,
@@ -70,14 +83,15 @@ export function computeHistogramLayout(histogramData, canvasWidth, canvasHeight)
     if (maxCount === 0) maxCount = 1;
 
     // Compute nice Y-axis max and ticks
-    const { yMax, yTicks } = computeYAxis(maxCount);
+    const { yMax, yTicks }
+        = logY ? computeLogYAxis(maxCount) : computeYAxis(maxCount);
 
     // Compute bar rectangles
     const barWidth = (chartWidth - kBarGap * (bins.length - 1)) / bins.length;
     const bars = [];
     for (let i = 0; i < bins.length; i++) {
         const bin = bins[i];
-        const barHeight = (bin.count / yMax) * chartHeight;
+        const barHeight = countFraction(bin.count, yMax, logY) * chartHeight;
         bars.push({
             x: chartLeft + i * (barWidth + kBarGap),
             y: chartBottom - barHeight,
@@ -90,10 +104,13 @@ export function computeHistogramLayout(histogramData, canvasWidth, canvasHeight)
         });
     }
 
-    return { bars, yMax, yTicks, chartArea };
+    return { bars, yMax, yTicks, chartArea, logY };
 }
 
 // Compute nice Y-axis max and tick values.
+// Picks a tick interval from {1, 2, 5} × 10^n targeting ~kTargetTicks ticks,
+// then rounds yMax up to the nearest interval so the tallest bar fills most
+// of the chart instead of leaving the upper half empty.
 function computeYAxis(maxCount) {
     if (maxCount <= 10) {
         const ticks = [];
@@ -101,27 +118,43 @@ function computeYAxis(maxCount) {
         return { yMax: maxCount, yTicks: ticks };
     }
 
-    // Snap to a nice ceiling
-    const digits = Math.floor(Math.log10(maxCount)) + 1;
-    const firstDigit = Math.floor(maxCount / Math.pow(10, digits - 1));
-    const snapMax = (firstDigit + 1) * Math.pow(10, digits - 1);
-
-    let total = Math.pow(10, digits);
-    if (firstDigit < 5) total /= 2;
-    const interval = Math.ceil(total / 10);
+    const kTargetTicks = 8;
+    const raw = maxCount / kTargetTicks;
+    const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+    const residual = raw / mag;
+    let niceCoeff;
+    if (residual < 1.5) niceCoeff = 1;
+    else if (residual < 3) niceCoeff = 2;
+    else if (residual < 7) niceCoeff = 5;
+    else niceCoeff = 10;
+    const interval = niceCoeff * mag;
+    const yMax = Math.ceil(maxCount / interval) * interval;
 
     const ticks = [];
-    for (let v = 0; v <= snapMax; v += interval) {
+    for (let v = 0; v <= yMax + interval / 2; v += interval) {
         ticks.push(v);
     }
+    return { yMax, yTicks: ticks };
+}
 
-    return { yMax: snapMax, yTicks: ticks };
+// Log-scale Y axis: ticks at powers of 10 up to the next decade above
+// maxCount, plus 0 at the bottom.  The bar height mapping uses log(c+1) so 0
+// counts render flat against the axis.
+function computeLogYAxis(maxCount) {
+    const topDecade = Math.max(1,
+        Math.pow(10, Math.ceil(Math.log10(Math.max(1, maxCount + 1)))));
+    const ticks = [0];
+    for (let v = 1; v <= topDecade + 0.5; v *= 10) {
+        ticks.push(v);
+    }
+    return { yMax: topDecade, yTicks: ticks };
 }
 
 export class ChartsWidget {
     constructor(app, redrawAllLayers) {
         this._app = app;
         this._redrawAllLayers = redrawAllLayers;
+        // 'setup' and 'hold' show endpoint slack; 'fanout' shows net fanout.
         this._currentTab = 'setup';
         this._histogramData = null;
         this._bars = [];
@@ -179,8 +212,13 @@ export class ChartsWidget {
         this._holdTab.className = 'timing-tab';
         this._holdTab.textContent = 'Hold Slack';
 
+        this._fanoutTab = document.createElement('div');
+        this._fanoutTab.className = 'timing-tab';
+        this._fanoutTab.textContent = 'Net Fanout';
+
         tabBar.appendChild(this._setupTab);
         tabBar.appendChild(this._holdTab);
+        tabBar.appendChild(this._fanoutTab);
         el.appendChild(tabBar);
 
         // Filter row
@@ -223,6 +261,8 @@ export class ChartsWidget {
         // Group histogram-specific elements so we can hide them
         // when a debug line chart tab is active.
         this._histogramControls = [toolbar, tabBar, filterRow];
+        // Filters only apply to slack histograms (Setup/Hold).
+        this._filterRow = filterRow;
 
         this.element = el;
 
@@ -237,21 +277,10 @@ export class ChartsWidget {
     _bindEvents() {
         this._updateBtn.addEventListener('click', () => this.update());
 
-        this._setupTab.addEventListener('click', () => {
-            if (this._currentTab === 'setup') return;
-            this._currentTab = 'setup';
-            this._setupTab.classList.add('active');
-            this._holdTab.classList.remove('active');
-            this.update();
-        });
-
-        this._holdTab.addEventListener('click', () => {
-            if (this._currentTab === 'hold') return;
-            this._currentTab = 'hold';
-            this._holdTab.classList.add('active');
-            this._setupTab.classList.remove('active');
-            this.update();
-        });
+        this._setupTab.addEventListener('click', () => this._selectTab('setup'));
+        this._holdTab.addEventListener('click', () => this._selectTab('hold'));
+        this._fanoutTab.addEventListener('click',
+            () => this._selectTab('fanout'));
 
         this._pathGroupSelect.addEventListener('change', () => this._fetchHistogram());
         this._clockSelect.addEventListener('change', () => this._fetchHistogram());
@@ -263,6 +292,8 @@ export class ChartsWidget {
             this._syncView();
         });
         this._canvas.addEventListener('click', (e) => this._handleClick(e));
+        this._canvas.addEventListener('dblclick',
+            (e) => this._handleDblClick(e));
 
         // Re-render on resize
         const ro = new ResizeObserver(() => {
@@ -279,12 +310,27 @@ export class ChartsWidget {
         this._ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
 
+    _selectTab(tab) {
+        if (this._currentTab === tab) return;
+        this._currentTab = tab;
+        this._setupTab.classList.toggle('active', tab === 'setup');
+        this._holdTab.classList.toggle('active', tab === 'hold');
+        this._fanoutTab.classList.toggle('active', tab === 'fanout');
+        // Path-group / clock filters only apply to slack histograms.
+        this._filterRow.style.display = (tab === 'fanout') ? 'none' : '';
+        this._hoveredBar = null;
+        this._tooltip.style.display = 'none';
+        this.update();
+    }
+
     async update() {
         this._updateBtn.disabled = true;
         this._updateBtn.textContent = 'Loading...';
         this._statusLabel.textContent = '';
         try {
-            await this._fetchFilters();
+            if (this._currentTab !== 'fanout') {
+                await this._fetchFilters();
+            }
             await this._fetchHistogram();
         } catch (err) {
             this._statusLabel.textContent = 'Error: ' + err.message;
@@ -318,25 +364,35 @@ export class ChartsWidget {
 
     async _fetchHistogram() {
         try {
-            const req = {
-                type: 'slack_histogram',
-                is_setup: this._currentTab === 'setup',
-            };
-            if (this._pathGroupSelect.value) {
-                req.path_group = this._pathGroupSelect.value;
-            }
-            if (this._clockSelect.value) {
-                req.clock_name = this._clockSelect.value;
+            let req;
+            if (this._currentTab === 'fanout') {
+                req = { type: 'fanout_histogram' };
+            } else {
+                req = {
+                    type: 'slack_histogram',
+                    is_setup: this._currentTab === 'setup',
+                };
+                if (this._pathGroupSelect.value) {
+                    req.path_group = this._pathGroupSelect.value;
+                }
+                if (this._clockSelect.value) {
+                    req.clock_name = this._clockSelect.value;
+                }
             }
             const data = await this._app.websocketManager.request(req);
             this._histogramData = data;
             this._syncView();
 
-            const total = data.total_endpoints || 0;
-            const unconstrained = data.unconstrained_count || 0;
-            const constrained = total - unconstrained;
-            this._statusLabel.textContent = `${constrained} endpoints` +
-                (unconstrained > 0 ? `, ${unconstrained} unconstrained` : '');
+            if (this._currentTab === 'fanout') {
+                const total = data.total_nets || 0;
+                this._statusLabel.textContent = `${total} nets`;
+            } else {
+                const total = data.total_endpoints || 0;
+                const unconstrained = data.unconstrained_count || 0;
+                const constrained = total - unconstrained;
+                this._statusLabel.textContent = `${constrained} endpoints` +
+                    (unconstrained > 0 ? `, ${unconstrained} unconstrained` : '');
+            }
         } catch (err) {
             this._statusLabel.textContent = 'Error: ' + err.message;
         }
@@ -346,11 +402,13 @@ export class ChartsWidget {
         if (!this._histogramData) return;
         const rect = this._canvas.getBoundingClientRect();
         const result = computeHistogramLayout(
-            this._histogramData, rect.width, rect.height);
+            this._histogramData, rect.width, rect.height,
+            { logY: this._currentTab === 'fanout' });
         this._bars = result.bars;
         this._yMax = result.yMax;
         this._yTicks = result.yTicks;
         this._chartArea = result.chartArea;
+        this._logY = !!result.logY;
     }
 
     render() { this._syncView(); }
@@ -411,8 +469,11 @@ export class ChartsWidget {
         ctx.textBaseline = 'middle';
         const chartHeight = ca.bottom - ca.top;
         for (const tick of this._yTicks) {
-            const y = ca.bottom - (tick / this._yMax) * chartHeight;
-            ctx.fillText(String(tick), ca.left - 6, y);
+            const frac = this._logY
+                ? Math.log10(tick + 1) / Math.log10(this._yMax + 1)
+                : tick / this._yMax;
+            const y = ca.bottom - frac * chartHeight;
+            ctx.fillText(this._formatCount(tick), ca.left - 6, y);
             if (tick > 0) {
                 ctx.strokeStyle = tc.canvasGrid;
                 ctx.beginPath();
@@ -423,6 +484,8 @@ export class ChartsWidget {
             }
         }
 
+        const isFanout = this._currentTab === 'fanout';
+
         // Y axis title
         ctx.save();
         ctx.translate(14, (ca.top + ca.bottom) / 2);
@@ -431,7 +494,8 @@ export class ChartsWidget {
         ctx.textBaseline = 'middle';
         ctx.fillStyle = tc.canvasTitle;
         ctx.font = '11px monospace';
-        ctx.fillText('Endpoints', 0, 0);
+        ctx.fillText(this._logY ? 'Nets (log)'
+                                : (isFanout ? 'Nets' : 'Endpoints'), 0, 0);
         ctx.restore();
 
         // X axis labels — show bin boundaries
@@ -443,9 +507,10 @@ export class ChartsWidget {
         const bins = this._histogramData.bins;
         const unit = this._histogramData.time_unit || '';
 
-        // Determine precision from bin width
+        // Determine precision from bin width.  Fanout bins are integer-valued.
         const binWidth = bins.length > 0 ? bins[0].upper - bins[0].lower : 1;
-        const precision = Math.max(0, -Math.floor(Math.log10(binWidth)));
+        const precision = isFanout
+            ? 0 : Math.max(0, -Math.floor(Math.log10(binWidth)));
 
         // Label at each bar boundary
         for (let i = 0; i <= this._bars.length; i++) {
@@ -461,7 +526,9 @@ export class ChartsWidget {
         ctx.font = '11px monospace';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
-        ctx.fillText(`Slack [${unit}]`, (ca.left + ca.right) / 2, ca.bottom + 22);
+        const xTitle = isFanout
+            ? 'Fanout (loads)' : `Slack [${unit}]`;
+        ctx.fillText(xTitle, (ca.left + ca.right) / 2, ca.bottom + 22);
     }
 
     _drawBars(ctx) {
@@ -494,12 +561,18 @@ export class ChartsWidget {
     }
 
     _drawTitle(ctx, canvasWidth, tc) {
-        const mode = this._currentTab === 'setup' ? 'Setup' : 'Hold';
+        let title;
+        if (this._currentTab === 'fanout') {
+            title = 'Net Fanout';
+        } else {
+            const mode = this._currentTab === 'setup' ? 'Setup' : 'Hold';
+            title = `${mode} Endpoint Slack`;
+        }
         ctx.fillStyle = tc.fgPrimary;
         ctx.font = '13px monospace';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
-        ctx.fillText(`${mode} Endpoint Slack`, canvasWidth / 2, 8);
+        ctx.fillText(title, canvasWidth / 2, 8);
     }
 
     _hitTestBar(e) {
@@ -522,17 +595,43 @@ export class ChartsWidget {
         }
 
         if (bar) {
-            const unit = this._histogramData?.time_unit || '';
+            const isFanout = this._currentTab === 'fanout';
             const binWidth = bar.upper - bar.lower;
-            const precision = Math.max(0, -Math.floor(Math.log10(binWidth)));
-            this._tooltip.textContent =
-                `Endpoints: ${bar.count}\n` +
-                `Slack: [${bar.lower.toFixed(precision)}, ${bar.upper.toFixed(precision)}) ${unit}`;
+            if (isFanout) {
+                // Bin upper is exclusive; show [lo, hi-1] inclusively when
+                // bin_width is 1 the range collapses to a single value.
+                const hiInclusive = bar.upper - 1;
+                const range = (bar.lower === hiInclusive)
+                    ? `${bar.lower}`
+                    : `[${bar.lower}, ${hiInclusive}]`;
+                this._tooltip.textContent =
+                    `Nets: ${bar.count}\nFanout: ${range}`;
+            } else {
+                const unit = this._histogramData?.time_unit || '';
+                const precision
+                    = Math.max(0, -Math.floor(Math.log10(binWidth)));
+                this._tooltip.textContent =
+                    `Endpoints: ${bar.count}\n`
+                    + `Slack: [${bar.lower.toFixed(precision)}, `
+                    + `${bar.upper.toFixed(precision)}) ${unit}`;
+            }
             this._tooltip.style.display = 'block';
 
+            // Flip the tooltip to the left of the cursor when it would
+            // overflow the widget's right edge; clamp inside otherwise.
             const rect = this.element.getBoundingClientRect();
-            const tx = e.clientX - rect.left + 12;
-            const ty = e.clientY - rect.top - 10;
+            const ttRect = this._tooltip.getBoundingClientRect();
+            const margin = 4;
+            const cursorX = e.clientX - rect.left;
+            const cursorY = e.clientY - rect.top;
+            let tx = cursorX + 12;
+            if (tx + ttRect.width > rect.width - margin) {
+                tx = cursorX - 12 - ttRect.width;
+            }
+            tx = Math.max(margin, tx);
+            let ty = cursorY - 10;
+            ty = Math.min(rect.height - ttRect.height - margin,
+                Math.max(margin, ty));
             this._tooltip.style.left = tx + 'px';
             this._tooltip.style.top = ty + 'px';
         } else {
@@ -542,6 +641,8 @@ export class ChartsWidget {
 
     async _handleClick(e) {
         if (this._activeDebugChart >= 0) return;
+        // Fanout bars are informational only — no timing-path drilldown.
+        if (this._currentTab === 'fanout') return;
         const bar = this._hitTestBar(e);
         if (!bar || bar.count === 0) return;
 
@@ -563,6 +664,34 @@ export class ChartsWidget {
             }
         } catch (err) {
             console.error('Charts bar click error:', err);
+        }
+    }
+
+    // Double-click on a fanout bar selects every net in that bin (server-
+    // side multi-selection) and opens the first one in the Inspector.  The
+    // prev/next chevrons in the Inspector then cycle through all of them.
+    async _handleDblClick(e) {
+        if (this._activeDebugChart >= 0) return;
+        if (this._currentTab !== 'fanout') return;
+        const bar = this._hitTestBar(e);
+        if (!bar || bar.count === 0) return;
+        try {
+            const resp = await this._app.websocketManager.request({
+                type: 'select_fanout_bin',
+                lower: bar.lower,
+                upper: bar.upper,
+            });
+            if (this._app.updateInspector) {
+                this._app.updateInspector(resp);
+            }
+            if (this._app.focusComponent) {
+                this._app.focusComponent('Inspector');
+            }
+            if (this._redrawAllLayers) {
+                this._redrawAllLayers();
+            }
+        } catch (err) {
+            console.error('Fanout bin select failed:', err);
         }
     }
 
@@ -627,6 +756,10 @@ export class ChartsWidget {
         }
         for (const el of this._histogramControls) {
             el.style.display = showHist ? '' : 'none';
+        }
+        // Filter row is slack-only; hide it on the fanout tab.
+        if (showHist && this._currentTab === 'fanout' && this._filterRow) {
+            this._filterRow.style.display = 'none';
         }
         this._sizeCanvas();
         if (showHist) {
@@ -783,5 +916,13 @@ export class ChartsWidget {
         if (abs >= 1e3) return (v / 1e3).toFixed(1) + 'k';
         if (abs >= 1) return v.toFixed(1);
         return v.toPrecision(3);
+    }
+
+    // Integer counts on Y axis: compact for large values, plain otherwise.
+    _formatCount(v) {
+        if (v === 0) return '0';
+        if (v >= 1e6) return (v / 1e6) + 'M';
+        if (v >= 1e3) return (v / 1e3) + 'k';
+        return String(v);
     }
 }

--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -364,13 +364,17 @@ export class ChartsWidget {
 
     async _fetchHistogram() {
         try {
+            // Remember which tab issued this request so a response that arrives
+            // after the user switches tabs can be discarded instead of being
+            // rendered/interpreted as the wrong histogram type.
+            const requestedTab = this._currentTab;
             let req;
-            if (this._currentTab === 'fanout') {
+            if (requestedTab === 'fanout') {
                 req = { type: 'fanout_histogram' };
             } else {
                 req = {
                     type: 'slack_histogram',
-                    is_setup: this._currentTab === 'setup',
+                    is_setup: requestedTab === 'setup',
                 };
                 if (this._pathGroupSelect.value) {
                     req.path_group = this._pathGroupSelect.value;
@@ -380,10 +384,14 @@ export class ChartsWidget {
                 }
             }
             const data = await this._app.websocketManager.request(req);
+            // Stale response: the user switched tabs while this was in flight.
+            if (this._currentTab !== requestedTab) {
+                return;
+            }
             this._histogramData = data;
             this._syncView();
 
-            if (this._currentTab === 'fanout') {
+            if (requestedTab === 'fanout') {
                 const total = data.total_nets || 0;
                 this._statusLabel.textContent = `${total} nets`;
             } else {
@@ -680,6 +688,7 @@ export class ChartsWidget {
                 type: 'select_fanout_bin',
                 lower: bar.lower,
                 upper: bar.upper,
+                use_dbu: this._app.showDbu,
             });
             if (resp && resp.truncated) {
                 console.warn(

--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -681,6 +681,11 @@ export class ChartsWidget {
                 lower: bar.lower,
                 upper: bar.upper,
             });
+            if (resp && resp.truncated) {
+                console.warn(
+                    `Fanout bin has ${resp.count} nets; selection capped at `
+                    + `${resp.selection_limit} for performance.`);
+            }
             if (this._app.updateInspector) {
                 this._app.updateInspector(resp);
             }

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1007,6 +1007,18 @@ WebSocketResponse SelectHandler::handleSelectFanoutBin(
     boost::json::object root;
     root["count"] = static_cast<int>(matched.size());
 
+    // Selecting/highlighting every net in a densely populated bin (tens of
+    // thousands of nets in a large design) is prohibitively expensive and can
+    // hang or exhaust memory. Cap the selection so navigation stays usable
+    // while reporting the true bin count above.
+    constexpr size_t kMaxFanoutSelection = 1000;
+    const bool truncated = matched.size() > kMaxFanoutSelection;
+    if (truncated) {
+      matched.resize(kMaxFanoutSelection);
+    }
+    root["truncated"] = truncated;
+    root["selection_limit"] = static_cast<int>(kMaxFanoutSelection);
+
     if (!matched.empty()) {
       // STA-touching code (descriptors, getProperties) must hold the
       // shared STA lock.

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -536,6 +536,11 @@ void SelectHandler::registerRequests(RequestDispatcher& d)
         [this](const WebSocketRequest& req, SessionState& state) {
           return handleSetFocusNets(req, state);
         });
+  d.add("select_fanout_bin",
+        WebSocketRequest::kSelectFanoutBin,
+        [this](const WebSocketRequest& req, SessionState& state) {
+          return handleSelectFanoutBin(req, state);
+        });
   d.add("set_route_guides",
         WebSocketRequest::kSetRouteGuides,
         [this](const WebSocketRequest& req, SessionState& state) {
@@ -961,6 +966,93 @@ WebSocketResponse SelectHandler::handleSetFocusNets(const WebSocketRequest& req,
     boost::json::object root;
     root["ok"] = 1;
     root["count"] = static_cast<int>(state.focus_net_ids.size());
+    writePayload(resp, root);
+  } catch (const std::exception& e) {
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
+  return resp;
+}
+
+WebSocketResponse SelectHandler::handleSelectFanoutBin(
+    const WebSocketRequest& req,
+    SessionState& state)
+{
+  WebSocketResponse resp;
+  resp.id = req.id;
+  resp.type = WebSocketResponse::kJson;
+  try {
+    const int lower = static_cast<int>(req.json.at("lower").as_int64());
+    const int upper = static_cast<int>(req.json.at("upper").as_int64());
+
+    odb::dbBlock* block = gen_->getBlock();
+    if (!block) {
+      throw std::runtime_error("no design loaded");
+    }
+
+    std::vector<odb::dbNet*> matched;
+    for (odb::dbNet* net : block->getNets()) {
+      if (net->getSigType().isSupply()) {
+        continue;
+      }
+      const int term_count = static_cast<int>(net->getITermCount())
+                             + static_cast<int>(net->getBTermCount());
+      const int fanout = std::max(0, term_count - 1);
+      if (fanout >= lower && fanout < upper) {
+        matched.push_back(net);
+      }
+    }
+
+    boost::json::object root;
+    root["count"] = static_cast<int>(matched.size());
+
+    if (!matched.empty()) {
+      // STA-touching code (descriptors, getProperties) must hold the
+      // shared STA lock.
+      std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+
+      auto* registry = gui::DescriptorRegistry::instance();
+      gui::SelectionSet new_selection;
+      for (auto* n : matched) {
+        new_selection.insert(registry->makeSelected(n));
+      }
+      gui::Selected first = registry->makeSelected(matched.front());
+
+      std::vector<gui::Selected> new_selectables;
+      writeInspectPayload(root,
+                          first,
+                          new_selectables,
+                          /*can_navigate_back=*/false);
+      {
+        std::lock_guard<std::mutex> lock(state.selectables_mutex);
+        state.selectables = std::move(new_selectables);
+      }
+      {
+        std::lock_guard<std::mutex> lock(state.selection_mutex);
+        state.hover_rects.clear();
+        state.timing_rects.clear();
+        state.timing_lines.clear();
+        state.navigation_history.clear();
+
+        state.selection_set = std::move(new_selection);
+        state.selection_itr = state.selection_set.find(first);
+        if (state.selection_itr == state.selection_set.end()) {
+          state.selection_itr = state.selection_set.begin();
+        }
+        // Highlight every selected net in the layout.
+        collectMultiHighlightShapes(
+            state.selection_set, state.highlight_rects, state.highlight_polys);
+        state.current_inspected = first;
+
+        root["selection_count"]
+            = static_cast<int64_t>(state.selection_set.size());
+        root["selection_index"]
+            = static_cast<int64_t>(selectionIteratorPosition(
+                state.selection_set, state.selection_itr));
+      }
+    }
+
     writePayload(resp, root);
   } catch (const std::exception& e) {
     resp.type = WebSocketResponse::kError;
@@ -1610,6 +1702,11 @@ void TimingHandler::registerRequests(RequestDispatcher& d)
         [this](const WebSocketRequest& req, SessionState&) {
           return handleSlackHistogram(req);
         });
+  d.add("fanout_histogram",
+        WebSocketRequest::kFanoutHistogram,
+        [this](const WebSocketRequest& req, SessionState&) {
+          return handleFanoutHistogram(req);
+        });
   d.add("chart_filters",
         WebSocketRequest::kChartFilters,
         [this](const WebSocketRequest& req, SessionState&) {
@@ -1720,6 +1817,25 @@ WebSocketResponse TimingHandler::handleSlackHistogram(
         jsonOr<std::string>(req.json, "path_group", ""),
         jsonOr<std::string>(req.json, "clock_name", ""));
     writePayload(resp, serializeSlackHistogram(histogram));
+  } catch (const std::exception& e) {
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
+  return resp;
+}
+
+WebSocketResponse TimingHandler::handleFanoutHistogram(
+    const WebSocketRequest& req)
+{
+  WebSocketResponse resp;
+  resp.id = req.id;
+  resp.type = WebSocketResponse::kJson;
+  try {
+    std::lock_guard<std::mutex> lock(tcl_eval_->mutex);
+    odb::dbBlock* block = gen_->getBlock();
+    auto histogram = computeFanoutHistogram(block);
+    writePayload(resp, serializeFanoutHistogram(histogram));
   } catch (const std::exception& e) {
     resp.type = WebSocketResponse::kError;
     const std::string err = std::string("server error: ") + e.what();

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -991,6 +991,13 @@ WebSocketResponse SelectHandler::handleSelectFanoutBin(
       throw std::runtime_error("no design loaded");
     }
 
+    // odb is not thread-safe against design-mutating Tcl commands, and the
+    // descriptor/getProperties work below is not thread-safe against STA;
+    // serialize the entire net walk and inspection with the shared STA lock.
+    std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    const bool use_dbu = jsonOr(req.json, "use_dbu", false);
+    ScopedDbuFormat dbu_fmt(block, use_dbu);
+
     std::vector<odb::dbNet*> matched;
     for (odb::dbNet* net : block->getNets()) {
       if (net->getSigType().isSupply()) {
@@ -1020,10 +1027,6 @@ WebSocketResponse SelectHandler::handleSelectFanoutBin(
     root["selection_limit"] = static_cast<int>(kMaxFanoutSelection);
 
     if (!matched.empty()) {
-      // STA-touching code (descriptors, getProperties) must hold the
-      // shared STA lock.
-      std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
-
       auto* registry = gui::DescriptorRegistry::instance();
       gui::SelectionSet new_selection;
       for (auto* n : matched) {

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -95,6 +95,8 @@ struct WebSocketRequest
     kClockTree,
     kClockTreeHighlight,
     kSlackHistogram,
+    kFanoutHistogram,
+    kSelectFanoutBin,
     kChartFilters,
     kModuleHierarchy,
     kSetModuleColors,
@@ -231,6 +233,8 @@ class SelectHandler
                                 SessionState& state);
   WebSocketResponse handleSetFocusNets(const WebSocketRequest& req,
                                        SessionState& state);
+  WebSocketResponse handleSelectFanoutBin(const WebSocketRequest& req,
+                                          SessionState& state);
   WebSocketResponse handleSetRouteGuides(const WebSocketRequest& req,
                                          SessionState& state);
   WebSocketResponse handleSelectNext(const WebSocketRequest& req,
@@ -276,6 +280,7 @@ class TimingHandler
   WebSocketResponse handleTimingHighlight(const WebSocketRequest& req,
                                           SessionState& state);
   WebSocketResponse handleSlackHistogram(const WebSocketRequest& req);
+  WebSocketResponse handleFanoutHistogram(const WebSocketRequest& req);
   WebSocketResponse handleChartFilters(const WebSocketRequest& req);
 
  private:

--- a/src/web/src/timing_report.cpp
+++ b/src/web/src/timing_report.cpp
@@ -638,4 +638,73 @@ boost::json::object serializeChartFilters(const ChartFilters& f)
   return o;
 }
 
+// ── Net fanout histogram ──
+
+FanoutHistogramResult computeFanoutHistogram(odb::dbBlock* block)
+{
+  FanoutHistogramResult result;
+  if (!block) {
+    return result;
+  }
+
+  std::vector<int> fanouts;
+  int max_fanout = 0;
+  for (odb::dbNet* net : block->getNets()) {
+    if (net->getSigType().isSupply()) {
+      continue;
+    }
+    const int term_count = static_cast<int>(net->getITermCount())
+                           + static_cast<int>(net->getBTermCount());
+    const int fanout = std::max(0, term_count - 1);
+    fanouts.push_back(fanout);
+    max_fanout = std::max(max_fanout, fanout);
+  }
+  result.total_nets = static_cast<int>(fanouts.size());
+  if (fanouts.empty()) {
+    return result;
+  }
+
+  int bin_width;
+  if (max_fanout <= 20) {
+    bin_width = 1;
+  } else {
+    constexpr int kDefaultBuckets = 10;
+    const float exact
+        = static_cast<float>(max_fanout) / static_cast<float>(kDefaultBuckets);
+    bin_width = std::max(1, static_cast<int>(snapBinInterval(exact)));
+  }
+  const int num_bins = std::max(1, max_fanout / bin_width + 1);
+
+  std::vector<int> counts(num_bins, 0);
+  for (int f : fanouts) {
+    int idx = f / bin_width;
+    idx = std::clamp(idx, 0, num_bins - 1);
+    counts[idx]++;
+  }
+  result.bins.reserve(num_bins);
+  for (int i = 0; i < num_bins; i++) {
+    const int lo = i * bin_width;
+    const int hi = lo + bin_width;
+    result.bins.push_back({lo, hi, counts[i]});
+  }
+  return result;
+}
+
+boost::json::object serializeFanoutHistogram(const FanoutHistogramResult& h)
+{
+  boost::json::object o;
+  boost::json::array bins;
+  bins.reserve(h.bins.size());
+  for (const auto& bin : h.bins) {
+    boost::json::object b;
+    b["lower"] = bin.lower;
+    b["upper"] = bin.upper;
+    b["count"] = bin.count;
+    bins.emplace_back(std::move(b));
+  }
+  o["bins"] = std::move(bins);
+  o["total_nets"] = h.total_nets;
+  return o;
+}
+
 }  // namespace web

--- a/src/web/src/timing_report.h
+++ b/src/web/src/timing_report.h
@@ -9,6 +9,10 @@
 
 #include "boost/json/object.hpp"
 
+namespace odb {
+class dbBlock;
+}  // namespace odb
+
 namespace sta {
 class dbSta;
 class Path;
@@ -67,6 +71,19 @@ struct ChartFilters
   std::vector<std::string> clocks;
 };
 
+struct FanoutHistogramBin
+{
+  int lower;  // bin lower edge (inclusive, in loads)
+  int upper;  // bin upper edge (exclusive, in loads)
+  int count;  // number of nets in this bin
+};
+
+struct FanoutHistogramResult
+{
+  std::vector<FanoutHistogramBin> bins;
+  int total_nets = 0;
+};
+
 class TimingReport
 {
  public:
@@ -104,5 +121,10 @@ boost::json::object serializeTimingPaths(
     const std::vector<TimingPathSummary>& paths);
 boost::json::object serializeSlackHistogram(const SlackHistogramResult& h);
 boost::json::object serializeChartFilters(const ChartFilters& f);
+
+// Net fanout histogram (loads = term_count - 1, skipping power/ground nets).
+// Free function: depends only on odb, not STA.
+FanoutHistogramResult computeFanoutHistogram(odb::dbBlock* block);
+boost::json::object serializeFanoutHistogram(const FanoutHistogramResult& h);
 
 }  // namespace web

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -1089,6 +1089,9 @@ void WebServer::saveReport(const std::string& filename,
     hist_hold = hist_setup;
     filters = boost::json::serialize(serializeChartFilters({}));
   }
+  // Net fanout histogram depends only on odb, so it's always populated.
+  const std::string hist_fanout = boost::json::serialize(
+      serializeFanoutHistogram(computeFanoutHistogram(block)));
   const std::string tech_json
       = boost::json::serialize(serializeTechResponse(*generator_));
   const std::string bounds_json
@@ -1222,6 +1225,8 @@ window.__STATIC_CACHE__ = {
       << hist_setup << R"(,
     "slack_histogram:hold": )"
       << hist_hold << R"(,
+    "fanout_histogram": )"
+      << hist_fanout << R"(,
     "chart_filters": )"
       << filters << R"(,
     "module_hierarchy": )"

--- a/src/web/test/js/test-charts-widget.js
+++ b/src/web/test/js/test-charts-widget.js
@@ -354,4 +354,56 @@ describe('ChartsWidget fanout tab', () => {
                 app.requests.filter((r) => r.type === 'timing_report').length,
                 0);
         });
+
+    it('forwards the Show DBU flag when selecting a fanout bin',
+        async () => {
+            const { app, widget } = createWidget({
+                fanout_histogram: fanoutResponse,
+            });
+            app.showDbu = true;
+            widget._selectTab('fanout');
+            await widget.update();
+            widget._bars = [{
+                x: 0, y: 0, width: 160, height: 120,
+                count: 12, lower: 1, upper: 2,
+            }];
+            widget._chartArea = { left: 0, right: 200, top: 0, bottom: 200 };
+            await widget._handleDblClick({ clientX: 50, clientY: 50 });
+            const sel = app.requests.find(
+                (r) => r.type === 'select_fanout_bin');
+            assert.ok(sel, 'select_fanout_bin is requested');
+            assert.equal(sel.use_dbu, true);
+        });
+
+    it('discards a histogram response after the tab changes', async () => {
+        // A request whose resolution we control, so we can switch tabs while
+        // it is still in flight.
+        let resolveReq;
+        const requests = [];
+        const app = {
+            requests,
+            websocketManager: {
+                request(msg) {
+                    requests.push(msg);
+                    return new Promise((resolve) => { resolveReq = resolve; });
+                },
+            },
+            focusComponent() {},
+        };
+        installCanvasStubs();
+        const widget = new ChartsWidget(app, () => {});
+        document.body.appendChild(widget.element);
+
+        widget._currentTab = 'fanout';
+        const pending = widget._fetchHistogram();
+        // User switches back to Setup before the fanout response arrives.
+        widget._currentTab = 'setup';
+        resolveReq(fanoutResponse);
+        await pending;
+
+        // The stale fanout payload must not be adopted as the active data,
+        // nor reported in the (now Setup) status label.
+        assert.notEqual(widget._histogramData, fanoutResponse);
+        assert.doesNotMatch(widget._statusLabel.textContent, /20 nets/);
+    });
 });

--- a/src/web/test/js/test-charts-widget.js
+++ b/src/web/test/js/test-charts-widget.js
@@ -39,13 +39,16 @@ function installCanvasStubs() {
     };
 }
 
-function createWidgetApp() {
+function createWidgetApp(responses = {}) {
     const requests = [];
     return {
         requests,
         websocketManager: {
             request(msg) {
                 requests.push(msg);
+                if (responses[msg.type]) {
+                    return Promise.resolve(responses[msg.type]);
+                }
                 if (msg.type === 'timing_report') {
                     return Promise.resolve({ paths: [] });
                 }
@@ -59,9 +62,9 @@ function createWidgetApp() {
     };
 }
 
-function createWidget() {
+function createWidget(responses) {
     installCanvasStubs();
-    const app = createWidgetApp();
+    const app = createWidgetApp(responses);
     const widget = new ChartsWidget(app, () => {});
     document.body.appendChild(widget.element);
     widget.element.getBoundingClientRect = () => ({
@@ -296,4 +299,59 @@ describe('ChartsWidget debug charts', () => {
             points: [{ x: 5, ys: [42] }],
         }]);
     });
+});
+
+describe('ChartsWidget fanout tab', () => {
+    const fanoutResponse = {
+        bins: [
+            { lower: 0, upper: 1, count: 3 },
+            { lower: 1, upper: 2, count: 12 },
+            { lower: 2, upper: 3, count: 5 },
+        ],
+        total_nets: 20,
+    };
+
+    it('requests fanout_histogram with no slack filters', async () => {
+        const { app, widget } = createWidget({
+            fanout_histogram: fanoutResponse,
+        });
+        widget._selectTab('fanout');
+        await widget.update();
+        const fanoutReqs = app.requests.filter(
+            (r) => r.type === 'fanout_histogram');
+        assert.equal(fanoutReqs.length >= 1, true,
+            'fanout_histogram is requested');
+        // Filters should not be fetched on fanout tab.
+        assert.equal(
+            app.requests.filter((r) => r.type === 'chart_filters').length, 0);
+        // Slack histogram should not be requested while on fanout tab.
+        assert.equal(
+            app.requests.filter((r) => r.type === 'slack_histogram').length, 0);
+    });
+
+    it('reports net count in the status label', async () => {
+        const { widget } = createWidget({ fanout_histogram: fanoutResponse });
+        widget._selectTab('fanout');
+        await widget.update();
+        assert.match(widget._statusLabel.textContent, /20 nets/);
+    });
+
+    it('does not invoke timing drilldown when a fanout bar is clicked',
+        async () => {
+            const { app, widget } = createWidget({
+                fanout_histogram: fanoutResponse,
+            });
+            widget._selectTab('fanout');
+            await widget.update();
+            // Force a bar to exist and be hit.
+            widget._bars = [{
+                x: 0, y: 0, width: 160, height: 120,
+                count: 12, lower: 1, upper: 2,
+            }];
+            widget._chartArea = { left: 0, right: 200, top: 0, bottom: 200 };
+            await widget._handleClick({ clientX: 50, clientY: 50 });
+            assert.equal(
+                app.requests.filter((r) => r.type === 'timing_report').length,
+                0);
+        });
 });


### PR DESCRIPTION
## Summary

Adds a **Net Fanout** tab to the web charts widget, alongside the existing Setup/Hold Slack views.

- New `fanout_histogram` request that bins per-net load count directly from odb (no STA dependency).
- Tightens the histogram Y-axis snap so a tall bar fills most of the chart height instead of ~half.
- Keeps the hover tooltip clamped inside the widget bounds.

## Changes

- `charts-widget.js` — Net Fanout tab + Y-axis snap / tooltip fixes
- `request_handler.{cpp,h}` — `fanout_histogram` request handler
- `timing_report.{cpp,h}` — per-net fanout binning from odb
- `web.cpp` — wire up the new request
- `test/js/test-charts-widget.js` — coverage for the new tab