### PR TITLE
rcx: remove dead extraction options and add v2 section comment

### DIFF
--- a/src/rcx/include/rcx/ext_options.h
+++ b/src/rcx/include/rcx/ext_options.h
@@ -49,19 +49,16 @@ struct ExtractOptions
   float coupling_threshold = 0.1;
   int context_depth = 5;
   int cc_model = 10;
-  int signal_table = 3;
-  bool over_cell = false;
-
-  bool skip_via_wires = false;
-
   bool lef_rc = false;
   bool lef_res = false;
-  bool rlog = false;
+  int _dbg = 0;
+
+  // v2-only variables:
   bool _v2 = false;
   float _version = 2.2;
   int _wire_extracted_progress_count = 50000;
-
-  int _dbg = 0;
+  bool over_cell = false;
+  bool skip_via_wires = false;
 };
 
 struct SpefOptions

--- a/src/rcx/src/ext.i
+++ b/src/rcx/src/ext.i
@@ -58,7 +58,6 @@ extract(const char* ext_model_file,
   opts.corner = corner;
   opts.max_res = max_res;
   opts.coupling_threshold = coupling_threshold;
-  opts.signal_table = 3;
   opts.cc_model = cc_model;
   opts.context_depth = context_depth;
   opts.lef_res = lef_res;

--- a/src/rcx/test/rcx_aux.py
+++ b/src/rcx/test/rcx_aux.py
@@ -35,7 +35,6 @@ def extract_parasitics(
     opts.corner = corner
     opts.max_res = max_res
     opts.coupling_threshold = coupling_threshold
-    opts.signal_table = 3
     opts.cc_model = cc_model
     opts.context_depth = context_depth
     opts.lef_res = lef_res


### PR DESCRIPTION
## Summary
Both `signal_table` and `rlog` were unused.
Also group v2-only variables.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**