### PR TITLE
cts: add regression test for single-sink cluster buffer balance (#9070)

### DIFF
--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -49,6 +49,7 @@ COMPULSORY_TESTS = [
     "simple_test_clustered_max_cap",
     "simple_test_hier",
     "sink_clustering_collision",
+    "sink_clustering_single_sink",
     "skip_nets",
     "twice",
     "virtual_clock_latency",

--- a/src/cts/test/CMakeLists.txt
+++ b/src/cts/test/CMakeLists.txt
@@ -44,6 +44,7 @@ or_integration_tests(
     simple_test_clustered_max_cap
     simple_test_hier
     sink_clustering_collision
+    sink_clustering_single_sink
     skip_nets
     twice
     virtual_clock_latency

--- a/src/cts/test/sink_clustering_single_sink.ok
+++ b/src/cts/test/sink_clustering_single_sink.ok
@@ -1,0 +1,51 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+Created 262 sinks total (256 clustered + 6 isolated orphans)
+[INFO CTS-0050] Root buffer is BUF_X4.
+[INFO CTS-0051] Sink buffer is BUF_X4.
+[INFO CTS-0052] The following clock buffers will be used for CTS:
+                    BUF_X4
+[INFO CTS-0049] Characterization buffer is BUF_X4.
+[INFO CTS-0007] Net "clk" found for clock "clk".
+[INFO CTS-0010]  Clock net "clk" has 262 sinks.
+[INFO CTS-0008] TritonCTS found 1 clock nets.
+[INFO CTS-0097] Characterization used 1 buffer(s) types.
+[INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
+[INFO CTS-0027] Generating H-Tree topology for net clk.
+[INFO CTS-0028]  Total number of sinks: 262.
+[INFO CTS-0059]  Register sinks will be clustered with maximum cluster diameter of 100.0 um and based on buffer max cap.
+[INFO CTS-0030]  Number of static layers: 0.
+[INFO CTS-0020]  Wire segment unit: 14000  dbu (7 um).
+[INFO CTS-0204] A clustering solution was found from max clustering size of 34 and clustering diameter of 100.
+[INFO CTS-0205] Better solution may be possible if either -sink_clustering_size, -sink_clustering_max_diameter, or both options are omitted to enable automatic clustering.
+[INFO CTS-0019]  Total number of sinks after clustering: 14.
+[INFO CTS-0024]  Normalized sink region: [(7.75676, 7.57357), (275.231, 275.088)].
+[INFO CTS-0025]     Width:  267.4740.
+[INFO CTS-0026]     Height: 267.5143.
+ Level 1
+    Direction: Vertical
+    Sinks per sub-region: 7
+    Sub-region size: 267.4740 X 133.7571
+[INFO CTS-0034]     Segment length (rounded): 66.
+[INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
+[INFO CTS-0035]  Number of sinks covered: 14.
+[INFO CTS-0018]     Created 19 clock buffers.
+[INFO CTS-0012]     Minimum number of buffers in the clock path: 4.
+[INFO CTS-0013]     Maximum number of buffers in the clock path: 4.
+[INFO CTS-0015]     Created 19 clock nets.
+[INFO CTS-0016]     Fanout distribution for the current clock = 1:6, 6:1, 8:1, 21:1, 33:3, 34:4..
+[INFO CTS-0017]     Max level of the clock tree: 1.
+[INFO CTS-0098] Clock net "clk"
+[INFO CTS-0099]  Sinks 266
+[INFO CTS-0100]  Leaf buffers 14
+[INFO CTS-0101]  Average sink wire length 3828.39 um
+[INFO CTS-0102]  Path depth 4 - 4
+[INFO CTS-0207]  Dummy loads inserted 4
+Total number of Clock Roots: 1.
+Total number of Buffers Inserted: 19.
+Total number of Clock Subnets: 19.
+Total number of Sinks: 262.
+Cells used:
+  BUF_X4: 19
+Dummys used:
+  INV_X1: 3
+  INV_X8: 1

--- a/src/cts/test/sink_clustering_single_sink.tcl
+++ b/src/cts/test/sink_clustering_single_sink.tcl
@@ -1,0 +1,92 @@
+# Regression test for issue #9070.
+#
+# CTS sink clustering must not leave any sink in a single-sink (orphan)
+# cluster that bypasses the leaf-buffer level.  When that happens, the
+# orphan sinks end up with one fewer buffer in their clock path than the
+# clustered sinks, creating skew between them (visible on sky130hd/aes).
+#
+# Strategy:
+#  1. Place a dense block of sinks (> 200, so sink clustering is enabled and
+#     forms normal multi-sink clusters, each driven by a clkbuf_leaf_ buffer).
+#  2. Place a handful of additional sinks far apart from the block and from
+#     each other (farther than the cluster diameter) so each one forms its
+#     own single-sink "orphan" cluster.
+#
+# Before the fix, single-sink clusters skipped the clkbuf_leaf_ buffer, so
+# CTS reported a minimum clock-path buffer count smaller than the maximum
+# (e.g. min 3 vs max 4).  After the fix, every cluster -- including
+# single-sink ones -- gets a leaf buffer, so the minimum equals the maximum
+# (balanced clock depth).
+#
+# The pass/fail signal is CTS-0012 (minimum) == CTS-0013 (maximum).
+
+source "helpers.tcl"
+
+proc create_orphan_test {} {
+  set db [ord::get_db]
+  set tech [$db getTech]
+  set chip [odb::dbChip_create $db $tech]
+  set block [odb::dbBlock_create $chip "orphan_test"]
+  set master [$db findMaster "DFF_X1"]
+  set layer [$tech findLayer "metal6"]
+
+  $block setDefUnits [$tech getDbUnitsPerMicron]
+  set rect [odb::Rect]
+  $rect init 0 0 4000000 4000000
+  $block setDieArea $rect
+
+  set clk [odb::dbNet_create $block "clk"]
+  set term [odb::dbBTerm_create $clk "clk"]
+  $term setIoType INPUT
+  set pin [odb::dbBPin_create $term]
+  $pin setPlacementStatus FIRM
+  odb::dbBox_create $pin $layer 0 0 2000 2000
+
+  set ff_idx 0
+
+  # Dense block of 16x16 = 256 sinks (above the 200-sink clustering threshold).
+  set base 100000
+  set step 2400
+  for {set gx 0} {$gx < 16} {incr gx} {
+    for {set gy 0} {$gy < 16} {incr gy} {
+      set x [expr {$base + $gx * $step}]
+      set y [expr {$base + $gy * $step}]
+      set inst [odb::dbInst_create $block $master "ff$ff_idx"]
+      $inst setOrigin $x $y
+      $inst setPlacementStatus PLACED
+      [$inst findITerm "CK"] connect $clk
+      incr ff_idx
+    }
+  }
+
+  # Isolated sinks placed far apart from each other (well beyond the cluster
+  # diameter) so each forms its own single-sink (orphan) cluster.
+  set far 2000000
+  foreach off {0 300000 650000 1000000 1400000 1850000} {
+    set xy [expr {$far + $off}]
+    set inst [odb::dbInst_create $block $master "orphan$ff_idx"]
+    $inst setOrigin $xy $xy
+    $inst setPlacementStatus PLACED
+    [$inst findITerm "CK"] connect $clk
+    incr ff_idx
+  }
+
+  sta::db_network_defined
+  puts "Created $ff_idx sinks total (256 clustered + 6 isolated orphans)"
+}
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+
+create_orphan_test
+
+create_clock -period 5 clk
+set_wire_rc -clock -layer metal5
+
+set_cts_config -sink_clustering_max_diameter 100 \
+  -root_buf BUF_X4 \
+  -buf_list BUF_X4
+
+clock_tree_synthesis -sink_clustering_enable
+
+report_cts

--- a/src/cts/test/sink_clustering_single_sink.tcl
+++ b/src/cts/test/sink_clustering_single_sink.tcl
@@ -22,7 +22,7 @@
 
 source "helpers.tcl"
 
-proc create_orphan_test {} {
+proc create_orphan_test { } {
   set db [ord::get_db]
   set tech [$db getTech]
   set chip [odb::dbChip_create $db $tech]
@@ -47,10 +47,10 @@ proc create_orphan_test {} {
   # Dense block of 16x16 = 256 sinks (above the 200-sink clustering threshold).
   set base 100000
   set step 2400
-  for {set gx 0} {$gx < 16} {incr gx} {
-    for {set gy 0} {$gy < 16} {incr gy} {
-      set x [expr {$base + $gx * $step}]
-      set y [expr {$base + $gy * $step}]
+  for { set gx 0 } { $gx < 16 } { incr gx } {
+    for { set gy 0 } { $gy < 16 } { incr gy } {
+      set x [expr { $base + $gx * $step }]
+      set y [expr { $base + $gy * $step }]
       set inst [odb::dbInst_create $block $master "ff$ff_idx"]
       $inst setOrigin $x $y
       $inst setPlacementStatus PLACED
@@ -63,7 +63,7 @@ proc create_orphan_test {} {
   # diameter) so each forms its own single-sink (orphan) cluster.
   set far 2000000
   foreach off {0 300000 650000 1000000 1400000 1850000} {
-    set xy [expr {$far + $off}]
+    set xy [expr { $far + $off }]
     set inst [odb::dbInst_create $block $master "orphan$ff_idx"]
     $inst setOrigin $xy $xy
     $inst setPlacementStatus PLACED


### PR DESCRIPTION
## Summary
Adds a regression test for single-sink ('orphan') cluster sink-buffer balance in TritonCTS. The behavior is **already correct on current master** — the referenced issue was already fixed; this test guards against regression of the per-cluster sink buffer for single-sink clusters (whose absence otherwise caused a buffer-depth/latency imbalance). Test-only, no code change.

**Related to #9070** (adds a regression testcase; does not itself fix the issue).

## Type of Change
- Tests

## Impact
Test-only; no code change.