### PR TITLE
bazel: avoid duplicate grt headers

### DIFF
--- a/src/est/BUILD
+++ b/src/est/BUILD
@@ -24,6 +24,7 @@ cc_library(
     visibility = ["//visibility:private"],
     deps = [
         "//src/grt:groute",
+        "//src/grt:route_pt",
         "//src/sta:opensta_lib",
     ],
 )

--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -36,6 +36,14 @@ cc_library(
 )
 
 cc_library(
+    name = "route_pt",
+    hdrs = ["include/grt/RoutePt.h"],
+    includes = [
+        "include",
+    ],
+)
+
+cc_library(
     name = "fastroute",
     srcs = [
         "src/fastroute/src/FastRoute.cpp",
@@ -121,17 +129,32 @@ cc_library(
 )
 
 cc_library(
-    name = "grt",
-    srcs = [
+    name = "grt_private_hdrs",
+    hdrs = [
         "src/AbstractGrouteRenderer.h",
         "src/AbstractRoutingCongestionDataSource.h",
+        "src/Net.h",
+        "src/Pin.h",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":groute",
+        ":route_pt",
+        "//src/odb/src/db",
+    ],
+)
+
+cc_library(
+    name = "grt",
+    srcs = [
         "src/GlobalRouter.cpp",
         "src/Grid.cpp",
         "src/Grid.h",
         "src/Net.cpp",
-        "src/Net.h",
         "src/Pin.cpp",
-        "src/Pin.h",
         "src/RepairAntennas.cpp",
         "src/RepairAntennas.h",
         "src/RoutingTracks.h",
@@ -140,7 +163,6 @@ cc_library(
     hdrs = [
         "include/grt/GlobalRouter.h",
         "include/grt/PinGridLocation.h",
-        "include/grt/RoutePt.h",
         "include/grt/Rudy.h",
     ],
     copts = [
@@ -154,6 +176,8 @@ cc_library(
         ":cugr",
         ":fastroute",
         ":groute",
+        ":grt_private_hdrs",
+        ":route_pt",
         "//src/ant",
         "//src/dbSta",
         "//src/dbSta:dbNetwork",
@@ -175,13 +199,9 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "src/AbstractGrouteRenderer.h",
-        "src/AbstractRoutingCongestionDataSource.h",
         "src/GrouteRenderer.cpp",
         "src/GrouteRenderer.h",
         "src/MakeGlobalRouter.cpp",
-        "src/Net.h",
-        "src/Pin.h",
         "src/fastroute/src/FastRouteRenderer.cpp",
         "src/heatMap.cpp",
         "src/heatMap.h",
@@ -207,6 +227,7 @@ cc_library(
         ":fastroute",
         ":groute",
         ":grt",
+        ":grt_private_hdrs",
         "//:ord",
         "//src/gui",
         "//src/odb/src/db",

--- a/src/rsz/BUILD
+++ b/src/rsz/BUILD
@@ -153,6 +153,7 @@ cc_library(
         "//src/est",
         "//src/grt",
         "//src/grt:groute",
+        "//src/grt:route_pt",
         "//src/odb/src/db",
         "//src/sta:opensta_lib",
         "//src/stt",


### PR DESCRIPTION
Addresses four entries from #10409.

`src/AbstractGrouteRenderer.h`, `src/AbstractRoutingCongestionDataSource.h`, `src/Net.h`, and `src/Pin.h` were listed in both `//src/grt` and `//src/grt:ui`. Add a package-private `:grt_private_hdrs` owner for those shared implementation headers and depend on it from both targets.

`Net.h` includes `grt/RoutePt.h`, so this also splits `RoutePt.h` into a small `:route_pt` header target to avoid a dependency cycle between `:grt` and `:grt_private_hdrs`. Downstream targets that directly include `grt/RoutePt.h` now depend on `//src/grt:route_pt` explicitly.

Test plan:
- `git diff --check`
- `buildifier -mode=check -lint=off src/grt/BUILD src/rsz/BUILD src/est/BUILD`
- `bazelisk query //src/grt:ui --noshow_progress`
- `bazelisk query //src/grt:grt --noshow_progress`
- `bazelisk query //src/grt:grt_private_hdrs --noshow_progress`
- `bazelisk query //src/grt:route_pt --noshow_progress`
- `bazelisk query //src/rsz:rsz --noshow_progress`
- `bazelisk query //src/est:private_hdrs --noshow_progress`