### PR TITLE
IWYU: Fix some missing includes

### DIFF
--- a/src/est/test/cpp/TestEstimateParasitics.cc
+++ b/src/est/test/cpp/TestEstimateParasitics.cc
@@ -10,6 +10,7 @@
 #include "sta/Mode.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
+#include "sta/SdcClass.hh"
 #include "sta/Search.hh"
 #include "sta/Units.hh"
 #include "tst/IntegratedFixture.h"

--- a/src/odb/include/odb/lefin.h
+++ b/src/odb/include/odb/lefin.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <list>
 #include <string>
 #include <utility>

--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <tuple>

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -3,8 +3,10 @@
 
 #include <algorithm>
 #include <any>
+#include <cstdint>
 #include <exception>
 #include <functional>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <set>


### PR DESCRIPTION
Breakdown:

```
src/est/test/cpp/TestEstimateParasitics.cc: #include "sta/SdcClass.hh" for sta::FloatSeq
src/odb/include/odb/lefin.h:             #include <cstdint> for (std::)?u?int.*_t
src/odb/src/lefin/lefLayerPropParser.h:  #include <cstdint> for (std::)?u?int.*_t
src/web/test/cpp/TestRequestHandler.cpp: #include <cstdint> for (std::)?u?int.*_t
src/web/test/cpp/TestRequestHandler.cpp: #include <iterator> for std::advance
```
