### PR TITLE
bazel: avoid duplicate dst header

### DIFF
--- a/src/dst/BUILD
+++ b/src/dst/BUILD
@@ -53,7 +53,6 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "include/dst/Distributed.h",
         "src/MakeDistributed.cc",
         ":swig",
         ":tcl",
@@ -65,6 +64,7 @@ cc_library(
         "include",
     ],
     deps = [
+        ":dst",
         "//:ord",
         "//src/utl",
         "@boost.asio",


### PR DESCRIPTION
Addresses one entry from #10409.

`include/dst/Distributed.h` was listed in both `//src/dst` and `//src/dst:ui`. The UI target uses the distributed interface, so make the dependency on `:dst` explicit and remove the duplicate header from `ui`'s `srcs`.

Test plan:
- `git diff --check`
- `bazelisk query //src/dst:ui --noshow_progress`