### PR TITLE
bazel: avoid duplicate exa header

### DIFF
--- a/src/exa/BUILD
+++ b/src/exa/BUILD
@@ -12,10 +12,24 @@ package(
 )
 
 cc_library(
+    name = "exa_private_hdrs",
+    hdrs = [
+        "src/observer.h",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/odb/src/db",
+        "//src/utl",
+    ],
+)
+
+cc_library(
     name = "exa",
     srcs = [
         "src/example.cpp",
-        "src/observer.h",
     ],
     hdrs = [
         "include/exa/example.h",
@@ -24,6 +38,7 @@ cc_library(
         "include",
     ],
     deps = [
+        ":exa_private_hdrs",
         "//src/odb/src/db",
         "//src/utl",
     ],
@@ -35,7 +50,6 @@ cc_library(
         "src/MakeExample.cpp",
         "src/graphics.cpp",
         "src/graphics.h",
-        "src/observer.h",
         ":swig",
         ":tcl",
     ],
@@ -48,6 +62,7 @@ cc_library(
     ],
     deps = [
         ":exa",
+        ":exa_private_hdrs",
         "//:ord",
         "//src/gui",
         "//src/odb/src/db",


### PR DESCRIPTION
Addresses one entry from #10409.

`src/observer.h` was listed in both `//src/exa` and `//src/exa:ui`. Add a package-private `:exa_private_hdrs` owner for the shared header and depend on it from both `:exa` and `:ui`, so the header has one Bazel owner while remaining available to the UI sources that include it.

Test plan:
- `git diff --check`
- `bazelisk query //src/exa:ui --noshow_progress`