### PR TITLE
dbSta: keep top-level supply ports visible in pin iterator (#10414)

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -522,16 +522,21 @@ DbInstancePinIterator::DbInstancePinIterator(const Instance* inst,
 bool DbInstancePinIterator::hasNext()
 {
   if (top_) {
-    while (bitr_ != bitr_end_) {
-      dbBTerm* bterm = *bitr_;
-      if (!network_->isPGSupply(bterm)) {
-        next_ = network_->dbToSta(bterm);
-        bitr_++;
-        return true;
-      }
-      bitr_++;
+    // Do not filter supply BTerms here.  The top-level block ports are the
+    // design's primary I/O (including power/ground pins) and must stay
+    // visible to consumers that walk the top instance's pins.  In
+    // particular write_verilog relies on this iterator to emit the
+    // "assign <port> = <net>;" aliases that connect a power/ground port to
+    // an internal supply net whose name differs from the port name.
+    // Filtering them out drops those connections and breaks LVS (#10414).
+    // Leaf instance terms are still filtered below.
+    if (bitr_ == bitr_end_) {
+      return false;
     }
-    return false;
+    dbBTerm* bterm = *bitr_;
+    next_ = network_->dbToSta(bterm);
+    bitr_++;
+    return true;
   }
 
   while (iitr_ != iitr_end_) {

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -693,16 +693,21 @@ bool DbInstancePinIterator::hasNext()
     return false;
   }
   if (top_) {
-    while (bitr_ != bitr_end_) {
-      dbBTerm* bterm = *bitr_;
-      if (!network_->isPGSupply(bterm)) {
-        next_ = network_->dbToSta(bterm);
-        bitr_++;
-        return true;
-      }
-      bitr_++;
+    // Do not filter supply BTerms here.  The top-level block ports are the
+    // design's primary I/O (including power/ground pins) and must stay
+    // visible to consumers that walk the top instance's pins.  In
+    // particular write_verilog relies on this iterator to emit the
+    // "assign <port> = <net>;" aliases that connect a power/ground port to
+    // an internal supply net whose name differs from the port name.
+    // Filtering them out drops those connections and breaks LVS (#10414).
+    // Leaf instance terms are still filtered below.
+    if (bitr_ == bitr_end_) {
+      return false;
     }
-    return false;
+    dbBTerm* bterm = *bitr_;
+    next_ = network_->dbToSta(bterm);
+    bitr_++;
+    return true;
   }
 
   while (iitr_ != iitr_end_) {

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -81,6 +81,7 @@ ALL_TESTS = [
     "write_verilog8",
     "write_verilog9",
     "write_verilog9_hier",
+    "write_verilog10",
 ]
 
 filegroup(
@@ -285,6 +286,9 @@ filegroup(
             ],
             "write_verilog9_hier": [
                 "write_verilog9.v",
+            ],
+            "write_verilog10": [
+                "write_verilog10.def",
             ],
         }.get(test_name, []),
     )

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -270,6 +270,9 @@ filegroup(
             "write_verilog1": [
                 "reg1.def",
             ],
+            "write_verilog10": [
+                "write_verilog10.def",
+            ],
             "write_verilog2": [
                 "reg4.def",
             ],
@@ -286,9 +289,6 @@ filegroup(
             ],
             "write_verilog9_hier": [
                 "write_verilog9.v",
-            ],
-            "write_verilog10": [
-                "write_verilog10.def",
             ],
         }.get(test_name, []),
     )

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -93,6 +93,7 @@ ALL_TESTS = [
     "sta5",
     "sta_to_db1",
     "sta_to_db1_hier",
+    "supply_port_graph",
     "write_sdc1",
     "write_verilog1",
     "write_verilog10",
@@ -321,9 +322,6 @@ filegroup(
             ],
             "write_verilog1": [
                 "reg1.def",
-            ],
-            "write_verilog10": [
-                "write_verilog10.def",
             ],
             "write_verilog2": [
                 "reg4.def",

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -95,6 +95,7 @@ ALL_TESTS = [
     "sta_to_db1_hier",
     "write_sdc1",
     "write_verilog1",
+    "write_verilog10",
     "write_verilog2",
     "write_verilog3",
     "write_verilog4",
@@ -320,6 +321,9 @@ filegroup(
             ],
             "write_verilog1": [
                 "reg1.def",
+            ],
+            "write_verilog10": [
+                "write_verilog10.def",
             ],
             "write_verilog2": [
                 "reg4.def",

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -316,6 +316,9 @@ filegroup(
                 "example1.lef",
                 "hier3.v",
             ],
+            "supply_port_graph": [
+                "write_verilog10.def",
+            ],
             "write_sdc1": [
                 "hier1.sdc",
                 "hier1.v",

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -71,6 +71,7 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+    write_verilog10
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -65,6 +65,7 @@ or_integration_tests(
     sta5
     sta_to_db1
     sta_to_db1_hier
+    supply_port_graph
     write_sdc1
     write_verilog1
     write_verilog2

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -76,6 +76,7 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+    write_verilog10
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/supply_port_graph.ok
+++ b/src/dbSta/test/supply_port_graph.ok
@@ -1,0 +1,48 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: top
+[INFO ODB-0130]     Created 6 pins.
+[INFO ODB-0131]     Created 1 components and 4 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 0 connections.
+[INFO ODB-0133]     Created 2 nets and 2 connections.
+--- timing graph vertices (supply pins must not appear) ---
+  in1
+  out1
+  u1/A
+  u1/Z
+  vertex count: 4
+--- top instance pins (supply ports are visible here) ---
+  in1
+  out1
+  vccd1
+  vccd2
+  vssd1
+  vssd2
+--- cross-check: supply BTerms on each supply net (odb) vs the pin walk ---
+  vdpwr bterms: vccd1 vccd2
+  vdpwr missing from pin walk: 
+  vgnd bterms: vssd1 vssd2
+  vgnd missing from pin walk: 
+--- write_verilog -include_pwr_gnd (assign aliases must stay) ---
+module top (in1,
+    out1,
+    vccd1,
+    vccd2,
+    vssd1,
+    vssd2);
+ input in1;
+ output out1;
+ inout vccd1;
+ inout vccd2;
+ inout vssd1;
+ inout vssd2;
+
+ wire vdpwr;
+ wire vgnd;
+
+ BUF_X1 u1 (.A(in1),
+    .Z(out1));
+ assign vccd1 = vdpwr;
+ assign vccd2 = vdpwr;
+ assign vssd1 = vgnd;
+ assign vssd2 = vgnd;
+endmodule

--- a/src/dbSta/test/supply_port_graph.tcl
+++ b/src/dbSta/test/supply_port_graph.tcl
@@ -1,0 +1,66 @@
+# Guard for #10414 and #8957 at the same time.
+#
+# DbInstancePinIterator exposes the top block's power/ground BTerms (needed so
+# write_verilog can emit the "assign <port> = <net>;" aliases when a supply port
+# and its net have different names -- #10414).  Graph::makeVerticesAndEdges()
+# walks that same iterator, so this test pins down that the supply terminals
+# still do NOT become timing-graph vertices (the growth #8957 fixed).
+#
+# It also cross-checks the top instance pin walk against the supply nets' pin
+# and term walks, so the golden records which iterators expose supply
+# terminals and any future change to that shows up here.
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_def write_verilog10.def
+
+# sta::vertex_iterator calls ensureGraph(), so this builds the timing graph.
+puts "--- timing graph vertices (supply pins must not appear) ---"
+set vertex_names {}
+set vertex_iter [sta::vertex_iterator]
+while { [$vertex_iter has_next] } {
+  set vertex [$vertex_iter next]
+  lappend vertex_names [get_full_name [$vertex pin]]
+}
+$vertex_iter finish
+foreach name [lsort $vertex_names] {
+  puts "  $name"
+}
+puts "  vertex count: [llength $vertex_names]"
+
+puts "--- top instance pins (supply ports are visible here) ---"
+set top_pin_names {}
+set pin_iter [[sta::top_instance] pin_iterator]
+while { [$pin_iter has_next] } {
+  lappend top_pin_names [get_full_name [$pin_iter next]]
+}
+$pin_iter finish
+foreach name [lsort $top_pin_names] {
+  puts "  $name"
+}
+
+puts "--- cross-check: supply BTerms on each supply net (odb) vs the pin walk ---"
+set block [ord::get_db_block]
+foreach net_name {vdpwr vgnd} {
+  set db_net [$block findNet $net_name]
+  set net_bterms {}
+  foreach bterm [$db_net getBTerms] {
+    lappend net_bterms [$bterm getName]
+  }
+  set net_bterms [lsort $net_bterms]
+  # Every BTerm odb reports on the supply net must also be reachable from the
+  # top instance pin walk; that is what write_verilog uses to emit the alias.
+  set missing {}
+  foreach bterm_name $net_bterms {
+    if { [lsearch -exact $top_pin_names $bterm_name] == -1 } {
+      lappend missing $bterm_name
+    }
+  }
+  puts "  $net_name bterms: $net_bterms"
+  puts "  $net_name missing from pin walk: $missing"
+}
+
+puts "--- write_verilog -include_pwr_gnd (assign aliases must stay) ---"
+set verilog_file [make_result_file supply_port_graph.v]
+write_verilog -include_pwr_gnd $verilog_file
+report_file $verilog_file

--- a/src/dbSta/test/write_verilog10.def
+++ b/src/dbSta/test/write_verilog10.def
@@ -1,0 +1,38 @@
+VERSION 5.8 ; 
+NAMESCASESENSITIVE ON ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+
+DESIGN top ;
+
+UNITS DISTANCE MICRONS 1000 ;
+
+DIEAREA ( 0 0 ) ( 1000 1000 ) ;
+
+
+COMPONENTS 1 ;
+- u1 BUF_X1 ;
+END COMPONENTS
+
+PINS 6 ;
+- in1 + NET in1 + DIRECTION INPUT ;
+- out1 + NET out1 + DIRECTION OUTPUT ;
+- vccd1 + NET vdpwr + DIRECTION INPUT + USE POWER ;
+- vccd2 + NET vdpwr + DIRECTION INPUT + USE POWER ;
+- vssd1 + NET vgnd + DIRECTION INPUT + USE GROUND ;
+- vssd2 + NET vgnd + DIRECTION INPUT + USE GROUND ;
+END PINS
+
+SPECIALNETS 2 ;
+- vgnd  ( * vssd1 ) ( * vssd2 )
+  + USE GROUND ;
+- vdpwr  ( * vccd1 ) ( * vccd2 )
+  + USE POWER ;
+END SPECIALNETS
+
+NETS 2 ;
+- in1 ( PIN in1 ) ( u1 A ) ;
+- out1 ( u1 Z ) ( PIN out1 ) ;
+END NETS
+
+END DESIGN

--- a/src/dbSta/test/write_verilog10.ok
+++ b/src/dbSta/test/write_verilog10.ok
@@ -1,0 +1,29 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: top
+[INFO ODB-0130]     Created 6 pins.
+[INFO ODB-0131]     Created 1 components and 4 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 0 connections.
+[INFO ODB-0133]     Created 2 nets and 2 connections.
+module top (in1,
+    out1,
+    vccd1,
+    vccd2,
+    vssd1,
+    vssd2);
+ input in1;
+ output out1;
+ inout vccd1;
+ inout vccd2;
+ inout vssd1;
+ inout vssd2;
+
+ wire vdpwr;
+ wire vgnd;
+
+ BUF_X1 u1 (.A(in1),
+    .Z(out1));
+ assign vccd1 = vdpwr;
+ assign vccd2 = vdpwr;
+ assign vssd1 = vgnd;
+ assign vssd2 = vgnd;
+endmodule

--- a/src/dbSta/test/write_verilog10.tcl
+++ b/src/dbSta/test/write_verilog10.tcl
@@ -1,0 +1,12 @@
+# Repro for issue #10414: multiple power/ground pins tied to one net
+# whose name differs from the port names.  write_verilog -include_pwr_gnd
+# must emit assign statements linking each port to the net, otherwise the
+# power connection is dropped and LVS breaks.
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_def write_verilog10.def
+
+set verilog_file [make_result_file write_verilog10.v]
+write_verilog -include_pwr_gnd $verilog_file
+report_file $verilog_file


### PR DESCRIPTION
## Summary
`write_verilog -include_pwr_gnd` stopped emitting `assign <port> = <net>;` for top-level supply ports wired to an internal supply net of a different name (e.g. `vccd1`/`vccd2` -> `vdpwr`), breaking LVS. This keeps top-level supply ports visible in the pin iterator so the assigns are restored.

## Type of Change
- Bug fix

## Impact
Power/ground port connections reappear in written Verilog; fixes the LVS breakage.

## Verification
- [x] Local build succeeds.
- [x] Relevant tests pass (rebuilt from source): `ctest -R '^dbSta\.'` 71/71.
- [x] Code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes #10414


---
*Developed with [SAIGE](https://fermions.co/), Fermions' autonomous RTL/EDA debugging agent; root-caused, tested, and signed off by the submitter (@saurav-fermions).*
