### PR TITLE
odb: decompose non-rectilinear LEF polygons into rectangles (#10256)

### DIFF
--- a/src/odb/src/db/poly_decomp.cpp
+++ b/src/odb/src/db/poly_decomp.cpp
@@ -54,6 +54,38 @@ void staircaseTrapezoid(const std::vector<gtl::point_data<int>>& v,
     y_hi = std::max(y_hi, gtl::y(p));
   }
 
+  // Fast path: a trapezoid with no sloped sides is an axis-aligned rectangle.
+  // The straight body of an octagonal pad fractures into such trapezoids, and
+  // they can be thousands of DBU tall; emit one rectangle directly instead of
+  // walking the band one DBU at a time. The output is identical to what the
+  // per-band loop would coalesce into.
+  bool has_sloped_edge = false;
+  for (int i = 0; i < n; ++i) {
+    const auto& a = v[i];
+    const auto& b = v[(i + 1) % n];
+    if (gtl::x(a) != gtl::x(b) && gtl::y(a) != gtl::y(b)) {
+      has_sloped_edge = true;
+      break;
+    }
+  }
+  if (!has_sloped_edge) {
+    int x_lo = std::numeric_limits<int>::max();
+    int x_hi = std::numeric_limits<int>::min();
+    for (const auto& p : v) {
+      x_lo = std::min(x_lo, gtl::x(p));
+      x_hi = std::max(x_hi, gtl::x(p));
+    }
+    if (x_hi > x_lo && y_hi > y_lo) {
+      if (!rects.empty() && rects.back().xMin() == x_lo
+          && rects.back().xMax() == x_hi && rects.back().yMax() == y_lo) {
+        rects.back().set_yhi(y_hi);
+      } else {
+        rects.emplace_back(x_lo, y_lo, x_hi, y_hi);
+      }
+    }
+    return;
+  }
+
   for (int y = y_lo; y < y_hi; ++y) {
     const double y_mid = y + 0.5;
     double x_min = std::numeric_limits<double>::max();

--- a/src/odb/src/db/poly_decomp.cpp
+++ b/src/odb/src/db/poly_decomp.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
+#include <cmath>
 #include <limits>
 #include <vector>
 
@@ -12,18 +13,133 @@ namespace gtl = boost::polygon;
 
 namespace odb {
 
+namespace {
+
+// A polygon is rectilinear (Manhattan) when every edge is either purely
+// horizontal or purely vertical.  Only such polygons can be tiled exactly by
+// Boost.Polygon's polygon_90 machinery.
+bool isRectilinear(const std::vector<Point>& points)
+{
+  const size_t n = points.size();
+  for (size_t i = 0; i < n; ++i) {
+    const Point& a = points[i];
+    const Point& b = points[(i + 1) % n];
+    if (a.x() != b.x() && a.y() != b.y()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Decompose a single horizontal trapezoid (a polygon whose top and bottom
+// edges are horizontal, with up to two sloped sides) into a staircase of
+// axis-aligned rectangles.  For each unit-tall band in Y the trapezoid's X
+// extent is computed from the edge crossings and rounded outward so the
+// resulting rectangles fully cover (never under-cover) the trapezoid.  This
+// guarantees that obstruction/pin geometry derived from a 45-degree polygon
+// does not leave gaps that would later read as missing metal (shorts) for
+// routing/DRC consumers.
+void staircaseTrapezoid(const std::vector<gtl::point_data<int>>& v,
+                        std::vector<Rect>& rects)
+{
+  const int n = static_cast<int>(v.size());
+  if (n < 3) {
+    return;
+  }
+
+  int y_lo = std::numeric_limits<int>::max();
+  int y_hi = std::numeric_limits<int>::min();
+  for (const auto& p : v) {
+    y_lo = std::min(y_lo, gtl::y(p));
+    y_hi = std::max(y_hi, gtl::y(p));
+  }
+
+  for (int y = y_lo; y < y_hi; ++y) {
+    const double y_mid = y + 0.5;
+    double x_min = std::numeric_limits<double>::max();
+    double x_max = std::numeric_limits<double>::lowest();
+
+    for (int i = 0; i < n; ++i) {
+      const auto& a = v[i];
+      const auto& b = v[(i + 1) % n];
+      const int ay = gtl::y(a);
+      const int by = gtl::y(b);
+      // Edge crosses the band's mid-line?
+      if ((ay <= y_mid && by > y_mid) || (by <= y_mid && ay > y_mid)) {
+        const double t = (y_mid - ay) / static_cast<double>(by - ay);
+        const double x = gtl::x(a) + t * (gtl::x(b) - gtl::x(a));
+        x_min = std::min(x_min, x);
+        x_max = std::max(x_max, x);
+      }
+    }
+
+    if (x_max <= x_min) {
+      continue;
+    }
+
+    // Round outward so the staircase fully covers the sloped edges.
+    const int x_lo = static_cast<int>(std::floor(x_min));
+    const int x_hi = static_cast<int>(std::ceil(x_max));
+    if (x_hi <= x_lo) {
+      continue;
+    }
+
+    // Coalesce with the previous band when it has the same X extent and is
+    // vertically contiguous, to keep the rectangle count down for vertical
+    // runs.
+    if (!rects.empty() && rects.back().xMin() == x_lo
+        && rects.back().xMax() == x_hi && rects.back().yMax() == y) {
+      rects.back().set_yhi(y + 1);
+    } else {
+      rects.emplace_back(x_lo, y, x_hi, y + 1);
+    }
+  }
+}
+
+}  // namespace
+
 void decompose_polygon(const std::vector<Point>& points,
                        std::vector<Rect>& rects)
 {
   using boost::polygon::operators::operator+=;
 
-  gtl::polygon_90_data<int> polygon;
+  // Fast, exact path for Manhattan polygons (the common case: obstructions,
+  // pin ports, and die-area blockages are almost always rectilinear).  This
+  // preserves the previous behaviour and output exactly.
+  if (isRectilinear(points)) {
+    gtl::polygon_90_data<int> polygon;
+    polygon.set(points.begin(), points.end());
+
+    gtl::polygon_90_set_data<int> polygon_set;
+    polygon_set += polygon;
+
+    polygon_set.get_rectangles(rects);
+    return;
+  }
+
+  // Non-rectilinear (e.g. 45-degree / octagonal pad) polygons cannot be
+  // expressed by polygon_90 without corrupting the shape (it fills corners
+  // that should be empty and leaves real metal uncovered).  Fracture the
+  // general polygon into horizontal trapezoids and staircase each one into
+  // axis-aligned rectangles.
+  gtl::polygon_data<int> polygon;
   polygon.set(points.begin(), points.end());
 
-  gtl::polygon_90_set_data<int> polygon_set;
+  gtl::polygon_set_data<int> polygon_set;
   polygon_set += polygon;
 
-  polygon_set.get_rectangles(rects);
+  std::vector<gtl::polygon_data<int>> trapezoids;
+  polygon_set.get_trapezoids(trapezoids, gtl::HORIZONTAL);
+
+  for (const auto& trapezoid : trapezoids) {
+    std::vector<gtl::point_data<int>> v(trapezoid.begin(), trapezoid.end());
+    // Boost may repeat the closing vertex; drop it so edge iteration is clean.
+    if (v.size() > 1 && gtl::x(v.front()) == gtl::x(v.back())
+        && gtl::y(v.front()) == gtl::y(v.back())) {
+      v.pop_back();
+    }
+    staircaseTrapezoid(v, rects);
+  }
 }
 
 // See "Orientation of a simple polygon" in

--- a/src/odb/test/cpp/TestGeom.cpp
+++ b/src/odb/test/cpp/TestGeom.cpp
@@ -3,9 +3,108 @@
 #include "gtest/gtest.h"
 #include "odb/geom.h"
 #include "odb/isotropy.h"
+#include "odb/poly_decomp.h"
 
 namespace odb {
 namespace {
+
+// Even-odd point-in-polygon test on the polygon interior (using the sample
+// point's center).  Used to validate that the rectangle decomposition covers
+// the same area as the source polygon.
+bool pointInPolygon(const std::vector<Point>& poly, double x, double y)
+{
+  bool inside = false;
+  const int n = static_cast<int>(poly.size());
+  for (int i = 0, j = n - 1; i < n; j = i++) {
+    const double xi = poly[i].x(), yi = poly[i].y();
+    const double xj = poly[j].x(), yj = poly[j].y();
+    if (((yi > y) != (yj > y))
+        && (x < (xj - xi) * (y - yi) / (yj - yi) + xi)) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+bool pointInRects(const std::vector<Rect>& rects, int x, int y)
+{
+  for (const Rect& r : rects) {
+    if (x >= r.xMin() && x < r.xMax() && y >= r.yMin() && y < r.yMax()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// A simple rectangle decomposes to itself.
+TEST(geom, decompose_rectangle)
+{
+  const std::vector<Point> rect = {{0, 0}, {100, 0}, {100, 50}, {0, 50}};
+  std::vector<Rect> rects;
+  decompose_polygon(rect, rects);
+
+  ASSERT_EQ(rects.size(), 1u);
+  EXPECT_EQ(rects[0], Rect(0, 0, 100, 50));
+}
+
+// A rectilinear (Manhattan) L-shape still uses the exact polygon_90 path and
+// decomposes into two rectangles, unchanged by the non-rectilinear support.
+TEST(geom, decompose_rectilinear_l_shape)
+{
+  const std::vector<Point> l_shape
+      = {{0, 0}, {20, 0}, {20, 10}, {10, 10}, {10, 20}, {0, 20}};
+  std::vector<Rect> rects;
+  decompose_polygon(l_shape, rects);
+
+  ASSERT_EQ(rects.size(), 2u);
+  EXPECT_EQ(rects[0], Rect(0, 0, 20, 10));
+  EXPECT_EQ(rects[1], Rect(0, 10, 10, 20));
+}
+
+// Regression for OpenROAD #10256: a 45-degree (octagonal) polygon, like the
+// pad geometry in sky130/gscl45 IO cells, must be decomposed into rectangles
+// that fully cover the polygon.  The previous polygon_90-only implementation
+// corrupted the shape, leaving real metal uncovered (which manifested as
+// missing obstructions/pins -> shorts) and filling empty corners.
+TEST(geom, decompose_octagon_covers_polygon)
+{
+  // gscl45nm_polygon.lef metal5 PAD octagon, scaled to integer DBU.
+  const std::vector<Point> octagon = {{1450, 542},
+                                      {542, 1450},
+                                      {-542, 1450},
+                                      {-1450, 542},
+                                      {-1450, -542},
+                                      {-542, -1450},
+                                      {542, -1450},
+                                      {1450, -542}};
+
+  std::vector<Rect> rects;
+  decompose_polygon(octagon, rects);
+
+  // The decomposition must produce geometry (the bug dropped/corrupted it).
+  ASSERT_FALSE(rects.empty());
+
+  // Every point inside the octagon must be covered by some rectangle
+  // (no under-coverage), and no point outside it should be covered
+  // (no over-coverage).
+  int undercovered = 0;
+  int overcovered = 0;
+  for (int y = -1450; y < 1450; y += 11) {
+    for (int x = -1450; x < 1450; x += 11) {
+      const bool in_poly = pointInPolygon(octagon, x + 0.5, y + 0.5);
+      const bool in_rects = pointInRects(rects, x, y);
+      if (in_poly && !in_rects) {
+        ++undercovered;
+      }
+      if (!in_poly && in_rects) {
+        ++overcovered;
+      }
+    }
+  }
+
+  EXPECT_EQ(undercovered, 0);
+  EXPECT_EQ(overcovered, 0);
+}
 
 TEST(geom, test_oct)
 {


### PR DESCRIPTION
## Summary
Non-rectilinear (45°/sloped) LEF polygons (e.g. octagonal IO pads) were corrupted during decomposition; rectilinear polygons were already handled correctly. This decomposes sloped polygons into rectangles, leaving the already-working rectilinear path byte-for-byte identical.

## Type of Change
- Bug fix

## Impact
Sloped LEF polygon geometry is preserved; rectilinear decomposition unchanged.

## Verification
- [x] Local build succeeds.
- [x] Relevant tests pass (rebuilt from source): `ctest -R '^odb\.' -E '\.py'` 82/82 (tcl+cpp).
- [x] Code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes #10256


---
*Developed with [SAIGE](https://fermions.co/), Fermions' autonomous RTL/EDA debugging agent; root-caused, tested, and signed off by the submitter (@saurav-fermions).*
