### PR TITLE
bazel: enable layering check for syn tests

### DIFF
--- a/src/syn/test/BUILD
+++ b/src/syn/test/BUILD
@@ -3,13 +3,14 @@
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
+package(features = ["layering_check"])
+
 # No gtest_main on ir/graph/opt tests: ABC (via //src/syn/src/ir →
 # TritModel) ships its own main() that wins over gtest_main; each TU
 # defines its own.
 cc_test(
     name = "ir_test",
     srcs = ["ir_test.cc"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn/src/ir",
         "@googletest//:gtest",
@@ -19,7 +20,6 @@ cc_test(
 cc_test(
     name = "graph_test",
     srcs = ["graph_test.cc"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn/src/ir",
         "@googletest//:gtest",
@@ -29,7 +29,6 @@ cc_test(
 cc_test(
     name = "opt_test",
     srcs = ["opt_test.cc"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn",
         "//src/syn/src/ir",
@@ -40,7 +39,6 @@ cc_test(
 cc_test(
     name = "liveness_test",
     srcs = ["liveness_test.cc"],
-    features = ["-layering_check"],
     # No gtest_main: ABC ships its own main() that wins over gtest_main;
     # the TU defines its own.
     deps = [
@@ -54,7 +52,6 @@ cc_test(
 cc_test(
     name = "parse_test",
     srcs = ["parse_test.cc"],
-    features = ["-layering_check"],
     # No gtest_main: ABC (via //src/syn/src/ir → TritModel) ships its own
     # main() that wins over gtest_main; parse_test.cc defines its own.
     deps = [
@@ -67,7 +64,6 @@ cc_test(
     name = "sm_test",
     srcs = ["sm_test.cc"],
     data = ["sm_test_cells.lib"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn",
         "//src/syn/src/ir",
@@ -83,7 +79,6 @@ cc_test(
         "equivalence_check.h",
     ],
     data = ["cm_test_cells.lib"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn",
         "//src/syn/src/ir",
@@ -95,7 +90,6 @@ cc_test(
 cc_test(
     name = "abc_test",
     srcs = ["abc_test.cc"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn",
         "//src/syn/src/ir",
@@ -107,7 +101,6 @@ cc_test(
 cc_test(
     name = "bitblast_test",
     srcs = ["bitblast_test.cc"],
-    features = ["-layering_check"],
     deps = [
         "//src/syn",
         "//src/syn/src/ir",
@@ -122,7 +115,6 @@ cc_test(
         "elab_testcases.h",
         "equivalence_check.h",
     ],
-    features = ["-layering_check"],
     deps = [
         "//src/syn/src/elab",
         "//src/syn/src/ir",


### PR DESCRIPTION
Addresses part of #10478.

`src/syn/test/BUILD` had per-test `features = ["-layering_check"]` entries, but the tests include exported `syn` headers through their declared deps. Enable layering checks for the package and remove the stale per-target disables from the ten `syn` cc_tests.

Test plan:
- `git diff --check`
- `buildifier -mode=check -lint=off src/syn/test/BUILD`
- `bazelisk query //src/syn/test:all --noshow_progress`

I also attempted `bazelisk cquery //src/syn/test:ir_test --features=layering_check --noshow_progress`; local analysis was blocked because this checkout is missing the `src/sta` submodule package required by `//src/syn/src/ir`.