### PR TITLE
Fix parallel test race condition in PDN tests

### DIFF
--- a/src/pdn/test/core_grid_with_M6_min_area_rule.tcl
+++ b/src/pdn/test/core_grid_with_M6_min_area_rule.tcl
@@ -22,6 +22,6 @@ add_pdn_connect -layers {metal4 metal7}
 
 pdngen
 
-set def_file [make_result_file core_grid_with_M6_min_area.def]
+set def_file [make_result_file core_grid_with_M6_min_area_rule.def]
 write_def $def_file
 diff_files core_grid_with_M6_min_area.defok $def_file


### PR DESCRIPTION
Ran into this issue earlier today in a different PR, https://jenkins.openroad.tools/job/OpenROAD-Public/job/PR-10642-merge/14/stages/

Pretty sure that both the  core_grid_with_M6_min_area  and  core_grid_with_M6_min_area_rule  tests were configured to write their temporary runtime DEF output to the exact same filename:  core_grid_with_M6_min_area-tcl.def  inside the  src/pdn/test/results/  directory.

Which caused a race condition and caused the test to fail during the file close/rename stage, throwing a  `filesystem error: cannot rename: No such file or directory error`.

I think we can fix it by changing the name of one of the output files.
