### PR TITLE
Mark non-hermetic targets 'manual'.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -555,7 +555,10 @@ sh_test(
         "tclint.toml",
         "//bazel:tclint",
     ],
-    tags = ["local"],
+    tags = [
+        "local",
+        "manual",
+    ],
 )
 
 # --- TCL formatting check (tclfmt --check) --------------------------------
@@ -569,7 +572,10 @@ sh_test(
         "tclint.toml",
         "//bazel:tclfmt",
     ],
-    tags = ["local"],
+    tags = [
+        "local",
+        "manual",
+    ],
 )
 
 # --- TCL auto-format only (tclfmt --in-place) -----------------------------
@@ -596,7 +602,10 @@ sh_test(
         "MODULE.bazel",
         "@buildifier_prebuilt//:buildifier",
     ],
-    tags = ["local"],
+    tags = [
+        "local",
+        "manual",
+    ],
 )
 
 # --- Bazel formatting check (buildifier -mode=check -lint=off) ------------
@@ -610,7 +619,10 @@ sh_test(
         "MODULE.bazel",
         "@buildifier_prebuilt//:buildifier",
     ],
-    tags = ["local"],
+    tags = [
+        "local",
+        "manual",
+    ],
 )
 
 # --- Bazel auto-format only (buildifier -mode=fix) ------------------------
@@ -629,6 +641,7 @@ sh_binary(
 
 test_suite(
     name = "lint_test",
+    tags = ["manual"],
     tests = [
         ":fmt_bzl_test",
         ":fmt_tcl_test",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -67,5 +67,6 @@ man_pages(
         "//docs/src/scripts:manpage.py",
         "//docs/src/scripts:extract_utils.py",
     ],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
They can only run on special machines that have the binaries `git` (for the format tests) or `make` installed AND with their bazel configured to actually look in the path.

These targets currently will fail on strict systems (such as NixOS), so make the whole process painful. To fix, the binaries either should be replaced with simpler processes (e.g. why use `make` if we have bazel), or commpiled as part of a bazel dependency.

Makes #10311 slightly less painful by not failing in globbing mode (`bazel build ...`).
