### PR TITLE
odb: remove unused per-corner child-block for parasitics code

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1027,11 +1027,6 @@ class dbBlock : public dbObject
   int getCornerCount();
 
   ///
-  /// having independent extraction corners ?
-  ///
-  bool extCornersAreIndependent();
-
-  ///
   /// Get the number of corners kept n this block
   ///
   int getCornersPerBlock();
@@ -1070,27 +1065,9 @@ class dbBlock : public dbObject
   void setCornerCount(int cnt);
 
   ///
-  /// Set the number of corners kept in this block
-  ///
-  void setCornersPerBlock(int cornersPerBlock);
-
-  ///
   /// Initialize the parasitics value tables
   ///
   void initParasiticsValueTables();
-
-  ///
-  /// create child block for one extraction corner
-  ///
-  dbBlock* createExtCornerBlock(uint32_t corner);
-  ///
-  /// find child block for one extraction corner
-  ///
-  dbBlock* findExtCornerBlock(uint32_t corner);
-  ///
-  /// get extraction data block for one extraction corner
-  ///
-  dbBlock* getExtCornerBlock(uint32_t corner);
 
   ///
   /// Get the track-grids of this block.

--- a/src/odb/include/odb/dbExtControl.h
+++ b/src/odb/include/odb/dbExtControl.h
@@ -16,7 +16,6 @@ class dbExtControl : public dbObject
 {
  public:
   // PERSISTANT-MEMBERS
-  bool _independentExtCorners;
   bool _foreign;
   bool _wireStamped;
   bool _rsegCoord;

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -2756,12 +2756,6 @@ int dbBlock::getCornersPerBlock()
   return block->corners_per_block_;
 }
 
-bool dbBlock::extCornersAreIndependent()
-{
-  bool independent = getExtControl()->_independentExtCorners;
-  return independent;
-}
-
 int dbBlock::getExtDbCount()
 {
   _dbBlock* block = (_dbBlock*) this;
@@ -2834,13 +2828,6 @@ void dbBlock::initParasiticsValueTables()
   block->c_val_tbl_->push_back(0.0);
 }
 
-void dbBlock::setCornersPerBlock(int cornersPerBlock)
-{
-  initParasiticsValueTables();
-  _dbBlock* block = (_dbBlock*) this;
-  block->corners_per_block_ = cornersPerBlock;
-}
-
 void dbBlock::setCornerCount(int cornersStoredCnt,
                              int extDbCnt,
                              const char* name_list)
@@ -2882,54 +2869,6 @@ void dbBlock::setCornerCount(int cornersStoredCnt,
     }
     block->corner_name_list_ = strdup((char*) name_list);
   }
-}
-dbBlock* dbBlock::getExtCornerBlock(uint32_t corner)
-{
-  dbBlock* block = findExtCornerBlock(corner);
-  if (!block) {
-    block = this;
-  }
-  return block;
-}
-
-dbBlock* dbBlock::findExtCornerBlock(uint32_t corner)
-{
-  char cornerName[64];
-  sprintf(cornerName, "extCornerBlock__%d", corner);
-  return findChild(cornerName);
-}
-
-dbBlock* dbBlock::createExtCornerBlock(uint32_t corner)
-{
-  char cornerName[64];
-  sprintf(cornerName, "extCornerBlock__%d", corner);
-  dbBlock* extBlk = dbBlock::create(this, cornerName, '/');
-  assert(extBlk);
-  char name[64];
-  for (dbNet* net : getNets()) {
-    sprintf(name, "%d", net->getId());
-    dbNet* xnet = dbNet::create(extBlk, name, true);
-    if (xnet == nullptr) {
-      getImpl()->getLogger()->error(
-          utl::ODB, 8, "Cannot duplicate net {}", net->getConstName());
-    }
-    if (xnet->getId() != net->getId()) {
-      getImpl()->getLogger()->warn(utl::ODB,
-                                   9,
-                                   "id mismatch ({},{}) for net {}",
-                                   xnet->getId(),
-                                   net->getId(),
-                                   net->getConstName());
-    }
-    dbSigType ty = net->getSigType();
-    if (ty.isSupply()) {
-      xnet->setSpecial();
-    }
-
-    xnet->setSigType(ty);
-  }
-  extBlk->setCornersPerBlock(1);
-  return extBlk;
 }
 
 char* dbBlock::getCornerNameList()
