### PR TITLE
mbff: Use getLibertyCell (now testCell) instead of libertyCell.

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -93,6 +93,7 @@ class dbNetwork : public ConcreteNetwork
 
   LibertyCell* libertyCell(Cell* cell) const override;
   const LibertyCell* libertyCell(const Cell* cell) const override;
+  const LibertyCell* testCell(const Cell* cell) const;
   LibertyCell* libertyCell(odb::dbInst* inst);
   LibertyPort* libertyPort(const Pin*) const override;
   odb::dbInst* staToDb(const Instance* instance) const;
@@ -521,7 +522,6 @@ class dbNetwork : public ConcreteNetwork
   static constexpr unsigned DBIDTAG_WIDTH = 0x4;
 
  private:
-  const LibertyCell* getLibertyCell(const Cell* cell) const;
   void addDriverToCacheIfPresent(const Net* net, const Pin* drvr);
   void removeDriverFromCache(const Net* net);
   void removeDriverFromCache(const Net* net, const Pin* drvr);

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -3496,7 +3496,7 @@ LibertyCell* dbNetwork::libertyCell(dbInst* inst)
   return libertyCell(dbToSta(inst));
 }
 
-const LibertyCell* dbNetwork::getLibertyCell(const Cell* cell) const
+const LibertyCell* dbNetwork::testCell(const Cell* cell) const
 {
   const LibertyCell* lib_cell = libertyCell(cell);
   if (!lib_cell) {
@@ -5280,7 +5280,7 @@ bool dbNetwork::isClockPin(odb::dbITerm* iterm) const
 bool dbNetwork::clockOn(odb::dbInst* inst) const
 {
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (!lib_cell) {
     return false;
   }
@@ -5359,7 +5359,7 @@ int dbNetwork::getNumD(odb::dbInst* inst) const
 {
   int cnt_d = 0;
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell == nullptr) {
     return 0;
   }
@@ -5423,7 +5423,7 @@ bool dbNetwork::isInvertingQPin(odb::dbITerm* iterm) const
 {
   odb::dbInst* inst = iterm->getInst();
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (!lib_cell) {
     return false;
   }
@@ -5473,7 +5473,7 @@ int dbNetwork::getNumQ(odb::dbInst* inst) const
 bool dbNetwork::hasClear(odb::dbInst* inst) const
 {
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (!lib_cell) {
     return false;
   }
@@ -5507,7 +5507,7 @@ bool dbNetwork::isClearPin(odb::dbITerm* iterm) const
 bool dbNetwork::hasPreset(odb::dbInst* inst) const
 {
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (!lib_cell) {
     return false;
   }
@@ -5542,7 +5542,7 @@ bool dbNetwork::isPresetPin(odb::dbITerm* iterm) const
 bool dbNetwork::isScanCell(odb::dbInst* inst) const
 {
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   return lib_cell && getLibertyScanIn(lib_cell)
          && getLibertyScanEnable(lib_cell);
 }
@@ -5550,7 +5550,7 @@ bool dbNetwork::isScanCell(odb::dbInst* inst) const
 bool dbNetwork::isScanIn(odb::dbITerm* iterm) const
 {
   const Cell* cell = dbToSta(iterm->getInst()->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell && getLibertyScanIn(lib_cell)) {
     odb::dbMTerm* mterm = staToDb(getLibertyScanIn(lib_cell));
     return iterm->getInst()->getITerm(mterm) == iterm;
@@ -5561,7 +5561,7 @@ bool dbNetwork::isScanIn(odb::dbITerm* iterm) const
 odb::dbITerm* dbNetwork::getScanIn(odb::dbInst* inst) const
 {
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell && getLibertyScanIn(lib_cell)) {
     odb::dbMTerm* mterm = staToDb(getLibertyScanIn(lib_cell));
     return inst->getITerm(mterm);
@@ -5572,7 +5572,7 @@ odb::dbITerm* dbNetwork::getScanIn(odb::dbInst* inst) const
 bool dbNetwork::isScanEnable(odb::dbITerm* iterm) const
 {
   const Cell* cell = dbToSta(iterm->getInst()->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell && getLibertyScanEnable(lib_cell)) {
     odb::dbMTerm* mterm = staToDb(getLibertyScanEnable(lib_cell));
     return (iterm->getInst()->getITerm(mterm) == iterm);
@@ -5583,7 +5583,7 @@ bool dbNetwork::isScanEnable(odb::dbITerm* iterm) const
 odb::dbITerm* dbNetwork::getScanEnable(odb::dbInst* inst) const
 {
   const Cell* cell = dbToSta(inst->getMaster());
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell && getLibertyScanEnable(lib_cell)) {
     odb::dbMTerm* mterm = staToDb(getLibertyScanEnable(lib_cell));
     return inst->getITerm(mterm);
@@ -5602,7 +5602,7 @@ bool dbNetwork::isValidFlop(odb::dbInst* FF) const
   if (cell == nullptr) {
     return false;
   }
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell == nullptr || !lib_cell->hasSequentials()) {
     return false;
   }
@@ -5642,7 +5642,7 @@ bool dbNetwork::isValidTray(odb::dbInst* tray) const
   if (cell == nullptr) {
     return false;
   }
-  const LibertyCell* lib_cell = getLibertyCell(cell);
+  const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell == nullptr || !lib_cell->hasSequentials()) {
     return false;
   }

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -207,7 +207,7 @@ MBFF::PortName MBFF::PortType(const sta::LibertyPort* lib_port, dbInst* inst)
   }
 
   const sta::Cell* cell = network_->dbToSta(inst->getMaster());
-  const sta::LibertyCell* lib_cell = network_->libertyCell(cell);
+  const sta::LibertyCell* lib_cell = network_->testCell(cell);
   for (const sta::Sequential& seq : lib_cell->sequentials()) {
     // function
     if (sta::LibertyPort::equiv(lib_port, seq.output())) {
@@ -280,7 +280,7 @@ MBFF::Mask MBFF::GetArrayMask(dbInst* inst, const bool isTray)
   }
 
   const sta::Cell* cell = network_->dbToSta(inst->getMaster());
-  const sta::LibertyCell* lib_cell = network_->libertyCell(cell);
+  const sta::LibertyCell* lib_cell = network_->testCell(cell);
   const auto& seqs = lib_cell->sequentials();
   if (!seqs.empty()) {
     ret.func_idx = GetMatchingFunc(seqs.front().data(), inst, isTray);
@@ -294,7 +294,7 @@ MBFF::Mask MBFF::GetArrayMask(dbInst* inst, const bool isTray)
 MBFF::DataToOutputsMap MBFF::GetPinMapping(dbInst* tray)
 {
   const sta::Cell* cell = network_->dbToSta(tray->getMaster());
-  const sta::LibertyCell* lib_cell = network_->libertyCell(cell);
+  const sta::LibertyCell* lib_cell = network_->testCell(cell);
   sta::LibertyCellPortIterator port_itr(lib_cell);
 
   std::vector<const sta::LibertyPort*> d_pins;

--- a/src/gpl/test/mbff_test.cpp
+++ b/src/gpl/test/mbff_test.cpp
@@ -31,6 +31,7 @@ class MBFFTestPeer
   {
     return uut->network_->isValidTray(tray);
   }
+  static void ReadLibs(MBFF* uut) { uut->ReadLibs(); }
 };
 
 namespace {
@@ -144,6 +145,14 @@ TEST_F(MBFFTestFixture, FlopsCanBeIdentifiedAsATrayAndNot)
       mbff_.get(), CreateTmpCell("test_tray", "test0", "MBFF2CLPS")));
   EXPECT_TRUE(MBFFTestPeer::IsValidTray(
       mbff_.get(), CreateTmpCell("test_tray", "test0", "MBFF2SECLPS")));
+}
+
+TEST_F(MBFFTestFixture, ReadLibsSuccessfullyProcessesTestCells)
+{
+  // In test0.lib, cells like MBFF2SE have their sequential definition
+  // nested inside a test_cell block. Without consistent Liberty cell views,
+  // GetPinMapping returns empty vectors and triggers an out-of-bounds crash.
+  EXPECT_NO_FATAL_FAILURE(MBFFTestPeer::ReadLibs(mbff_.get()));
 }
 
 }  // namespace


### PR DESCRIPTION
dbNetwork::getLibertyCell (now testCell) returns the TestCell if available. After 89f47ff, certain parts of the MBFF code began to compare the TestCell against the base cell. This causes a crash in GetPinMapping() in certain PDKs.