### PR TITLE
bazel: avoid duplicate dft header

### DIFF
--- a/src/dft/BUILD
+++ b/src/dft/BUILD
@@ -40,7 +40,6 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "include/dft/Dft.hh",
         "src/MakeDft.cpp",
         ":swig",
         ":tcl",
@@ -53,6 +52,7 @@ cc_library(
         "src",
     ],
     deps = [
+        ":dft",
         "//:ord",
         "//src/dbSta",
         "//src/dft/src/architect",


### PR DESCRIPTION
Addresses one entry from #10409.

`include/dft/Dft.hh` was listed in both `//src/dft` and `//src/dft:ui`. The SWIG source in `ui` includes this header, so make that dependency explicit through `:dft` and remove the duplicate header from `ui`'s `srcs`.

Test plan:
- `git diff --check`
- `bazelisk query //src/dft:ui --noshow_progress`