@@ -3149,15 +3088,6 @@ void dbBlock::destroyCornerParasitics(std::vector<dbNet*>& nets)
 void dbBlock::destroyParasitics(std::vector<dbNet*>& nets)
 {
   destroyCornerParasitics(nets);
-  if (!extCornersAreIndependent()) {
-    return;
-  }
-  int numcorners = getCornerCount();
-  dbBlock* extBlock;
-  for (int corner = 1; corner < numcorners; corner++) {
-    extBlock = findExtCornerBlock(corner);
-    extBlock->destroyCornerParasitics(nets);
-  }
 }
 
 void dbBlock::getCcHaloNets(std::vector<dbNet*>& changedNets,

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 133;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 134;  // Current revision number
+
+// Revision where the per-corner child-block feature for parasitics was removed
+inline constexpr uint32_t kSchemaRemovePerCornerBlock = 134;
 
 // Revision where the corner data (corner count + corner/factor lists) was
 // removed from dbExtControl

--- a/src/odb/src/db/dbExtControl.cpp
+++ b/src/odb/src/db/dbExtControl.cpp
@@ -10,7 +10,6 @@ namespace odb {
 
 dbExtControl::dbExtControl()
 {
-  _independentExtCorners = false;
   _wireStamped = false;
   _foreign = false;
   _rsegCoord = false;
@@ -39,7 +38,6 @@ dbOStream& operator<<(dbOStream& stream, const dbExtControl& extControl)
   if (!extControl._extracted) {
     return stream;
   }
-  stream << extControl._independentExtCorners;
   stream << extControl._wireStamped;
   stream << extControl._foreign;
   stream << extControl._rsegCoord;
@@ -72,7 +70,10 @@ dbIStream& operator>>(dbIStream& stream, dbExtControl& extControl)
 
   _dbDatabase* db = stream.getDatabase();
 
-  stream >> extControl._independentExtCorners;
+  if (!db->isSchema(kSchemaRemovePerCornerBlock)) {
+    bool obsolete_independent_ext_corners;
+    stream >> obsolete_independent_ext_corners;
+  }
   stream >> extControl._wireStamped;
   stream >> extControl._foreign;
   stream >> extControl._rsegCoord;

--- a/src/odb/test/test_block.py
+++ b/src/odb/test/test_block.py
@@ -20,7 +20,6 @@ class TestBlock(odbUnitTest.TestCase):
         self.parentBlock = odb.dbBlock_create(self.db.getChip(), "Parent")
         self.block = helper.create2LevelBlock(self.db, self.lib, self.parentBlock)
         self.block.setCornerCount(4)
-        self.extcornerblock = self.block.createExtCornerBlock(1)
         odb.dbTechNonDefaultRule_create(self.block, "non_default_1")
         self.parentRegion = odb.dbRegion_create(self.block, "parentRegion")
 
@@ -43,11 +42,6 @@ class TestBlock(odbUnitTest.TestCase):
         self.assertEqual(self.block.findITerm("i1,o").getInst().getName(), "i1")
         self.assertEqual(self.block.findITerm("i1,o").getMTerm().getName(), "o")
         self.assertIsNone(self.block.findITerm("i1\\o"))
-        # extcornerblock
-        self.assertEqual(
-            self.block.findExtCornerBlock(1).getName(), "extCornerBlock__1"
-        )
-        self.assertIsNone(self.block.findExtCornerBlock(0))
         # nondefaultrule
         self.assertEqual(
             self.block.findNonDefaultRule("non_default_1").getName(), "non_default_1"

--- a/src/odb/test/test_block.tcl
+++ b/src/odb/test/test_block.tcl
@@ -22,7 +22,6 @@ proc setUp { } {
   set parentBlock [odb::dbBlock_create [$db getChip] "Parent"]
   set block [create2LevelBlock $db $lib $parentBlock]
   $block setCornerCount 4
-  set extcornerblock [$block createExtCornerBlock 1]
   odb::dbTechNonDefaultRule_create $block "non_default_1"
   set parentRegion [odb::dbRegion_create $block "parentRegion"]
   return [list $db $lib $block $parentBlock]
@@ -52,9 +51,6 @@ proc test_find { } {
   assertStringEq [[$iterm getInst] getName] "i1"
   assertStringEq [[$iterm getMTerm] getName] "o"
   assertObjIsNull [$block findITerm "i1\o"]
-  # extcornerblock
-  assertStringEq [[$block findExtCornerBlock 1] getName] "extCornerBlock__1"
-  assertObjIsNull [$block findExtCornerBlock 0]
   # nondefaultrule
   assertStringEq [[$block findNonDefaultRule "non_default_1"] getName] "non_default_1"
   assertObjIsNull [$block findNonDefaultRule "non_default_2"]


### PR DESCRIPTION
## Summary
Remove old feature that is not being used. This feature's code is somewhat coupled to the mechanism that parasitics objects e.g., dbRSeg use for value retrieving (we store parasitics for each corner and resolve the parasitics value against the index of that corner). With the changes here, it will be easier to make the resolving mechanism more concise for new RCX code.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
