### PR TITLE
ord: default thread count to number of available CPUs (#10350)

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -117,6 +117,13 @@ OpenRoad* OpenRoad::app_ = nullptr;
 OpenRoad::OpenRoad()
 {
   db_ = dbDatabase::create();
+
+  // Default the thread count to the number of available CPUs (i.e. behave
+  // like "-threads max" by default) so users who do not pass "-threads N"
+  // are not silently running single-threaded. An explicit "-threads N" (or
+  // a set_thread_count call) still overrides this default. See issue #10350.
+  unsigned int hw_threads = std::thread::hardware_concurrency();
+  threads_ = (hw_threads == 0) ? 1 : static_cast<int>(hw_threads);
 }
 
 OpenRoad::~OpenRoad()


### PR DESCRIPTION
## Summary
Defaults `thread_count` to the number of available CPUs instead of 1, so users who do not pass `-threads N` no longer run single-threaded unknowingly. Explicit `-threads N` overrides still work and regression-test determinism is preserved.

## Type of Change
- Enhancement

## Impact
Faster default runs on multi-core machines; explicit overrides unchanged.

## Verification
- [x] Local build succeeds.
- [x] Relevant tests pass (rebuilt from source): Measured default `thread_count` 1 -> nCPU; `-threads N` override verified.
- [x] Code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes #10350


---
*Developed with [SAIGE](https://fermions.co/), Fermions' autonomous RTL/EDA debugging agent; root-caused, tested, and signed off by the submitter (@saurav-fermions).*
