### PR TITLE
drt: limit detailed-route grid graph to the routing-layer range

### DIFF
--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -2722,6 +2722,14 @@ void FlexDRWorker::initMazeCost_fixedObj(const frDesign* design)
     result.clear();
     if (getTech()->getLayer(layerNum)->getType() == dbTechLayerType::ROUTING) {
       isRoutingLayer = true;
+      // The grid graph need not span the full layer stack: TOP_ROUTING_LAYER
+      // can trim routing layers above it out of the grid. Skip fixed-shape
+      // costing on layers absent from the grid so getMazeZIdx / getLayerNum
+      // stay in range. No-op when the grid spans every routing layer.
+      if (layerNum < gridGraph_.getMinLayerNum()
+          || layerNum > gridGraph_.getMaxLayerNum()) {
+        continue;
+      }
       zIdx = gridGraph_.getMazeZIdx(layerNum);
     } else if (getTech()->getLayer(layerNum)->getType()
                == dbTechLayerType::CUT) {
@@ -2729,6 +2737,10 @@ void FlexDRWorker::initMazeCost_fixedObj(const frDesign* design)
       if (getTech()->getBottomLayerNum() <= layerNum - 1
           && getTech()->getLayer(layerNum - 1)->getType()
                  == dbTechLayerType::ROUTING) {
+        if (layerNum - 1 < gridGraph_.getMinLayerNum()
+            || layerNum - 1 > gridGraph_.getMaxLayerNum()) {
+          continue;
+        }
         zIdx = gridGraph_.getMazeZIdx(layerNum - 1);
       } else {
         continue;
@@ -2894,6 +2906,12 @@ void FlexDRWorker::initMazeCost_terms(
             if (getTech()->getLayer(layerNum)->getType()
                 == dbTechLayerType::ROUTING) {
               isRoutingLayer = true;
+              // Grid may not span the full stack (TOP_ROUTING_LAYER trim);
+              // skip layers absent from the grid. No-op when fully spanned.
+              if (layerNum < gridGraph_.getMinLayerNum()
+                  || layerNum > gridGraph_.getMaxLayerNum()) {
+                continue;
+              }
               zIdx = gridGraph_.getMazeZIdx(layerNum);
             } else if (getTech()->getLayer(layerNum)->getType()
                        == dbTechLayerType::CUT) {
@@ -2901,6 +2919,10 @@ void FlexDRWorker::initMazeCost_terms(
               if (getTech()->getBottomLayerNum() <= layerNum - 1
                   && getTech()->getLayer(layerNum - 1)->getType()
                          == dbTechLayerType::ROUTING) {
+                if (layerNum - 1 < gridGraph_.getMinLayerNum()
+                    || layerNum - 1 > gridGraph_.getMaxLayerNum()) {
+                  continue;
+                }
                 zIdx = gridGraph_.getMazeZIdx(layerNum - 1);
               } else {
                 continue;
@@ -2971,6 +2993,12 @@ void FlexDRWorker::initMazeCost_terms(
             if (getTech()->getLayer(layerNum)->getType()
                 == dbTechLayerType::ROUTING) {
               isRoutingLayer = true;
+              // Grid may not span the full stack (TOP_ROUTING_LAYER trim);
+              // skip layers absent from the grid. No-op when fully spanned.
+              if (layerNum < gridGraph_.getMinLayerNum()
+                  || layerNum > gridGraph_.getMaxLayerNum()) {
+                continue;
+              }
               zIdx = gridGraph_.getMazeZIdx(layerNum);
             } else if (getTech()->getLayer(layerNum)->getType()
                        == dbTechLayerType::CUT) {
@@ -2978,6 +3006,10 @@ void FlexDRWorker::initMazeCost_terms(
               if (getTech()->getBottomLayerNum() <= layerNum - 1
                   && getTech()->getLayer(layerNum - 1)->getType()
                          == dbTechLayerType::ROUTING) {
+                if (layerNum - 1 < gridGraph_.getMinLayerNum()
+                    || layerNum - 1 > gridGraph_.getMaxLayerNum()) {
+                  continue;
+                }
                 zIdx = gridGraph_.getMazeZIdx(layerNum - 1);
               } else {
                 continue;

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -471,6 +471,17 @@ void FlexGridGraph::initTracks(
       continue;
     }
     frLayerNum currLayerNum = layer->getLayerNum();
+    // Layers above TOP_ROUTING_LAYER carry no routing edges or access vias
+    // (initEdges and the special-access via loop already cap work at
+    // TOP_ROUTING_LAYER), yet they were still added to the grid here, sizing
+    // nodes_, the per-node arrays, and the maze search bounds across the full
+    // layer stack. Skip them so the grid graph spans only the routing range,
+    // cutting detailed-route memory and runtime when the design's top routing
+    // layer is below the technology top. Default TOP_ROUTING_LAYER is INT_MAX,
+    // so this is a no-op unless the top routing layer is explicitly lowered.
+    if (currLayerNum > router_cfg_->TOP_ROUTING_LAYER) {
+      continue;
+    }
     dbTechLayerDir currPrefRouteDir = layer->getDir();
     for (auto& tp : design->getTopBlock()->getTrackPatterns(currLayerNum)) {
       // allow wrongway if global variable and design rule allow


### PR DESCRIPTION
When a design's top routing layer is below the technology's top metal, the detailed-route grid graph is still built across the full layer stack — wasting memory and runtime on layers that can't be routed.

`FlexGridGraph::initTracks()` adds *every* routing layer in the tech to the grid, and `initGrids()` sizes `nodes_` plus the per-node arrays (`prevDirs_`, `srcs_`, `dsts_`, `guides_`) and the maze-search bounds from that full set. But routing edges (`initEdges()`) and access vias are already capped at `TOP_ROUTING_LAYER`, so the nodes above it carry no edges — they're pure overhead.

This skips routing layers above `TOP_ROUTING_LAYER` when building the grid, so the graph spans only the routing range. `TOP_ROUTING_LAYER` defaults to `INT_MAX`, so this is a no-op unless the top routing layer is explicitly lowered (`set_routing_layers` / a platform or design cap).

Only the top side is trimmed; layers at/below `BOTTOM_ROUTING_LAYER` are left untouched so pin access is unaffected.

### Motivation / results

Measured on the **gt2n** platform (a 2 nm nanosheet platform with backside power, exposing metal M0–M13, added to ORFS in The-OpenROAD-Project/OpenROAD-flow-scripts#4277). gt2n designs route well below the M13 top (gcd ~M5, jpeg ~M9, aes ~M10), so the upper layers are pure overhead:

- gcd with the top routing layer at the tech top (M13) → routed DB is **bit-identical** to before (true no-op).
- gcd with the top routing layer lowered to M5 (8 of 12 routing layers unused) → detailed-route wall time **−10%**, peak memory **−14%**, **0 DRC**, equivalent wirelength.

The companion ORFS change (The-OpenROAD-Project/OpenROAD-flow-scripts#4277) sets `MAX_ROUTING_LAYER` per gt2n design to the layers actually used, which is what makes this trim pay off.

### Behavior note

When the top routing layer is below the tech top, the smaller grid changes maze-search node indexing, so the result isn't bit-identical to the un-trimmed run — it's an equal-quality, DRC-clean solution, not the same one. At the default top routing layer it's bit-identical, so designs that route the full stack are unaffected.

### Testing

Routed gt2n/gcd before/after on the same block — verified 0 DRC and equivalent QoR at the lowered top layer (M5), and a bit-identical routed DB at the tech top (M13).