### PR TITLE
rsz: exclude delay/clock-delay cells from data buffering (#10622)

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -60,7 +60,12 @@ namespace rsz {
 enum class BufferUse
 {
   DATA,
-  CLOCK
+  CLOCK,
+  // Dedicated delay cells and clock-delay buffers (e.g.
+  // sky130_fd_sc_hd__clkdlybuf4s25_1, *dlygate*, *dlymetal*). These are not
+  // intended for general data buffering, but are legitimately used elsewhere
+  // (e.g. hold-violation delay insertion).
+  DELAY
 };
 
 using LibertyPortTuple = std::tuple<sta::LibertyPort*, sta::LibertyPort*>;
@@ -462,6 +467,10 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
     return clock_buffer_footprint_;
   }
   BufferUse getBufferUse(sta::LibertyCell* buffer);
+
+  // Returns true for dedicated delay cells and clock-delay buffers that
+  // should not be used for general data buffering (issue #10622).
+  bool isDelayCell(sta::LibertyCell* buffer) const;
 
   // Clone inverters next to the registers they drive to remove them
   // from the clock network.

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -6311,14 +6311,10 @@ bool Resizer::isDelayCell(sta::LibertyCell* buffer) const
   // Match by dedicated delay-cell footprint when the library provides one.
   //   common: DEL (leading 3nm), DLY (7nm/12nm), sky130: "delay"
   const std::string& footprint = buffer->footprint();
-  if (!footprint.empty()
-      && (containsIgnoreCase(footprint, "delay")
-          || containsIgnoreCase(footprint, "DEL")
-          || containsIgnoreCase(footprint, "DLY"))) {
-    return true;
-  }
-
-  return false;
+  return !footprint.empty()
+         && (containsIgnoreCase(footprint, "delay")
+             || containsIgnoreCase(footprint, "DEL")
+             || containsIgnoreCase(footprint, "DLY"));
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1019,6 +1019,17 @@ void Resizer::findBuffers()
     if (master == nullptr) {
       continue;
     }
+
+    // Exclude dedicated delay cells and clock-delay buffers from the
+    // data-buffer candidate set (issue #10622). getBufferList() keeps these
+    // (so hold fixing can still use them); they must be pruned here so they
+    // are not chosen for general data buffering.
+    if (exclude_clock_buffers_ && getBufferUse(buffer) == BufferUse::DELAY) {
+      debugRDPrint2("findBuffers: {} is not added because it is a delay cell",
+                    buffer->name());
+      continue;
+    }
+
     auto vt_type = cellVTType(master);
     bool footprint_matches
         = best_footprint.empty() || (best_footprint == footprint);
@@ -6272,7 +6283,42 @@ BufferUse Resizer::getBufferUse(sta::LibertyCell* buffer)
     }
   }
 
+  // Dedicated delay cells and clock-delay buffers should not be used as
+  // general-purpose data buffers. They show up in some PDKs (notably sky130)
+  // with the same "buf" footprint as normal data buffers, so they would
+  // otherwise leak into the data-buffer candidate set (see issue #10622).
+  // They remain available where appropriate (e.g. hold delay insertion uses
+  // getBufferList(), which only excludes CLOCK buffers).
+  if (isDelayCell(buffer)) {
+    return BufferUse::DELAY;
+  }
+
   return BufferUse::DATA;
