### PR TITLE
bazel: avoid duplicate cts Clock header

### DIFF
--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -39,7 +39,6 @@ cc_library(
     name = "cts",
     srcs = [
         "src/Clock.cpp",
-        "src/Clock.h",
         "src/Clustering.cpp",
         "src/CtsOptions.cpp",
         "src/HTreeBuilder.cpp",


### PR DESCRIPTION
Addresses one entry from #10409.

`src/cts/src/Clock.h` was listed in both `//src/cts` and `//src/cts:private_hdrs`. The header is already provided by `private_hdrs`, which `//src/cts` depends on, so remove the duplicate from the `//src/cts` `srcs` list.

Test plan:
- `git diff --check`
- `bazelisk query //src/cts --noshow_progress`