### PR TITLE
rsz: tie-break buffer size sort for deterministic output

### DIFF
--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1500,8 +1500,10 @@ void Rebuffer::init()
   }
 
   std::ranges::sort(buffer_sizes_, [=](BufferSize a, BufferSize b) {
-    if (bufferCin(a.cell) != bufferCin(b.cell)) {
-      return bufferCin(a.cell) < bufferCin(b.cell);
+    const float cin_a = bufferCin(a.cell);
+    const float cin_b = bufferCin(b.cell);
+    if (cin_a != cin_b) {
+      return cin_a < cin_b;
     }
     return a.cell->id() < b.cell->id();
   });

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1500,12 +1500,8 @@ void Rebuffer::init()
   }
 
   std::ranges::sort(buffer_sizes_, [=](BufferSize a, BufferSize b) {
-    const float cin_a = bufferCin(a.cell);
-    const float cin_b = bufferCin(b.cell);
-    if (cin_a != cin_b) {
-      return cin_a < cin_b;
-    }
-    return a.cell->id() < b.cell->id();
+    return std::make_tuple(bufferCin(a.cell), a.cell->id())
+           < std::make_tuple(bufferCin(b.cell), b.cell->id());
   });
 
   buffer_sizes_index_.clear();

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1500,8 +1500,12 @@ void Rebuffer::init()
   }
 
   std::ranges::sort(buffer_sizes_, [=](BufferSize a, BufferSize b) {
-    return std::make_tuple(bufferCin(a.cell), a.cell->id())
-           < std::make_tuple(bufferCin(b.cell), b.cell->id());
+    const float cin_a = bufferCin(a.cell);
+    const float cin_b = bufferCin(b.cell);
+    if (cin_a != cin_b) {
+      return cin_a < cin_b;
+    }
+    return a.cell->id() < b.cell->id();
   });
 
   buffer_sizes_index_.clear();

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1508,7 +1508,7 @@ void Rebuffer::init()
       return false;
     }
     // buffer_fast_sizes_ is unordered; tie-break for stable output.
-    return std::string(a.cell->name()) < std::string(b.cell->name());
+    return std::string_view(a.cell->name()) < std::string_view(b.cell->name());
   });
 
   buffer_sizes_index_.clear();

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1500,15 +1500,10 @@ void Rebuffer::init()
   }
 
   std::ranges::sort(buffer_sizes_, [=](BufferSize a, BufferSize b) {
-    const float cin_a = bufferCin(a.cell), cin_b = bufferCin(b.cell);
-    if (cin_a < cin_b) {
-      return true;
+    if (bufferCin(a.cell) != bufferCin(b.cell)) {
+      return bufferCin(a.cell) < bufferCin(b.cell);
     }
-    if (cin_b < cin_a) {
-      return false;
-    }
-    // buffer_fast_sizes_ is unordered; tie-break for stable output.
-    return std::string_view(a.cell->name()) < std::string_view(b.cell->name());
+    return a.cell->id() < b.cell->id();
   });
 
   buffer_sizes_index_.clear();

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1500,7 +1500,15 @@ void Rebuffer::init()
   }
 
   std::ranges::sort(buffer_sizes_, [=](BufferSize a, BufferSize b) {
-    return bufferCin(a.cell) < bufferCin(b.cell);
+    const float cin_a = bufferCin(a.cell), cin_b = bufferCin(b.cell);
+    if (cin_a < cin_b) {
+      return true;
+    }
+    if (cin_b < cin_a) {
+      return false;
+    }
+    // buffer_fast_sizes_ is unordered; tie-break for stable output.
+    return std::string(a.cell->name()) < std::string(b.cell->name());
   });
 
   buffer_sizes_index_.clear();

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -656,7 +656,7 @@ void RepairDesign::findBufferSizes()
                       }
                       // buffer_fast_sizes_ is unordered; tie-break for stable
                       // output.
