### PR TITLE
odb: guard optional dbId getters against invalid id resolution

### DIFF
--- a/src/odb/src/db/dbMetalWidthViaMap.cpp
+++ b/src/odb/src/db/dbMetalWidthViaMap.cpp
@@ -209,6 +209,9 @@ bool dbMetalWidthViaMap::isPgVia() const
 dbTechLayer* dbMetalWidthViaMap::getCutLayer() const
 {
   _dbMetalWidthViaMap* obj = (_dbMetalWidthViaMap*) this;
+  if (!obj->cut_layer_.isValid()) {
+    return nullptr;
+  }
   dbTech* tech = (dbTech*) obj->getOwner();
   return dbTechLayer::getTechLayer(tech, obj->cut_layer_);
 }

--- a/src/odb/src/db/dbTechLayerAreaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAreaRule.cpp
@@ -276,6 +276,9 @@ void dbTechLayerAreaRule::setTrimLayer(dbTechLayer* trim_layer)
 dbTechLayer* dbTechLayerAreaRule::getTrimLayer() const
 {
   _dbTechLayerAreaRule* obj = (_dbTechLayerAreaRule*) this;
+  if (!obj->trim_layer_.isValid()) {
+    return nullptr;
+  }
   odb::dbTech* tech = getDb()->getTech();
   return odb::dbTechLayer::getTechLayer(tech, obj->trim_layer_);
 }


### PR DESCRIPTION
## Summary
Guard `dbTechLayerAreaRule::getTrimLayer()` and `dbMetalWidthViaMap::getCutLayer()` against resolving an unset `dbId`. Both fields are optional (not set in the constructor or `create()`), so when unset they default to OID 0; passing 0 to `getTechLayer()` returned a garbage non-null pointer instead of `nullptr`. Now guarded with `dbId::isValid()`.

## Type of Change
- Bug fix

## Impact
`getTrimLayer()`/`getCutLayer()` now return `nullptr` when no layer is set, instead of a garbage pointer. This stops DRT from spuriously firing `DRT-0316` on `LEF58_AREA` rules that have no `LAYER` clause and ignoring valid LEF58_AREA rules

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [ ] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**