### PR TITLE
web: scope netlistsvg skin styles to the schematic widget

### DIFF
--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -389,6 +389,7 @@ export class SchematicWidget {
             this._svgIdToInstName.clear();
             this.svgContainer.innerHTML = svgString;
             this._svgEl = this.svgContainer.querySelector('svg');
+            this._scopeSkinStyles();
 
             // Build SVG-id → ODB instance-name map.
             // netlistsvg renders each cell with id="cell_<instName>", so we
@@ -487,6 +488,47 @@ export class SchematicWidget {
         }
     }
 
+    // netlistsvg's skin embeds a <style> with unscoped element selectors
+    // (e.g. `svg { fill:none; stroke:#000 }`, `text { fill:#000 }`). A <style>
+    // inside an inline SVG is NOT scoped to that SVG -- once injected into the
+    // page its rules apply document-wide, clobbering the fill/stroke of every
+    // other inline-SVG icon in the app (the inspector/ruler buttons rendered as
+    // black, unfilled outlines). Prefix each rule with the widget's container
+    // class so the skin only styles this schematic.
+    _scopeSkinStyles() {
+        if (!this._svgEl) return;
+        const scope = '.schematic-widget';
+        for (const styleEl of this._svgEl.querySelectorAll('style')) {
+            const sheet = styleEl.sheet;
+            if (!sheet) continue;
+            let rules;
+            try {
+                rules = sheet.cssRules;
+            } catch (e) {
+                continue;  // Should not happen for same-origin inline styles.
+            }
+            for (const rule of rules) {
+                if (!rule.selectorText) continue;
+                rule.selectorText = scopeCssSelector(rule.selectorText, scope);
+            }
+        }
+    }
+}
+
+// Prefix every comma-separated selector in `selectorText` with `scope` so the
+// rule only matches descendants of the scope container. Idempotent: selectors
+// already carrying the scope are left untouched (a re-render must not nest the
+// prefix repeatedly).
+export function scopeCssSelector(selectorText, scope) {
+    return selectorText
+        .split(',')
+        .map((sel) => {
+            const trimmed = sel.trim();
+            return trimmed.startsWith(scope + ' ') || trimmed === scope
+                ? trimmed
+                : `${scope} ${trimmed}`;
+        })
+        .join(', ');
 }
 
 // ── Skin canonicalization ──────────────────────────────────────────────────

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -498,36 +498,48 @@ export class SchematicWidget {
     _scopeSkinStyles() {
         if (!this._svgEl) return;
         const scope = '.schematic-widget';
+        // Recurse so selectors nested inside @media/@supports blocks (which
+        // expose .cssRules but no .selectorText) are scoped too.
+        const scopeRules = (rules) => {
+            for (const rule of rules) {
+                if (rule.selectorText) {
+                    rule.selectorText = scopeCssSelector(rule.selectorText, scope);
+                } else if (rule.cssRules) {
+                    scopeRules(rule.cssRules);
+                }
+            }
+        };
         for (const styleEl of this._svgEl.querySelectorAll('style')) {
             const sheet = styleEl.sheet;
             if (!sheet) continue;
-            let rules;
             try {
-                rules = sheet.cssRules;
+                scopeRules(sheet.cssRules);
             } catch (e) {
                 continue;  // Should not happen for same-origin inline styles.
-            }
-            for (const rule of rules) {
-                if (!rule.selectorText) continue;
-                rule.selectorText = scopeCssSelector(rule.selectorText, scope);
             }
         }
     }
 }
 
 // Prefix every comma-separated selector in `selectorText` with `scope` so the
-// rule only matches descendants of the scope container. Idempotent: selectors
-// already carrying the scope are left untouched (a re-render must not nest the
-// prefix repeatedly).
+// rule only matches descendants of the scope container. Idempotent: a selector
+// already carrying the scope is left untouched, so a re-render never nests the
+// prefix. "Already scoped" means it begins with `scope` and the next character
+// is not part of an identifier -- so `.scope`, `.scope svg`, `.scope>svg` and
+// `.scope.active` are kept, while a different class like `.scope-foo` is still
+// scoped.
 export function scopeCssSelector(selectorText, scope) {
     return selectorText
         .split(',')
         .map((sel) => {
             const trimmed = sel.trim();
-            return trimmed.startsWith(scope + ' ') || trimmed === scope
-                ? trimmed
-                : `${scope} ${trimmed}`;
+            if (!trimmed) return '';
+            const after = trimmed.charAt(scope.length);
+            const alreadyScoped = trimmed.startsWith(scope)
+                && (after === '' || !/[\w-]/.test(after));
+            return alreadyScoped ? trimmed : `${scope} ${trimmed}`;
         })
+        .filter(Boolean)
         .join(', ');
 }
 

