### PR TITLE
odb: remove corner data from dbExtControl

### DIFF
--- a/src/odb/include/odb/dbExtControl.h
+++ b/src/odb/include/odb/dbExtControl.h
@@ -23,7 +23,6 @@ class dbExtControl : public dbObject
   bool _overCell;
   bool _extracted;
   bool _lefRC;
-  uint32_t _cornerCnt;
   uint32_t _ccPreseveGeom;
   uint32_t _ccUp;
   uint32_t _couplingFlag;
@@ -38,12 +37,6 @@ class dbExtControl : public dbObject
   uint32_t _ccNoPowerTarget;
   bool _usingMetalPlanes;
   std::string _ruleFileName;
-  std::string _extractedCornerList;
-  std::string _derivedCornerList;
-  std::string _cornerIndexList;
-  std::string _resFactorList;
-  std::string _gndcFactorList;
-  std::string _ccFactorList;
 
   dbExtControl();
 };

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,11 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 132;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 133;  // Current revision number
+
+// Revision where the corner data (corner count + corner/factor lists) was
+// removed from dbExtControl
+inline constexpr uint32_t kSchemaRemoveExtControlCornerData = 133;
 
 // Revision where dbInst::bump_ was added
 inline constexpr uint32_t kSchemaInstBump = 132;

--- a/src/odb/src/db/dbExtControl.cpp
+++ b/src/odb/src/db/dbExtControl.cpp
@@ -17,7 +17,6 @@ dbExtControl::dbExtControl()
   _overCell = false;
   _extracted = false;
   _lefRC = false;
-  _cornerCnt = 0;
   _ccPreseveGeom = 0;
   _ccUp = 0;
   _couplingFlag = 3;
@@ -45,7 +44,6 @@ dbOStream& operator<<(dbOStream& stream, const dbExtControl& extControl)
   stream << extControl._foreign;
   stream << extControl._rsegCoord;
   stream << extControl._lefRC;
-  stream << extControl._cornerCnt;
   stream << extControl._ccPreseveGeom;
   stream << extControl._ccUp;
   stream << extControl._couplingFlag;
@@ -60,13 +58,6 @@ dbOStream& operator<<(dbOStream& stream, const dbExtControl& extControl)
   stream << extControl._ccNoPowerTarget;
   stream << extControl._usingMetalPlanes;
   stream << extControl._ruleFileName;
-  // new fields
-  stream << extControl._extractedCornerList;
-  stream << extControl._derivedCornerList;
-  stream << extControl._cornerIndexList;
-  stream << extControl._resFactorList;
-  stream << extControl._gndcFactorList;
-  stream << extControl._ccFactorList;
 
   return stream;
 }
@@ -78,12 +69,18 @@ dbIStream& operator>>(dbIStream& stream, dbExtControl& extControl)
   if (!extControl._extracted) {
     return stream;
   }
+
+  _dbDatabase* db = stream.getDatabase();
+
   stream >> extControl._independentExtCorners;
   stream >> extControl._wireStamped;
   stream >> extControl._foreign;
   stream >> extControl._rsegCoord;
   stream >> extControl._lefRC;
-  stream >> extControl._cornerCnt;
+  if (!db->isSchema(kSchemaRemoveExtControlCornerData)) {
+    uint32_t obsolete_corner_cnt;
+    stream >> obsolete_corner_cnt;
+  }
   stream >> extControl._ccPreseveGeom;
   stream >> extControl._ccUp;
   stream >> extControl._couplingFlag;
@@ -98,12 +95,15 @@ dbIStream& operator>>(dbIStream& stream, dbExtControl& extControl)
   stream >> extControl._ccNoPowerTarget;
   stream >> extControl._usingMetalPlanes;
   stream >> extControl._ruleFileName;
-  stream >> extControl._extractedCornerList;
-  stream >> extControl._derivedCornerList;
-  stream >> extControl._cornerIndexList;
-  stream >> extControl._resFactorList;
-  stream >> extControl._gndcFactorList;
-  stream >> extControl._ccFactorList;
+  if (!db->isSchema(kSchemaRemoveExtControlCornerData)) {
+    std::string obsolete_corner_list;
+    stream >> obsolete_corner_list;  // _extractedCornerList
+    stream >> obsolete_corner_list;  // _derivedCornerList
+    stream >> obsolete_corner_list;  // _cornerIndexList
+    stream >> obsolete_corner_list;  // _resFactorList
+    stream >> obsolete_corner_list;  // _gndcFactorList
+    stream >> obsolete_corner_list;  // _ccFactorList
+  }
 
   return stream;
 }

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2276,7 +2276,6 @@ class extMain
   void genScaledExt();
   void makeCornerNameMap();
   void getExtractedCorners();
