### PR TITLE
DependencyInstaller: pin Abseil with lower-case absl_ROOT for custom prefix

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -713,7 +713,14 @@ _install_abseil() {
     else
         INSTALL_SUMMARY+=("Abseil: system=${absl_installed_version}, required=${required_version}, path=${absl_prefix_found}, status=skipped")
     fi
-    CMAKE_PACKAGE_ROOT_ARGS+=" -D ABSL_ROOT=$(realpath "${absl_prefix_found}") "
+    # Emit both the upper- and lower-case root hints. find_package(absl) only
+    # honors the upper-case ABSL_ROOT under policy CMP0144 NEW, but the root
+    # CMakeLists forces CMP0144 OLD on CMake >= 3.27, which silently drops it.
+    # The lower-case absl_ROOT is honored by CMP0074 NEW (already set), matching
+    # ortools_ROOT, so the prefix wins over a system absl regardless of CMP0144.
+    local absl_root_real
+    absl_root_real=$(realpath "${absl_prefix_found}")
+    CMAKE_PACKAGE_ROOT_ARGS+=" -D ABSL_ROOT=${absl_root_real} -D absl_ROOT=${absl_root_real} "
 }
 
 # Returns 0 if the given directory looks like a dedicated or-tools install


### PR DESCRIPTION
Fixes #10651

### Problem

A `-prefix` install correctly pins or-tools to the local copy, but not Abseil. On a machine that also has a system or-tools (whose bundled Abseil differs from the required version), a `-prefix` build compiles `odb` against the prefix Abseil headers but links the system Abseil, failing the `odb` SWIG binaries (`odb_py`, `odbtcl`):

```
/usr/bin/ld: ../../db/libdb.a(dbDatabase.cpp.o): in function `absl::lts_20260107::MutexLock::MutexLock(...)':
.../dependencies/include/absl/synchronization/mutex.h:614: undefined reference to `absl::lts_20260107::Mutex::lock()'
```

This is reachable from a stock setup: `OpenROAD-Flow-Scripts/setup.sh` runs the installer once as root with no `-prefix` (or-tools binary archive → `/opt/or-tools`, bundling one Abseil LTS) and once with `-prefix` (builds the newer required Abseil into the prefix). Two Abseil LTS versions then coexist.

### Cause

`find_package(absl)` only honors the upper-case `ABSL_ROOT` hint under policy `CMP0144 NEW`, but the root `CMakeLists.txt` forces `CMP0144 OLD` on CMake ≥ 3.27 (see its `TODO: resolve absl/or-tools issue and switch to NEW`). So `_install_abseil` emitting only `-D ABSL_ROOT=...` has its hint silently dropped, `find_package(absl)` falls back to the default search, and the system or-tools' Abseil wins. or-tools itself is unaffected because it is pinned with the lower-case `ortools_ROOT`, which `CMP0074 NEW` honors.

### Fix

Also emit the lower-case `absl_ROOT`, which `CMP0074 NEW` honors regardless of the `CMP0144` state — mirroring what `ortools_ROOT` already does — so the prefix Abseil wins over a system copy. The existing upper-case `ABSL_ROOT` is kept for CMake < 3.27, where `CMP0144` stays NEW.

### Testing

On a machine with a system `/opt/or-tools` (bundling an older Abseil) present, a clean configure + full build into a local `-prefix` now resolves the local Abseil and builds end to end. Before the change the `odb_py` link line pulled `/opt/or-tools/lib/libabsl_synchronization.so.<ver>`; after it, it resolves `<prefix>/lib/cmake/absl` → `<prefix>/lib/libabsl_synchronization.a`, and the build completes with no `/opt/or-tools` references on the odb link line.