--- a/src/web/test/js/test-schematic-widget.js
+++ b/src/web/test/js/test-schematic-widget.js
@@ -4,7 +4,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-    canonicalizeCell, canonicalizeForSkin,
+    canonicalizeCell, canonicalizeForSkin, scopeCssSelector,
 } from '../../src/schematic-widget.js';
 
 // Helper: a server-style cell object.
@@ -198,4 +198,49 @@ describe('canonicalizeForSkin', () => {
         const json = { foo: 1 };
         assert.strictEqual(canonicalizeForSkin(json), json);
     });
+});
+
+// netlistsvg's skin injects a <style> with unscoped element selectors that
+// would otherwise leak document-wide (e.g. `svg { fill:none }` clobbering every
+// inline-SVG icon in the app). scopeCssSelector() prefixes each selector with
+// the widget container so the skin only styles the schematic.
+describe('scopeCssSelector', () => {
+    const SCOPE = '.schematic-widget';
+
+    it('prefixes a bare element selector', () => {
+        assert.equal(scopeCssSelector('svg', SCOPE), '.schematic-widget svg');
+    });
+
+    it('prefixes each selector in a comma list independently', () => {
+        assert.equal(
+            scopeCssSelector('svg, text, .splitjoinBody', SCOPE),
+            '.schematic-widget svg, .schematic-widget text, '
+                + '.schematic-widget .splitjoinBody');
+    });
+
+    it('trims whitespace around list members', () => {
+        assert.equal(
+            scopeCssSelector('  svg ,  text  ', SCOPE),
+            '.schematic-widget svg, .schematic-widget text');
+    });
+
+    it('is idempotent: already-scoped selectors are left untouched', () => {
+        const once = scopeCssSelector('svg, text', SCOPE);
+        assert.equal(scopeCssSelector(once, SCOPE), once);
+    });
+
+    it('does not re-prefix a selector that already starts with the scope', () => {
+        assert.equal(
+            scopeCssSelector('.schematic-widget svg', SCOPE),
+            '.schematic-widget svg');
+    });
+
+    it('still scopes a selector that merely contains the scope word elsewhere',
+       () => {
+           // The scope only counts as "already applied" at the start, so a
+           // descendant reference to it elsewhere must still be prefixed.
+           assert.equal(
+               scopeCssSelector('div .schematic-widget', SCOPE),
+               '.schematic-widget div .schematic-widget');
+       });
 });

--- a/src/web/test/js/test-schematic-widget.js
+++ b/src/web/test/js/test-schematic-widget.js
@@ -233,6 +233,23 @@ describe('scopeCssSelector', () => {
         assert.equal(
             scopeCssSelector('.schematic-widget svg', SCOPE),
             '.schematic-widget svg');
+        // The scope followed by a combinator or class/pseudo is still scoped.
+        assert.equal(
+            scopeCssSelector('.schematic-widget>svg', SCOPE),
+            '.schematic-widget>svg');
+        assert.equal(
+            scopeCssSelector('.schematic-widget.active', SCOPE),
+            '.schematic-widget.active');
+        assert.equal(
+            scopeCssSelector('.schematic-widget:hover', SCOPE),
+            '.schematic-widget:hover');
+    });
+
+    it('still scopes a different class that shares the scope as a prefix', () => {
+        // `.schematic-widget-foo` is a distinct class, not the scope itself.
+        assert.equal(
+            scopeCssSelector('.schematic-widget-foo', SCOPE),
+            '.schematic-widget .schematic-widget-foo');
     });
 
     it('still scopes a selector that merely contains the scope word elsewhere',


### PR DESCRIPTION
## Problem

Inspector and ruler toolbar icons render as black, unfilled outlines on the dark panel once the **Schematic** panel has been opened in the web GUI — i.e. "black on dark gray," not visible in dark mode.

## Root cause

netlistsvg's skin (`default.svg`) embeds a `<style>` with **unscoped element selectors**:

```css
svg  { stroke:#000; fill:none; }
text { fill:#000; stroke:none; ... }
```

A `<style>` inside an inline SVG is **not** scoped to that SVG. netlistsvg copies the skin's `<style>` verbatim into its output and assumes that output is a standalone file. We inject the rendered schematic into the page via `innerHTML`, so those bare selectors apply **document-wide** and clobber the `fill`/`stroke` of every other inline-SVG icon in the app (inspector zoom/back/focus, ruler delete).

## Fix

After injecting the schematic SVG, `_scopeSkinStyles()` rewrites each skin rule's selector to be prefixed with the `.schematic-widget` container, so the skin only styles its own schematic. The schematic itself renders unchanged (its paths stay `fill:none`).

The selector rewriting is extracted into a pure, exported `scopeCssSelector()` helper with unit tests (`schematic_widget_test`, registered in Bazel BUILD).