-  void makeCornerMapFromExtControl();
   bool checkLayerResistance();
 
   uint32_t getNetBbox(odb::dbNet* net, odb::Rect& maxRect);

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1439,6 +1439,17 @@ int extMain::getDbCornerModel(const char* name)
 void extMain::makeCornerNameMap()
 {
   // Stores the corner names and count on the dbBlock.
+  if (!_block) {
+    logger_->error(
+        utl::RCX, 12, "Could not make corner name map. No block found.");
+  }
+
+  if (_cornerCnt == 0) {
+    logger_->error(
+        utl::RCX,
+        13,
+        "Could not make corner name map. The number of corner is undefined.");
+  }
 
   extCorner** map = new extCorner*[_cornerCnt];
   for (uint32_t jj = 0; jj < _cornerCnt; jj++) {
@@ -1628,6 +1639,14 @@ void extMain::getPrevControl()
   if (!_prevControl) {
     return;
   }
+
+  if (!_block) {
+    logger_->error(
+        utl::RCX,
+        6,
+        "Could not access previous extraction control. No block found.");
+  }
+
   _foreign = _prevControl->_foreign;
   _rsegCoord = _prevControl->_rsegCoord;
   _extracted = _prevControl->_extracted;

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1149,127 +1149,25 @@ extCorner::extCorner()
 
 void extMain::getExtractedCorners()
 {
-  if (_prevControl == nullptr) {
-    return;
-  }
-  if (_prevControl->_extractedCornerList.empty()) {
-    return;
-  }
   if (_processCornerTable != nullptr) {
     return;
   }
 
-  Parser parser(logger_);
-  uint32_t pCornerCnt
-      = parser.mkWords(_prevControl->_extractedCornerList.c_str(), " ");
-  if (pCornerCnt <= 0) {
+  if (!_block) {
+    return;
+  }
+
+  const int corner_count = _block->getCornerCount();
+  if (corner_count <= 0) {
     return;
   }
 
   _processCornerTable = new Array1D<extCorner*>();
-
-  uint32_t cornerCnt = 0;
-  uint32_t ii, jj;
-  std::string cName;
-  for (ii = 0; ii < pCornerCnt; ii++) {
-    extCorner* t = new extCorner();
-    t->_model = parser.getInt(ii);
-
-    t->_dbIndex = cornerCnt++;
-    _processCornerTable->add(t);
-  }
-
-  if (_prevControl->_derivedCornerList.empty()) {
-    makeCornerMapFromExtControl();
-    return;
-  }
-
-  uint32_t sCornerCnt
-      = parser.mkWords(_prevControl->_derivedCornerList.c_str(), " ");
-  if (sCornerCnt <= 0) {
-    return;
-  }
-
-  if (_scaledCornerTable == nullptr) {
-    _scaledCornerTable = new Array1D<extCorner*>();
-  }
-
-  for (ii = 0; ii < sCornerCnt; ii++) {
-    extCorner* t = new extCorner();
-    t->_model = parser.getInt(ii);
-    for (jj = 0; jj < pCornerCnt; jj++) {
-      if (t->_model != _processCornerTable->get(jj)->_model) {
-        continue;
-      }
-      t->_extCornerPtr = _processCornerTable->get(jj);
-      break;
-    }
-    cName = _block->getExtCornerName(pCornerCnt + ii);
-    if (jj == pCornerCnt) {
-      logger_->warn(RCX,
-                    120,
-                    "No matching process corner for scaled corner {}, model {}",
-                    cName,
-                    t->_model);
-    }
-    t->_dbIndex = cornerCnt++;
-    _scaledCornerTable->add(t);
-  }
-  Array1D<double> A;
-
-  parser.mkWords(_prevControl->_resFactorList.c_str(), " ");
-  parser.getDoubleArray(&A, 0);
-  for (ii = 0; ii < sCornerCnt; ii++) {
-    extCorner* t = _scaledCornerTable->get(ii);
-    t->_resFactor = A.get(ii);
-  }
-  parser.mkWords(_prevControl->_ccFactorList.c_str(), " ");
-  A.resetCnt();
-  parser.getDoubleArray(&A, 0);
-  for (ii = 0; ii < sCornerCnt; ii++) {
-    extCorner* t = _scaledCornerTable->get(ii);
-    t->_ccFactor = A.get(ii);
-  }
-  parser.mkWords(_prevControl->_gndcFactorList.c_str(), " ");
-  A.resetCnt();
-  parser.getDoubleArray(&A, 0);
-  for (ii = 0; ii < sCornerCnt; ii++) {
-    extCorner* t = _scaledCornerTable->get(ii);
-    t->_gndFactor = A.get(ii);
-  }
-  makeCornerMapFromExtControl();
-}
-
-void extMain::makeCornerMapFromExtControl()
-{
-  if (_prevControl->_cornerIndexList.empty()) {
-    return;
-  }
-  if (_processCornerTable == nullptr) {
-    return;
-  }
-
-  Parser parser(logger_);
-  uint32_t wordCnt
-      = parser.mkWords(_prevControl->_cornerIndexList.c_str(), " ");
-  if (wordCnt <= 0) {
-    return;
-  }
-
-  std::string cName;
-  for (uint32_t ii = 0; ii < wordCnt; ii++) {
-    int index = parser.getInt(ii);
-    extCorner* t = nullptr;
-    if (index > 0) {  // extracted corner
-      t = _processCornerTable->get(index - 1);
-      t->_dbIndex = ii;
-    } else {
-      t = _scaledCornerTable->get((-index) - 1);
-    }
-    t->_dbIndex = ii;
-    cName = _block->getExtCornerName(ii);
-    free(t->_name);
-    t->_name = strdup(cName.c_str());
+  for (int corner = 0; corner < corner_count; corner++) {
+    extCorner* process_corner = new extCorner();
+    process_corner->_dbIndex = corner;
+    process_corner->_name = strdup(_block->getExtCornerName(corner).c_str());
+    _processCornerTable->add(process_corner);
   }
 }
 
@@ -1540,66 +1438,25 @@ int extMain::getDbCornerModel(const char* name)
 
 void extMain::makeCornerNameMap()
 {
-  // This function updates the dbExtControl object and
-  // creates the corner information to be stored at dbBlock object
+  // Stores the corner names and count on the dbBlock.
 
-  int A[128];
   extCorner** map = new extCorner*[_cornerCnt];
   for (uint32_t jj = 0; jj < _cornerCnt; jj++) {
     map[jj] = nullptr;
-    A[jj] = 0;
   }
-
-  char cornerList[128];
-  strcpy(cornerList, "");
 
   if (_scaledCornerTable != nullptr) {
-    char buf[128];
-    std::string extList;
-    std::string resList;
-    std::string ccList;
-    std::string gndcList;
     for (uint32_t ii = 0; ii < _scaledCornerTable->getCnt(); ii++) {
       extCorner* s = _scaledCornerTable->get(ii);
-
       map[s->_dbIndex] = s;
-      A[s->_dbIndex] = -(ii + 1);
-
-      sprintf(buf, " %d", s->_model);
-      extList += buf;
-      sprintf(buf, " %g", s->_resFactor);
-      resList += buf;
-      sprintf(buf, " %g", s->_ccFactor);
-      ccList += buf;
-      sprintf(buf, " %g", s->_gndFactor);
-      gndcList += buf;
     }
-    _prevControl->_derivedCornerList = extList;
-    _prevControl->_resFactorList = resList;
-    _prevControl->_ccFactorList = ccList;
-    _prevControl->_gndcFactorList = gndcList;
   }
   if (_processCornerTable != nullptr) {
-    std::string extList;
-    char buf[128];
-
     for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {
       extCorner* s = _processCornerTable->get(ii);
-
-      A[s->_dbIndex] = ii + 1;
       map[s->_dbIndex] = s;
-
-      sprintf(buf, " %d", s->_model);
-      extList += buf;
     }
-    _prevControl->_extractedCornerList = extList;
   }
-  std::string aList;
-
-  for (uint32_t k = 0; k < _cornerCnt; k++) {
-    aList += " " + std::to_string(A[k]);
-  }
-  _prevControl->_cornerIndexList = aList;
 
   std::string buff;
   if (map[0] == nullptr) {
@@ -1751,7 +1608,6 @@ void extMain::updatePrevControl()
   _prevControl->_foreign = _foreign;
   _prevControl->_rsegCoord = _rsegCoord;
   _prevControl->_extracted = _extracted;
-  _prevControl->_cornerCnt = _cornerCnt;
   _prevControl->_ccUp = _ccUp;
   _prevControl->_couplingFlag = _couplingFlag;
   _prevControl->_coupleThreshold = _coupleThreshold;
@@ -1775,7 +1631,7 @@ void extMain::getPrevControl()
   _foreign = _prevControl->_foreign;
   _rsegCoord = _prevControl->_rsegCoord;
   _extracted = _prevControl->_extracted;
-  _cornerCnt = _prevControl->_cornerCnt;
+  _cornerCnt = _block->getCornerCount();
   _ccUp = _prevControl->_ccUp;
   _couplingFlag = _prevControl->_couplingFlag;
   _coupleThreshold = _prevControl->_coupleThreshold;

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1448,7 +1448,7 @@ void extMain::makeCornerNameMap()
     logger_->error(
         utl::RCX,
         13,
-        "Could not make corner name map. The number of corner is undefined.");
+        "Could not make corner name map. The number of corners is undefined.");
   }
 
   extCorner** map = new extCorner*[_cornerCnt];


### PR DESCRIPTION
## Summary
Remove the data regarding the corners used in extraction from the legacy dbExtControl object and make RCX build the corner data from the block.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