-                      return std::string(a->name()) < std::string(b->name());
+                      return std::string_view(a->name()) < std::string_view(b->name());
                     });
 }
 

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -647,7 +647,16 @@ void RepairDesign::findBufferSizes()
                    resizer_->buffer_fast_sizes_.end()};
   std::ranges::sort(buffer_sizes_,
                     [=](sta::LibertyCell* a, sta::LibertyCell* b) {
-                      return bufferCin(a) < bufferCin(b);
+                      const float cin_a = bufferCin(a), cin_b = bufferCin(b);
+                      if (cin_a < cin_b) {
+                        return true;
+                      }
+                      if (cin_b < cin_a) {
+                        return false;
+                      }
+                      // buffer_fast_sizes_ is unordered; tie-break for stable
+                      // output.
+                      return std::string(a->name()) < std::string(b->name());
                     });
 }
 

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -14,6 +14,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -647,12 +648,8 @@ void RepairDesign::findBufferSizes()
                    resizer_->buffer_fast_sizes_.end()};
   std::ranges::sort(buffer_sizes_,
                     [=](sta::LibertyCell* a, sta::LibertyCell* b) {
-                      const float cin_a = bufferCin(a);
-                      const float cin_b = bufferCin(b);
-                      if (cin_a != cin_b) {
-                        return cin_a < cin_b;
-                      }
-                      return a->id() < b->id();
+                      return std::make_tuple(bufferCin(a), a->id())
+                             < std::make_tuple(bufferCin(b), b->id());
                     });
 }
 

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -647,16 +647,10 @@ void RepairDesign::findBufferSizes()
                    resizer_->buffer_fast_sizes_.end()};
   std::ranges::sort(buffer_sizes_,
                     [=](sta::LibertyCell* a, sta::LibertyCell* b) {
-                      const float cin_a = bufferCin(a), cin_b = bufferCin(b);
-                      if (cin_a < cin_b) {
-                        return true;
+                      if (bufferCin(a) != bufferCin(b)) {
+                        return bufferCin(a) < bufferCin(b);
                       }
-                      if (cin_b < cin_a) {
-                        return false;
-                      }
-                      // buffer_fast_sizes_ is unordered; tie-break for stable
-                      // output.
-                      return std::string_view(a->name()) < std::string_view(b->name());
+                      return a->id() < b->id();
                     });
 }
 

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -14,7 +14,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -648,8 +647,12 @@ void RepairDesign::findBufferSizes()
                    resizer_->buffer_fast_sizes_.end()};
   std::ranges::sort(buffer_sizes_,
                     [=](sta::LibertyCell* a, sta::LibertyCell* b) {
-                      return std::make_tuple(bufferCin(a), a->id())
-                             < std::make_tuple(bufferCin(b), b->id());
+                      const float cin_a = bufferCin(a);
+                      const float cin_b = bufferCin(b);
+                      if (cin_a != cin_b) {
+                        return cin_a < cin_b;
+                      }
+                      return a->id() < b->id();
                     });
 }
 

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -647,8 +647,10 @@ void RepairDesign::findBufferSizes()
                    resizer_->buffer_fast_sizes_.end()};
   std::ranges::sort(buffer_sizes_,
                     [=](sta::LibertyCell* a, sta::LibertyCell* b) {
-                      if (bufferCin(a) != bufferCin(b)) {
-                        return bufferCin(a) < bufferCin(b);
+                      const float cin_a = bufferCin(a);
+                      const float cin_b = bufferCin(b);
+                      if (cin_a != cin_b) {
+                        return cin_a < cin_b;
                       }
                       return a->id() < b->id();
                     });


### PR DESCRIPTION
`RepairDesign::findBufferSizes()` and `Rebuffer::init()` build `buffer_sizes_` from `buffer_fast_sizes_` (a `std::unordered_set`) and then `std::ranges::sort` it by `bufferCin()` alone.

`std::ranges::sort` is not stable, so cells with equal input capacitance retain an iteration order that depends on pointer addresses, which varies from run to run. The greedy buffer selection downstream then differs, making the inserted-buffer netlist nondeterministic — which breaks reproducible builds / remote-cache sharing.

This tie-breaks both sorts on the cell name so equal-`Cin` cells get a stable, reproducible order. No behavior change beyond determinism. Same shape as the previously-merged `OptMirror` tie-break (`net_box_map_ is unordered; tie-break for stable output`).