### PR TITLE
bazel: avoid duplicate ifp header

### DIFF
--- a/src/ifp/BUILD
+++ b/src/ifp/BUILD
@@ -35,7 +35,6 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "include/ifp/InitFloorplan.hh",
         "src/MakeInitFloorplan.cc",
         ":swig",
         ":tcl",
@@ -48,6 +47,7 @@ cc_library(
         "src",
     ],
     deps = [
+        ":ifp",
         "//:ord",
         "//src/dbSta",
         "//src/odb/src/db",


### PR DESCRIPTION
Addresses one entry from #10409.

`include/ifp/InitFloorplan.hh` was listed in both `//src/ifp` and `//src/ifp:ui`. The Tcl wrapper in `ui` includes the header, so make the dependency on `:ifp` explicit and remove the duplicate header from `ui`'s `srcs`.

Test plan:
- `git diff --check`
- `bazelisk query //src/ifp:ui --noshow_progress`