### PR TITLE
bazel: avoid duplicate rsz headers

### DIFF
--- a/src/rsz/BUILD
+++ b/src/rsz/BUILD
@@ -13,10 +13,27 @@ package(
 )
 
 cc_library(
+    name = "rsz_private_hdrs",
+    hdrs = [
+        "src/BufferedNet.hh",
+        "src/ResizerObserver.hh",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/odb/src/db",
+        "//src/sta:opensta_lib",
+        "//src/utl",
+        "@spdlog",
+    ],
+)
+
+cc_library(
     name = "rsz",
     srcs = [
         "src/BufferedNet.cc",
-        "src/BufferedNet.hh",
         "src/ConcreteSwapArithModules.cc",
         "src/ConcreteSwapArithModules.hh",
         "src/DelayEstimator.cc",
@@ -48,7 +65,6 @@ cc_library(
         "src/RepairTargetCollector.cc",
         "src/RepairTargetCollector.hh",
         "src/Resizer.cc",
-        "src/ResizerObserver.hh",
         "src/SwapArithModules.hh",
         "src/move/BufferCandidate.cc",
         "src/move/BufferCandidate.hh",
@@ -146,6 +162,7 @@ cc_library(
     ],
     linkopts = ["-pthread"],
     deps = [
+        ":rsz_private_hdrs",
         "//src/dbSta",
         "//src/dbSta:SpefWriter",
         "//src/dbSta:dbNetwork",
@@ -166,11 +183,9 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "src/BufferedNet.hh",
         "src/Graphics.cc",
         "src/Graphics.hh",
         "src/MakeResizer.cc",
-        "src/ResizerObserver.hh",
         ":swig",
         ":tcl",
     ],
@@ -183,6 +198,7 @@ cc_library(
     ],
     deps = [
         ":rsz",
+        ":rsz_private_hdrs",
         "//:ord",
         "//src/dbSta:dbNetwork",
         "//src/gui",


### PR DESCRIPTION
Addresses two entries from #10409.

`src/BufferedNet.hh` and `src/ResizerObserver.hh` were listed in both `//src/rsz` and `//src/rsz:ui`. Add a package-private `:rsz_private_hdrs` owner for the shared headers and depend on it from both `:rsz` and `:ui`, so each header has one Bazel owner while remaining available to sources that include it.

Test plan:
- `git diff --check`
- `buildifier -mode=check -lint=off src/rsz/BUILD`
- `bazelisk query //src/rsz:ui --noshow_progress`