### PR TITLE
cts: tie-break dummy-cell sort for deterministic output

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -22,6 +22,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -2473,10 +2474,8 @@ void TritonCTS::findCandidateDummyCells(
   std::ranges::sort(
       dummyCandidates,
       [](const sta::LibertyCell* cell1, const sta::LibertyCell* cell2) {
-        if (getInputCap(cell1) != getInputCap(cell2)) {
-          return getInputCap(cell1) < getInputCap(cell2);
-        }
-        return cell1->id() < cell2->id();
+        return std::make_tuple(getInputCap(cell1), cell1->id())
+               < std::make_tuple(getInputCap(cell2), cell2->id());
       });
 
   if (logger_->debugCheck(utl::CTS, "dummy load", 1)) {

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -2473,15 +2473,10 @@ void TritonCTS::findCandidateDummyCells(
   std::ranges::sort(
       dummyCandidates,
       [](const sta::LibertyCell* cell1, const sta::LibertyCell* cell2) {
-        const float cap1 = getInputCap(cell1), cap2 = getInputCap(cell2);
-        if (cap1 < cap2) {
-          return true;
+        if (getInputCap(cell1) != getInputCap(cell2)) {
+          return getInputCap(cell1) < getInputCap(cell2);
         }
-        if (cap2 < cap1) {
-          return false;
-        }
-        // dummyCandidates is unordered; tie-break for stable output.
-        return std::string(cell1->name()) < std::string(cell2->name());
+        return cell1->id() < cell2->id();
       });
 
   if (logger_->debugCheck(utl::CTS, "dummy load", 1)) {

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -22,7 +22,6 @@
 #include <set>
 #include <sstream>
 #include <string>
-#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -2474,8 +2473,12 @@ void TritonCTS::findCandidateDummyCells(
   std::ranges::sort(
       dummyCandidates,
       [](const sta::LibertyCell* cell1, const sta::LibertyCell* cell2) {
-        return std::make_tuple(getInputCap(cell1), cell1->id())
-               < std::make_tuple(getInputCap(cell2), cell2->id());
+        const float cap1 = getInputCap(cell1);
+        const float cap2 = getInputCap(cell2);
+        if (cap1 != cap2) {
+          return cap1 < cap2;
+        }
+        return cell1->id() < cell2->id();
       });
 
   if (logger_->debugCheck(utl::CTS, "dummy load", 1)) {

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -2473,7 +2473,15 @@ void TritonCTS::findCandidateDummyCells(
   std::ranges::sort(
       dummyCandidates,
       [](const sta::LibertyCell* cell1, const sta::LibertyCell* cell2) {
-        return (getInputCap(cell1) < getInputCap(cell2));
+        const float cap1 = getInputCap(cell1), cap2 = getInputCap(cell2);
+        if (cap1 < cap2) {
+          return true;
+        }
+        if (cap2 < cap1) {
+          return false;
+        }
+        // dummyCandidates is unordered; tie-break for stable output.
+        return std::string(cell1->name()) < std::string(cell2->name());
       });
 
   if (logger_->debugCheck(utl::CTS, "dummy load", 1)) {


### PR DESCRIPTION
`findCandidateDummyCells()` gathers `dummyCandidates` by iterating the STA libraries, then `std::ranges::sort`s them by `getInputCap()` alone.

`std::ranges::sort` is not stable, and `findBestDummyCell()` subsequently takes the first candidate with the minimal `|cap - deltaCap|`. So among candidates with equal input cap, the selected dummy cell depends on the unspecified sort order and varies run to run — a source of nondeterminism in CTS output.

This tie-breaks the sort on the cell name so equal-cap candidates get a stable, reproducible order. Same shape as the previously-merged `OptMirror` tie-break.