### PR TITLE
Update drt/test/fixture.{cpp.h} use of drt-global.h header path for consistency

### DIFF
--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -22,12 +22,12 @@
 #include "db/tech/frLookupTbl.h"
 #include "db/tech/frTechObject.h"
 #include "db/tech/frViaDef.h"
+#include "drt-global.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "frRegionQuery.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
-#include "src/drt/src/drt-global.h"
 #include "utl/Logger.h"
 
 using odb::dbTechLayerDir;

--- a/src/drt/test/fixture.h
+++ b/src/drt/test/fixture.h
@@ -12,12 +12,12 @@
 #include "db/tech/frConstraint.h"
 #include "db/tech/frTechObject.h"
 #include "db/tech/frViaDef.h"
+#include "drt-global.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
-#include "src/drt/src/drt-global.h"
 #include "utl/Logger.h"
 
 namespace odb {


### PR DESCRIPTION
Until https://github.com/The-OpenROAD-Project/OpenROAD/issues/10449 is adopted, make include certain paths the more common case of relative to module rather than project root.