### PR TITLE
bazel: enable layering check for gpl fft test

### DIFF
--- a/src/gpl/BUILD
+++ b/src/gpl/BUILD
@@ -14,11 +14,12 @@ package(
     features = ["layering_check"],
 )
 
-# Headers owned by :gpl but also consumed by :ui. Kept package-private so
-# nothing outside //src/gpl can depend on them.
+# Headers owned by :gpl but also consumed by :ui and GPL tests. Keep them
+# visible only to //src/gpl and its tests.
 cc_library(
     name = "gpl_private_hdrs",
     hdrs = [
+        "src/fft.h",
         "src/nesterovBase.h",
         "src/nesterovPlace.h",
         "src/placerBase.h",
@@ -26,7 +27,10 @@ cc_library(
         "src/routeBase.h",
     ],
     includes = ["src"],
-    visibility = ["//visibility:private"],
+    visibility = [
+        "//src/gpl/test:__pkg__",
+        "//visibility:private",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/utl",
@@ -44,7 +48,6 @@ cc_library(
         "src/densityGradient.cpp",
         "src/densityGradientBackend.h",
         "src/fft.cpp",
-        "src/fft.h",
         "src/fftBackend.h",
         "src/fftsg.cpp",
         "src/fftsg2d.cpp",

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -144,10 +144,10 @@ PY_TESTS = [
 cc_test(
     name = "gpl_fft_unittest",
     srcs = ["fft_test.cc"],
-    features = ["-layering_check"],  # TODO: includes private headers
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/gpl",
+        "//src/gpl:gpl_private_hdrs",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@spdlog",


### PR DESCRIPTION
Addresses one target from #10478.

`//src/gpl/test:gpl_fft_unittest` disabled layering checks because it includes `src/gpl/src/fft.h` directly. Move `fft.h` into the existing `:gpl_private_hdrs` owner, allow the GPL test package to depend on that private-header target, and remove the test's `-layering_check` override.

Test plan:
- `git diff --check`
- `buildifier -mode=check -lint=off src/gpl/BUILD src/gpl/test/BUILD`
- `bazelisk query //src/gpl/test:gpl_fft_unittest --noshow_progress`

I also attempted `bazelisk test //src/gpl/test:gpl_fft_unittest --workspace_status_command=/bin/true --test_output=errors --noshow_progress`; local analysis was blocked because this checkout is missing the `src/sta` submodule package required by `//src/gpl`.