### PR TITLE
ord: implement whitelist-based Tcl command logging

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -112,7 +112,7 @@ int logCommandCallback(ClientData clientData,
                        int level,
                        const char* command,
                        Tcl_Command commandInfo,
-                       Tcl_Size objc,
+                       int objc,
                        Tcl_Obj* const objv[])
 {
   (void) interp;
@@ -135,7 +135,7 @@ int logCommandCallback(ClientData clientData,
   }
   Tcl_DString ds;
   Tcl_DStringInit(&ds);
-  for (Tcl_Size i = 0; i < objc; ++i) {
+  for (int i = 0; i < objc; ++i) {
     Tcl_DStringAppendElement(&ds, Tcl_GetString(objv[i]));
   }
   data->logger->report("cmd: {}", Tcl_DStringValue(&ds));

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -97,6 +97,12 @@ FOREACH_TOOL(X)
 
 namespace {
 
+#if TCL_MAJOR_VERSION < 9 && !defined(Tcl_Size)
+typedef int Tcl_Size;
+#endif
+
+
+
 struct CommandTraceData
 {
   utl::Logger* logger;
@@ -108,7 +114,7 @@ int logCommandCallback(ClientData clientData,
                        int level,
                        const char* command,
                        Tcl_Command commandInfo,
-                       int objc,
+                       Tcl_Size objc,
                        Tcl_Obj* const objv[])
 {
   (void) interp;
@@ -125,7 +131,7 @@ int logCommandCallback(ClientData clientData,
   }
   Tcl_DString ds;
   Tcl_DStringInit(&ds);
-  for (int i = 0; i < objc; ++i) {
+  for (Tcl_Size i = 0; i < objc; ++i) {
     Tcl_DStringAppendElement(&ds, Tcl_GetString(objv[i]));
   }
   data->logger->report("cmd: {}", Tcl_DStringValue(&ds));
@@ -143,10 +149,10 @@ std::unordered_set<std::string> getTclCommands(Tcl_Interp* interp)
   std::unordered_set<std::string> cmds;
   if (Tcl_Eval(interp, "info commands") == TCL_OK) {
     Tcl_Obj* cmd_list = Tcl_GetObjResult(interp);
-    int objc = 0;
+    Tcl_Size objc = 0;
     Tcl_Obj** objv = nullptr;
     if (Tcl_ListObjGetElements(interp, cmd_list, &objc, &objv) == TCL_OK) {
-      for (int i = 0; i < objc; ++i) {
+      for (Tcl_Size i = 0; i < objc; ++i) {
         cmds.insert(Tcl_GetString(objv[i]));
       }
     }

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <system_error>
+#include <unordered_set>
 
 #include "absl/base/no_destructor.h"
 #include "boost/stacktrace/stacktrace.hpp"
@@ -93,6 +94,87 @@ FOREACH_TOOL(X)
 #undef X
 }
 #endif
+
+namespace {
+
+struct CommandTraceData
+{
+  utl::Logger* logger;
+  std::unordered_set<std::string> whitelist;
+};
+
+int logCommandCallback(ClientData clientData,
+                       Tcl_Interp* interp,
+                       int level,
+                       const char* command,
+                       Tcl_Command commandInfo,
+                       int objc,
+                       Tcl_Obj* const objv[])
+{
+  (void) interp;
+  (void) level;
+  (void) command;
+  (void) commandInfo;
+  auto* data = static_cast<CommandTraceData*>(clientData);
+  if (objc <= 0 || data == nullptr || data->logger == nullptr) {
+    return TCL_OK;
+  }
+  const char* cmd_name = Tcl_GetString(objv[0]);
+  if (cmd_name == nullptr || data->whitelist.count(cmd_name) == 0) {
+    return TCL_OK;
+  }
+  Tcl_DString ds;
+  Tcl_DStringInit(&ds);
+  for (int i = 0; i < objc; ++i) {
+    Tcl_DStringAppendElement(&ds, Tcl_GetString(objv[i]));
+  }
+  data->logger->report("cmd: {}", Tcl_DStringValue(&ds));
+  Tcl_DStringFree(&ds);
+  return TCL_OK;
+}
+
+void deleteCommandTrace(ClientData clientData)
+{
+  delete static_cast<CommandTraceData*>(clientData);
+}
+
+std::unordered_set<std::string> getTclCommands(Tcl_Interp* interp)
+{
+  std::unordered_set<std::string> cmds;
+  if (Tcl_Eval(interp, "info commands") == TCL_OK) {
+    Tcl_Obj* cmd_list = Tcl_GetObjResult(interp);
+    int objc = 0;
+    Tcl_Obj** objv = nullptr;
+    if (Tcl_ListObjGetElements(interp, cmd_list, &objc, &objv) == TCL_OK) {
+      for (int i = 0; i < objc; ++i) {
+        cmds.insert(Tcl_GetString(objv[i]));
+      }
+    }
+  }
+  Tcl_ResetResult(interp);
+  return cmds;
+}
+
+void setupCommandTrace(Tcl_Interp* interp,
+                       const std::unordered_set<std::string>& initial_cmds,
+                       const char* log_filename)
+{
+  if (log_filename == nullptr) {
+    return;
+  }
+  const auto all_cmds = getTclCommands(interp);
+  auto* trace_data = new CommandTraceData;
+  trace_data->logger = ord::OpenRoad::openRoad()->getLogger();
+  for (const auto& cmd : all_cmds) {
+    if (initial_cmds.find(cmd) == initial_cmds.end()) {
+      trace_data->whitelist.insert(cmd);
+    }
+  }
+  Tcl_CreateObjTrace(
+      interp, 0, 0, logCommandCallback, trace_data, deleteCommandTrace);
+}
+
+}  // namespace
 
 int cmd_argc;
 char** cmd_argv;
@@ -306,7 +388,9 @@ int main(int argc, char* argv[])
         = std::make_unique<ord::Design>(the_tech_and_design->tech.get());
     ord::OpenRoad::setOpenRoad(the_tech_and_design->design->getOpenRoad());
     const bool exit = findCmdLineFlag(cmd_argc, cmd_argv, "-exit");
+    auto initial_cmds = getTclCommands(interp);
     ord::initOpenRoad(interp, log_filename, metrics_filename, exit);
+    setupCommandTrace(interp, initial_cmds, log_filename);
     if (!findCmdLineFlag(cmd_argc, cmd_argv, "-no_splash")) {
       showSplash();
     }
@@ -408,8 +492,10 @@ static int tclAppInit(int& argc,
       printf("Failed to set up tclreadline shim\n");
     }
 
+    auto initial_cmds = getTclCommands(interp);
     ord::initOpenRoad(
         interp, log_filename, metrics_filename, exit_after_cmd_file);
+    setupCommandTrace(interp, initial_cmds, log_filename);
 
     // Register the web server's log sink early (before splash/thread output
     // and read_db) so the WebLogSink captures all startup messages for the

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -126,7 +126,13 @@ int logCommandCallback(ClientData clientData,
     return TCL_OK;
   }
   const char* cmd_name = Tcl_GetString(objv[0]);
-  if (cmd_name == nullptr || data->whitelist.count(cmd_name) == 0) {
+  if (cmd_name == nullptr) {
+    return TCL_OK;
+  }
+  if (std::strncmp(cmd_name, "::", 2) == 0) {
+    cmd_name += 2;
+  }
+  if (data->whitelist.count(cmd_name) == 0) {
     return TCL_OK;
   }
   Tcl_DString ds;
@@ -176,8 +182,12 @@ void setupCommandTrace(Tcl_Interp* interp,
       trace_data->whitelist.insert(cmd);
     }
   }
-  Tcl_CreateObjTrace(
-      interp, 0, 0, logCommandCallback, trace_data, deleteCommandTrace);
+  Tcl_CreateObjTrace(interp,
+                     0,
+                     TCL_ALLOW_INLINE_COMPILATION,
+                     logCommandCallback,
+                     trace_data,
+                     deleteCommandTrace);
 }
 
 }  // namespace

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -101,8 +101,6 @@ namespace {
 typedef int Tcl_Size;
 #endif
 
-
-
 struct CommandTraceData
 {
   utl::Logger* logger;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 or_integration_tests(
   "openroad"
   TESTS
+    cmd_log_trace
     error1
     get_core_die_areas
     ord_tclsh_completion

--- a/test/cmd_log_trace.ok
+++ b/test/cmd_log_trace.ok
@@ -1,0 +1,5 @@
+TEST: Verifying command tracing in log
+PASS: Found logged commands
+PASS: Found nested sourced command
+PASS: internal commands not logged
+pass

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -23,12 +23,12 @@ close $f
 set ord_exe [info nameofexecutable]
 
 # After the exec/run step
-catch {exec $ord_exe -log $log_file -no_splash -no_init -exit $test_script}
+catch { exec $ord_exe -log $log_file -no_splash -no_init -exit $test_script }
 
 # 4. explicitly check file exists before opening it
 if { ![file exists $log_file] } {
-    puts "FAIL: Log file does not exist: $log_file"
-    exit 1
+  puts "FAIL: Log file does not exist: $log_file"
+  exit 1
 }
 
 set f [open $log_file r]
@@ -36,28 +36,32 @@ set content [read $f]
 close $f
 
 # 1. A real OR command appears as "cmd: <command>"
-if { [regexp "cmd: suppress_message ODB 127" $content] && \
-     [regexp "cmd: help help" $content] } {
-    puts "PASS: Found logged commands"
+if {
+  [regexp "cmd: suppress_message ODB 127" $content] &&
+  [regexp "cmd: help help" $content]
+} {
+  puts "PASS: Found logged commands"
 } else {
-    puts "FAIL: Logged commands not found"
-    exit 1
+  puts "FAIL: Logged commands not found"
+  exit 1
 }
 
 if { [regexp "cmd: suppress_message ORD 30" $content] } {
-    puts "PASS: Found nested sourced command"
+  puts "PASS: Found nested sourced command"
 } else {
-    puts "FAIL: Nested sourced command not found"
-    exit 1
+  puts "FAIL: Nested sourced command not found"
+  exit 1
 }
 
 # 2. Tcl builtins do NOT appear: assert "cmd: set", "cmd: if", "cmd: puts", "cmd: while" are all absent
-if { [regexp "cmd: set" $content] || [regexp "cmd: if" $content] || \
-     [regexp "cmd: puts" $content] || [regexp "cmd: while" $content] } {
-    puts "FAIL: internal commands logged"
-    exit 1
+if {
+  [regexp "cmd: set" $content] || [regexp "cmd: if" $content] ||
+  [regexp "cmd: puts" $content] || [regexp "cmd: while" $content]
+} {
+  puts "FAIL: internal commands logged"
+  exit 1
 } else {
-    puts "PASS: internal commands not logged"
+  puts "PASS: internal commands not logged"
 }
 
 puts "pass"

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -14,6 +14,7 @@ close $f
 set f [open $test_script w]
 puts $f "suppress_message ODB 127"
 puts $f "help help"
+puts $f "::help help"
 puts $f "set x 1"
 puts $f "if { \$x == 1 } { puts \"internal_skip_if\" }"
 puts $f "while { \$x < 1 } { puts \"internal_skip_while\" }"
@@ -38,7 +39,8 @@ close $f
 # 1. A real OR command appears as "cmd: <command>"
 if {
   [regexp "cmd: suppress_message ODB 127" $content] &&
-  [regexp "cmd: help help" $content]
+  [regexp "cmd: help help" $content] &&
+  [regexp "cmd: ::help help" $content]
 } {
   puts "PASS: Found logged commands"
 } else {

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -1,0 +1,63 @@
+source "helpers.tcl"
+puts "TEST: Verifying command tracing in log"
+
+set result_dir [make_result_dir]
+set log_file [file join $result_dir "cmd_log_trace_output.log"]
+set test_script [file join $result_dir "test_inner.tcl"]
+set nested_file [file join $result_dir "nested.tcl"]
+
+# 3. NESTED SOURCE CASE
+set f [open $nested_file w]
+puts $f "suppress_message ORD 30"
+close $f
+
+set f [open $test_script w]
+puts $f "suppress_message ODB 127"
+puts $f "help help"
+puts $f "set x 1"
+puts $f "if { \$x == 1 } { puts \"internal_skip_if\" }"
+puts $f "while { \$x < 1 } { puts \"internal_skip_while\" }"
+puts $f "source \"$nested_file\""
+close $f
+
+set ord_exe [info nameofexecutable]
+
+# After the exec/run step
+catch {exec $ord_exe -log $log_file -no_splash -no_init -exit $test_script}
+
+# 4. explicitly check file exists before opening it
+if { ![file exists $log_file] } {
+    puts "FAIL: Log file does not exist: $log_file"
+    exit 1
+}
+
+set f [open $log_file r]
+set content [read $f]
+close $f
+
+# 1. A real OR command appears as "cmd: <command>"
+if { [regexp "cmd: suppress_message ODB 127" $content] && \
+     [regexp "cmd: help help" $content] } {
+    puts "PASS: Found logged commands"
+} else {
+    puts "FAIL: Logged commands not found"
+    exit 1
+}
+
+if { [regexp "cmd: suppress_message ORD 30" $content] } {
+    puts "PASS: Found nested sourced command"
+} else {
+    puts "FAIL: Nested sourced command not found"
+    exit 1
+}
+
+# 2. Tcl builtins do NOT appear: assert "cmd: set", "cmd: if", "cmd: puts", "cmd: while" are all absent
+if { [regexp "cmd: set" $content] || [regexp "cmd: if" $content] || \
+     [regexp "cmd: puts" $content] || [regexp "cmd: while" $content] } {
+    puts "FAIL: internal commands logged"
+    exit 1
+} else {
+    puts "PASS: internal commands not logged"
+}
+
+puts "pass"

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -55,7 +55,8 @@ if { [regexp "cmd: suppress_message ORD 30" $content] } {
   exit 1
 }
 
-# 2. Tcl builtins do NOT appear: assert "cmd: set", "cmd: if", "cmd: puts", "cmd: while" are all absent
+# 2. Tcl builtins do NOT appear:
+# assert "cmd: set", "cmd: if", "cmd: puts", "cmd: while" are all absent
 if {
   [regexp "cmd: set" $content] || [regexp "cmd: if" $content] ||
   [regexp "cmd: puts" $content] || [regexp "cmd: while" $content]

--- a/test/regression_tests.tcl
+++ b/test/regression_tests.tcl
@@ -21,6 +21,7 @@ record_flow_tests {
 }
 
 # Database loading tests for -db flag functionality
+record_test cmd_log_trace $test_dir "compare_logfile"
 record_test open_db $test_dir "compare_logfile" "-db gcd_sky130hd.odb"
 # For invalid DB, allow non-zero exit but require log to match ok
 record_test open_db_invalid $test_dir "compare_logfile_allow_error" "-db nonexistent_file.odb"


### PR DESCRIPTION
# Description

This PR implements Tcl command logging (Issue #3539) by logging every registered OpenROAD command executed by the user to the file specified by the `-log` flag, as `cmd: <command>` with its variables expanded. 

To avoid the noise of internal implementation details (such as `set`, `if`, and internal proc bodies) flooding the log, this implementation utilizes a whitelist approach. 

### Key Changes
- **Command Whitelist:** Captured the output of `info commands` before and after `ord::initOpenRoad` is called. The difference forms a robust whitelist of OpenROAD-registered commands, explicitly excluding Tcl builtins.
- **Tcl Object Trace:** Used `Tcl_CreateObjTrace` to intercept commands before they are executed. If the command name is present in the whitelist, the full command string is reconstructed using `Tcl_GetString` on the already-expanded `objv` arguments and logged via `logger->report()`.
- **Conditional Logging to Protect Tests:** The command logging trace is strictly registered only when the `-log` parameter is provided (`log_filename != nullptr`). This ensures that standard CTest regression runs (which capture stdout via redirection rather than the `-log` flag) do not fail their `compare_logfile` checks due to unexpected `cmd:` lines.
- **Regression Testing:** Added a dedicated regression test (`cmd_log_trace`) that spawns an OpenROAD subprocess with `-log`, executes a mix of whitelisted commands and internal Tcl builtins, and automatically reads back its own log to verify that only the correct commands are traced.

### Prerequisites
- [x] Clang-format has been run.
- [x] Commits follow DCO compliance (`git commit -s`).
- [x] Build locally using ./etc/Build.sh
- [x] Ran related regression tests 

### Related Issues
- Closes #3539 
- Supersedes #9704 