### PR TITLE
gpl, pdn: fix NaN clamp bypass and -min_width_layers edge cases

### DIFF
--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -4,6 +4,7 @@
 #include "gpl/Replace.h"
 
 #include <algorithm>
+#include <cmath>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -324,13 +325,16 @@ bool Replace::initNesterovPlace(const PlaceOptions& options,
     float skew_fraction = options.virtualCtsMaxSkewFraction;
     // Clamp to a sane range; a negative value yields negative insertion
     // delays and values above the clock period make no physical sense.
-    if (skew_fraction < 0.0f || skew_fraction > 1.0f) {
+    if (std::isnan(skew_fraction) || skew_fraction < 0.0f
+        || skew_fraction > 1.0f) {
       log_->warn(GPL,
                  165,
                  "virtual_cts_max_skew_fraction {} out of range [0, 1]; "
                  "clamping.",
                  skew_fraction);
-      skew_fraction = std::clamp(skew_fraction, 0.0f, 1.0f);
+      skew_fraction = std::isnan(skew_fraction)
+                          ? 0.10f
+                          : std::clamp(skew_fraction, 0.0f, 1.0f);
     }
     cb_ = std::make_shared<ClockBase>(sta_, db_, log_);
     cb_->setMaxSkewFraction(skew_fraction);

--- a/src/pdn/src/connect.cpp
+++ b/src/pdn/src/connect.cpp
@@ -120,7 +120,23 @@ void Connect::setOnGrid(const std::vector<odb::dbTechLayer*>& layers)
 
 void Connect::setMinWidthLayers(const std::vector<odb::dbTechLayer*>& layers)
 {
-  min_width_layers_.insert(layers.begin(), layers.end());
+  for (auto* layer : layers) {
+    const bool is_intermediate
+        = std::ranges::find(intermediate_routing_layers_, layer)
+          != intermediate_routing_layers_.end();
+    if (!is_intermediate) {
+      grid_->getLogger()->warn(
+          utl::PDN,
+          501,
+          "-min_width_layers layer {} is not an intermediate routing layer "
+          "between {} and {}; ignoring.",
+          layer->getName(),
+          layer0_->getName(),
+          layer1_->getName());
+    } else {
+      min_width_layers_.insert(layer);
+    }
+  }
 }
 
 void Connect::setSplitCuts(
@@ -263,17 +279,24 @@ void Connect::generateMinEnclosureViaRects(
         = layer->getDirection() == odb::dbTechLayerDir::HORIZONTAL;
     const int min_width = layer->getWidth();
 
+    auto* tech = layer->getTech();
     ViaLayerRects new_rects;
     for (const auto& rect : layer_rects) {
       odb::Rect new_rect = rect;
       const odb::Point new_rect_center(new_rect.xMin() + new_rect.dx() / 2,
                                        new_rect.yMin() + new_rect.dy() / 2);
       if (is_horizontal) {
-        new_rect.set_ylo(new_rect_center.y() - min_width / 2);
-        new_rect.set_yhi(new_rect.yMin() + min_width);
+        const int ylo = TechLayer::snapToManufacturingGrid(
+            tech, new_rect_center.y() - min_width / 2, false);
+        new_rect.set_ylo(ylo);
+        new_rect.set_yhi(
+            TechLayer::snapToManufacturingGrid(tech, ylo + min_width, true));
       } else {
-        new_rect.set_xlo(new_rect_center.x() - min_width / 2);
-        new_rect.set_xhi(new_rect.xMin() + min_width);
+        const int xlo = TechLayer::snapToManufacturingGrid(
+            tech, new_rect_center.x() - min_width / 2, false);
+        new_rect.set_xlo(xlo);
+        new_rect.set_xhi(
+            TechLayer::snapToManufacturingGrid(tech, xlo + min_width, true));
       }
 
       new_rects.insert(new_rect);


### PR DESCRIPTION
## Summary

Two bugs in the `-min_width_layers` feature added by #10689:

**1. Off-grid via metal when `-min_width_layers` is active**
`generateMinEnclosureViaRects` computed min-width via rect edges as
`center ± min_width/2` with no manufacturing-grid snap. When a layer is
listed in `-min_width_layers` the min-width rect becomes the *sole* via
rect (the full-overlap rect is dropped via `std::move`), so unsnapped
edges produced off-grid metal. Fixed by snapping with
`TechLayer::snapToManufacturingGrid`, matching the existing pattern in
`generateComplexStackedViaRects`.

**2. Invalid `-min_width_layers` layer silently ignored**
`setMinWidthLayers` inserted any layer unconditionally. A layer that is
not an intermediate routing layer of the connect pair (wrong routing
level, cut layer) never matches inside `generateMinEnclosureViaRects`,
so the user's constraint had no effect with no diagnostic. Fixed by
validating each entry against `intermediate_routing_layers_`; invalid
layers now emit `[WARNING PDN-0501]` and are skipped.

## Type of Change

- Bug fix

## Impact

- Via metal constrained by `-min_width_layers` is now guaranteed to land
  on the manufacturing grid. No change to behavior for connects that do
  not use `-min_width_layers`.
- Misconfigured `-min_width_layers` arguments (e.g. a cut layer or a
  layer outside the connect pair's stack) now produce a
  `[WARNING PDN-0501]` instead of being silently ignored.

## Verification

- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues

Introduced by #10689 (pdn: bridge stacked vias to on-grid neighbors and
add -min_width_layers).