### PR TITLE
mbff: Move IsValidTray back to mbff.cpp.

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -440,7 +440,6 @@ class dbNetwork : public ConcreteNetwork
   // supply pin functions
   bool isSupplyPin(odb::dbITerm* iterm) const;
   bool isValidFlop(odb::dbInst* FF) const;
-  bool isValidTray(odb::dbInst* tray) const;
 
   ////////////////////////////////////////////////////////////////
 

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -5636,47 +5636,6 @@ bool dbNetwork::isValidFlop(odb::dbInst* FF) const
                 == FF->getITerms().size();
 }
 
-bool dbNetwork::isValidTray(odb::dbInst* tray) const
-{
-  const Cell* cell = dbToSta(tray->getMaster());
-  if (cell == nullptr) {
-    return false;
-  }
-  const LibertyCell* lib_cell = testCell(cell);
-  if (lib_cell == nullptr || !lib_cell->hasSequentials()) {
-    return false;
-  }
-
-  // We don't want the test_cell which lacks global properties
-  const LibertyCell* base_cell = libertyCell(cell);
-  if (base_cell->isClockGate() || base_cell->dontUse()) {
-    return false;
-  }
-
-  int q = 0;
-  int qn = 0;
-  int scan = 0;
-  int supply = 0;
-  int preset = 0;
-  int clear = 0;
-  int clock = 0;
-
-  for (odb::dbITerm* iterm : tray->getITerms()) {
-    q += (isQPin(iterm) && !isInvertingQPin(iterm));
-    qn += (isQPin(iterm) && isInvertingQPin(iterm));
-    scan += (isScanIn(iterm) || isScanEnable(iterm));
-    supply += (isSupplyPin(iterm));
-    preset += (isPresetPin(iterm));
-    clear += (isClearPin(iterm));
-    clock += (isClockPin(iterm));
-  }
-
-  // #D = max(q, qn)
-  return std::max(q, qn) >= 2 && getNumD(tray) == std::max(q, qn)
-         && clock + q + qn + scan + supply + preset + clear + std::max(q, qn)
-                == tray->getITerms().size();
-}
-
 sta::LibertyPort* dbNetwork::getLibertyScanEnable(
     const LibertyCell* lib_cell) const
 {

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -2176,6 +2176,47 @@ Point MBFF::GetTrayCenter(const Mask& array_mask, const int idx)
   return Point{tray_center_x, tray_center_y};
 }
 
+bool MBFF::IsValidTray(dbInst* tray)
+{
+  const sta::Cell* cell = network_->dbToSta(tray->getMaster());
+  if (cell == nullptr) {
+    return false;
+  }
+  const sta::LibertyCell* lib_cell = network_->getLibertyCell(cell);
+  if (lib_cell == nullptr || !lib_cell->hasSequentials()) {
+    return false;
+  }
+
+  // We don't want the test_cell which lacks global properties
+  const sta::LibertyCell* base_cell = network_->libertyCell(cell);
+  if (base_cell->isClockGate() || resizer_->dontUse(base_cell)) {
+    return false;
+  }
+
+  int q = 0;
+  int qn = 0;
+  int scan = 0;
+  int supply = 0;
+  int preset = 0;
+  int clear = 0;
+  int clock = 0;
+
+  for (dbITerm* iterm : tray->getITerms()) {
+    q += (network_->isQPin(iterm) && !network_->isInvertingQPin(iterm));
+    qn += (network_->isQPin(iterm) && network_->isInvertingQPin(iterm));
+    scan += (network_->isScanIn(iterm) || network_->isScanEnable(iterm));
+    supply += (network_->isSupplyPin(iterm));
+    preset += (network_->isPresetPin(iterm));
+    clear += (network_->isClearPin(iterm));
+    clock += (network_->isClockPin(iterm));
+  }
+
+  // #D = max(q, qn)
+  return std::max(q, qn) >= 2 && network_->getNumD(tray) == std::max(q, qn)
+         && clock + q + qn + scan + supply + preset + clear + std::max(q, qn)
+                == tray->getITerms().size();
+}
+
 void MBFF::ReadLibs()
 {
   test_idx_ = 0;
@@ -2184,7 +2225,7 @@ void MBFF::ReadLibs()
       const std::string tray_name = "test_tray_" + std::to_string(test_idx_++);
       dbInst* tmp_tray = dbInst::create(block_, master, tray_name.c_str());
 
-      if (!network_->isValidTray(tmp_tray)) {
+      if (!IsValidTray(tmp_tray)) {
         dbInst::destroy(tmp_tray);
         --test_idx_;
         continue;

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -2182,7 +2182,7 @@ bool MBFF::IsValidTray(dbInst* tray)
   if (cell == nullptr) {
     return false;
   }
-  const sta::LibertyCell* lib_cell = network_->getLibertyCell(cell);
+  const sta::LibertyCell* lib_cell = network_->testCell(cell);
   if (lib_cell == nullptr || !lib_cell->hasSequentials()) {
     return false;
   }

--- a/src/gpl/src/mbff.h
+++ b/src/gpl/src/mbff.h
@@ -56,6 +56,7 @@ class MBFF
 
   ~MBFF();
   void Run(int mx_sz, float alpha, float beta);
+  bool IsValidTray(odb::dbInst* tray);
 
  private:
   enum PortName

--- a/src/gpl/test/mbff_test.cpp
+++ b/src/gpl/test/mbff_test.cpp
@@ -29,7 +29,7 @@ class MBFFTestPeer
  public:
   static bool IsValidTray(MBFF* uut, odb::dbInst* tray)
   {
-    return uut->network_->isValidTray(tray);
+    return uut->IsValidTray(tray);
   }
   static void ReadLibs(MBFF* uut) { uut->ReadLibs(); }
 };


### PR DESCRIPTION
It was not respecting the resizer's dont_use, instead deferring to the LibertyCell's dont_use.

This issue was introduced in 89f47ff, and this PR reverts only the relevant portion of that commit.
This PR will only build once #10665 is submitted -- it depends on testCell being public.