### PR TITLE
bazel: avoid duplicate dbSta IpChecker header

### DIFF
--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -134,7 +134,6 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "include/db_sta/IpChecker.hh",
         "src/MakeDbSta.cc",
         ":swig",
         ":tcl",


### PR DESCRIPTION
Addresses one entry from #10409.

`include/db_sta/IpChecker.hh` was listed in both `//src/dbSta:IpChecker` and `//src/dbSta:ui`. The UI target already depends on `:IpChecker`, so remove the duplicate header from `ui`'s `srcs`.

Test plan:
- `git diff --check`
- `bazelisk query //src/dbSta:ui --noshow_progress`