### PR TITLE
bazel: avoid duplicate upf header

### DIFF
--- a/src/upf/BUILD
+++ b/src/upf/BUILD
@@ -36,7 +36,6 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "include/upf/upf.h",
         "src/MakeUpf.cpp",
         ":swig",
         ":tcl",
@@ -48,6 +47,7 @@ cc_library(
         "include",
     ],
     deps = [
+        ":upf",
         "//:ord",
         "//src/odb/src/db",
         "//src/utl",


### PR DESCRIPTION
Addresses one entry from #10409.

`include/upf/upf.h` was listed in both `//src/upf` and `//src/upf:ui`. The Tcl wrapper in `ui` includes the header, so make the dependency on `:upf` explicit and remove the duplicate header from `ui`'s `srcs`.

Test plan:
- `git diff --check`
- `bazelisk query //src/upf:ui --noshow_progress`