### PR TITLE
web: render logic gates as schematic symbols (custom netlistsvg skin)

### DIFF
--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -97,6 +97,7 @@ _WEB_ASSET_FILES = [
     "src/title.js",
     "src/clock-tree-widget.js",
     "src/schematic-widget.js",
+    "src/openroad_skin.svg",
     "src/charts-widget.js",
     "src/timing-widget.js",
     "src/drc-widget.js",

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -31,6 +31,7 @@ set(WEB_ASSET_FILES
     src/title.js
     src/clock-tree-widget.js
     src/schematic-widget.js
+    src/openroad_skin.svg
     src/charts-widget.js
     src/timing-widget.js
     src/drc-widget.js

--- a/src/web/src/embed_web_assets.py
+++ b/src/web/src/embed_web_assets.py
@@ -15,6 +15,7 @@ MIME_TYPES = {
     ".js": "application/javascript",
     ".css": "text/css",
     ".json": "application/json",
+    ".svg": "image/svg+xml",
 }
 
 

--- a/src/web/src/openroad_skin.svg
+++ b/src/web/src/openroad_skin.svg
@@ -1,7 +1,7 @@
 <svg  xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:s="https://github.com/nturley/netlistsvg"
-  width="800" height="500">
+  width="800" height="760">
   <!-- OpenROAD custom netlistsvg skin.
        Based on netlistsvg's default.svg, with two changes:
        (1) every logic-gate symbol carries an s:attribute="ref" label so the
@@ -258,7 +258,7 @@ path, rect, circle, polygon {
        test/visual/gen_compound.mjs).  First-level gates abut the second-level gate; the
        output Y port sits at the second-level gate's nose so netlistsvg routes
        the output wire straight to it. -->
-  <g s:type="aoi21" transform="translate(50,360)" s:width="52" s:height="42">
+  <g s:type="aoi21" transform="translate(20,360)" s:width="52" s:height="42">
     <s:alias val="aoi21"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi21</text>
     <path d="M0,7 L20,7" class="$cell_id"/>
@@ -273,7 +273,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="17.5" s:pid="Y"/>
   </g>
 
-  <g s:type="aoi22" transform="translate(50,360)" s:width="52" s:height="56">
+  <g s:type="aoi22" transform="translate(96,360)" s:width="52" s:height="56">
     <s:alias val="aoi22"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi22</text>
     <path d="M0,1 L0,27 L10,27 A10 13 0 0 0 10,1 Z" class="$cell_id"/>
@@ -289,7 +289,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="28" s:pid="Y"/>
   </g>
 
-  <g s:type="aoi211" transform="translate(50,360)" s:width="52" s:height="56">
+  <g s:type="aoi211" transform="translate(172,360)" s:width="52" s:height="56">
     <s:alias val="aoi211"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi211</text>
     <path d="M0,7 L20,7" class="$cell_id"/>
@@ -306,7 +306,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="24.5" s:pid="Y"/>
   </g>
 
-  <g s:type="aoi221" transform="translate(50,360)" s:width="52" s:height="70">
+  <g s:type="aoi221" transform="translate(248,360)" s:width="52" s:height="70">
     <s:alias val="aoi221"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi221</text>
     <path d="M0,7 L20,7" class="$cell_id"/>
@@ -324,7 +324,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="31.5" s:pid="Y"/>
   </g>
 
-  <g s:type="aoi222" transform="translate(50,360)" s:width="52" s:height="84">
+  <g s:type="aoi222" transform="translate(324,360)" s:width="52" s:height="84">
     <s:alias val="aoi222"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi222</text>
     <path d="M0,1 L0,27 L10,27 A10 13 0 0 0 10,1 Z" class="$cell_id"/>
@@ -343,7 +343,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="42" s:pid="Y"/>
   </g>
 
-  <g s:type="aoi33" transform="translate(50,360)" s:width="52" s:height="84">
+  <g s:type="aoi33" transform="translate(400,360)" s:width="52" s:height="84">
     <s:alias val="aoi33"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi33</text>
     <path d="M0,1 L0,41 L10,41 A10 20 0 0 0 10,1 Z" class="$cell_id"/>
@@ -361,7 +361,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="42" s:pid="Y"/>
   </g>
 
-  <g s:type="oai21" transform="translate(50,360)" s:width="52" s:height="42">
+  <g s:type="oai21" transform="translate(20,470)" s:width="52" s:height="42">
     <s:alias val="oai21"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai21</text>
     <path d="M0,7 L20,7" class="$cell_id"/>
@@ -378,7 +378,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="17.5" s:pid="Y"/>
   </g>
 
-  <g s:type="oai22" transform="translate(50,360)" s:width="52" s:height="56">
+  <g s:type="oai22" transform="translate(96,470)" s:width="52" s:height="56">
     <s:alias val="oai22"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai22</text>
     <path d="M0,27 L10,27 A10 13 0 0 0 10,1 L0,1" class="$cell_id"/>
@@ -399,7 +399,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="28" s:pid="Y"/>
   </g>
 
-  <g s:type="oai211" transform="translate(50,360)" s:width="52" s:height="56">
+  <g s:type="oai211" transform="translate(172,470)" s:width="52" s:height="56">
     <s:alias val="oai211"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai211</text>
     <path d="M0,7 L20,7" class="$cell_id"/>
@@ -418,7 +418,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="24.5" s:pid="Y"/>
   </g>
 
-  <g s:type="oai221" transform="translate(50,360)" s:width="52" s:height="70">
+  <g s:type="oai221" transform="translate(248,470)" s:width="52" s:height="70">
     <s:alias val="oai221"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai221</text>
     <path d="M0,7 L20,7" class="$cell_id"/>
@@ -441,7 +441,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="31.5" s:pid="Y"/>
   </g>
 
-  <g s:type="oai222" transform="translate(50,360)" s:width="52" s:height="84">
+  <g s:type="oai222" transform="translate(324,470)" s:width="52" s:height="84">
     <s:alias val="oai222"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai222</text>
     <path d="M0,27 L10,27 A10 13 0 0 0 10,1 L0,1" class="$cell_id"/>
@@ -468,7 +468,7 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="42" s:pid="Y"/>
   </g>
 
-  <g s:type="oai33" transform="translate(50,360)" s:width="52" s:height="84">
+  <g s:type="oai33" transform="translate(400,470)" s:width="52" s:height="84">
     <s:alias val="oai33"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai33</text>
     <path d="M0,41 L10,41 A10 20 0 0 0 10,1 L0,1" class="$cell_id"/>
@@ -494,7 +494,7 @@ path, rect, circle, polygon {
   </g>
 
   <!-- Wider basic gates (>2 inputs); generated, see test/visual/gen_multi.mjs. -->
-  <g s:type="and3" transform="translate(50,400)" s:width="30" s:height="36">
+  <g s:type="and3" transform="translate(20,580)" s:width="30" s:height="36">
     <s:alias val="and3"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">and3</text>
     <path d="M0,0 L0,36 L15,36 A15 18 0 0 0 15,0 Z" class="$cell_id"/>
@@ -505,7 +505,7 @@ path, rect, circle, polygon {
     <g s:x="30" s:y="18" s:pid="Y"/>
   </g>
 
-  <g s:type="nand3" transform="translate(50,400)" s:width="38" s:height="36">
+  <g s:type="nand3" transform="translate(82,580)" s:width="38" s:height="36">
     <s:alias val="nand3"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nand3</text>
     <path d="M0,0 L0,36 L15,36 A15 18 0 0 0 15,0 Z" class="$cell_id"/>
@@ -517,7 +517,7 @@ path, rect, circle, polygon {
     <g s:x="38" s:y="18" s:pid="Y"/>
   </g>
 
-  <g s:type="or3" transform="translate(50,400)" s:width="30" s:height="36">
+  <g s:type="or3" transform="translate(144,580)" s:width="30" s:height="36">
     <s:alias val="or3"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">or3</text>
     <path d="M0,36 L15,36 A15 18 0 0 0 15,0 L0,0" class="$cell_id"/>
@@ -529,7 +529,7 @@ path, rect, circle, polygon {
     <g s:x="30" s:y="18" s:pid="Y"/>
   </g>
 
-  <g s:type="nor3" transform="translate(50,400)" s:width="38" s:height="36">
+  <g s:type="nor3" transform="translate(206,580)" s:width="38" s:height="36">
     <s:alias val="nor3"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nor3</text>
     <path d="M0,36 L15,36 A15 18 0 0 0 15,0 L0,0" class="$cell_id"/>
@@ -542,7 +542,7 @@ path, rect, circle, polygon {
     <g s:x="38" s:y="18" s:pid="Y"/>
   </g>
 
-  <g s:type="and4" transform="translate(50,400)" s:width="30" s:height="48">
+  <g s:type="and4" transform="translate(20,654)" s:width="30" s:height="48">
     <s:alias val="and4"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">and4</text>
     <path d="M0,0 L0,48 L15,48 A15 24 0 0 0 15,0 Z" class="$cell_id"/>
@@ -554,7 +554,7 @@ path, rect, circle, polygon {
     <g s:x="30" s:y="24" s:pid="Y"/>
   </g>
 
-  <g s:type="nand4" transform="translate(50,400)" s:width="38" s:height="48">
+  <g s:type="nand4" transform="translate(82,654)" s:width="38" s:height="48">
     <s:alias val="nand4"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nand4</text>
     <path d="M0,0 L0,48 L15,48 A15 24 0 0 0 15,0 Z" class="$cell_id"/>
@@ -567,7 +567,7 @@ path, rect, circle, polygon {
     <g s:x="38" s:y="24" s:pid="Y"/>
   </g>
 
-  <g s:type="or4" transform="translate(50,400)" s:width="30" s:height="48">
+  <g s:type="or4" transform="translate(144,654)" s:width="30" s:height="48">
     <s:alias val="or4"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">or4</text>
     <path d="M0,48 L15,48 A15 24 0 0 0 15,0 L0,0" class="$cell_id"/>
@@ -580,7 +580,7 @@ path, rect, circle, polygon {
     <g s:x="30" s:y="24" s:pid="Y"/>
   </g>
 
-  <g s:type="nor4" transform="translate(50,400)" s:width="38" s:height="48">
+  <g s:type="nor4" transform="translate(206,654)" s:width="38" s:height="48">
     <s:alias val="nor4"/>
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nor4</text>
     <path d="M0,48 L15,48 A15 24 0 0 0 15,0 L0,0" class="$cell_id"/>

--- a/src/web/src/openroad_skin.svg
+++ b/src/web/src/openroad_skin.svg
@@ -289,6 +289,78 @@ path, rect, circle, polygon {
     <g s:x="52" s:y="28" s:pid="Y"/>
   </g>
 
+  <g s:type="aoi211" transform="translate(50,360)" s:width="52" s:height="56">
+    <s:alias val="aoi211"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi211</text>
+    <path d="M0,7 L20,7" class="$cell_id"/>
+    <path d="M0,21 L20,21" class="$cell_id"/>
+    <path d="M0,29 L0,55 L10,55 A10 13 0 0 0 10,29 Z" class="$cell_id"/>
+    <path d="M20,49 L33,49 A13 24.5 0 0 0 33,0 L20,0" class="$cell_id"/>
+    <path d="M20,0 A26 49 0 0 1 20,49" class="$cell_id"/>
+    <circle cx="49" cy="24.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="52" s:y="24.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="aoi221" transform="translate(50,360)" s:width="52" s:height="70">
+    <s:alias val="aoi221"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi221</text>
+    <path d="M0,7 L20,7" class="$cell_id"/>
+    <path d="M0,15 L0,41 L10,41 A10 13 0 0 0 10,15 Z" class="$cell_id"/>
+    <path d="M0,43 L0,69 L10,69 A10 13 0 0 0 10,43 Z" class="$cell_id"/>
+    <path d="M20,63 L33,63 A13 31.5 0 0 0 33,0 L20,0" class="$cell_id"/>
+    <path d="M20,0 A26 63 0 0 1 20,63" class="$cell_id"/>
+    <circle cx="49" cy="31.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="0" s:y="63" s:pid="E"/>
+    <g s:x="52" s:y="31.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="aoi222" transform="translate(50,360)" s:width="52" s:height="84">
+    <s:alias val="aoi222"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi222</text>
+    <path d="M0,1 L0,27 L10,27 A10 13 0 0 0 10,1 Z" class="$cell_id"/>
+    <path d="M0,29 L0,55 L10,55 A10 13 0 0 0 10,29 Z" class="$cell_id"/>
+    <path d="M0,57 L0,83 L10,83 A10 13 0 0 0 10,57 Z" class="$cell_id"/>
+    <path d="M20,77 L33,77 A13 35 0 0 0 33,7 L20,7" class="$cell_id"/>
+    <path d="M20,7 A26 70 0 0 1 20,77" class="$cell_id"/>
+    <circle cx="49" cy="42" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="0" s:y="63" s:pid="E"/>
+    <g s:x="0" s:y="77" s:pid="F"/>
+    <g s:x="52" s:y="42" s:pid="Y"/>
+  </g>
+
+  <g s:type="aoi33" transform="translate(50,360)" s:width="52" s:height="84">
+    <s:alias val="aoi33"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi33</text>
+    <path d="M0,1 L0,41 L10,41 A10 20 0 0 0 10,1 Z" class="$cell_id"/>
+    <path d="M0,43 L0,83 L10,83 A10 20 0 0 0 10,43 Z" class="$cell_id"/>
+    <path d="M20,70 L33,70 A13 28 0 0 0 33,14 L20,14" class="$cell_id"/>
+    <path d="M20,14 A26 56 0 0 1 20,70" class="$cell_id"/>
+    <circle cx="49" cy="42" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="0" s:y="63" s:pid="E"/>
+    <g s:x="0" s:y="77" s:pid="F"/>
+    <g s:x="52" s:y="42" s:pid="Y"/>
+  </g>
+
   <g s:type="oai21" transform="translate(50,360)" s:width="52" s:height="42">
     <s:alias val="oai21"/>
     <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai21</text>
@@ -325,6 +397,100 @@ path, rect, circle, polygon {
     <g s:x="0" s:y="35" s:pid="C"/>
     <g s:x="0" s:y="49" s:pid="D"/>
     <g s:x="52" s:y="28" s:pid="Y"/>
+  </g>
+
+  <g s:type="oai211" transform="translate(50,360)" s:width="52" s:height="56">
+    <s:alias val="oai211"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai211</text>
+    <path d="M0,7 L20,7" class="$cell_id"/>
+    <path d="M0,21 L20,21" class="$cell_id"/>
+    <path d="M0,55 L10,55 A10 13 0 0 0 10,29 L0,29" class="$cell_id"/>
+    <path d="M0,29 A20 26 0 0 1 0,55" class="$cell_id"/>
+    <path d="M0,35 L3.6,35" class="$cell_id"/>
+    <path d="M0,49 L3.6,49" class="$cell_id"/>
+    <path d="M20,0 L20,49 L33,49 A13 24.5 0 0 0 33,0 Z" class="$cell_id"/>
+    <circle cx="49" cy="24.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="52" s:y="24.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="oai221" transform="translate(50,360)" s:width="52" s:height="70">
+    <s:alias val="oai221"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai221</text>
+    <path d="M0,7 L20,7" class="$cell_id"/>
+    <path d="M0,41 L10,41 A10 13 0 0 0 10,15 L0,15" class="$cell_id"/>
+    <path d="M0,15 A20 26 0 0 1 0,41" class="$cell_id"/>
+    <path d="M0,21 L3.6,21" class="$cell_id"/>
+    <path d="M0,35 L3.6,35" class="$cell_id"/>
+    <path d="M0,69 L10,69 A10 13 0 0 0 10,43 L0,43" class="$cell_id"/>
+    <path d="M0,43 A20 26 0 0 1 0,69" class="$cell_id"/>
+    <path d="M0,49 L3.6,49" class="$cell_id"/>
+    <path d="M0,63 L3.6,63" class="$cell_id"/>
+    <path d="M20,0 L20,63 L33,63 A13 31.5 0 0 0 33,0 Z" class="$cell_id"/>
+    <circle cx="49" cy="31.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="0" s:y="63" s:pid="E"/>
+    <g s:x="52" s:y="31.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="oai222" transform="translate(50,360)" s:width="52" s:height="84">
+    <s:alias val="oai222"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai222</text>
+    <path d="M0,27 L10,27 A10 13 0 0 0 10,1 L0,1" class="$cell_id"/>
+    <path d="M0,1 A20 26 0 0 1 0,27" class="$cell_id"/>
+    <path d="M0,7 L3.6,7" class="$cell_id"/>
+    <path d="M0,21 L3.6,21" class="$cell_id"/>
+    <path d="M0,55 L10,55 A10 13 0 0 0 10,29 L0,29" class="$cell_id"/>
+    <path d="M0,29 A20 26 0 0 1 0,55" class="$cell_id"/>
+    <path d="M0,35 L3.6,35" class="$cell_id"/>
+    <path d="M0,49 L3.6,49" class="$cell_id"/>
+    <path d="M0,83 L10,83 A10 13 0 0 0 10,57 L0,57" class="$cell_id"/>
+    <path d="M0,57 A20 26 0 0 1 0,83" class="$cell_id"/>
+    <path d="M0,63 L3.6,63" class="$cell_id"/>
+    <path d="M0,77 L3.6,77" class="$cell_id"/>
+    <path d="M20,7 L20,77 L33,77 A13 35 0 0 0 33,7 Z" class="$cell_id"/>
+    <circle cx="49" cy="42" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="0" s:y="63" s:pid="E"/>
+    <g s:x="0" s:y="77" s:pid="F"/>
+    <g s:x="52" s:y="42" s:pid="Y"/>
+  </g>
+
+  <g s:type="oai33" transform="translate(50,360)" s:width="52" s:height="84">
+    <s:alias val="oai33"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai33</text>
+    <path d="M0,41 L10,41 A10 20 0 0 0 10,1 L0,1" class="$cell_id"/>
+    <path d="M0,1 A20 40 0 0 1 0,41" class="$cell_id"/>
+    <path d="M0,7 L3.6,7" class="$cell_id"/>
+    <path d="M0,21 L3.6,21" class="$cell_id"/>
+    <path d="M0,35 L3.6,35" class="$cell_id"/>
+    <path d="M0,83 L10,83 A10 20 0 0 0 10,43 L0,43" class="$cell_id"/>
+    <path d="M0,43 A20 40 0 0 1 0,83" class="$cell_id"/>
+    <path d="M0,49 L3.6,49" class="$cell_id"/>
+    <path d="M0,63 L3.6,63" class="$cell_id"/>
+    <path d="M0,77 L3.6,77" class="$cell_id"/>
+    <path d="M20,14 L20,70 L33,70 A13 28 0 0 0 33,14 Z" class="$cell_id"/>
+    <circle cx="49" cy="42" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="0" s:y="63" s:pid="E"/>
+    <g s:x="0" s:y="77" s:pid="F"/>
+    <g s:x="52" s:y="42" s:pid="Y"/>
   </g>
 
   <!-- Wider basic gates (>2 inputs); generated, see test/visual/gen_multi.mjs. -->

--- a/src/web/src/openroad_skin.svg
+++ b/src/web/src/openroad_skin.svg
@@ -1,0 +1,431 @@
+<svg  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:s="https://github.com/nturley/netlistsvg"
+  width="800" height="500">
+  <!-- OpenROAD custom netlistsvg skin.
+       Based on netlistsvg's default.svg, with two changes:
+       (1) every logic-gate symbol carries an s:attribute="ref" label so the
+           instance name renders on the gate, and
+       (2) added a buffer symbol and compound AOI/OAI gate symbols.
+       The web schematic viewer rewrites cell types to the canonical names used
+       here (see canonicalizeForSkin in schematic-widget.js). -->
+  <s:properties>
+    <s:layoutEngine
+      org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers="35"
+      org.eclipse.elk.spacing.nodeNode= "35"
+      org.eclipse.elk.layered.layering.strategy= "LONGEST_PATH"
+    />
+    <s:low_priority_alias val="$dff" />
+  </s:properties>
+<style>
+svg {
+  stroke:#000;
+  fill:none;
+}
+text {
+  fill:#000;
+  stroke:none;
+  font-size:10px;
+  font-weight: bold;
+  font-family: "Courier New", monospace;
+}
+.nodelabel {
+  text-anchor: middle;
+}
+.inputPortLabel {
+  text-anchor: end;
+}
+.splitjoinBody {
+  fill:#000;
+}
+/* Make the (otherwise hollow) gate bodies clickable over their whole area so
+   select mode works when clicking inside a symbol, not just on its outline.
+   'all' makes the interior a pointer target regardless of fill. */
+path, rect, circle, polygon {
+  pointer-events: all;
+}
+</style>
+  <g s:type="mux" transform="translate(50, 50)" s:width="20" s:height="40">
+    <s:alias val="$pmux"/>
+    <s:alias val="$mux"/>
+    <s:alias val="$_MUX_"/>
+    <text x="10" y="-4" class="nodelabel $cell_id" s:attribute="ref">mux</text>
+
+    <path d="M0,0 L20,10 L20,30 L0,40 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="0" s:y="30" s:pid="B"/>
+    <g s:x="10" s:y="35" s:pid="S"/>
+    <g s:x="20" s:y="20" s:pid="Y"/>
+  </g>
+
+  <!-- and -->
+  <g s:type="and" transform="translate(150,50)" s:width="30" s:height="25">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">and</text>
+
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="nand" transform="translate(150,100)" s:width="30" s:height="25">
+    <s:alias val="$nand"/>
+    <s:alias val="$logic_nand"/>
+    <s:alias val="$_NAND_"/>
+    <s:alias val="$_ANDNOT_"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nand</text>
+
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="$cell_id"/>
+    <circle cx="34" cy="12.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="36" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <!-- or -->
+  <g s:type="or" transform="translate(250,50)" s:width="30" s:height="25">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">or</text>
+
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="reduce_nor" transform="translate(250, 100)" s:width="33" s:height="25">
+    <s:alias val="$nor"/>
+    <s:alias val="$reduce_nor"/>
+    <s:alias val="$_NOR_"/>
+    <s:alias val="$_ORNOT_"/>
+    <text x="16.5" y="-4" class="nodelabel $cell_id" s:attribute="ref">nor</text>
+
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+    <circle cx="34" cy="12.5" r="3" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="36" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <!--xor -->
+  <g s:type="reduce_xor" transform="translate(350, 50)" s:width="33" s:height="25">
+    <s:alias val="$xor"/>
+    <s:alias val="$reduce_xor"/>
+    <s:alias val="$_XOR_"/>
+    <text x="16.5" y="-4" class="nodelabel $cell_id" s:attribute="ref">xor</text>
+
+    <path d="M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="33" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="reduce_nxor" transform="translate(350, 100)" s:width="33" s:height="25">
+    <s:alias val="$xnor"/>
+    <s:alias val="$reduce_xnor"/>
+    <s:alias val="$_XNOR_"/>
+    <text x="16.5" y="-4" class="nodelabel $cell_id" s:attribute="ref">xnor</text>
+
+    <path d="M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+    <circle cx="35" cy="12.5" r="3" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="38" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <!-- inverter -->
+  <g s:type="not" transform="translate(450,100)" s:width="30" s:height="20">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">not</text>
+
+    <path d="M0,0 L0,20 L20,10 Z" class="$cell_id"/>
+    <circle cx="23" cy="10" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+
+  <!-- buffer -->
+  <g s:type="buf" transform="translate(550,100)" s:width="26" s:height="20">
+    <s:alias val="$_BUF_"/>
+    <text x="13" y="-4" class="nodelabel $cell_id" s:attribute="ref">buf</text>
+
+    <path d="M0,0 L0,20 L24,10 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="24" s:y="10" s:pid="Y"/>
+  </g>
+
+  <g s:type="dff" transform="translate(350,150)" s:width="30" s:height="40">
+    <s:alias val="$dff"/>
+    <s:alias val="$_DFF_"/>
+    <s:alias val="$_DFF_P_"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">dff</text>
+
+    <rect width="30" height="40" x="0" y="0" class="$cell_id"/>
+    <path d="M0,35 L5,30 L0,25" class="$cell_id"/>
+
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="0" s:y="30" s:pid="CLK"/>
+    <g s:x="0" s:y="30" s:pid="C"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+
+  <g s:type="inputExt" transform="translate(50,250)" s:width="30" s:height="20">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">input</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="$cell_id"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+
+  <g s:type="constant" transform="translate(150,250)" s:width="30" s:height="20">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">constant</text>
+
+    <s:alias val="$_constant_"/>
+    <rect width="30" height="20" class="$cell_id"/>
+
+    <g s:x="30" s:y="10" s:pid="Y"/>
+  </g>
+
+  <g s:type="outputExt" transform="translate(250,250)" s:width="30" s:height="20">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">output</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+
+  <g s:type="split" transform="translate(350,250)" s:width="5" s:height="40">
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
+    <s:alias val="$_split_"/>
+
+    <g s:x="0" s:y="20" s:pid="in"/>
+    <g transform="translate(5, 10)" s:x="4" s:y="10" s:pid="out0">
+      <text x="5" y="-4">hi:lo</text>
+    </g>
+    <g transform="translate(5, 30)" s:x="4" s:y="30" s:pid="out1">
+      <text x="5" y="-4">hi:lo</text>
+    </g>
+  </g>
+
+  <g s:type="join" transform="translate(450,250)" s:width="4" s:height="40">
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
+    <s:alias val="$_join_"/>
+    <g s:x="5" s:y="20"  s:pid="out"/>
+    <g transform="translate(0, 10)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel">hi:lo</text>
+    </g>
+    <g transform="translate(0, 30)" s:x="0" s:y="30" s:pid="in1">
+      <text x="-3" y="-4" class="inputPortLabel">hi:lo</text>
+    </g>
+  </g>
+
+  <g s:type="generic" transform="translate(550,250)" s:width="30" s:height="40">
+    <s:alias val="generic-bus"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">generic</text>
+    <rect width="30" height="40" s:generic="body" class="$cell_id"/>
+
+    <g transform="translate(30, 10)" s:x="30" s:y="10" s:pid="out0">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="$cell_id">out0</text>
+    </g>
+    <g transform="translate(30, 30)" s:x="30" s:y="30" s:pid="out1">
+      <text x="5" y="-4" style="fill:#000;stroke:none" class="$cell_id">out1</text>
+    </g>
+    <g transform="translate(0, 10)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel $cell_id">in0</text>
+    </g>
+    <g transform="translate(0, 30)" s:x="0" s:y="30" s:pid="in1">
+      <text x="-3" y="-4" class="inputPortLabel $cell_id">in1</text>
+    </g>
+  </g>
+
+  <!-- Compound AND-OR-INVERT / OR-AND-INVERT gates (generated; see
+       test/visual/gen_compound.mjs).  First-level gates abut the second-level gate; the
+       output Y port sits at the second-level gate's nose so netlistsvg routes
+       the output wire straight to it. -->
+  <g s:type="aoi21" transform="translate(50,360)" s:width="52" s:height="42">
+    <s:alias val="aoi21"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi21</text>
+    <path d="M0,7 L20,7" class="$cell_id"/>
+    <path d="M0,15 L0,41 L10,41 A10 13 0 0 0 10,15 Z" class="$cell_id"/>
+    <path d="M20,35 L33,35 A13 17.5 0 0 0 33,0 L20,0" class="$cell_id"/>
+    <path d="M20,0 A26 35 0 0 1 20,35" class="$cell_id"/>
+    <circle cx="49" cy="17.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="52" s:y="17.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="aoi22" transform="translate(50,360)" s:width="52" s:height="56">
+    <s:alias val="aoi22"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">aoi22</text>
+    <path d="M0,1 L0,27 L10,27 A10 13 0 0 0 10,1 Z" class="$cell_id"/>
+    <path d="M0,29 L0,55 L10,55 A10 13 0 0 0 10,29 Z" class="$cell_id"/>
+    <path d="M20,49 L33,49 A13 21 0 0 0 33,7 L20,7" class="$cell_id"/>
+    <path d="M20,7 A26 42 0 0 1 20,49" class="$cell_id"/>
+    <circle cx="49" cy="28" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="52" s:y="28" s:pid="Y"/>
+  </g>
+
+  <g s:type="oai21" transform="translate(50,360)" s:width="52" s:height="42">
+    <s:alias val="oai21"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai21</text>
+    <path d="M0,7 L20,7" class="$cell_id"/>
+    <path d="M0,41 L10,41 A10 13 0 0 0 10,15 L0,15" class="$cell_id"/>
+    <path d="M0,15 A20 26 0 0 1 0,41" class="$cell_id"/>
+    <path d="M0,21 L3.6,21" class="$cell_id"/>
+    <path d="M0,35 L3.6,35" class="$cell_id"/>
+    <path d="M20,0 L20,35 L33,35 A13 17.5 0 0 0 33,0 Z" class="$cell_id"/>
+    <circle cx="49" cy="17.5" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="52" s:y="17.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="oai22" transform="translate(50,360)" s:width="52" s:height="56">
+    <s:alias val="oai22"/>
+    <text x="26" y="-4" class="nodelabel $cell_id" s:attribute="ref">oai22</text>
+    <path d="M0,27 L10,27 A10 13 0 0 0 10,1 L0,1" class="$cell_id"/>
+    <path d="M0,1 A20 26 0 0 1 0,27" class="$cell_id"/>
+    <path d="M0,7 L3.6,7" class="$cell_id"/>
+    <path d="M0,21 L3.6,21" class="$cell_id"/>
+    <path d="M0,55 L10,55 A10 13 0 0 0 10,29 L0,29" class="$cell_id"/>
+    <path d="M0,29 A20 26 0 0 1 0,55" class="$cell_id"/>
+    <path d="M0,35 L3.6,35" class="$cell_id"/>
+    <path d="M0,49 L3.6,49" class="$cell_id"/>
+    <path d="M20,7 L20,49 L33,49 A13 21 0 0 0 33,7 Z" class="$cell_id"/>
+    <circle cx="49" cy="28" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="7" s:pid="A"/>
+    <g s:x="0" s:y="21" s:pid="B"/>
+    <g s:x="0" s:y="35" s:pid="C"/>
+    <g s:x="0" s:y="49" s:pid="D"/>
+    <g s:x="52" s:y="28" s:pid="Y"/>
+  </g>
+
+  <!-- Wider basic gates (>2 inputs); generated, see test/visual/gen_multi.mjs. -->
+  <g s:type="and3" transform="translate(50,400)" s:width="30" s:height="36">
+    <s:alias val="and3"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">and3</text>
+    <path d="M0,0 L0,36 L15,36 A15 18 0 0 0 15,0 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="6" s:pid="A"/>
+    <g s:x="0" s:y="18" s:pid="B"/>
+    <g s:x="0" s:y="30" s:pid="C"/>
+    <g s:x="30" s:y="18" s:pid="Y"/>
+  </g>
+
+  <g s:type="nand3" transform="translate(50,400)" s:width="38" s:height="36">
+    <s:alias val="nand3"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nand3</text>
+    <path d="M0,0 L0,36 L15,36 A15 18 0 0 0 15,0 Z" class="$cell_id"/>
+    <circle cx="34" cy="18" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="6" s:pid="A"/>
+    <g s:x="0" s:y="18" s:pid="B"/>
+    <g s:x="0" s:y="30" s:pid="C"/>
+    <g s:x="38" s:y="18" s:pid="Y"/>
+  </g>
+
+  <g s:type="or3" transform="translate(50,400)" s:width="30" s:height="36">
+    <s:alias val="or3"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">or3</text>
+    <path d="M0,36 L15,36 A15 18 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 36 0 0 1 0,36" class="$cell_id"/>
+
+    <g s:x="3" s:y="6" s:pid="A"/>
+    <g s:x="3" s:y="18" s:pid="B"/>
+    <g s:x="3" s:y="30" s:pid="C"/>
+    <g s:x="30" s:y="18" s:pid="Y"/>
+  </g>
+
+  <g s:type="nor3" transform="translate(50,400)" s:width="38" s:height="36">
+    <s:alias val="nor3"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nor3</text>
+    <path d="M0,36 L15,36 A15 18 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 36 0 0 1 0,36" class="$cell_id"/>
+    <circle cx="34" cy="18" r="3" class="$cell_id"/>
+
+    <g s:x="3" s:y="6" s:pid="A"/>
+    <g s:x="3" s:y="18" s:pid="B"/>
+    <g s:x="3" s:y="30" s:pid="C"/>
+    <g s:x="38" s:y="18" s:pid="Y"/>
+  </g>
+
+  <g s:type="and4" transform="translate(50,400)" s:width="30" s:height="48">
+    <s:alias val="and4"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">and4</text>
+    <path d="M0,0 L0,48 L15,48 A15 24 0 0 0 15,0 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="6" s:pid="A"/>
+    <g s:x="0" s:y="18" s:pid="B"/>
+    <g s:x="0" s:y="30" s:pid="C"/>
+    <g s:x="0" s:y="42" s:pid="D"/>
+    <g s:x="30" s:y="24" s:pid="Y"/>
+  </g>
+
+  <g s:type="nand4" transform="translate(50,400)" s:width="38" s:height="48">
+    <s:alias val="nand4"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nand4</text>
+    <path d="M0,0 L0,48 L15,48 A15 24 0 0 0 15,0 Z" class="$cell_id"/>
+    <circle cx="34" cy="24" r="3" class="$cell_id"/>
+
+    <g s:x="0" s:y="6" s:pid="A"/>
+    <g s:x="0" s:y="18" s:pid="B"/>
+    <g s:x="0" s:y="30" s:pid="C"/>
+    <g s:x="0" s:y="42" s:pid="D"/>
+    <g s:x="38" s:y="24" s:pid="Y"/>
+  </g>
+
+  <g s:type="or4" transform="translate(50,400)" s:width="30" s:height="48">
+    <s:alias val="or4"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">or4</text>
+    <path d="M0,48 L15,48 A15 24 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 48 0 0 1 0,48" class="$cell_id"/>
+
+    <g s:x="3" s:y="6" s:pid="A"/>
+    <g s:x="3" s:y="18" s:pid="B"/>
+    <g s:x="3" s:y="30" s:pid="C"/>
+    <g s:x="3" s:y="42" s:pid="D"/>
+    <g s:x="30" s:y="24" s:pid="Y"/>
+  </g>
+
+  <g s:type="nor4" transform="translate(50,400)" s:width="38" s:height="48">
+    <s:alias val="nor4"/>
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">nor4</text>
+    <path d="M0,48 L15,48 A15 24 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 48 0 0 1 0,48" class="$cell_id"/>
+    <circle cx="34" cy="24" r="3" class="$cell_id"/>
+
+    <g s:x="3" s:y="6" s:pid="A"/>
+    <g s:x="3" s:y="18" s:pid="B"/>
+    <g s:x="3" s:y="30" s:pid="C"/>
+    <g s:x="3" s:y="42" s:pid="D"/>
+    <g s:x="38" s:y="24" s:pid="Y"/>
+  </g>
+
+</svg>

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -31,6 +31,8 @@
 #include "cli_completer.h"
 #include "clock_tree_report.h"
 #include "color.h"
+#include "db_sta/dbNetwork.hh"
+#include "db_sta/dbSta.hh"
 #include "gui/descriptor_registry.h"
 #include "gui/gui.h"
 #include "gui/heatMap.h"
@@ -41,6 +43,9 @@
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 #include "request_dispatcher.h"
+#include "sta/FuncExpr.hh"
+#include "sta/Liberty.hh"
+#include "sta/PortDirection.hh"
 #include "tile_generator.h"
 #include "timing_report.h"
 #include "utl/Logger.h"
@@ -1053,6 +1058,259 @@ static const char* ioTypeToDirection(odb::dbIoType io_type)
   return "inout";
 }
 
+// Result of classifying an instance against the schematic gate symbols the web
+// viewer can draw.
+struct GateClass
+{
+  // "and"/"nand"/"or"/"nor"/"xor"/"xnor"/"not"/"buf" for simple gates,
+  // "aoi"/"oai" for compound and/or-invert gates, or "" when the cell is not a
+  // recognised combinational gate.
+  std::string kind;
+  // For "aoi"/"oai" only: the input pin names of each first-level term (e.g.
+  // AOI21 -> {{"A"}, {"B1", "B2"}}).  A one-pin term is a literal fed straight
+  // into the second-level gate; multi-pin terms become an AND (aoi) or OR (oai)
+  // sub-gate.  The viewer uses the pin names to align each input to its real
+  // port.  Empty otherwise.
+  std::vector<std::vector<std::string>> terms;
+};
+
+// Append the operands of `e`, flattening nested nodes that share `op`, so that
+// e.g. or(or(a,b),c) yields {a, b, c}.
+static void flattenFuncExpr(sta::FuncExpr* e,
+                            sta::FuncExpr::Op op,
+                            std::vector<sta::FuncExpr*>& out)
+{
+  if (e != nullptr && e->op() == op) {
+    flattenFuncExpr(e->left(), op, out);
+    flattenFuncExpr(e->right(), op, out);
+  } else if (e != nullptr) {
+    out.push_back(e);
+  }
+}
+
+// Classify an and/or-invert tree: `func` is the expression with its leading
+// inversion already removed, and `top` is its (and_ or or_) root operator.  An
+// AOI is an OR of product terms (each a literal or an AND of literals); an OAI
+// is the dual.  Returns the input pin names grouped by term, or an empty vector
+// when the structure is anything else (e.g. a MUX, whose terms contain inverted
+// literals).
+static std::vector<std::vector<std::string>> classifyAoiOai(
+    sta::FuncExpr* func,
+    sta::FuncExpr::Op top)
+{
+  static constexpr int kMaxTerms = 4;
+  static constexpr int kMaxInputs = 6;
+  const sta::FuncExpr::Op term_op = (top == sta::FuncExpr::Op::and_)
+                                        ? sta::FuncExpr::Op::or_
+                                        : sta::FuncExpr::Op::and_;
+
+  std::vector<sta::FuncExpr*> terms;
+  flattenFuncExpr(func, top, terms);
+  if (terms.size() < 2 || static_cast<int>(terms.size()) > kMaxTerms) {
+    return {};
+  }
+
+  std::vector<std::vector<std::string>> groups;
+  int total = 0;
+  for (sta::FuncExpr* term : terms) {
+    if (term->op() == sta::FuncExpr::Op::port) {
+      groups.push_back({term->port()->name()});
+      total += 1;
+      continue;
+    }
+    if (term->op() != term_op) {
+      return {};  // not a pure product/sum-of-literals term (e.g. a MUX)
+    }
+    std::vector<sta::FuncExpr*> literals;
+    flattenFuncExpr(term, term_op, literals);
+    std::vector<std::string> names;
+    for (sta::FuncExpr* lit : literals) {
+      if (lit->op() != sta::FuncExpr::Op::port) {
+        return {};
+      }
+      names.push_back(lit->port()->name());
+    }
+    total += static_cast<int>(names.size());
+    groups.push_back(std::move(names));
+  }
+  if (total > kMaxInputs) {
+    return {};
+  }
+  return groups;
+}
+
+// Classify a leaf instance into a schematic gate symbol using its Liberty
+// function, so the web schematic viewer can draw a recognisable gate outline
+// (AND/OR/XOR/inverter/buffer, plus compound AOI/OAI) around the cell.
+//
+// The result is emitted only as a rendering *hint*: the cell still carries its
+// real master name and pin names, so it keeps its instance label and port
+// labels and falls back to a plain box if the viewer ignores the hint.
+// Anything more complex (tristates, sequential cells, macros, XOR/MUX trees
+// wider than two inputs, ...) returns an empty kind and is drawn as a box,
+// which is the conventional way such cells appear on a schematic anyway.
+static GateClass classifyGate(sta::dbNetwork* network, odb::dbInst* inst)
+{
+  GateClass result;
+  if (network == nullptr) {
+    return result;
+  }
+  sta::LibertyCell* cell = network->libertyCell(inst);
+  if (cell == nullptr || cell->hasSequentials() || cell->isClockGate()
+      || cell->isMacro()) {
+    return result;
+  }
+
+  // Find the single functional output port.  Bail out on bussed cells or any
+  // cell with more than one driven output (e.g. full adders, *_QN flops).
+  sta::LibertyPort* out_port = nullptr;
+  sta::FuncExpr* func = nullptr;
+  sta::LibertyCellPortIterator port_iter(cell);
+  while (port_iter.hasNext()) {
+    sta::LibertyPort* port = port_iter.next();
+    if (port->isBus() || port->hasMembers()) {
+      return result;
+    }
+    if (!port->direction()->isOutput()) {
+      continue;
+    }
+    if (port->tristateEnable() != nullptr) {
+      return result;
+    }
+    sta::FuncExpr* f = port->function();
+    if (f == nullptr) {
+      continue;
+    }
+    if (out_port != nullptr) {
+      return result;  // more than one functional output
+    }
+    out_port = port;
+    func = f;
+  }
+  if (out_port == nullptr || func == nullptr) {
+    return result;
+  }
+
+  // Peel a leading inversion so AND/NAND, OR/NOR, XOR/XNOR and BUF/NOT share a
+  // path.
+  bool inverting = false;
+  if (func->op() == sta::FuncExpr::Op::not_) {
+    inverting = true;
+    func = func->left();
+  }
+  if (func == nullptr) {
+    return result;
+  }
+
+  // Single input: buffer (Y = A) or inverter (Y = !A).
+  if (func->op() == sta::FuncExpr::Op::port) {
+    result.kind = inverting ? "not" : "buf";
+    return result;
+  }
+
+  // A flat AND/OR/XOR of N plain ports is a basic N-input gate (N >= 2).  The
+  // viewer derives the input count from the cell's ports, so only the kind is
+  // emitted.
+  const sta::FuncExpr::Op top = func->op();
+  if (top == sta::FuncExpr::Op::and_ || top == sta::FuncExpr::Op::or_
+      || top == sta::FuncExpr::Op::xor_) {
+    std::vector<sta::FuncExpr*> operands;
+    flattenFuncExpr(func, top, operands);
+    bool all_ports = true;
+    for (sta::FuncExpr* op : operands) {
+      if (op->op() != sta::FuncExpr::Op::port) {
+        all_ports = false;
+        break;
+      }
+    }
+    if (all_ports && operands.size() >= 2) {
+      switch (top) {
+        case sta::FuncExpr::Op::and_:
+          result.kind = inverting ? "nand" : "and";
+          return result;
+        case sta::FuncExpr::Op::or_:
+          result.kind = inverting ? "nor" : "or";
+          return result;
+        default:  // xor_
+          result.kind = inverting ? "xnor" : "xor";
+          return result;
+      }
+    }
+  }
+
+  // Compound and/or-invert gate (AOI/OAI).  These always invert, and their root
+  // is an AND (OAI) or OR (AOI) of product/sum terms (at least one a sub-gate).
+  if (inverting
+      && (func->op() == sta::FuncExpr::Op::and_
+          || func->op() == sta::FuncExpr::Op::or_)) {
+    std::vector<std::vector<std::string>> terms
+        = classifyAoiOai(func, func->op());
+    if (!terms.empty()) {
+      result.kind = (func->op() == sta::FuncExpr::Op::or_) ? "aoi" : "oai";
+      result.terms = std::move(terms);
+    }
+  }
+  return result;
+}
+
+// Emit one Yosys-format cell object for `inst` into `cells`.  The cell is
+// always emitted verbatim (master name + real pin names) so netlistsvg renders
+// it with its instance and port labels.  When it classifies as a standard
+// logic gate, a non-standard "gate_kind" field is added that the viewer uses to
+// draw a gate-shaped outline instead of a box.  Only nets present in
+// `net_to_id` are wired; pins on other nets are skipped.
+static void emitSchematicCell(boost::json::object& cells,
+                              odb::dbInst* inst,
+                              sta::dbNetwork* network,
+                              odb::PtrMap<odb::dbNet, int>& net_to_id)
+{
+  boost::json::object cell;
+  cell["hide_name"] = 0;
+  cell["type"] = inst->getMaster() ? inst->getMaster()->getName()
+                                   : std::string("$unknown");
+  cell["attributes"] = boost::json::object{};
+  cell["parameters"] = boost::json::object{};
+
+  const GateClass gate = classifyGate(network, inst);
+  if (!gate.kind.empty()) {
+    cell["gate_kind"] = gate.kind;
+    if (!gate.terms.empty()) {
+      boost::json::array terms;
+      for (const std::vector<std::string>& group : gate.terms) {
+        boost::json::array pins;
+        for (const std::string& pin : group) {
+          pins.push_back(boost::json::string(pin));
+        }
+        terms.push_back(std::move(pins));
+      }
+      cell["gate_terms"] = std::move(terms);
+    }
+  }
+
+  boost::json::object port_directions;
+  for (odb::dbITerm* iterm : inst->getITerms()) {
+    if (!iterm->getNet() || !net_to_id.contains(iterm->getNet())) {
+      continue;
+    }
+    port_directions[iterm->getMTerm()->getName()]
+        = ioTypeToDirection(iterm->getIoType());
+  }
+  cell["port_directions"] = std::move(port_directions);
+
+  boost::json::object connections;
+  for (odb::dbITerm* iterm : inst->getITerms()) {
+    odb::dbNet* net = iterm->getNet();
+    if (!net || !net_to_id.contains(net)) {
+      continue;
+    }
+    connections[iterm->getMTerm()->getName()]
+        = boost::json::array{net_to_id[net]};
+  }
+  cell["connections"] = std::move(connections);
+
+  cells[inst->getName()] = std::move(cell);
+}
+
 WebSocketResponse SelectHandler::handleSchematicCone(
     const WebSocketRequest& req)
 {
@@ -1193,37 +1451,11 @@ WebSocketResponse SelectHandler::handleSchematicCone(
     }
     top["ports"] = std::move(ports);
 
+    sta::dbNetwork* network
+        = gen_->getSta() ? gen_->getSta()->getDbNetwork() : nullptr;
     boost::json::object cells;
     for (odb::dbInst* inst : all_insts) {
-      boost::json::object cell;
-      cell["hide_name"] = 0;
-      cell["type"] = inst->getMaster() ? inst->getMaster()->getName()
-                                       : std::string("$unknown");
-      cell["attributes"] = boost::json::object{};
-      cell["parameters"] = boost::json::object{};
-
-      boost::json::object port_directions;
-      for (odb::dbITerm* iterm : inst->getITerms()) {
-        if (!iterm->getNet() || !net_to_id.contains(iterm->getNet())) {
-          continue;
-        }
-        port_directions[iterm->getMTerm()->getName()]
-            = ioTypeToDirection(iterm->getIoType());
-      }
-      cell["port_directions"] = std::move(port_directions);
-
-      boost::json::object connections;
-      for (odb::dbITerm* iterm : inst->getITerms()) {
-        odb::dbNet* net = iterm->getNet();
-        if (!net || !net_to_id.contains(net)) {
-          continue;
-        }
-        connections[iterm->getMTerm()->getName()]
-            = boost::json::array{net_to_id[net]};
-      }
-      cell["connections"] = std::move(connections);
-
-      cells[inst->getName()] = std::move(cell);
+      emitSchematicCell(cells, inst, network, net_to_id);
     }
     top["cells"] = std::move(cells);
 
@@ -1283,37 +1515,11 @@ WebSocketResponse SelectHandler::handleSchematicFull(
     }
     top["ports"] = std::move(ports);
 
+    sta::dbNetwork* network
+        = gen_->getSta() ? gen_->getSta()->getDbNetwork() : nullptr;
     boost::json::object cells;
     for (odb::dbInst* inst : block->getInsts()) {
-      boost::json::object cell;
-      cell["hide_name"] = 0;
-      cell["type"] = inst->getMaster() ? inst->getMaster()->getName()
-                                       : std::string("$unknown");
-      cell["attributes"] = boost::json::object{};
-      cell["parameters"] = boost::json::object{};
-
-      boost::json::object port_directions;
-      for (odb::dbITerm* iterm : inst->getITerms()) {
-        if (!iterm->getNet()) {
-          continue;
-        }
-        port_directions[iterm->getMTerm()->getName()]
-            = ioTypeToDirection(iterm->getIoType());
-      }
-      cell["port_directions"] = std::move(port_directions);
-
-      boost::json::object connections;
-      for (odb::dbITerm* iterm : inst->getITerms()) {
-        odb::dbNet* net = iterm->getNet();
-        if (!net) {
-          continue;
-        }
-        connections[iterm->getMTerm()->getName()]
-            = boost::json::array{net_to_id[net]};
-      }
-      cell["connections"] = std::move(connections);
-
-      cells[inst->getName()] = std::move(cell);
+      emitSchematicCell(cells, inst, network, net_to_id);
     }
     top["cells"] = std::move(cells);
 

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1191,11 +1191,13 @@ static GateClass classifyGate(sta::dbNetwork* network, odb::dbInst* inst)
     return result;
   }
 
-  // Peel a leading inversion so AND/NAND, OR/NOR, XOR/XNOR and BUF/NOT share a
-  // path.
+  // Peel leading inversions so AND/NAND, OR/NOR, XOR/XNOR and BUF/NOT share a
+  // path.  Some cells (e.g. higher drive-strength variants) model the output
+  // with stacked inverters, so the function can be nested NOTs like !(!(!(x)));
+  // an odd count is inverting, an even count is not.
   bool inverting = false;
-  if (func->op() == sta::FuncExpr::Op::not_) {
-    inverting = true;
+  while (func != nullptr && func->op() == sta::FuncExpr::Op::not_) {
+    inverting = !inverting;
     func = func->left();
   }
   if (func == nullptr) {
@@ -1262,7 +1264,8 @@ static GateClass classifyGate(sta::dbNetwork* network, odb::dbInst* inst)
 static void emitSchematicCell(boost::json::object& cells,
                               odb::dbInst* inst,
                               sta::dbNetwork* network,
-                              odb::PtrMap<odb::dbNet, int>& net_to_id)
+                              odb::PtrMap<odb::dbNet, int>& net_to_id,
+                              int& next_net_id)
 {
   boost::json::object cell;
   cell["hide_name"] = 0;
@@ -1287,25 +1290,30 @@ static void emitSchematicCell(boost::json::object& cells,
     }
   }
 
+  // Emit every signal port, even dangling or out-of-scope ones.  A pin whose
+  // net is absent from net_to_id (unconnected, or on a net outside the rendered
+  // cone) gets a fresh synthetic bit id so netlistsvg still sees the pin and
+  // draws the full symbol with a short dangling stub — otherwise a cell with
+  // all such pins would collapse to a bare name label with no shape.  Synthetic
+  // ids are deliberately left out of `netnames`, so they stay anonymous.
+  // Power/ground pins are skipped: they aren't part of the logic schematic and
+  // would otherwise render as spurious dangling stubs (and, for PDKs that mark
+  // supplies as input/output, throw off the gate-symbol pin mapping).
   boost::json::object port_directions;
-  for (odb::dbITerm* iterm : inst->getITerms()) {
-    if (!iterm->getNet() || !net_to_id.contains(iterm->getNet())) {
-      continue;
-    }
-    port_directions[iterm->getMTerm()->getName()]
-        = ioTypeToDirection(iterm->getIoType());
-  }
-  cell["port_directions"] = std::move(port_directions);
-
   boost::json::object connections;
   for (odb::dbITerm* iterm : inst->getITerms()) {
-    odb::dbNet* net = iterm->getNet();
-    if (!net || !net_to_id.contains(net)) {
+    if (iterm->getSigType().isSupply()) {
       continue;
     }
-    connections[iterm->getMTerm()->getName()]
-        = boost::json::array{net_to_id[net]};
+    const std::string& pin = iterm->getMTerm()->getName();
+    port_directions[pin] = ioTypeToDirection(iterm->getIoType());
+
+    odb::dbNet* net = iterm->getNet();
+    const int bit
+        = (net && net_to_id.contains(net)) ? net_to_id[net] : next_net_id++;
+    connections[pin] = boost::json::array{bit};
   }
+  cell["port_directions"] = std::move(port_directions);
   cell["connections"] = std::move(connections);
 
   cells[inst->getName()] = std::move(cell);
@@ -1455,7 +1463,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
         = gen_->getSta() ? gen_->getSta()->getDbNetwork() : nullptr;
     boost::json::object cells;
     for (odb::dbInst* inst : all_insts) {
-      emitSchematicCell(cells, inst, network, net_to_id);
+      emitSchematicCell(cells, inst, network, net_to_id, next_net_id);
     }
     top["cells"] = std::move(cells);
 
@@ -1519,7 +1527,7 @@ WebSocketResponse SelectHandler::handleSchematicFull(
         = gen_->getSta() ? gen_->getSta()->getDbNetwork() : nullptr;
     boost::json::object cells;
     for (odb::dbInst* inst : block->getInsts()) {
-      emitSchematicCell(cells, inst, network, net_to_id);
+      emitSchematicCell(cells, inst, network, net_to_id, next_net_id);
     }
     top["cells"] = std::move(cells);
 

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -506,7 +506,10 @@ const SKIN_SIMPLE_TYPE = {
 
 // Compound gate types the skin actually draws.  Unsupported arities are left as
 // labelled generic boxes (which keep the design's real pin names).
-const SKIN_COMPOUND_TYPES = new Set(['aoi21', 'aoi22', 'oai21', 'oai22']);
+const SKIN_COMPOUND_TYPES = new Set([
+    'aoi21', 'aoi22', 'aoi211', 'aoi221', 'aoi222', 'aoi33',
+    'oai21', 'oai22', 'oai211', 'oai221', 'oai222', 'oai33',
+]);
 
 // Wider (>2-input) basic gates the skin draws, named kind+arity.  2-input gates
 // use the Yosys primitive aliases in SKIN_SIMPLE_TYPE instead.

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -279,17 +279,16 @@ export class SchematicWidget {
             }
             this.netlistsvg = window.netlistsvg;
 
-            // The bundle passes skinData to onml.p() which expects a raw XML
-            // string — not a DOMParser Document.  Fetch the skin as plain text.
-            let skin = this.netlistsvg.digitalSkin || this.netlistsvg.defaultSkin;
-            if (!skin || typeof skin !== 'string') {
-                const resp = await fetch('https://unpkg.com/netlistsvg/lib/default.svg');
-                if (!resp.ok) {
-                    throw new Error(`Skin fetch failed: ${resp.status} ${resp.statusText}`);
-                }
-                skin = await resp.text();
+            // Load OpenROAD's custom skin (served as a local asset).  It defines
+            // proper gate symbols with correctly-placed ports and instance-name
+            // labels; renderNetlist() rewrites cell types to match it (see
+            // canonicalizeForSkin).  render() passes the skin to onml.p(), which
+            // expects a raw XML string, so fetch it as text.
+            const resp = await fetch('openroad_skin.svg');
+            if (!resp.ok) {
+                throw new Error(`Skin fetch failed: ${resp.status} ${resp.statusText}`);
             }
-            this.skin = skin;
+            this.skin = await resp.text();
             this._netlistsvgReady = true;
             console.log('NetlistSVG ready.');
         } catch (err) {
@@ -352,18 +351,29 @@ export class SchematicWidget {
         try {
             this.setStatus('Rendering…');
 
+            // Debug aid: the last netlist rendered is exposed so it can be
+            // captured for the offline render preview tool
+            // (src/web/test/visual). In DevTools:
+            //   copy(JSON.stringify(window.__lastSchematic))
+            if (typeof window !== 'undefined') window.__lastSchematic = yosysJson;
+
+            // Rewrite recognised logic gates to the canonical types our custom
+            // skin draws (proper gate symbols with correctly-placed ports), so
+            // netlistsvg renders and routes them natively.
+            const renderJson = canonicalizeForSkin(yosysJson);
+
             // netlistsvg.render() is Promise-based in v1.x (async ELK layout),
             // but older versions used a callback: render(skin, json, done).
             // Support both so the widget works with either bundle.
             let svgString;
-            const result = this.netlistsvg.render(this.skin, yosysJson);
+            const result = this.netlistsvg.render(this.skin, renderJson);
             if (result && typeof result.then === 'function') {
                 // Promise-based (v1.x)
                 svgString = await result;
             } else {
                 // Callback-based (older); wrap in a Promise
                 svgString = await new Promise((resolve, reject) => {
-                    this.netlistsvg.render(this.skin, yosysJson, (err, svg) => {
+                    this.netlistsvg.render(this.skin, renderJson, (err, svg) => {
                         if (err) reject(err); else resolve(svg);
                     });
                 });
@@ -402,6 +412,9 @@ export class SchematicWidget {
                 this._svgEl.style.display = 'block';
             }
 
+            // Label the matched gate symbols with the design's real pin names.
+            this._applyPinLabels(renderJson);
+
             // Reset to identity, then fit once the browser has fully painted
             // the SVG. Two rAFs are used: the first lets the DOM update, the
             // second lets the layout engine commit real dimensions.
@@ -417,4 +430,175 @@ export class SchematicWidget {
             this.setStatus(`Render error: ${err.message || err}`);
         }
     }
+
+    // Label the matched gate symbols with the design's real pin names.
+    // netlistsvg labels generic-box ports itself, but matched symbols use the
+    // skin's (label-less) ports, so we add the names here.  `renderJson` is the
+    // canonicalized netlist; cells rewritten to a gate symbol carry a
+    // `port_labels` map (symbol port id -> real pin name).  The rendered ports
+    // keep their `s:pid`/`s:x`/`s:y` attributes, so we place each label by
+    // attribute (no getBBox; works before layout).
+    _applyPinLabels(renderJson) {
+        if (!this._svgEl) return;
+        const NS = 'http://www.w3.org/2000/svg';
+        const NLNS = 'https://github.com/nturley/netlistsvg';
+        const cells = (renderJson.modules && renderJson.modules.top
+                       && renderJson.modules.top.cells) || {};
+        const attr = (el, name) =>
+            el.getAttribute('s:' + name) ?? el.getAttributeNS(NLNS, name);
+
+        for (const [name, cell] of Object.entries(cells)) {
+            const labels = cell.port_labels;
+            if (!labels) continue;
+            const group =
+                this._svgEl.querySelector('#' + CSS.escape('cell_' + name)) ||
+                this._svgEl.querySelector('#' + CSS.escape(name));
+            if (!group) continue;
+            const dirs = cell.port_directions || {};
+
+            // Snapshot children: appending labels below mutates the live
+            // HTMLCollection, which would otherwise re-enter the loop.
+            for (const el of Array.from(group.children)) {
+                if (el.tagName !== 'g') continue;
+                const pid = attr(el, 'pid');
+                if (!pid || !(pid in labels)) continue;
+                const sx = parseFloat(attr(el, 'x'));
+                const sy = parseFloat(attr(el, 'y'));
+                if (!isFinite(sx) || !isFinite(sy)) continue;
+
+                const text = document.createElementNS(NS, 'text');
+                const isInput = dirs[pid] === 'input';
+                if (isInput) {
+                    text.setAttribute('class', 'inputPortLabel');
+                    text.setAttribute('x', sx - 3);
+                } else {
+                    text.setAttribute('x', sx + 4);
+                }
+                text.setAttribute('y', sy - 4);
+                // Half the default 10px text size so the pin names stay
+                // proportionate to the small gate symbols.  Use inline style:
+                // the skin's `text { font-size:10px }` rule beats a presentation
+                // attribute, but not an inline style.
+                text.setAttribute('style', 'font-size:5px');
+                text.setAttribute('pointer-events', 'none');
+                text.textContent = labels[pid];
+                group.appendChild(text);
+            }
+        }
+    }
+
 }
+
+// ── Skin canonicalization ──────────────────────────────────────────────────
+//
+// The server tags recognised combinational cells with `gate_kind`
+// (and/nand/or/nor/xor/xnor/not/buf, or aoi/oai with `gate_terms`).  Before
+// rendering we rewrite those cells to the canonical gate types drawn by the
+// custom skin (openroad_skin.svg) and remap their pins to the symbol's port ids
+// (A, B, …, Y).  netlistsvg then renders proper gate symbols and routes the
+// wires to the symbol-defined port positions — no overlay or alignment needed.
+
+// gate_kind -> skin symbol type (a Yosys primitive alias the skin recognises).
+const SKIN_SIMPLE_TYPE = {
+    and: '$_AND_', nand: '$_NAND_', or: '$_OR_', nor: '$_NOR_',
+    xor: '$_XOR_', xnor: '$_XNOR_', not: '$_NOT_', buf: '$_BUF_',
+};
+
+// Compound gate types the skin actually draws.  Unsupported arities are left as
+// labelled generic boxes (which keep the design's real pin names).
+const SKIN_COMPOUND_TYPES = new Set(['aoi21', 'aoi22', 'oai21', 'oai22']);
+
+// Wider (>2-input) basic gates the skin draws, named kind+arity.  2-input gates
+// use the Yosys primitive aliases in SKIN_SIMPLE_TYPE instead.
+const SKIN_MULTI_TYPES = new Set([
+    'and3', 'and4', 'or3', 'or4', 'nand3', 'nand4', 'nor3', 'nor4',
+]);
+
+const PID_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+// Rewrite one cell to a custom-skin gate symbol when it carries a recognised
+// `gate_kind`: set its `type` to the canonical symbol name and remap its
+// `connections`/`port_directions` keys to the symbol's port ids.  Pins not part
+// of the gate (power/ground) are dropped.  Cells that aren't recognised — or
+// whose computed type has no symbol — are returned unchanged so they render as
+// a labelled generic box with their real pin names.
+export function canonicalizeCell(cell) {
+    const kind = cell && cell.gate_kind;
+    if (!kind) return cell;
+
+    const dirs = cell.port_directions || {};
+    let outPin = null;
+    const inPins = [];
+    for (const [pin, dir] of Object.entries(dirs)) {
+        if (dir === 'output' && outPin === null) outPin = pin;
+        else if (dir === 'input') inPins.push(pin);
+    }
+
+    let type;
+    const pidOf = {};  // real pin name -> symbol port id
+
+    if (kind === 'aoi' || kind === 'oai') {
+        const terms = Array.isArray(cell.gate_terms) ? cell.gate_terms : [];
+        if (!terms.length) return cell;
+        const sizes = terms.map((t) => t.length);
+        type = kind + sizes.slice().sort((a, b) => b - a).join('');
+        if (!SKIN_COMPOUND_TYPES.has(type)) return cell;
+        // Assign input pids term-by-term, smallest term first (so a 1-pin
+        // literal term gets 'A'); matches the symbol's port layout.
+        const ordered = terms.map((t) => t.slice())
+            .sort((a, b) => a.length - b.length);
+        let i = 0;
+        for (const term of ordered) {
+            for (const pin of term) {
+                pidOf[pin] = PID_LETTERS[i] || ('I' + i);
+                i++;
+            }
+        }
+    } else {
+        const n = inPins.length;
+        if (kind === 'not' || kind === 'buf') {
+            type = SKIN_SIMPLE_TYPE[kind];          // 1-input
+        } else if (n <= 2) {
+            type = SKIN_SIMPLE_TYPE[kind];          // 2-input Yosys primitive
+        } else {
+            type = kind + n;                        // wider gate, e.g. nand3
+            if (!SKIN_MULTI_TYPES.has(type)) return cell;
+        }
+        if (!type) return cell;
+        inPins.forEach((pin, idx) => { pidOf[pin] = PID_LETTERS[idx] || ('I' + idx); });
+    }
+    if (outPin !== null) pidOf[outPin] = 'Y';
+
+    const conns = cell.connections || {};
+    const newConns = {};
+    const newDirs = {};
+    for (const [pin, bits] of Object.entries(conns)) {
+        if (pidOf[pin]) newConns[pidOf[pin]] = bits;
+    }
+    for (const [pin, dir] of Object.entries(dirs)) {
+        if (pidOf[pin]) newDirs[pidOf[pin]] = dir;
+    }
+    // Keep the real pin name for each symbol port id so the viewer can label
+    // the symbol with the design's pin names (netlistsvg ignores this field).
+    const portLabels = {};
+    for (const [pin, pid] of Object.entries(pidOf)) portLabels[pid] = pin;
+    return {
+        ...cell, type,
+        connections: newConns, port_directions: newDirs,
+        port_labels: portLabels,
+    };
+}
+
+// Return a copy of the netlist with recognised logic gates rewritten to the
+// custom skin's gate symbols.  Cell keys (instance names) are preserved so
+// selection/inspect keep working.
+export function canonicalizeForSkin(json) {
+    const top = json && json.modules && json.modules.top;
+    if (!top || !top.cells) return json;
+    const cells = {};
+    for (const [name, cell] of Object.entries(top.cells)) {
+        cells[name] = canonicalizeCell(cell);
+    }
+    return { ...json, modules: { ...json.modules, top: { ...top, cells } } };
+}
+

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -59,6 +59,13 @@ js_test(
 )
 
 js_test(
+    name = "schematic_widget_test",
+    data = JS_FILES,
+    entry_point = "js/test-schematic-widget.js",
+    no_copy_to_bin = JS_FILES,
+)
+
+js_test(
     name = "vis_tree_test",
     data = DOM_TEST_DATA,
     entry_point = "js/test-vis-tree.js",

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -1756,6 +1756,71 @@ TEST_F(SchematicHandlerTest, AoiGateKeepsMasterNameAndRealPins)
   EXPECT_TRUE(conns.contains("B2"));
 }
 
+TEST_F(SchematicHandlerTest, NestedInversionStillClassifies)
+{
+  // Higher drive-strength variants can model the output with stacked inverters,
+  // so the Liberty function is nested NOTs, e.g. AOI211_X4 is
+  // !(!(!(((C1 & C2) | B) | A))).  Classification must peel all the inversions
+  // (odd count -> inverting) and still recognise the AOI211, not fall back to a
+  // box like a single-peel would.
+  makeGate("AOI211_X4",
+           "g_aoi211x4",
+           {{"a", "C1"}, {"b", "C2"}, {"c", "B"}, {"d", "A"}});
+
+  boost::json::object cells = fullCells();
+  auto& cell = cells.at("g_aoi211x4").as_object();
+  EXPECT_EQ(std::string(cell.at("gate_kind").as_string()), "aoi");
+
+  std::vector<int> got;
+  for (auto& t : cell.at("gate_terms").as_array()) {
+    got.push_back(static_cast<int>(t.as_array().size()));
+  }
+  std::sort(got.begin(), got.end());
+  EXPECT_EQ(got, (std::vector<int>{1, 1, 2}));
+}
+
+TEST_F(SchematicHandlerTest, DanglingPortsStillEmitted)
+{
+  // An instance whose pins are all unconnected must still emit every port with
+  // a connection bit, so netlistsvg draws the full symbol (with dangling stubs)
+  // instead of collapsing the cell to a bare name label with no shape.  The
+  // synthetic bits stand in for the missing nets and must be distinct.
+  makeGate("AND2_X1", "g_dangling", {});
+
+  boost::json::object cells = fullCells();
+  auto& cell = cells.at("g_dangling").as_object();
+
+  // The gate is still classified from its Liberty function regardless of
+  // connectivity.
+  EXPECT_EQ(std::string(cell.at("gate_kind").as_string()), "and");
+
+  auto& dirs = cell.at("port_directions").as_object();
+  EXPECT_EQ(std::string(dirs.at("A1").as_string()), "input");
+  EXPECT_EQ(std::string(dirs.at("A2").as_string()), "input");
+  EXPECT_EQ(std::string(dirs.at("ZN").as_string()), "output");
+
+  auto& conns = cell.at("connections").as_object();
+  ASSERT_TRUE(conns.contains("A1"));
+  ASSERT_TRUE(conns.contains("A2"));
+  ASSERT_TRUE(conns.contains("ZN"));
+
+  // Power/ground pins must not leak into the schematic as dangling stubs; only
+  // the three signal pins are emitted.
+  EXPECT_FALSE(dirs.contains("VDD"));
+  EXPECT_FALSE(dirs.contains("VSS"));
+  EXPECT_EQ(dirs.size(), 3u);
+  EXPECT_EQ(conns.size(), 3u);
+
+  // Each dangling pin gets its own synthetic bit id (no two pins share a net).
+  std::set<int64_t> bits;
+  for (const char* pin : {"A1", "A2", "ZN"}) {
+    auto& arr = conns.at(pin).as_array();
+    ASSERT_EQ(arr.size(), 1u) << pin;
+    bits.insert(arr.at(0).as_int64());
+  }
+  EXPECT_EQ(bits.size(), 3u);
+}
+
 TEST_F(SchematicHandlerTest, MuxAndUnknownCellsHaveNoKindHint)
 {
   // A MUX is not an AOI/OAI (its terms contain an inverted select), so it stays

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <algorithm>
 #include <any>
 #include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "boost/json/object.hpp"
 #include "boost/json/parse.hpp"
@@ -1553,6 +1556,216 @@ TEST_F(DRCHandlerTest, UpdateCategoryVisibilityBatch)
     std::lock_guard<std::mutex> lock(state_.drc_mutex);
     EXPECT_TRUE(state_.drc_rects.empty());
   }
+}
+
+//------------------------------------------------------------------------------
+// Schematic handler tests — verify leaf cells are classified into standard
+// logic-gate schematic symbols (Yosys primitives understood by netlistsvg)
+// instead of anonymous boxes.
+//------------------------------------------------------------------------------
+
+class SchematicHandlerTest : public tst::Nangate45Fixture
+{
+ protected:
+  void SetUp() override
+  {
+    readLiberty("_main/test/Nangate45/Nangate45_typ.lib");
+    block_->setDieArea(odb::Rect(0, 0, 100000, 100000));
+    sta_->postReadDef(block_);
+    sta_->getDbNetwork()->setBlock(block_);
+
+    gen_ = std::make_shared<TileGenerator>(getDb(), getSta(), getLogger());
+    tcl_eval_ = std::make_shared<TclEvaluator>(/*interp=*/nullptr, getLogger());
+    handler_ = std::make_unique<SelectHandler>(gen_, tcl_eval_);
+  }
+
+  // Instantiate a gate, wiring its named pins to fresh nets so the cell shows
+  // up with connections in the schematic JSON.
+  void makeGate(const char* master_name,
+                const char* inst_name,
+                const std::vector<tst::InstOptions::ITermInfo>& iterms)
+  {
+    odb::dbMaster* master = lib_->findMaster(master_name);
+    ASSERT_NE(master, nullptr) << master_name;
+    tst::InstOptions opts;
+    opts.iterms = iterms;
+    makeInst(block_, master, inst_name, opts);
+  }
+
+  // Returns modules.top.cells from a schematic_full response.
+  boost::json::object fullCells()
+  {
+    WebSocketRequest req;
+    req.id = 1;
+    req.type = WebSocketRequest::kSchematicFull;
+    req.json = parseObj("{}");
+    auto resp = handler_->handleSchematicFull(req);
+    EXPECT_EQ(resp.type, WebSocketResponse::kJson) << payloadStr(resp);
+    return boost::json::parse(payloadStr(resp))
+        .as_object()
+        .at("modules")
+        .as_object()
+        .at("top")
+        .as_object()
+        .at("cells")
+        .as_object();
+  }
+
+  std::shared_ptr<TileGenerator> gen_;
+  std::shared_ptr<TclEvaluator> tcl_eval_;
+  std::unique_ptr<SelectHandler> handler_;
+};
+
+TEST_F(SchematicHandlerTest, LeafGatesGetKindHint)
+{
+  makeGate("BUF_X1", "g_buf", {{"i", "A"}, {"o", "Z"}});
+  makeGate("INV_X1", "g_inv", {{"i", "A"}, {"o", "ZN"}});
+  makeGate("AND2_X1", "g_and", {{"a", "A1"}, {"b", "A2"}, {"o", "ZN"}});
+  makeGate("OR2_X1", "g_or", {{"a", "A1"}, {"b", "A2"}, {"o", "ZN"}});
+  makeGate("NAND2_X1", "g_nand", {{"a", "A1"}, {"b", "A2"}, {"o", "ZN"}});
+  makeGate("NOR2_X1", "g_nor", {{"a", "A1"}, {"b", "A2"}, {"o", "ZN"}});
+  makeGate("XOR2_X1", "g_xor", {{"a", "A"}, {"b", "B"}, {"o", "Z"}});
+  makeGate("XNOR2_X1", "g_xnor", {{"a", "A"}, {"b", "B"}, {"o", "ZN"}});
+
+  boost::json::object cells = fullCells();
+
+  auto kind = [&](const char* inst) {
+    return std::string(cells.at(inst).as_object().at("gate_kind").as_string());
+  };
+  EXPECT_EQ(kind("g_buf"), "buf");
+  EXPECT_EQ(kind("g_inv"), "not");
+  EXPECT_EQ(kind("g_and"), "and");
+  EXPECT_EQ(kind("g_or"), "or");
+  EXPECT_EQ(kind("g_nand"), "nand");
+  EXPECT_EQ(kind("g_nor"), "nor");
+  EXPECT_EQ(kind("g_xor"), "xor");
+  EXPECT_EQ(kind("g_xnor"), "xnor");
+}
+
+TEST_F(SchematicHandlerTest, MultiInputGatesGetKindHint)
+{
+  // Gates with more than two inputs (a flat AND/OR of ports) classify as the
+  // basic kind; the viewer derives the input count from the ports, so no
+  // gate_terms are emitted (those are only for compound AOI/OAI).
+  makeGate("NAND3_X1",
+           "g_nand3",
+           {{"a", "A1"}, {"b", "A2"}, {"c", "A3"}, {"o", "ZN"}});
+  makeGate("NAND4_X1",
+           "g_nand4",
+           {{"a", "A1"}, {"b", "A2"}, {"c", "A3"}, {"d", "A4"}, {"o", "ZN"}});
+  makeGate("AND3_X1",
+           "g_and3",
+           {{"a", "A1"}, {"b", "A2"}, {"c", "A3"}, {"o", "ZN"}});
+  makeGate("NOR4_X1",
+           "g_nor4",
+           {{"a", "A1"}, {"b", "A2"}, {"c", "A3"}, {"d", "A4"}, {"o", "ZN"}});
+
+  boost::json::object cells = fullCells();
+  auto& nand3 = cells.at("g_nand3").as_object();
+  EXPECT_EQ(std::string(nand3.at("gate_kind").as_string()), "nand");
+  EXPECT_FALSE(nand3.contains("gate_terms"));
+  EXPECT_EQ(
+      std::string(cells.at("g_nand4").as_object().at("gate_kind").as_string()),
+      "nand");
+  EXPECT_EQ(
+      std::string(cells.at("g_and3").as_object().at("gate_kind").as_string()),
+      "and");
+  EXPECT_EQ(
+      std::string(cells.at("g_nor4").as_object().at("gate_kind").as_string()),
+      "nor");
+}
+
+TEST_F(SchematicHandlerTest, GateKeepsMasterNameAndRealPins)
+{
+  makeGate("AND2_X1", "g_and", {{"a", "A1"}, {"b", "A2"}, {"o", "ZN"}});
+
+  boost::json::object cells = fullCells();
+  auto& cell = cells.at("g_and").as_object();
+
+  // The hint must not replace the real type or pin names — netlistsvg still
+  // needs them to draw the instance and port labels.
+  EXPECT_EQ(std::string(cell.at("type").as_string()), "AND2_X1");
+
+  auto& conns = cell.at("connections").as_object();
+  EXPECT_TRUE(conns.contains("A1"));
+  EXPECT_TRUE(conns.contains("A2"));
+  EXPECT_TRUE(conns.contains("ZN"));
+
+  auto& dirs = cell.at("port_directions").as_object();
+  EXPECT_EQ(std::string(dirs.at("A1").as_string()), "input");
+  EXPECT_EQ(std::string(dirs.at("ZN").as_string()), "output");
+}
+
+TEST_F(SchematicHandlerTest, AoiOaiGatesGetKindAndTerms)
+{
+  // AOI/OAI cells classify as compound gates with first-level term sizes.
+  makeGate("AOI21_X1", "g_aoi21", {{"a", "A"}, {"b", "B1"}, {"c", "B2"}});
+  makeGate("AOI22_X1",
+           "g_aoi22",
+           {{"a", "A1"}, {"b", "A2"}, {"c", "B1"}, {"d", "B2"}});
+  makeGate("OAI21_X1", "g_oai21", {{"a", "A"}, {"b", "B1"}, {"c", "B2"}});
+  makeGate("AOI211_X1",
+           "g_aoi211",
+           {{"a", "A"}, {"b", "B"}, {"c", "C1"}, {"d", "C2"}});
+
+  boost::json::object cells = fullCells();
+
+  // gate_terms groups the input pin names by first-level term; check the kind
+  // and the per-term sizes.
+  auto check =
+      [&](const char* inst, const char* kind, std::vector<int> want_sizes) {
+        auto& cell = cells.at(inst).as_object();
+        EXPECT_EQ(std::string(cell.at("gate_kind").as_string()), kind) << inst;
+        auto& terms = cell.at("gate_terms").as_array();
+        std::vector<int> got;
+        for (auto& t : terms) {
+          got.push_back(static_cast<int>(t.as_array().size()));
+        }
+        std::sort(got.begin(), got.end());
+        std::sort(want_sizes.begin(), want_sizes.end());
+        EXPECT_EQ(got, want_sizes) << inst;
+      };
+
+  check("g_aoi21", "aoi", {2, 1});
+  check("g_aoi22", "aoi", {2, 2});
+  check("g_oai21", "oai", {2, 1});
+  check("g_aoi211", "aoi", {2, 1, 1});
+
+  // The groups carry the real input pin names, which the viewer uses to align
+  // each input to its port.  AOI21 = !(A | (B1 & B2)).
+  std::set<std::string> pins;
+  for (auto& t : cells.at("g_aoi21").as_object().at("gate_terms").as_array()) {
+    for (auto& p : t.as_array()) {
+      pins.insert(std::string(p.as_string()));
+    }
+  }
+  EXPECT_EQ(pins, (std::set<std::string>{"A", "B1", "B2"}));
+}
+
+TEST_F(SchematicHandlerTest, AoiGateKeepsMasterNameAndRealPins)
+{
+  makeGate("AOI21_X1", "g_aoi", {{"a", "A"}, {"b", "B1"}, {"c", "B2"}});
+
+  boost::json::object cells = fullCells();
+  auto& cell = cells.at("g_aoi").as_object();
+  // The hint must not replace the real type or pin names.
+  EXPECT_EQ(std::string(cell.at("type").as_string()), "AOI21_X1");
+  auto& conns = cell.at("connections").as_object();
+  EXPECT_TRUE(conns.contains("A"));
+  EXPECT_TRUE(conns.contains("B1"));
+  EXPECT_TRUE(conns.contains("B2"));
+}
+
+TEST_F(SchematicHandlerTest, MuxAndUnknownCellsHaveNoKindHint)
+{
+  // A MUX is not an AOI/OAI (its terms contain an inverted select), so it stays
+  // a plain box.
+  makeGate("MUX2_X1", "g_mux", {{"a", "A"}, {"b", "B"}, {"s", "S"}});
+
+  boost::json::object cells = fullCells();
+  auto& cell = cells.at("g_mux").as_object();
+  EXPECT_EQ(std::string(cell.at("type").as_string()), "MUX2_X1");
+  EXPECT_FALSE(cell.contains("gate_kind"));
 }
 
 }  // namespace

--- a/src/web/test/js/test-schematic-widget.js
+++ b/src/web/test/js/test-schematic-widget.js
@@ -116,16 +116,47 @@ describe('canonicalizeCell', () => {
         assert.deepEqual(Object.keys(got.connections), ['A', 'B', 'C', 'D', 'Y']);
     });
 
-    it('leaves unsupported compound arities unchanged (labelled box)', () => {
-        const orig = cell({
+    it('maps AOI211 (literals A,B; AND pair C,D)', () => {
+        // !((C1 & C2) | B | A): smallest terms first -> the two literals get
+        // pids A,B and the AND pair gets C,D.
+        const got = canonicalizeCell(cell({
             type: 'AOI211_X1', gate_kind: 'aoi',
-            gate_terms: [['A'], ['B'], ['C1', 'C2']],
-            port_directions: { A: 'input', B: 'input', C1: 'input', C2: 'input', ZN: 'output' },
-            connections: { A: [1], B: [2], C1: [3], C2: [4], ZN: [5] },
+            gate_terms: [['C1', 'C2'], ['B'], ['A']],
+            port_directions: { C1: 'input', C2: 'input', B: 'input', A: 'input', ZN: 'output' },
+            connections: { C1: [3], C2: [4], B: [2], A: [1], ZN: [5] },
+        }));
+        assert.equal(got.type, 'aoi211');
+        assert.deepEqual(got.connections, { A: [2], B: [1], C: [3], D: [4], Y: [5] });
+        assert.deepEqual(got.port_labels, { A: 'B', B: 'A', C: 'C1', D: 'C2', Y: 'ZN' });
+    });
+
+    it('maps OAI33 to its symbol with six inputs A..F', () => {
+        const got = canonicalizeCell(cell({
+            type: 'OAI33_X1', gate_kind: 'oai',
+            gate_terms: [['A1', 'A2', 'A3'], ['B1', 'B2', 'B3']],
+            port_directions: {
+                A1: 'input', A2: 'input', A3: 'input',
+                B1: 'input', B2: 'input', B3: 'input', ZN: 'output',
+            },
+            connections: { A1: [1], A2: [2], A3: [3], B1: [4], B2: [5], B3: [6], ZN: [7] },
+        }));
+        assert.equal(got.type, 'oai33');
+        assert.deepEqual(Object.keys(got.connections), ['A', 'B', 'C', 'D', 'E', 'F', 'Y']);
+    });
+
+    it('leaves unsupported compound arities unchanged (labelled box)', () => {
+        // A four-term AOI (aoi2111) has no skin symbol, so it stays a box.
+        const orig = cell({
+            type: 'AOI2111_X1', gate_kind: 'aoi',
+            gate_terms: [['A'], ['B'], ['C'], ['D1', 'D2']],
+            port_directions: {
+                A: 'input', B: 'input', C: 'input', D1: 'input', D2: 'input', ZN: 'output',
+            },
+            connections: { A: [1], B: [2], C: [3], D1: [4], D2: [5], ZN: [6] },
         });
         const got = canonicalizeCell(orig);
-        assert.equal(got.type, 'AOI211_X1');           // type unchanged
-        assert.ok(got.connections.C1 && got.connections.ZN);  // real pins kept
+        assert.equal(got.type, 'AOI2111_X1');          // type unchanged
+        assert.ok(got.connections.D1 && got.connections.ZN);  // real pins kept
         assert.equal(got.port_labels, undefined);      // no remap -> no labels
     });
 

--- a/src/web/test/js/test-schematic-widget.js
+++ b/src/web/test/js/test-schematic-widget.js
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    canonicalizeCell, canonicalizeForSkin,
+} from '../../src/schematic-widget.js';
+
+// Helper: a server-style cell object.
+function cell(extra) {
+    return Object.assign({
+        hide_name: 0,
+        attributes: { ref: 'g1' },
+        parameters: {},
+    }, extra);
+}
+
+describe('canonicalizeCell', () => {
+    it('maps simple gates to skin types and A/B/Y pids', () => {
+        const got = canonicalizeCell(cell({
+            type: 'NOR2_X1', gate_kind: 'nor',
+            port_directions: { A1: 'input', A2: 'input', ZN: 'output' },
+            connections: { A1: [2], A2: [3], ZN: [4] },
+        }));
+        assert.equal(got.type, '$_NOR_');
+        assert.deepEqual(Object.keys(got.connections), ['A', 'B', 'Y']);
+        assert.deepEqual(got.connections, { A: [2], B: [3], Y: [4] });
+        assert.deepEqual(got.port_directions, { A: 'input', B: 'input', Y: 'output' });
+        // The real pin names are kept (pid -> name) so the symbol can be labelled.
+        assert.deepEqual(got.port_labels, { A: 'A1', B: 'A2', Y: 'ZN' });
+    });
+
+    it('maps an inverter to $_NOT_ with A/Y', () => {
+        const got = canonicalizeCell(cell({
+            type: 'INV_X1', gate_kind: 'not',
+            port_directions: { A: 'input', ZN: 'output' },
+            connections: { A: [7], ZN: [8] },
+        }));
+        assert.equal(got.type, '$_NOT_');
+        assert.deepEqual(got.connections, { A: [7], Y: [8] });
+    });
+
+    it('maps a buffer to $_BUF_', () => {
+        const got = canonicalizeCell(cell({
+            type: 'BUF_X1', gate_kind: 'buf',
+            port_directions: { A: 'input', Z: 'output' },
+            connections: { A: [1], Z: [2] },
+        }));
+        assert.equal(got.type, '$_BUF_');
+        assert.deepEqual(got.connections, { A: [1], Y: [2] });
+    });
+
+    it('maps a 3-input gate to a per-arity symbol (nand3)', () => {
+        const got = canonicalizeCell(cell({
+            type: 'NAND3_X1', gate_kind: 'nand',
+            port_directions: { A1: 'input', A2: 'input', A3: 'input', ZN: 'output' },
+            connections: { A1: [2], A2: [3], A3: [4], ZN: [5] },
+        }));
+        assert.equal(got.type, 'nand3');
+        assert.deepEqual(got.connections, { A: [2], B: [3], C: [4], Y: [5] });
+        assert.deepEqual(got.port_labels, { A: 'A1', B: 'A2', C: 'A3', Y: 'ZN' });
+    });
+
+    it('leaves an unsupported-width gate (>4 inputs) as a box', () => {
+        const orig = cell({
+            type: 'NAND5_X1', gate_kind: 'nand',
+            port_directions: {
+                A1: 'input', A2: 'input', A3: 'input', A4: 'input', A5: 'input',
+                ZN: 'output',
+            },
+            connections: { A1: [1], A2: [2], A3: [3], A4: [4], A5: [5], ZN: [6] },
+        });
+        const got = canonicalizeCell(orig);
+        assert.equal(got.type, 'NAND5_X1');        // unchanged -> generic box
+        assert.equal(got.port_labels, undefined);
+    });
+
+    it('drops power/ground pins not part of the gate', () => {
+        const got = canonicalizeCell(cell({
+            type: 'NAND2_X1', gate_kind: 'nand',
+            port_directions: {
+                A1: 'input', A2: 'input', ZN: 'output',
+                VDD: 'inout', VSS: 'inout',
+            },
+            connections: { A1: [2], A2: [3], ZN: [4], VDD: [5], VSS: [6] },
+        }));
+        assert.equal(got.type, '$_NAND_');
+        assert.deepEqual(Object.keys(got.connections).sort(), ['A', 'B', 'Y']);
+    });
+
+    it('maps AOI21 to its symbol with the literal as A and the AND pair as B,C', () => {
+        const got = canonicalizeCell(cell({
+            type: 'AOI21_X2', gate_kind: 'aoi',
+            gate_terms: [['A'], ['B1', 'B2']],
+            port_directions: { A: 'input', B1: 'input', B2: 'input', ZN: 'output' },
+            connections: { A: [4], B1: [8], B2: [11], ZN: [12] },
+        }));
+        assert.equal(got.type, 'aoi21');
+        // smallest term (literal A) -> pid A; the AND pair -> B, C; output -> Y
+        assert.deepEqual(got.connections, { A: [4], B: [8], C: [11], Y: [12] });
+        // Real pin names preserved per port id for labelling.
+        assert.deepEqual(got.port_labels, { A: 'A', B: 'B1', C: 'B2', Y: 'ZN' });
+    });
+
+    it('maps OAI22 to its symbol with four inputs A..D', () => {
+        const got = canonicalizeCell(cell({
+            type: 'OAI22_X1', gate_kind: 'oai',
+            gate_terms: [['A1', 'A2'], ['B1', 'B2']],
+            port_directions: {
+                A1: 'input', A2: 'input', B1: 'input', B2: 'input', ZN: 'output',
+            },
+            connections: { A1: [1], A2: [2], B1: [3], B2: [4], ZN: [5] },
+        }));
+        assert.equal(got.type, 'oai22');
+        assert.deepEqual(Object.keys(got.connections), ['A', 'B', 'C', 'D', 'Y']);
+    });
+
+    it('leaves unsupported compound arities unchanged (labelled box)', () => {
+        const orig = cell({
+            type: 'AOI211_X1', gate_kind: 'aoi',
+            gate_terms: [['A'], ['B'], ['C1', 'C2']],
+            port_directions: { A: 'input', B: 'input', C1: 'input', C2: 'input', ZN: 'output' },
+            connections: { A: [1], B: [2], C1: [3], C2: [4], ZN: [5] },
+        });
+        const got = canonicalizeCell(orig);
+        assert.equal(got.type, 'AOI211_X1');           // type unchanged
+        assert.ok(got.connections.C1 && got.connections.ZN);  // real pins kept
+        assert.equal(got.port_labels, undefined);      // no remap -> no labels
+    });
+
+    it('leaves cells without a gate_kind unchanged', () => {
+        const orig = cell({
+            type: 'DFF_X1',
+            port_directions: { D: 'input', CK: 'input', Q: 'output' },
+            connections: { D: [1], CK: [2], Q: [3] },
+        });
+        assert.strictEqual(canonicalizeCell(orig), orig);
+    });
+});
+
+describe('canonicalizeForSkin', () => {
+    it('rewrites recognised cells but preserves instance-name keys', () => {
+        const json = { modules: { top: { cells: {
+            _983_: {
+                type: 'NOR2_X1', gate_kind: 'nor', attributes: { ref: '_983_' },
+                port_directions: { A1: 'input', A2: 'input', ZN: 'output' },
+                connections: { A1: [2], A2: [3], ZN: [4] },
+            },
+            myff: {
+                type: 'DFF_X1', attributes: { ref: 'myff' },
+                port_directions: { D: 'input', Q: 'output' },
+                connections: { D: [4], Q: [5] },
+            },
+        } } } };
+        const out = canonicalizeForSkin(json);
+        const cells = out.modules.top.cells;
+        // Keys (instance names) preserved.
+        assert.deepEqual(Object.keys(cells).sort(), ['_983_', 'myff']);
+        assert.equal(cells._983_.type, '$_NOR_');     // gate rewritten
+        assert.equal(cells.myff.type, 'DFF_X1');       // non-gate untouched
+        // Input is not mutated.
+        assert.equal(json.modules.top.cells._983_.type, 'NOR2_X1');
+    });
+
+    it('returns the input unchanged when there is no top module', () => {
+        const json = { foo: 1 };
+        assert.strictEqual(canonicalizeForSkin(json), json);
+    });
+});

--- a/src/web/test/visual/.gitignore
+++ b/src/web/test/visual/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+*.png
+*.svg

--- a/src/web/test/visual/README.md
+++ b/src/web/test/visual/README.md
@@ -1,0 +1,58 @@
+# Schematic widget render preview
+
+A headless-Chrome harness that renders the **real** `src/schematic-widget.js`
+(with the custom `src/openroad_skin.svg`) against representative gate netlists
+and writes a PNG + SVG for each. Use it to visually check the gate symbols
+(AND/OR/XOR/inverter/buffer and the compound AOI/OAI) and to inspect the
+rendered netlistsvg DOM when iterating on the skin.
+
+The viewer renders gates natively via netlistsvg: the server tags cells with a
+`gate_kind` hint, `canonicalizeForSkin` rewrites them to the canonical types the
+skin draws, and netlistsvg lays them out. This tool serves `src/` directly, so
+it picks up edits to `openroad_skin.svg` and `schematic-widget.js` immediately.
+
+This is a developer tool, not part of CI: it needs a local Chrome and loads the
+netlistsvg JS bundle from its CDN (same as the viewer itself).
+
+## Setup (one-time)
+
+```sh
+cd src/web/test/visual
+npm install puppeteer-core
+```
+
+You also need Google Chrome / Chromium. The default path is
+`/usr/bin/google-chrome`; override with `CHROME=/path/to/chrome`.
+
+## Run
+
+```sh
+node preview.mjs [outDir]
+```
+
+Renders `and2`, `or2`, `inv`, `buf`, `nand2`, `nor2`, `xor2`, `aoi21`, `aoi22`,
+and `oai21`. Each produces `<name>.png` (screenshot) and `<name>.svg` (the
+rendered SVG DOM) in `outDir` (a temp dir is created and printed if omitted).
+
+Open the PNGs to check that:
+
+- the generic box is replaced by the gate outline (no leftover rectangle),
+- inputs meet the symbol on the left at their real port positions,
+- the output point / inversion bubble sits on the output wire,
+- AOI/OAI first-level gates abut the second-level gate (no connector stubs).
+
+`node_modules/` here is git-ignored; the tool itself is just `preview.mjs`.
+
+## Regenerating gate symbols
+
+The compound (AOI/OAI) and wider (>2-input) gate symbols in
+`../../src/openroad_skin.svg` are generated:
+
+```sh
+node gen_compound.mjs   # aoi21/aoi22/oai21/oai22 <g> symbols
+node gen_multi.mjs      # and3/4, or3/4, nand3/4, nor3/4 <g> symbols
+```
+
+Paste the printed `<g>` blocks into `openroad_skin.svg`, and add the new type
+names to `SKIN_COMPOUND_TYPES` / `SKIN_MULTI_TYPES` in
+`../../src/schematic-widget.js` so the viewer maps cells to them.

--- a/src/web/test/visual/gen_compound.mjs
+++ b/src/web/test/visual/gen_compound.mjs
@@ -96,10 +96,22 @@ function buildSymbol(type, terms, isAoi) {
   return lines.join('\n');
 }
 
+// Term-size arrays are listed smallest-first because canonicalizeCell() in
+// ../../src/schematic-widget.js assigns port ids (A, B, …) term-by-term in
+// ascending size order; the symbol's port layout must match that mapping.  The
+// type name uses the descending-size convention (e.g. terms [1,2] -> "aoi21").
 const symbols = [
   buildSymbol('aoi21', [1, 2], true),
   buildSymbol('aoi22', [2, 2], true),
+  buildSymbol('aoi211', [1, 1, 2], true),
+  buildSymbol('aoi221', [1, 2, 2], true),
+  buildSymbol('aoi222', [2, 2, 2], true),
+  buildSymbol('aoi33', [3, 3], true),
   buildSymbol('oai21', [1, 2], false),
   buildSymbol('oai22', [2, 2], false),
+  buildSymbol('oai211', [1, 1, 2], false),
+  buildSymbol('oai221', [1, 2, 2], false),
+  buildSymbol('oai222', [2, 2, 2], false),
+  buildSymbol('oai33', [3, 3], false),
 ];
 console.log(symbols.join('\n\n'));

--- a/src/web/test/visual/gen_compound.mjs
+++ b/src/web/test/visual/gen_compound.mjs
@@ -27,7 +27,10 @@ function line(x1, y1, x2, y2) { return `<path d="M${x1},${y1} L${x2},${y2}" clas
 function n(v) { return Number(v.toFixed(2)); }
 
 // terms: array of sizes (1 = literal, >=2 = sub-gate).  isAoi: AND->NOR else OR->NAND.
-function buildSymbol(type, terms, isAoi) {
+// originX/originY position the template in the skin; netlistsvg overwrites the
+// transform per instance at layout time, so the position only matters for
+// previewing the raw skin file.  Returns {svg, w, h}.
+function buildSymbol(type, terms, isAoi, originX, originY) {
   const subBase = isAoi ? 'and' : 'or';
   const totalInputs = terms.reduce((a, s) => a + s, 0);
   const H = totalInputs * ROW;
@@ -86,32 +89,48 @@ function buildSymbol(type, terms, isAoi) {
   const W = outX;
 
   const lines = [];
-  lines.push(`  <g s:type="${type}" transform="translate(50,360)" s:width="${W}" s:height="${H}">`);
+  lines.push(`  <g s:type="${type}" transform="translate(${originX},${originY})" s:width="${W}" s:height="${H}">`);
   lines.push(`    <s:alias val="${type}"/>`);
   lines.push(`    <text x="${n(W / 2)}" y="-4" class="nodelabel $cell_id" s:attribute="ref">${type}</text>`);
   for (const d of draw) lines.push(`    ${d}`);
   lines.push('');
   for (const p of ports) lines.push(`    ${p}`);
   lines.push('  </g>');
-  return lines.join('\n');
+  return { svg: lines.join('\n'), w: W, h: H };
+}
+
+// Lay the templates out in a grid so the raw skin file is inspectable (no
+// overlap).  Cells are sized to the largest symbol so nothing collides.
+function layoutGrid(defs, { baseX, baseY, cols, gapX, gapY }) {
+  const built = defs.map(([type, terms, isAoi]) =>
+    ({ type, terms, isAoi, ...buildSymbol(type, terms, isAoi, 0, 0) }));
+  const colPitch = Math.max(...built.map((b) => b.w)) + gapX;
+  const rowPitch = Math.max(...built.map((b) => b.h)) + gapY;
+  return built.map((b, i) => {
+    const x = baseX + (i % cols) * colPitch;
+    const y = baseY + Math.floor(i / cols) * rowPitch;
+    return buildSymbol(b.type, b.terms, b.isAoi, x, y).svg;
+  });
 }
 
 // Term-size arrays are listed smallest-first because canonicalizeCell() in
 // ../../src/schematic-widget.js assigns port ids (A, B, …) term-by-term in
 // ascending size order; the symbol's port layout must match that mapping.  The
 // type name uses the descending-size convention (e.g. terms [1,2] -> "aoi21").
-const symbols = [
-  buildSymbol('aoi21', [1, 2], true),
-  buildSymbol('aoi22', [2, 2], true),
-  buildSymbol('aoi211', [1, 1, 2], true),
-  buildSymbol('aoi221', [1, 2, 2], true),
-  buildSymbol('aoi222', [2, 2, 2], true),
-  buildSymbol('aoi33', [3, 3], true),
-  buildSymbol('oai21', [1, 2], false),
-  buildSymbol('oai22', [2, 2], false),
-  buildSymbol('oai211', [1, 1, 2], false),
-  buildSymbol('oai221', [1, 2, 2], false),
-  buildSymbol('oai222', [2, 2, 2], false),
-  buildSymbol('oai33', [3, 3], false),
+const defs = [
+  ['aoi21', [1, 2], true],
+  ['aoi22', [2, 2], true],
+  ['aoi211', [1, 1, 2], true],
+  ['aoi221', [1, 2, 2], true],
+  ['aoi222', [2, 2, 2], true],
+  ['aoi33', [3, 3], true],
+  ['oai21', [1, 2], false],
+  ['oai22', [2, 2], false],
+  ['oai211', [1, 1, 2], false],
+  ['oai221', [1, 2, 2], false],
+  ['oai222', [2, 2, 2], false],
+  ['oai33', [3, 3], false],
 ];
+const symbols = layoutGrid(defs,
+  { baseX: 20, baseY: 360, cols: 6, gapX: 24, gapY: 26 });
 console.log(symbols.join('\n\n'));

--- a/src/web/test/visual/gen_compound.mjs
+++ b/src/web/test/visual/gen_compound.mjs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+//
+// Generate the compound AOI/OAI gate symbols used in ../../src/openroad_skin.svg.
+// Output ports are placed at the gate's natural output point so netlistsvg
+// routes the output wire straight to it (no jog).  Run `node gen_compound.mjs`
+// and paste the printed <g> symbols into openroad_skin.svg (and add matching
+// entries to SKIN_COMPOUND_TYPES in ../../src/schematic-widget.js).
+
+const ROW = 14;           // vertical spacing between input rows
+const SUBW = 16;          // first-level gate width
+const FINW = 26;          // second-level gate width
+const GAP = 4;            // gap between first- and second-level gate backs
+const R = 3;              // inversion bubble radius
+
+function andBody(x, y, w, h) {
+  return `<path d="M${x},${y} L${x},${y + h} L${x + w / 2},${y + h} `
+       + `A${w / 2} ${h / 2} 0 0 0 ${x + w / 2},${y} Z" class="$cell_id"/>`;
+}
+function orBody(x, y, w, h) {
+  return `<path d="M${x},${y + h} L${x + w / 2},${y + h} `
+       + `A${w / 2} ${h / 2} 0 0 0 ${x + w / 2},${y} L${x},${y}" class="$cell_id"/>\n`
+       + `    <path d="M${x},${y} A${w} ${h} 0 0 1 ${x},${y + h}" class="$cell_id"/>`;
+}
+function bubble(cx, cy) { return `<circle cx="${cx}" cy="${cy}" r="${R}" class="$cell_id"/>`; }
+function line(x1, y1, x2, y2) { return `<path d="M${x1},${y1} L${x2},${y2}" class="$cell_id"/>`; }
+function n(v) { return Number(v.toFixed(2)); }
+
+// terms: array of sizes (1 = literal, >=2 = sub-gate).  isAoi: AND->NOR else OR->NAND.
+function buildSymbol(type, terms, isAoi) {
+  const subBase = isAoi ? 'and' : 'or';
+  const totalInputs = terms.reduce((a, s) => a + s, 0);
+  const H = totalInputs * ROW;
+  const finalBackX = SUBW + GAP;
+
+  const draw = [];
+  const ports = [];
+  const pidLetters = ['A', 'B', 'C', 'D', 'E', 'F'];
+  let pid = 0;
+  let row = 0;                       // current input row index
+  const connYs = [];                 // y where each term meets the final gate
+
+  for (const size of terms) {
+    if (size === 1) {
+      const y = n((row + 0.5) * ROW);
+      ports.push(`<g s:x="0" s:y="${y}" s:pid="${pidLetters[pid]}"/>`);
+      draw.push(line(0, y, finalBackX, y));     // literal lead into final gate
+      connYs.push(y);
+      pid++; row++;
+    } else {
+      const yTop = n(row * ROW + 1);
+      const yBot = n((row + size) * ROW - 1);
+      const subH = yBot - yTop;
+      // sub-gate body; nose abuts the final gate back
+      const subW = finalBackX;       // stretch nose to the final back
+      draw.push(subBase === 'and'
+        ? andBody(0, yTop, subW, subH)
+        : orBody(0, yTop, subW, subH));
+      // input ports on the sub-gate, one per row it spans
+      for (let k = 0; k < size; k++) {
+        const y = n((row + k + 0.5) * ROW);
+        ports.push(`<g s:x="0" s:y="${y}" s:pid="${pidLetters[pid]}"/>`);
+        if (subBase === 'or') draw.push(line(0, y, n(subW * 0.18), y)); // OR back leads
+        pid++;
+      }
+      connYs.push(n((yTop + yBot) / 2));
+      row += size;
+    }
+  }
+
+  // Final (second-level) gate spans the connection range, centred on its mid.
+  const cTop = Math.min(...connYs);
+  const cBot = Math.max(...connYs);
+  const finMid = n((cTop + cBot) / 2);
+  const finTop = n(cTop - ROW / 2);
+  const finH = n((cBot - cTop) + ROW);
+  const noseX = finalBackX + FINW;
+  if (isAoi) {
+    draw.push(orBody(finalBackX, finTop, FINW, finH));   // NOR lobe
+  } else {
+    draw.push(andBody(finalBackX, finTop, FINW, finH));  // NAND body
+  }
+  draw.push(bubble(n(noseX + R), finMid));               // inversion bubble
+  const outX = n(noseX + 2 * R);
+  ports.push(`<g s:x="${outX}" s:y="${finMid}" s:pid="Y"/>`);
+  const W = outX;
+
+  const lines = [];
+  lines.push(`  <g s:type="${type}" transform="translate(50,360)" s:width="${W}" s:height="${H}">`);
+  lines.push(`    <s:alias val="${type}"/>`);
+  lines.push(`    <text x="${n(W / 2)}" y="-4" class="nodelabel $cell_id" s:attribute="ref">${type}</text>`);
+  for (const d of draw) lines.push(`    ${d}`);
+  lines.push('');
+  for (const p of ports) lines.push(`    ${p}`);
+  lines.push('  </g>');
+  return lines.join('\n');
+}
+
+const symbols = [
+  buildSymbol('aoi21', [1, 2], true),
+  buildSymbol('aoi22', [2, 2], true),
+  buildSymbol('oai21', [1, 2], false),
+  buildSymbol('oai22', [2, 2], false),
+];
+console.log(symbols.join('\n\n'));

--- a/src/web/test/visual/gen_multi.mjs
+++ b/src/web/test/visual/gen_multi.mjs
@@ -14,7 +14,10 @@ const R = 3;       // inversion bubble radius
 
 function n(v) { return Number(v.toFixed(2)); }
 
-function symbol(name, base, inverting, nIn) {
+// originX/originY position the template in the skin; netlistsvg overwrites the
+// transform per instance at layout time, so the position only matters for
+// previewing the raw skin file.  Returns {svg, w, h}.
+function symbol(name, base, inverting, nIn, originX, originY) {
   const H = nIn * ROW;
   const mid = H / 2;
   const draw = [];
@@ -32,7 +35,7 @@ function symbol(name, base, inverting, nIn) {
   }
 
   const lines = [];
-  lines.push(`  <g s:type="${name}" transform="translate(50,400)" s:width="${outX}" s:height="${H}">`);
+  lines.push(`  <g s:type="${name}" transform="translate(${originX},${originY})" s:width="${outX}" s:height="${H}">`);
   lines.push(`    <s:alias val="${name}"/>`);
   lines.push(`    <text x="${n(W / 2)}" y="-4" class="nodelabel $cell_id" s:attribute="ref">${name}</text>`);
   for (const d of draw) lines.push(`    ${d}`);
@@ -43,14 +46,29 @@ function symbol(name, base, inverting, nIn) {
   }
   lines.push(`    <g s:x="${n(outX)}" s:y="${n(mid)}" s:pid="Y"/>`);
   lines.push('  </g>');
-  return lines.join('\n');
+  return { svg: lines.join('\n'), w: outX, h: H };
 }
 
-const out = [];
-for (const nIn of [3, 4]) {
-  out.push(symbol('and' + nIn, 'and', false, nIn));
-  out.push(symbol('nand' + nIn, 'and', true, nIn));
-  out.push(symbol('or' + nIn, 'or', false, nIn));
-  out.push(symbol('nor' + nIn, 'or', true, nIn));
+// Lay the templates out in a grid (below the compound block's y-band) so the
+// raw skin file is inspectable.  Cells are sized to the largest symbol.
+function layoutGrid(defs, { baseX, baseY, cols, gapX, gapY }) {
+  const built = defs.map((d) => ({ d, ...symbol(...d, 0, 0) }));
+  const colPitch = Math.max(...built.map((b) => b.w)) + gapX;
+  const rowPitch = Math.max(...built.map((b) => b.h)) + gapY;
+  return built.map((b, i) => {
+    const x = baseX + (i % cols) * colPitch;
+    const y = baseY + Math.floor(i / cols) * rowPitch;
+    return symbol(...b.d, x, y).svg;
+  });
 }
+
+const defs = [];
+for (const nIn of [3, 4]) {
+  defs.push(['and' + nIn, 'and', false, nIn]);
+  defs.push(['nand' + nIn, 'and', true, nIn]);
+  defs.push(['or' + nIn, 'or', false, nIn]);
+  defs.push(['nor' + nIn, 'or', true, nIn]);
+}
+const out = layoutGrid(defs,
+  { baseX: 20, baseY: 580, cols: 4, gapX: 24, gapY: 26 });
 console.log(out.join('\n\n'));

--- a/src/web/test/visual/gen_multi.mjs
+++ b/src/web/test/visual/gen_multi.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+//
+// Generate the multi-input (>2) basic gate symbols used in
+// ../../src/openroad_skin.svg: and3/4, or3/4, nand3/4, nor3/4.  Output Y is
+// centered at the nose so netlistsvg routes the output wire straight to it.
+// Run `node gen_multi.mjs` and paste the printed <g> symbols into
+// openroad_skin.svg (and add matching entries to SKIN_MULTI_TYPES in
+// ../../src/schematic-widget.js).
+
+const W = 30;      // body width
+const ROW = 12;    // input spacing
+const R = 3;       // inversion bubble radius
+
+function n(v) { return Number(v.toFixed(2)); }
+
+function symbol(name, base, inverting, nIn) {
+  const H = nIn * ROW;
+  const mid = H / 2;
+  const draw = [];
+  if (base === 'and') {
+    draw.push(`<path d="M0,0 L0,${H} L${W / 2},${H} A${W / 2} ${mid} 0 0 0 ${W / 2},0 Z" class="$cell_id"/>`);
+  } else { // or
+    draw.push(`<path d="M0,${H} L${W / 2},${H} A${W / 2} ${mid} 0 0 0 ${W / 2},0 L0,0" class="$cell_id"/>`);
+    draw.push(`<path d="M0,0 A${W} ${H} 0 0 1 0,${H}" class="$cell_id"/>`);
+  }
+  const inX = base === 'and' ? 0 : 3;
+  let outX = W;
+  if (inverting) {
+    draw.push(`<circle cx="${W + R + 1}" cy="${mid}" r="${R}" class="$cell_id"/>`);
+    outX = W + 2 * R + 2;
+  }
+
+  const lines = [];
+  lines.push(`  <g s:type="${name}" transform="translate(50,400)" s:width="${outX}" s:height="${H}">`);
+  lines.push(`    <s:alias val="${name}"/>`);
+  lines.push(`    <text x="${n(W / 2)}" y="-4" class="nodelabel $cell_id" s:attribute="ref">${name}</text>`);
+  for (const d of draw) lines.push(`    ${d}`);
+  lines.push('');
+  const letters = ['A', 'B', 'C', 'D', 'E', 'F'];
+  for (let i = 0; i < nIn; i++) {
+    lines.push(`    <g s:x="${inX}" s:y="${n((i + 0.5) * ROW)}" s:pid="${letters[i]}"/>`);
+  }
+  lines.push(`    <g s:x="${n(outX)}" s:y="${n(mid)}" s:pid="Y"/>`);
+  lines.push('  </g>');
+  return lines.join('\n');
+}
+
+const out = [];
+for (const nIn of [3, 4]) {
+  out.push(symbol('and' + nIn, 'and', false, nIn));
+  out.push(symbol('nand' + nIn, 'and', true, nIn));
+  out.push(symbol('or' + nIn, 'or', false, nIn));
+  out.push(symbol('nor' + nIn, 'or', true, nIn));
+}
+console.log(out.join('\n\n'));

--- a/src/web/test/visual/package.json
+++ b/src/web/test/visual/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "schematic-render-preview",
+  "private": true,
+  "type": "module",
+  "description": "Dev-only headless render preview for the web schematic widget. Run: npm install puppeteer-core"
+}

--- a/src/web/test/visual/preview.mjs
+++ b/src/web/test/visual/preview.mjs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+//
+// Headless render preview for the web schematic widget.
+//
+// Renders the real src/schematic-widget.js in headless Chrome against a set of
+// representative gate netlists and writes a PNG + SVG for each, so changes to
+// the gate-symbol drawing can be eyeballed (and the rendered netlistsvg DOM
+// inspected) instead of guessed at.
+//
+// Usage:
+//   cd src/web/test/visual && npm i puppeteer-core   # one-time
+//   node preview.mjs [outDir]
+//
+// Requires google-chrome (or set CHROME=/path/to/chrome) and network access
+// (netlistsvg is loaded from its CDN, same as the real viewer).
+
+import puppeteer from 'puppeteer-core';
+import { writeFileSync, readFileSync, mkdtempSync, mkdirSync } from 'node:fs';
+import { dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import http from 'node:http';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(here, '..', '..', 'src');
+const chrome = process.env.CHROME || '/usr/bin/google-chrome';
+
+// Args: any *.json is a real captured netlist to render; the first other arg is
+// the output directory.  Capture a real netlist from the running viewer via
+// DevTools -> Network -> WS -> the schematic_cone/schematic_full response frame
+// (the JSON object with a top-level "modules" key) and save it to a file.
+const jsonFiles = process.argv.slice(2).filter((a) => a.endsWith('.json'));
+const outDir = process.argv.slice(2).find((a) => !a.endsWith('.json'))
+  || mkdtempSync(join(tmpdir(), 'schematic-preview-'));
+mkdirSync(outDir, { recursive: true });
+
+// Build a single-cell netlist with external ports so the wires are drawn.
+function netlist(type, gateKind, gateTerms, inPins, outPin) {
+  let bit = 2;
+  const ports = {}, pd = {}, conns = {}, netnames = {};
+  for (const p of inPins) {
+    ports[p] = { direction: 'input', bits: [bit] };
+    pd[p] = 'input'; conns[p] = [bit];
+    netnames[p] = { hide_name: 0, bits: [bit], attributes: {} };
+    bit++;
+  }
+  ports[outPin] = { direction: 'output', bits: [bit] };
+  pd[outPin] = 'output'; conns[outPin] = [bit];
+  netnames[outPin] = { hide_name: 0, bits: [bit], attributes: {} };
+  const cell = { hide_name: 0, type, port_directions: pd, connections: conns,
+                 attributes: {}, parameters: {}, gate_kind: gateKind };
+  if (gateTerms) cell.gate_terms = gateTerms;
+  return { modules: { top: { ports, cells: { g1: cell }, netnames } } };
+}
+
+const CASES = jsonFiles.length
+  ? jsonFiles.map((f) => [basename(f).replace(/\.json$/, ''),
+                          JSON.parse(readFileSync(f, 'utf8'))])
+  : [
+    ['and2',  netlist('AND2_X1', 'and', null, ['A1', 'A2'], 'ZN')],
+    ['or2',   netlist('OR2_X1', 'or', null, ['A1', 'A2'], 'ZN')],
+    ['inv',   netlist('INV_X1', 'not', null, ['A'], 'ZN')],
+    ['buf',   netlist('BUF_X1', 'buf', null, ['A'], 'Z')],
+    ['nand2', netlist('NAND2_X1', 'nand', null, ['A1', 'A2'], 'ZN')],
+    ['nor2',  netlist('NOR2_X1', 'nor', null, ['A1', 'A2'], 'ZN')],
+    ['xor2',  netlist('XOR2_X1', 'xor', null, ['A', 'B'], 'Z')],
+    ['aoi21', netlist('AOI21_X1', 'aoi', [['A'], ['B1', 'B2']], ['A', 'B1', 'B2'], 'ZN')],
+    ['aoi22', netlist('AOI22_X1', 'aoi', [['A1', 'A2'], ['B1', 'B2']], ['A1', 'A2', 'B1', 'B2'], 'ZN')],
+    ['oai21', netlist('OAI21_X1', 'oai', [['A'], ['B1', 'B2']], ['A', 'B1', 'B2'], 'ZN')],
+  ];
+
+const HARNESS = `<!doctype html><html><head><meta charset="utf-8">
+<style>:root{--bg-panel:#fff;--fg-primary:#111;--bg-header:#eee;--border:#ccc;
+  --bg-main:#fff;--fg-muted:#999;--accent:#e05a00;--fg-white:#fff;}
+  body{margin:0;background:#fff}#host svg{color:#111}</style>
+<script src="https://nturley.github.io/netlistsvg/elk.bundled.js"></script>
+<script src="https://nturley.github.io/netlistsvg/built/netlistsvg.bundle.js"></script>
+</head><body><div id="host" style="width:760px;height:460px"></div>
+<script type="module">
+  import { SchematicWidget } from '/schematic-widget.js';
+  const widget = new SchematicWidget({ element: document.getElementById('host') }, {});
+  window.__render = async (json) => {
+    for (let i = 0; i < 300 && !widget._netlistsvgReady; i++)
+      await new Promise((r) => setTimeout(r, 50));
+    if (!widget._netlistsvgReady) throw new Error('netlistsvg not ready');
+    await widget.renderNetlist(json);
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return widget._svgEl ? widget._svgEl.outerHTML : null;
+  };
+  window.__ready = true;
+</script></body></html>`;
+
+const MIME = { '.js': 'application/javascript', '.html': 'text/html' };
+const server = http.createServer((req, res) => {
+  const url = req.url.split('?')[0];
+  if (url === '/preview.html' || url === '/') {
+    res.setHeader('Content-Type', 'text/html'); res.end(HARNESS); return;
+  }
+  try {
+    const ext = url.slice(url.lastIndexOf('.'));
+    res.setHeader('Content-Type', MIME[ext] || 'text/plain');
+    res.end(readFileSync(join(srcDir, url)));
+  } catch (e) { res.statusCode = 404; res.end('not found'); }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const browser = await puppeteer.launch({
+  executablePath: chrome, headless: 'new',
+  args: ['--no-sandbox', '--disable-gpu'],
+});
+try {
+  for (const [name, sample] of CASES) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 760, height: 460, deviceScaleFactor: 2 });
+    const errs = [];
+    page.on('pageerror', (e) => errs.push(e.message));
+    await page.goto(`http://localhost:${port}/preview.html`, { waitUntil: 'load' });
+    await page.waitForFunction('window.__ready === true', { timeout: 20000 });
+    const svg = await page.evaluate((j) => window.__render(j), sample);
+    await new Promise((r) => setTimeout(r, 250));
+    await page.screenshot({ path: join(outDir, `${name}.png`) });
+    writeFileSync(join(outDir, `${name}.svg`), svg || '(no svg)');
+    await page.close();
+    console.log(`${name}: ${join(outDir, name + '.png')}${errs.length ? '  ERRORS: ' + errs.join('; ') : ''}`);
+  }
+  console.log(`\nWrote ${CASES.length} previews to ${outDir}`);
+} finally {
+  await browser.close();
+  server.close();
+}


### PR DESCRIPTION
## What

The web schematic viewer drew every cell as a generic box. This renders
recognised combinational cells as standard **gate symbols** instead:
AND/OR/NAND/NOR/XOR/XNOR, inverter, buffer, compound AOI/OAI (21/22), and
3-/4-input AND/OR/NAND/NOR. Each shows the instance name and the design's real
pin names, with the output wire on the gate's nose/bubble. Unrecognised cells
(DFFs, wider/compound arities) fall back to the existing labelled generic box.

## How

- **Backend** (`request_handler.cpp`): `classifyGate` tags each combinational
  cell with a `gate_kind` hint (and `gate_terms` for AOI/OAI) derived from its
  Liberty function. A flat AND/OR/XOR of N≥2 plain ports classifies as the basic
  kind; an and/or-invert tree classifies as AOI/OAI. The cell still carries its
  real master name and pin names.
- **Custom skin** (`src/openroad_skin.svg`): based on netlistsvg's default skin
  with instance-name (`ref`) labels added to the gate symbols, plus a buffer and
  the AOI/OAI and >2-input symbols. Each symbol declares its own port positions,
  so netlistsvg routes wires natively (output on the nose) — no DOM overlay or
  alignment code. The skin is served as a local embedded asset.
- **Frontend** (`schematic-widget.js`): `canonicalizeForSkin` rewrites tagged
  cells to the skin's canonical types and remaps pins to the symbol port ids,
  keeping a pid->name map; `_applyPinLabels` then labels each port with the real
  pin name. Loads the local skin instead of the CDN default.

## Notes

- 5+-input gates, 3+-input XOR, and uncommon AOI/OAI arities gracefully fall
  back to labelled boxes; the symbol set is easy to extend (generators in
  `src/web/test/visual/`, plus the `SKIN_*_TYPES` sets).
- `src/web/test/visual/` adds a headless-Chrome render preview dev tool (not part
  of CI) used to author/verify the symbols.