+}
+
+bool Resizer::isDelayCell(sta::LibertyCell* buffer) const
+{
+  // Match dedicated delay cells and clock-delay buffers by name pattern.
+  // "dly" reliably identifies delay cells across PDKs without matching normal
+  // data buffers (buf/bufbuf/clkbuf do not contain "dly"):
+  //   sky130: clkdlybuf*, dlygate*, dlymetal*
+  //   gf180:  dlya*, dlyb*, dlyc*, dlyd*
+  const std::string& name = buffer->name();
+  if (containsIgnoreCase(name, "dly")) {
+    return true;
+  }
+
+  // Match by dedicated delay-cell footprint when the library provides one.
+  //   common: DEL (leading 3nm), DLY (7nm/12nm), sky130: "delay"
+  const std::string& footprint = buffer->footprint();
+  if (!footprint.empty()
+      && (containsIgnoreCase(footprint, "delay")
+          || containsIgnoreCase(footprint, "DEL")
+          || containsIgnoreCase(footprint, "DLY"))) {
+    return true;
+  }
+
+  return false;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -256,6 +256,7 @@ PASSFAIL_TESTS = [
     # "cpp_tests",
     "repair_setup_legacy_mt",
     "repair_setup_mt1",
+    "buffer_ports_data_only",
 ]
 
 ALL_TESTS = TESTS + PASSFAIL_TESTS

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -239,6 +239,7 @@ or_integration_tests(
     repair_setup_legacy_mt
     repair_setup_mt1
     cpp_tests
+    buffer_ports_data_only
 )
 
 add_subdirectory(cpp)

--- a/src/rsz/test/buffer_ports_data_only.tcl
+++ b/src/rsz/test/buffer_ports_data_only.tcl
@@ -13,14 +13,16 @@ buffer_ports -inputs -outputs
 set bad 0
 foreach inst [[ord::get_db_block] getInsts] {
   set master [[$inst getMaster] getName]
-  if {[string match "*clkdlybuf*" $master]
-      || [string match "*dlygate*" $master]
-      || [string match "*dlymetal*" $master]} {
+  if {
+    [string match "*clkdlybuf*" $master]
+    || [string match "*dlygate*" $master]
+    || [string match "*dlymetal*" $master]
+  } {
     puts "ERROR: delay/clock-delay cell used for data buffering: [$inst getName] $master"
     incr bad
   }
 }
-if {$bad == 0} {
+if { $bad == 0 } {
   puts "pass"
 } else {
   puts "FAIL: $bad delay/clock-delay cells used for data buffering"

--- a/src/rsz/test/buffer_ports_data_only.tcl
+++ b/src/rsz/test/buffer_ports_data_only.tcl
@@ -1,0 +1,27 @@
+# Regression for issue #10622: buffer_ports must use normal DATA buffers
+# (*_buf_*) for data nets, not clock-delay buffers (*clkdlybuf*) or dedicated
+# delay cells (*dlygate*, *dlymetal*).
+source "helpers.tcl"
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130hd_std_cell.lef
+read_liberty sky130hd/sky130hd_tt.lib
+read_def repair_design2.def
+
+buffer_ports -inputs -outputs
+
+# Fail loudly if any inserted buffer is a clock-delay or dedicated delay cell.
+set bad 0
+foreach inst [[ord::get_db_block] getInsts] {
+  set master [[$inst getMaster] getName]
+  if {[string match "*clkdlybuf*" $master]
+      || [string match "*dlygate*" $master]
+      || [string match "*dlymetal*" $master]} {
+    puts "ERROR: delay/clock-delay cell used for data buffering: [$inst getName] $master"
+    incr bad
+  }
+}
+if {$bad == 0} {
+  puts "pass"
+} else {
+  puts "FAIL: $bad delay/clock-delay cells used for data buffering"
+}

--- a/src/rsz/test/repair_fanout6.ok
+++ b/src/rsz/test/repair_fanout6.ok
@@ -8,11 +8,11 @@
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       502
-    final |     +3.3% |       0 |      33 |             1 |         0
+    final |     +1.2% |       0 |      33 |             1 |         0
 ---------------------------------------------------------------------
 [INFO RSZ-0035] Found 1 fanout violations.
 [INFO RSZ-0038] Inserted 33 buffers in 1 nets.
-worst slack max -2.36
+worst slack max -1.63
 max fanout
 
 Pin                                   Limit Fanout  Slack
@@ -25,11 +25,11 @@ fanout1/X                                20     20      0 (MET)
    Iter   | Removed | Resized | Inserted | Cloned |  Pin  |   Area   |    WNS   |   StTNS    |   EnTNS    |  Viol  |  Worst  
           | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |          |            |            | Endpts | St/EnPt 
 ------------------------------------------------------------------------------------------------------------------------------
-       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -2.358 |       -2.4 |    -1081.9 |    500 | sink263/D
-     182* |       0 |     159 |        2 |      0 |     0 |    +0.0% |   -0.804 |       -0.8 |     -384.7 |    500 | sink247/D
-    final |       0 |     182 |        2 |      0 |     0 |    +0.4% |   -0.804 |       -0.8 |     -374.6 |    500 | sink247/D
+       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -1.632 |       -1.6 |     -719.0 |    500 | sink263/D
+     157* |       0 |     127 |        2 |      0 |     0 |    +2.2% |   -0.802 |       -0.8 |     -386.0 |    500 | sink247/D
+    final |       0 |     149 |        2 |      0 |     0 |    +2.5% |   -0.802 |       -0.8 |     -376.3 |    500 | sink247/D
 ------------------------------------------------------------------------------------------------------------------------------
 [INFO RSZ-0045] Inserted 2 buffers, 2 to split loads.
-[INFO RSZ-0051] Resized 182 instances: 182 up, 0 up match, 0 down, 0 VT
+[INFO RSZ-0051] Resized 149 instances: 149 up, 0 up match, 0 down, 0 VT
 [WARNING RSZ-0062] Unable to repair all setup violations.
 worst slack max -0.80

--- a/src/rsz/test/repair_fanout6_multi.ok
+++ b/src/rsz/test/repair_fanout6_multi.ok
@@ -8,11 +8,11 @@
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       502
-    final |     +3.3% |       0 |      33 |             1 |         0
+    final |     +1.2% |       0 |      33 |             1 |         0
 ---------------------------------------------------------------------
 [INFO RSZ-0035] Found 1 fanout violations.
 [INFO RSZ-0038] Inserted 33 buffers in 1 nets.
-worst slack max -2.36
+worst slack max -1.63
 max fanout
 
 Pin                                   Limit Fanout  Slack
@@ -25,11 +25,10 @@ fanout1/X                                20     20      0 (MET)
    Iter   | Removed | Resized | Inserted | Cloned |  Pin  |   Area   |    WNS   |   StTNS    |   EnTNS    |  Viol  |  Worst  
           | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |          |            |            | Endpts | St/EnPt 
 ------------------------------------------------------------------------------------------------------------------------------
-       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -2.358 |       -2.4 |    -1081.9 |    500 | sink263/D
-       9* |       0 |      14 |        1 |      0 |     0 |    +0.2% |   -1.668 |       -1.7 |     -688.2 |    500 | sink483/D
-    final |       0 |      38 |        1 |      0 |     0 |    +0.6% |   -1.400 |       -1.4 |     -533.1 |    500 | sink120/D
+       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -1.632 |       -1.6 |     -719.0 |    500 | sink263/D
+     175* |       0 |     148 |        0 |      0 |     0 |    +2.2% |   -0.711 |       -0.7 |     -347.9 |    500 | sink235/D
+    final |       0 |     148 |        0 |      0 |     0 |    +2.2% |   -0.711 |       -0.7 |     -347.9 |    500 | sink235/D
 ------------------------------------------------------------------------------------------------------------------------------
-[INFO RSZ-0040] Inserted 1 buffers.
-[INFO RSZ-0051] Resized 38 instances: 38 up, 0 up match, 0 down, 0 VT
+[INFO RSZ-0051] Resized 148 instances: 148 up, 0 up match, 0 down, 0 VT
 [WARNING RSZ-0062] Unable to repair all setup violations.
-worst slack max -1.40
+worst slack max -0.71

--- a/src/rsz/test/repair_slew13.ok
+++ b/src/rsz/test/repair_slew13.ok
@@ -15,7 +15,7 @@ b1/A                                    0.03    0.07   -0.04 (VIOLATED)
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |         3
-    final |   +133.3% |       0 |       1 |             1 |         0
+    final |    +50.0% |       0 |       1 |             1 |         0
 ---------------------------------------------------------------------
 [INFO RSZ-0034] Found 1 slew violations.
 [INFO RSZ-0038] Inserted 1 buffers in 1 nets.
@@ -23,5 +23,5 @@ max slew
 
 Pin                                    Limit    Slew   Slack
 ------------------------------------------------------------
-b1/A                                    0.03    0.05   -0.02 (VIOLATED)
+b1/A                                    0.03    0.04   -0.01 (VIOLATED)
 

--- a/src/rsz/test/repair_slew14.ok
+++ b/src/rsz/test/repair_slew14.ok
@@ -14,7 +14,7 @@ u2/A                                    1.50    1.82   -0.32 (VIOLATED)
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |         3
-    final |   +118.8% |       0 |       2 |             1 |         0
+    final |   +156.2% |       0 |       2 |             1 |         0
 ---------------------------------------------------------------------
 [INFO RSZ-0034] Found 1 slew violations.
 [INFO RSZ-0036] Found 1 capacitance violations.
@@ -23,5 +23,5 @@ max slew
 
 Pin                                    Limit    Slew   Slack
 ------------------------------------------------------------
-u1/Y                                    1.49    0.54    0.95 (MET)
+u1/Y                                    1.49    0.57    0.92 (MET)
 

--- a/src/rsz/test/repair_slew6.ok
+++ b/src/rsz/test/repair_slew6.ok
@@ -64,7 +64,7 @@ r9/D                                    1.50    3.33   -1.83 (VIOLATED)
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |        52
-    final |     +1.9% |       1 |       1 |             1 |         0
+    final |     +3.1% |       1 |       1 |             1 |         0
 ---------------------------------------------------------------------
 [INFO RSZ-0034] Found 1 slew violations.
 [INFO RSZ-0039] Resized 1 instances.

--- a/src/rsz/test/report_buffers_gf180.ok
+++ b/src/rsz/test/report_buffers_gf180.ok
@@ -45,35 +45,39 @@ gf180mcu_fd_sc_mcu9t5v0__dlyb_1           11074.9 2.9e-11 1.6e-10 10080 N/A     
 gf180mcu_fd_sc_mcu9t5v0__dlyd_1           11084.9 2.9e-11 2.6e-10 10080 N/A     -
 
 Filtered Buffer Report:
-There are 10 buffers after filtering based on threshold voltage,
+There are 8 buffers after filtering based on threshold voltage,
 cell footprint, drive strength and cell site
 --------------------------------------------------------------------------------
 Cell                                        Drive Drive    Leak   Site Cell   VT
                                             Res   Res*Cin          Ht Footpt Type
 --------------------------------------------------------------------------------
+gf180mcu_fd_sc_mcu9t5v0__buf_16             690.9 3.8e-11 6.8e-10 10080 N/A     -
+gf180mcu_fd_sc_mcu9t5v0__buf_20             553.6 3.8e-11 8.4e-10 10080 N/A     -
 gf180mcu_fd_sc_mcu9t5v0__buf_8             1378.8 3.8e-11 3.7e-10 10080 N/A     -
 gf180mcu_fd_sc_mcu9t5v0__buf_12             920.5 3.8e-11 5.2e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlya_4            2764.7 6.8e-12 2.4e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlyb_4            2767.3 7.3e-12 2.3e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlyc_4            2773.0 7.2e-12 2.9e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlya_2            5507.4 1.4e-11 1.8e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlyc_2            5514.2 1.4e-11 2.3e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlyb_2            5526.0 1.5e-11 1.8e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlyd_1           11084.9 2.9e-11 2.6e-10 10080 N/A     -
-gf180mcu_fd_sc_mcu9t5v0__dlyc_1           11055.3 2.9e-11 2.1e-10 10080 N/A     -
+gf180mcu_fd_sc_mcu9t5v0__buf_3             3673.0 2.6e-11 1.6e-10 10080 N/A     -
+gf180mcu_fd_sc_mcu9t5v0__buf_4             2750.7 3.8e-11 2.1e-10 10080 N/A     -
+gf180mcu_fd_sc_mcu9t5v0__buf_2             5505.1 3.9e-11 1.3e-10 10080 N/A     -
+gf180mcu_fd_sc_mcu9t5v0__buf_1            11053.1 4.3e-11 1.0e-10 10080 N/A     -
 
 Hold Buffer Report:
 gf180mcu_fd_sc_mcu9t5v0__dlyc_1 is the buffer chosen for hold fixing
 ********************************************************************************
 
 Fast Buffer Report:
-There are 2 fast buffers
+There are 8 fast buffers
 --------------------------------------------------------------------------------
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
+gf180mcu_fd_sc_mcu9t5v0__buf_1               16.9 3.9e-15 1.5e-10 11053.1
+gf180mcu_fd_sc_mcu9t5v0__buf_2               22.6 7.1e-15 1.3e-10  5505.1
+gf180mcu_fd_sc_mcu9t5v0__buf_3               28.2 7.1e-15 1.7e-10  3673.0
+gf180mcu_fd_sc_mcu9t5v0__buf_4               39.5 1.4e-14 1.2e-10  2750.7
 gf180mcu_fd_sc_mcu9t5v0__buf_8               73.4 2.8e-14 1.3e-10  1378.8
 gf180mcu_fd_sc_mcu9t5v0__buf_12             107.3 4.1e-14 1.3e-10   920.5
+gf180mcu_fd_sc_mcu9t5v0__buf_16             141.1 5.5e-14 1.3e-10   690.9
+gf180mcu_fd_sc_mcu9t5v0__buf_20             175.0 6.9e-14 1.3e-10   553.6
 --------------------------------------------------------------------------------
 [INFO RSZ-0165] Buffer pruning will be disabled to enable all buffers for repair_design and repair_timing
 ********************************************************************************
@@ -146,11 +150,17 @@ gf180mcu_fd_sc_mcu9t5v0__dlyc_1 is the buffer chosen for hold fixing
 ********************************************************************************
 
 Fast Buffer Report:
-There are 2 fast buffers
+There are 8 fast buffers
 --------------------------------------------------------------------------------
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
+gf180mcu_fd_sc_mcu9t5v0__buf_1               16.9 3.9e-15 1.5e-10 11053.1
+gf180mcu_fd_sc_mcu9t5v0__buf_2               22.6 7.1e-15 1.3e-10  5505.1
+gf180mcu_fd_sc_mcu9t5v0__buf_3               28.2 7.1e-15 1.7e-10  3673.0
+gf180mcu_fd_sc_mcu9t5v0__buf_4               39.5 1.4e-14 1.2e-10  2750.7
 gf180mcu_fd_sc_mcu9t5v0__buf_8               73.4 2.8e-14 1.3e-10  1378.8
 gf180mcu_fd_sc_mcu9t5v0__buf_12             107.3 4.1e-14 1.3e-10   920.5
+gf180mcu_fd_sc_mcu9t5v0__buf_16             141.1 5.5e-14 1.3e-10   690.9
+gf180mcu_fd_sc_mcu9t5v0__buf_20             175.0 6.9e-14 1.3e-10   553.6
 --------------------------------------------------------------------------------

--- a/src/rsz/test/report_buffers_sky130hd.ok
+++ b/src/rsz/test/report_buffers_sky130hd.ok
@@ -52,34 +52,37 @@ sky130_fd_sc_hd__clkdlybuf4s25_1           9879.3 2.3e-11 3.8e-12 2720 sky130_fd
 sky130_fd_sc_hd__buf_1                    11515.6 2.5e-11 1.2e-12 2720 sky130_fd_sc_hd__buf -
 
 Filtered Buffer Report:
-There are 10 buffers after filtering based on threshold voltage,
+There are 9 buffers after filtering based on threshold voltage,
 cell footprint, drive strength and cell site
 --------------------------------------------------------------------------------
 Cell                                        Drive Drive    Leak   Site Cell   VT
                                             Res   Res*Cin          Ht Footpt Type
 --------------------------------------------------------------------------------
 sky130_fd_sc_hd__bufbuf_16                 1006.1 2.4e-12 1.9e-11 2720 sky130_fd_sc_hd__buf -
+sky130_fd_sc_hd__buf_16                    1002.5 1.4e-11 1.3e-11 2720 sky130_fd_sc_hd__buf -
 sky130_fd_sc_hd__buf_12                    1076.6 1.0e-11 9.4e-12 2720 sky130_fd_sc_hd__buf -
+sky130_fd_sc_hd__buf_8                     1527.4 1.1e-11 7.4e-12 2720 sky130_fd_sc_hd__buf -
 sky130_fd_sc_hd__bufbuf_8                  1598.6 2.9e-12 1.1e-11 2720 sky130_fd_sc_hd__buf -
+sky130_fd_sc_hd__buf_6                     1902.3 9.2e-12 6.1e-12 2720 sky130_fd_sc_hd__buf -
 sky130_fd_sc_hd__buf_4                     2675.4 6.8e-12 4.8e-12 2720 sky130_fd_sc_hd__buf -
-sky130_fd_sc_hd__clkdlybuf4s50_2           5102.1 1.2e-11 4.4e-12 2720 sky130_fd_sc_hd__buf -
-sky130_fd_sc_hd__clkdlybuf4s18_2           5041.3 1.2e-11 5.0e-12 2720 sky130_fd_sc_hd__buf -
-sky130_fd_sc_hd__dlygate4sd1_1             9406.9 1.6e-11 5.8e-12 2720 sky130_fd_sc_hd__buf -
-sky130_fd_sc_hd__dlygate4sd2_1             9477.4 1.7e-11 5.3e-12 2720 sky130_fd_sc_hd__buf -
-sky130_fd_sc_hd__dlygate4sd3_1             9660.2 1.7e-11 4.2e-12 2720 sky130_fd_sc_hd__buf -
-sky130_fd_sc_hd__clkdlybuf4s50_1           9545.1 2.2e-11 3.9e-12 2720 sky130_fd_sc_hd__buf -
+sky130_fd_sc_hd__buf_2                     4789.2 8.7e-12 3.9e-12 2720 sky130_fd_sc_hd__buf -
+sky130_fd_sc_hd__buf_1                    11515.6 2.5e-11 1.2e-12 2720 sky130_fd_sc_hd__buf -
 
 Hold Buffer Report:
 sky130_fd_sc_hd__dlygate4sd3_1 is the buffer chosen for hold fixing
 ********************************************************************************
 
 Fast Buffer Report:
-There are 2 fast buffers
+There are 6 fast buffers
 --------------------------------------------------------------------------------
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
+sky130_fd_sc_hd__buf_2                        5.0 1.8e-15 8.3e-11  4789.2
+sky130_fd_sc_hd__buf_1                        3.8 2.2e-15 5.2e-11 11515.6
 sky130_fd_sc_hd__buf_4                        7.5 2.5e-15 9.8e-11  2675.4
+sky130_fd_sc_hd__buf_6                       11.3 4.9e-15 8.1e-11  1902.3
+sky130_fd_sc_hd__buf_8                       15.0 7.3e-15 8.5e-11  1527.4
 sky130_fd_sc_hd__buf_12                      20.0 9.6e-15 9.0e-11  1076.6
 --------------------------------------------------------------------------------
 [INFO RSZ-0165] Buffer pruning will be disabled to enable all buffers for repair_design and repair_timing
@@ -166,11 +169,15 @@ sky130_fd_sc_hd__dlygate4sd3_1 is the buffer chosen for hold fixing
 ********************************************************************************
 
 Fast Buffer Report:
-There are 2 fast buffers
+There are 6 fast buffers
 --------------------------------------------------------------------------------
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
+sky130_fd_sc_hd__buf_2                        5.0 1.8e-15 8.3e-11  4789.2
+sky130_fd_sc_hd__buf_1                        3.8 2.2e-15 5.2e-11 11515.6
 sky130_fd_sc_hd__buf_4                        7.5 2.5e-15 9.8e-11  2675.4
+sky130_fd_sc_hd__buf_6                       11.3 4.9e-15 8.1e-11  1902.3
+sky130_fd_sc_hd__buf_8                       15.0 7.3e-15 8.5e-11  1527.4
 sky130_fd_sc_hd__buf_12                      20.0 9.6e-15 9.0e-11  1076.6
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`buffer_ports`/`repair_design` were selecting clock-delay buffers (`*clkdlybuf*`) and dedicated delay cells (`*dlygate*`, `*dlymetal*`, gf180 `dly*`) as general-purpose data buffers. This restores filtering so the data-buffer candidate set excludes delay/clock-delay cells.

## Type of Change
- Bug fix

## Impact
Data buffering no longer uses delay cells; affected golden outputs updated.

## Verification
- [x] Local build succeeds.
- [x] Relevant tests pass (rebuilt from source): `ctest -R '^rsz\.'` 238/238; real fail/pass.
- [x] Code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes #10622


---
*Developed with [SAIGE](https://fermions.co/), Fermions' autonomous RTL/EDA debugging agent; root-caused, tested, and signed off by the submitter (@saurav-fermions).*
