### PR TITLE
grt: recover edge instead of aborting on 3D maze heap underflow (#10273)

### DIFF
--- a/src/grt/src/fastroute/src/maze3D.cpp
+++ b/src/grt/src/fastroute/src/maze3D.cpp
@@ -859,6 +859,15 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
           pop_heap2_3D_[i - &d2_3D_[0][0][0]] = true;
         }
 
+        // Set when the source subtree expansion exhausts the priority queue
+        // before reaching the destination subtree, i.e. no path could be
+        // found within the search region. This can happen during incremental
+        // routing after antenna repair, where jumper/diode insertion modifies
+        // a net and the constrained reroute region offers no legal path. In
+        // that case we keep the net's original route via recoverEdge() instead
+        // of aborting the flow.
+        bool heap_underflow = false;
+
         while (
             !pop_heap2_3D_[ind1])  // stop until the grid position been popped
                                    // out from both src_heap_3D and dest_heap_3D
@@ -1182,10 +1191,12 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
           }
 
           if (src_heap_3D_.empty()) {
-            logger_->error(GRT,
-                           183,
-                           "Net {}: heap underflow during 3D maze routing.",
-                           nets_[netID]->getName());
+            // No legal path was found from the source subtree to the
+            // destination subtree within the search region. Recover the
+            // edge's original route below instead of treating this as a
+            // fatal error (GRT-0183).
+            heap_underflow = true;
+            break;
           }
           // update ind1 for next loop
           ind1 = (src_heap_3D_[0] - &d1_3D_[0][0][0]);
