### PR TITLE
Runtime reporting 5003

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -55,6 +55,7 @@
 #include "sta/Sdc.hh"
 #include "stt/SteinerTreeBuilder.h"
 #include "utl/Logger.h"
+#include "utl/timer.h"
 
 namespace cts {
 
@@ -85,6 +86,7 @@ TritonCTS::~TritonCTS()
 
 void TritonCTS::runTritonCts()
 {
+  utl::Timer timer;
   odb::dbChip* chip = db_->getChip();
   odb::dbBlock* block = chip->getBlock();
   options_->addOwner(block);
@@ -121,6 +123,7 @@ void TritonCTS::runTritonCts()
   regTreeRootBufIndex_ = 0;
   delayBufIndex_ = 0;
   options_->removeOwner();
+  logger_->info(CTS, 500, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 TreeBuilder* TritonCTS::addBuilder(CtsOptions* options,

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -238,8 +238,8 @@ void Opendp::detailedPlacement(const int max_displacement_x,
 
     findDisplacementStats();
     updateDbInstLocations();
-      logger_->info(DPL, 500, "Runtime: {:.2f}s", timer.elapsed());
   }
+  logger_->info(DPL, 500, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 void Opendp::updateDbInstLocations()

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -30,6 +30,7 @@
 #include "odb/util.h"
 #include "util/journal.h"
 #include "utl/Logger.h"
+#include "utl/timer.h"
 
 namespace dpl {
 
@@ -120,6 +121,7 @@ void Opendp::detailedPlacement(const int max_displacement_x,
                                const bool use_negotiation,
                                const bool run_abacus)
 {
+  utl::Timer timer;
   incremental_ = incremental;
   use_negotiation_ |= use_negotiation;
   importDb();

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -238,6 +238,7 @@ void Opendp::detailedPlacement(const int max_displacement_x,
 
     findDisplacementStats();
     updateDbInstLocations();
+      logger_->info(DPL, 500, "Runtime: {:.2f}s", timer.elapsed());
   }
 }
 

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1076,6 +1076,7 @@ int TritonRoute::main()
   if (!router_cfg_->SINGLE_STEP_DR) {
     endFR();
   }
+  logger_->info(DRT, 501, "Runtime: {:.2f}s", timer.elapsed());
   return 0;
 }
 

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -61,6 +61,7 @@
 #include "utl/Logger.h"
 #include "utl/ScopedTemporaryFile.h"
 #include "utl/ServiceRegistry.h"
+#include "utl/timer.h"
 
 using odb::dbTechLayerType;
 
@@ -981,6 +982,7 @@ void TritonRoute::sendDesignUpdates(const std::string& router_cfg_path,
 
 int TritonRoute::main()
 {
+  utl::Timer timer;
   // Just to verify that OMP support is compiled in correctly.
   omp_set_num_threads(2);
 #pragma omp parallel

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -28,6 +28,7 @@
 #include "sta/StaState.hh"
 #include "timingBase.h"
 #include "utl/Logger.h"
+#include "utl/timer.h"
 #include "utl/validation.h"
 
 namespace gpl {
@@ -203,8 +204,10 @@ void Replace::doIncrementalPlace(const int threads, const PlaceOptions& options)
 
 void Replace::doPlace(const int threads, const PlaceOptions& options)
 {
+  utl::Timer timer;
   doInitialPlace(threads, options);
   doNesterovPlace(threads, options);
+  log_->info(GPL, 500, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 void Replace::doInitialPlace(const int threads, const PlaceOptions& options)

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -62,6 +62,7 @@
 #include "utl/Logger.h"
 #include "utl/ServiceRegistry.h"
 #include "utl/algorithms.h"
+#include "utl/timer.h"
 
 namespace grt {
 
@@ -384,7 +385,7 @@ void GlobalRouter::endIncremental(bool save_guides)
 
 void GlobalRouter::globalRoute(bool save_guides)
 {
-  auto start = std::chrono::steady_clock::now();
+  utl::Timer timer;
   bool has_routable_nets = false;
 
   for (auto net : db_->getChip()->getBlock()->getNets()) {
@@ -435,13 +436,11 @@ void GlobalRouter::globalRoute(bool save_guides)
   }
 
   finishGlobalRouting(save_guides);
-  auto end = std::chrono::steady_clock::now();
   if (verbose_) {
-    auto runtime
-        = std::chrono::duration_cast<std::chrono::seconds>(end - start);
-    int hour = runtime.count() / 3600;
-    int min = (runtime.count() % 3600) / 60;
-    int sec = runtime.count() % 60;
+    const int elapsed = static_cast<int>(timer.elapsed());
+    const int hour = elapsed / 3600;
+    const int min = (elapsed % 3600) / 60;
+    const int sec = elapsed % 60;
     logger_->info(
         GRT, 303, "Global routing runtime = {:02}:{:02}:{:02}", hour, min, sec);
   }

--- a/src/ifp/src/InitFloorplan.cc
+++ b/src/ifp/src/InitFloorplan.cc
@@ -27,6 +27,7 @@
 #include "sta/StringUtil.hh"
 #include "upf/upf.h"
 #include "utl/Logger.h"
+#include "utl/timer.h"
 #include "utl/validation.h"
 
 namespace ifp {
@@ -137,10 +138,12 @@ void InitFloorplan::initFloorplan(
     const odb::PtrSet<odb::dbSite>& flipped_sites,
     const int gap)
 {
+  utl::Timer timer;
   checkGap(gap);
 
   makeDie(die);
   makeRows(core, base_site, additional_sites, row_parity, flipped_sites, gap);
+  logger_->info(IFP, 501, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 void InitFloorplan::makeDieUtilization(double utilization,

--- a/src/ifp/src/InitFloorplan.cc
+++ b/src/ifp/src/InitFloorplan.cc
@@ -126,6 +126,7 @@ void InitFloorplan::initFloorplan(
                       row_parity,
                       flipped_sites,
                       gap);
+  logger_->info(IFP, 500, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 // The base_site determines the single-height rows.  For hybrid rows it is

--- a/src/ifp/src/InitFloorplan.cc
+++ b/src/ifp/src/InitFloorplan.cc
@@ -108,6 +108,7 @@ void InitFloorplan::initFloorplan(
     const odb::PtrSet<odb::dbSite>& flipped_sites,
     const int gap)
 {
+  utl::Timer timer;
   checkGap(gap);
 
   makeDieUtilization(utilization,

--- a/src/ifp/test/init_floorplan1.py
+++ b/src/ifp/test/init_floorplan1.py
@@ -5,7 +5,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan2.py
+++ b/src/ifp/test/init_floorplan2.py
@@ -5,7 +5,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan3.py
+++ b/src/ifp/test/init_floorplan3.py
@@ -5,7 +5,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan4.py
+++ b/src/ifp/test/init_floorplan4.py
@@ -5,7 +5,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan5.py
+++ b/src/ifp/test/init_floorplan5.py
@@ -3,7 +3,7 @@ import helpers
 
 tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan6.py
+++ b/src/ifp/test/init_floorplan6.py
@@ -5,7 +5,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan7.py
+++ b/src/ifp/test/init_floorplan7.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan8.py
+++ b/src/ifp/test/init_floorplan8.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan9.py
+++ b/src/ifp/test/init_floorplan9.py
@@ -7,7 +7,7 @@ tech.readLef("sky130hd/sky130hd.tlef")
 tech.readLef("sky130hd/sky130_fd_sc_hd_merged.lef")
 tech.readLiberty("sky130hd/sky130_fd_sc_hd__tt_025C_1v80.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg2.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan_dbl_row.py
+++ b/src/ifp/test/init_floorplan_dbl_row.py
@@ -8,7 +8,7 @@ tech.readLef("Nangate45/Nangate45.lef")
 tech.readLef("init_floorplan_dbl_row.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan_flip_sites.py
+++ b/src/ifp/test/init_floorplan_flip_sites.py
@@ -6,7 +6,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/init_floorplan_gap.py
+++ b/src/ifp/test/init_floorplan_gap.py
@@ -13,7 +13,7 @@ tech.readLef("Nangate45/Nangate45.lef")
 tech.readLef("init_floorplan_gap.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/make_tracks1.py
+++ b/src/ifp/test/make_tracks1.py
@@ -5,7 +5,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/make_tracks2.py
+++ b/src/ifp/test/make_tracks2.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/make_tracks3.py
+++ b/src/ifp/test/make_tracks3.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/make_tracks4.py
+++ b/src/ifp/test/make_tracks4.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/make_tracks5.py
+++ b/src/ifp/test/make_tracks5.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/make_tracks6.py
+++ b/src/ifp/test/make_tracks6.py
@@ -6,7 +6,7 @@ import helpers
 tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/placement_blockage1.py
+++ b/src/ifp/test/placement_blockage1.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/placement_blockage2.py
+++ b/src/ifp/test/placement_blockage2.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("reg1.v")
 design.link("top")
 

--- a/src/ifp/test/tiecells.py
+++ b/src/ifp/test/tiecells.py
@@ -7,7 +7,7 @@ tech = Tech()
 tech.readLef("Nangate45/Nangate45.lef")
 tech.readLiberty("Nangate45/Nangate45_typ.lib")
 
-design = Design(tech)
+design = helpers.make_design(tech)
 design.readVerilog("tiecells.v")
 design.link("top")
 

--- a/src/mpl/src/rtl_mp.cpp
+++ b/src/mpl/src/rtl_mp.cpp
@@ -14,6 +14,7 @@
 #include "odb/geom.h"
 #include "snapper.h"
 #include "utl/Logger.h"
+#include "utl/timer.h"
 
 namespace mpl {
 using std::string;
@@ -56,6 +57,7 @@ bool MacroPlacer::place(const int num_threads,
                         const char* report_directory,
                         const bool keep_clustering_data)
 {
+  utl::Timer timer;
   hier_rtlmp_->init();
   hier_rtlmp_->setClusterSize(
       max_num_macro, min_num_macro, max_num_inst, min_num_inst);
@@ -80,6 +82,7 @@ bool MacroPlacer::place(const int num_threads,
   hier_rtlmp_->setGuidanceRegions(guidance_regions_);
 
   hier_rtlmp_->run();
+  logger_->info(MPL, 500, "Runtime: {:.2f}s", timer.elapsed());
 
   return true;
 }

--- a/src/pdn/src/PdnGen.i
+++ b/src/pdn/src/PdnGen.i
@@ -4,6 +4,7 @@
 %{
 #include "pdn/PdnGen.hh"
 #include "odb/db.h"
+#include "utl/timer.h"
 #include <array>
 #include <regex>
 #include <memory>
@@ -46,6 +47,17 @@ using utl::PDN;
 %inline %{
 
 namespace pdn {
+
+void run_pdngen(bool trim, bool add_pins, const char* report_file)
+{
+  utl::Timer timer;
+  PdnGen* pdngen = ord::getPdnGen();
+  pdngen->checkSetup();
+  pdngen->buildGrids(trim);
+  pdngen->writeToDb(add_pins, report_file);
+  pdngen->resetShapes();
+  ord::getLogger()->info(utl::PDN, 500, "Runtime: {:.2f}s", timer.elapsed());
+}
 
 void set_core_domain(odb::dbNet* power, odb::dbNet* switched_power, odb::dbNet* ground, const std::vector<odb::dbNet*>& secondary_nets)
 {

--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -61,10 +61,7 @@ proc pdngen { args } {
     set failed_via_report $keys(-failed_via_report)
   }
 
-  pdn::check_setup
-  pdn::build_grids $trim
-  pdn::write_to_db $add_pins $failed_via_report
-  pdn::reset_shapes
+  pdn::run_pdngen $trim $add_pins $failed_via_report
 }
 
 sta::define_cmd_args "set_voltage_domain" {-name domain_name \

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -5073,7 +5073,9 @@ bool Resizer::recoverPower(float recover_power_percent,
              == est::ParasiticsSrc::kDetailedRouting) {
     opendp_->initMacrosAndGrid();
   }
-  return recover_power_->recoverPower(recover_power_percent, verbose);
+  bool result = recover_power_->recoverPower(recover_power_percent, verbose);
+  logger_->info(RSZ, 503, "Runtime: {:.2f}s", timer.elapsed());
+  return result;
 }
 ////////////////////////////////////////////////////////////////
 void Resizer::swapArithModules(int path_count,

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -4745,7 +4745,7 @@ void Resizer::repairDesign(double max_wire_length,
   }
   repair_design_->repairDesign(
       max_wire_length, slew_margin, cap_margin, buffer_gain, verbose);
-  logger_->info(RSZ, 500, "Runtime: {:.2f}s", timer.elapsed());
+  logger_->info(RSZ, 504, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 int Resizer::repairDesignBufferCount() const
@@ -4943,7 +4943,7 @@ bool Resizer::repairSetup(double setup_margin,
   rsz::Optimizer optimizer(this);
   optimizer.configure(config);
   bool result = optimizer.run();
-  logger_->info(RSZ, 501, "Runtime: {:.2f}s", timer.elapsed());
+  logger_->info(RSZ, 505, "Runtime: {:.2f}s", timer.elapsed());
   return result;
 }
 
@@ -5029,7 +5029,7 @@ bool Resizer::repairHold(
                                          max_passes,
                                          max_iterations,
                                          verbose);
-  logger_->info(RSZ, 502, "Runtime: {:.2f}s", timer.elapsed());
+  logger_->info(RSZ, 506, "Runtime: {:.2f}s", timer.elapsed());
   return result;
 }
 
@@ -5074,7 +5074,7 @@ bool Resizer::recoverPower(float recover_power_percent,
     opendp_->initMacrosAndGrid();
   }
   bool result = recover_power_->recoverPower(recover_power_percent, verbose);
-  logger_->info(RSZ, 503, "Runtime: {:.2f}s", timer.elapsed());
+  logger_->info(RSZ, 507, "Runtime: {:.2f}s", timer.elapsed());
   return result;
 }
 ////////////////////////////////////////////////////////////////

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -89,6 +89,7 @@
 #include "utl/Logger.h"
 #include "utl/algorithms.h"
 #include "utl/scope.h"
+#include "utl/timer.h"
 
 // http://vlsicad.eecs.umich.edu/BK/Slots/cache/dropzone.tamu.edu/~zhuoli/GSRC/fast_buffer_insertion.html
 
@@ -4732,6 +4733,7 @@ void Resizer::repairDesign(double max_wire_length,
                            bool match_cell_footprint,
                            bool verbose)
 {
+  utl::Timer timer;
   utl::SetAndRestore set_match_footprint(match_cell_footprint_,
                                          match_cell_footprint);
   resizePreamble();
@@ -4743,6 +4745,7 @@ void Resizer::repairDesign(double max_wire_length,
   }
   repair_design_->repairDesign(
       max_wire_length, slew_margin, cap_margin, buffer_gain, verbose);
+  logger_->info(RSZ, 500, "Runtime: {:.2f}s", timer.elapsed());
 }
 
 int Resizer::repairDesignBufferCount() const
@@ -4916,6 +4919,7 @@ bool Resizer::repairSetup(double setup_margin,
                           bool skip_vt_swap,
                           bool skip_crit_vt_swap)
 {
+  utl::Timer timer;
   OptimizerRunConfig config;
   // Freeze Tcl-facing repair setup knobs before policy dispatch.
   config.setup_slack_margin = setup_margin;
@@ -4938,7 +4942,9 @@ bool Resizer::repairSetup(double setup_margin,
 
   rsz::Optimizer optimizer(this);
   optimizer.configure(config);
-  return optimizer.run();
+  bool result = optimizer.run();
+  logger_->info(RSZ, 501, "Runtime: {:.2f}s", timer.elapsed());
+  return result;
 }
 
 void Resizer::reportSwappablePins()
@@ -5015,13 +5021,15 @@ bool Resizer::repairHold(
              == est::ParasiticsSrc::kDetailedRouting) {
     opendp_->initMacrosAndGrid();
   }
-  return repair_hold_->repairHold(setup_margin,
-                                  hold_margin,
-                                  allow_setup_violations,
-                                  max_buffer_percent,
-                                  max_passes,
-                                  max_iterations,
-                                  verbose);
+  bool result = repair_hold_->repairHold(setup_margin,
+                                         hold_margin,
+                                         allow_setup_violations,
+                                         max_buffer_percent,
+                                         max_passes,
+                                         max_iterations,
+                                         verbose);
+  logger_->info(RSZ, 502, "Runtime: {:.2f}s", timer.elapsed());
+  return result;
 }
 
 void Resizer::repairHold(const sta::Pin* end_pin,

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -5003,6 +5003,7 @@ bool Resizer::repairHold(
     bool match_cell_footprint,
     bool verbose)
 {
+  utl::Timer timer;
   utl::SetAndRestore set_match_footprint(match_cell_footprint_,
                                          match_cell_footprint);
   // Some technologies such as nangate45 don't have delay cells. Hence,
@@ -5062,6 +5063,7 @@ bool Resizer::recoverPower(float recover_power_percent,
                            bool match_cell_footprint,
                            bool verbose)
 {
+  utl::Timer timer;
   utl::SetAndRestore set_match_footprint(match_cell_footprint_,
                                          match_cell_footprint);
   resizePreamble();

--- a/src/rsz/test/helpers.py
+++ b/src/rsz/test/helpers.py
@@ -111,4 +111,18 @@ def make_design(tech):
     logger.suppressMessage(utl.GRT, 303)
     logger.suppressMessage(utl.GRT, 704)
 
+    # suppress elapsed time messages (non-deterministic)
+    logger.suppressMessage(utl.CTS, 500)
+    logger.suppressMessage(utl.DPL, 500)
+    logger.suppressMessage(utl.DRT, 501)
+    logger.suppressMessage(utl.GPL, 500)
+    logger.suppressMessage(utl.IFP, 500)
+    logger.suppressMessage(utl.IFP, 501)
+    logger.suppressMessage(utl.MPL, 500)
+    logger.suppressMessage(utl.RSZ, 504)
+    logger.suppressMessage(utl.RSZ, 505)
+    logger.suppressMessage(utl.RSZ, 506)
+    logger.suppressMessage(utl.RSZ, 507)
+    logger.suppressMessage(utl.PDN, 500)
+
     return design

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -118,4 +118,18 @@ def make_design(tech):
     logger.suppressMessage(utl.GRT, 303)
     logger.suppressMessage(utl.GRT, 704)
 
+    # suppress elapsed time messages (non-deterministic)
+    logger.suppressMessage(utl.CTS, 500)
+    logger.suppressMessage(utl.DPL, 500)
+    logger.suppressMessage(utl.DRT, 501)
+    logger.suppressMessage(utl.GPL, 500)
+    logger.suppressMessage(utl.IFP, 500)
+    logger.suppressMessage(utl.IFP, 501)
+    logger.suppressMessage(utl.MPL, 500)
+    logger.suppressMessage(utl.RSZ, 500)
+    logger.suppressMessage(utl.RSZ, 501)
+    logger.suppressMessage(utl.RSZ, 502)
+    logger.suppressMessage(utl.RSZ, 503)
+    logger.suppressMessage(utl.PDN, 500)
+
     return design

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -126,10 +126,10 @@ def make_design(tech):
     logger.suppressMessage(utl.IFP, 500)
     logger.suppressMessage(utl.IFP, 501)
     logger.suppressMessage(utl.MPL, 500)
-    logger.suppressMessage(utl.RSZ, 500)
-    logger.suppressMessage(utl.RSZ, 501)
-    logger.suppressMessage(utl.RSZ, 502)
-    logger.suppressMessage(utl.RSZ, 503)
+    logger.suppressMessage(utl.RSZ, 504)
+    logger.suppressMessage(utl.RSZ, 505)
+    logger.suppressMessage(utl.RSZ, 506)
+    logger.suppressMessage(utl.RSZ, 507)
     logger.suppressMessage(utl.PDN, 500)
 
     return design

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -312,10 +312,10 @@ suppress_message GPL 500
 suppress_message IFP 500
 suppress_message IFP 501
 suppress_message MPL 500
-suppress_message RSZ 500
-suppress_message RSZ 501
-suppress_message RSZ 502
-suppress_message RSZ 503
+suppress_message RSZ 504
+suppress_message RSZ 505
+suppress_message RSZ 506
+suppress_message RSZ 507
 suppress_message PDN 500
 
 proc get_3dblox_marker_count { category_name } {

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -304,6 +304,20 @@ suppress_message ORD 30
 suppress_message GRT 303
 suppress_message GRT 704
 
+# suppress elapsed time messages (non-deterministic)
+suppress_message CTS 500
+suppress_message DPL 500
+suppress_message DRT 501
+suppress_message GPL 500
+suppress_message IFP 500
+suppress_message IFP 501
+suppress_message MPL 500
+suppress_message RSZ 500
+suppress_message RSZ 501
+suppress_message RSZ 502
+suppress_message RSZ 503
+suppress_message PDN 500
+
 proc get_3dblox_marker_count { category_name } {
   set top_chip [[ord::get_db] getChip]
   if { $top_chip == "NULL" } {


### PR DESCRIPTION
## Summary

This PR implements elapsed time reporting for major, long-running OpenROAD commands as requested in issue #5003. It provides a consistent measurement and logging approach across several modules, building upon and superseding the previous work in #9513.

**Key Changes:**

* **Consistent Measurement**: Integrated `utl::Timer` across multiple C++ entry points to report execution time in a uniform format: `Runtime: {:.2f}s`.
* **Modules Updated**:

  * **CTS**: Added timer to `run_triton_cts`.
  * **DPL**: Added timer to `detailed_placement`.
  * **DRT**: Added timer to the `main` execution of `detailed_route`.
  * **GPL**: Added timer to `global_placement`.
  * **GRT**: Migrated existing custom `chrono` logic to standard `utl::Timer` in `global_route`.
  * **IFP**: Added timers to both `initialize_floorplan` overloads.
  * **MPL**: Added timer to `rtl_macro_placer`.
  * **RSZ**: Added timers to `repair_design`, `repair_timing` (setup and hold phases), and `recover_power`.
  * **PDN**: Created a new C++ wrapper `run_pdngen` in `PdnGen.i` that encapsulates multiple internal steps, providing a single consolidated runtime report.
* **Message Management**:

  * Re-assigned new RSZ runtime messages to IDs `504-507` to avoid conflicts with existing IDs.
  * Updated `test/helpers.tcl` and `test/helpers.py` to suppress these new non-deterministic messages during regression tests.
* **Submodule Alignment**: Synchronized the `src/sta` submodule with the version used in the upstream master.

## Type of Change

* New feature
* Refactoring

## Impact

Users can now see the elapsed time for major flow steps directly in the log file, facilitating performance comparisons across different environments and versions.

## Verification

* [x] I have verified that the local build succeeds (`./etc/Build.sh`).
* [x] I have run the relevant tests and they pass.
* [x] My code follows the repository's formatting guidelines.
* [x] **I have signed my commits (DCO).**

## Related Issues

* Closes #5003
* Supersedes #9513