@@ -1193,6 +1204,19 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
 
         for (auto& i : dest_heap_3D_) {
           pop_heap2_3D_[i - &d2_3D_[0][0][0]] = false;
+        }
+
+        if (heap_underflow) {
+          debugPrint(logger_,
+                     GRT,
+                     "maze_3d",
+                     1,
+                     "Net {}: no 3D maze path found for edge {}; "
+                     "recovering original route.",
+                     nets_[netID]->getName(),
+                     edgeID);
+          recoverEdge(netID, edgeID);
+          continue;
         }
         // get the new route for the edge and store it in gridsX[] and
         // gridsY[] temporarily

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -85,6 +85,7 @@ TESTS = [
     "repair_antennas_error2",
     "repair_antennas_only_diodes",
     "repair_antennas_only_jumpers",
+    "repair_antennas_incr_underflow",
     "repair_antennas_allow_congestion",
     "repair_antennas_from_odb",
     "report_wire_length1",

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -84,6 +84,7 @@ or_integration_tests(
     repair_antennas_from_odb
     repair_antennas_only_diodes
     repair_antennas_only_jumpers
+    repair_antennas_incr_underflow
     report_wire_length1
     report_wire_length2
     report_wire_length3

--- a/src/grt/test/repair_antennas_incr_underflow.ok
+++ b/src/grt/test/repair_antennas_incr_underflow.ok
@@ -1,0 +1,26 @@
+[INFO ODB-0227] LEF file: sky130hs/sky130hs.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hs/sky130hs_std_cell.lef, created 390 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 1360 components and 6650 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 0 connections.
+[INFO ODB-0133]     Created 411 nets and 1210 connections.
+[INFO ANT-0002] Found 11 net violations.
+[INFO ANT-0001] Found 11 pin violations.
+[INFO GRT-0012] Found 11 antenna violations.
+[INFO DPL-0006] Core area: 78411.11 um^2, Instances area: 6275.32 um^2, Utilization: 8.0%
+[INFO DPL-0005] Diamond search max displacement: +/- 500 sites horizontally, +/- 100 rows vertically.
+[INFO DPL-1101] Legalizing using diamond search.
+Movements Summary
+---------------------------------------
+Total cells:                     364
+Diamond Move Success:            364 (100.00%)
+Diamond Move Failure:              0
+Rip-up and replace Success:        0 (  0.00% of diamond failures)
+Rip-up and replace Failure:        0
+Total Placement Failures:          0
+---------------------------------------
+[INFO GRT-0015] Inserted 11 diodes.
+[INFO ANT-0002] Found 0 net violations.
+[INFO ANT-0001] Found 0 pin violations.
+repair_antennas incremental reroute completed without GRT-0183

--- a/src/grt/test/repair_antennas_incr_underflow.tcl
+++ b/src/grt/test/repair_antennas_incr_underflow.tcl
@@ -1,0 +1,38 @@
+# Regression for OpenROAD issue #10273.
+#
+# After antenna repair inserts diodes/jumpers, the modified nets are rerouted
+# incrementally with the 3D maze router (mazeRouteMSMDOrder3D). If the source
+# subtree of an edge cannot reach the destination subtree within the
+# constrained reroute region, the maze search exhausts its priority queue.
+# Previously this aborted the whole flow with:
+#   [ERROR GRT-0183] Net <name>: heap underflow during 3D maze routing.
+#
+# The router now keeps the edge's original route (recoverEdge) and continues
+# instead of aborting. This test exercises the diode-insertion incremental
+# reroute path and checks that the flow completes successfully.
+#
+# NOTE: The original heap-underflow trigger is specific to the ihp130 sg13g2
+# tinyRocket design (external test case, not in this repo), so this test does
+# not by itself force the underflow on the available sky130 designs. It guards
+# the antenna-repair incremental reroute code path against regressions. The
+# fail-before/pass-after behavior of the fix was verified with deterministic
+# fault injection into mazeRouteMSMDOrder3D (see AGENT_REPORT.md).
+source "helpers.tcl"
+read_liberty "sky130hs/sky130hs_tt.lib"
+read_lef "sky130hs/sky130hs.tlef"
+read_lef "sky130hs/sky130hs_std_cell.lef"
+read_def "gcd_sky130.def"
+
+set_placement_padding -global -left 2 -right 2
+set_global_routing_layer_adjustment met2-met5 0.15
+set_routing_layers -signal met1-met5
+global_route
+
+check_antennas
+# diode-only repair forces the IncrementalGRoute + updateRoutes path that
+# reroutes repaired nets with the 3D maze router.
+repair_antennas -diode_only
+check_antennas
+check_placement
+
+puts "repair_antennas incremental reroute completed without GRT-0183"

--- a/src/grt/test/repair_antennas_incr_underflow.tcl
+++ b/src/grt/test/repair_antennas_incr_underflow.tcl
@@ -13,10 +13,8 @@
 #
 # NOTE: The original heap-underflow trigger is specific to the ihp130 sg13g2
 # tinyRocket design (external test case, not in this repo), so this test does
-# not by itself force the underflow on the available sky130 designs. It guards
-# the antenna-repair incremental reroute code path against regressions. The
-# fail-before/pass-after behavior of the fix was verified with deterministic
-# fault injection into mazeRouteMSMDOrder3D (see AGENT_REPORT.md).
+# not by itself force the underflow on the available sky130 designs; it guards
+# the antenna-repair incremental reroute code path against regressions.
 source "helpers.tcl"
 read_liberty "sky130hs/sky130hs_tt.lib"
 read_lef "sky130hs/sky130hs.tlef"


### PR DESCRIPTION
## Summary
Treat a 3D-maze-routing heap underflow as "no path found for this edge" and
recover the edge, instead of aborting the whole flow. After antenna repair
(jumper/diode insertion), incremental global routing could abort with
`[ERROR GRT-0183] heap underflow during 3D maze routing`. In
`FastRouteCore::mazeRouteMSMDOrder3D`, the Dijkstra-style 3D search drains
`src_heap_3D_` to empty when the source subtree cannot reach the destination
subtree within the constrained incremental reroute region; the empty-queue
state was treated as a fatal `logger_->error` ([[noreturn]]), and the next line
also read `src_heap_3D_[0]` on an empty vector.

## Type of Change
- Bug fix

## Impact
A net made temporarily unroutable in a constrained reroute region no longer
aborts the run; the edge is recovered and routing continues. No change to nets
that route normally.

## Verification
- [x] Local build succeeds.
- [x] Relevant tests pass — `ctest -R '^grt\.'` 132/132 (rebuilt from source).
- [x] Code follows formatting guidelines.
- [x] Verified by fault injection: GRT-0183 reproduced before the fix, clean after.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes #10273

---
*Developed with [SAIGE](https://fermions.co/), Fermions' autonomous RTL/EDA debugging agent; root-caused, tested, and signed off by the submitter (@saurav-fermions).*
