### PR TITLE
Fix two syn correctness bugs

### DIFF
--- a/src/syn/BUILD
+++ b/src/syn/BUILD
@@ -23,7 +23,6 @@ cc_library(
         "src/flow/export.cc",
         "src/flow/export.h",
         "src/flow/import.cc",
-        "src/flow/import.h",
         "src/flow/liveness.cc",
         "src/flow/opt_gatefusion.cc",
         "src/flow/opt_gatefusion.h",
@@ -33,6 +32,7 @@ cc_library(
     hdrs = [
         "include/syn/synthesis.h",
         "src/flow/constant_fold.h",
+        "src/flow/import.h",
     ],
     includes = [
         "include",

--- a/src/syn/src/elab/driver.h
+++ b/src/syn/src/elab/driver.h
@@ -32,6 +32,7 @@ std::unique_ptr<Graph> elaborate(utl::Logger* logger,
                                  const std::vector<std::string>& args,
                                  sta::dbSta* sta = nullptr);
 std::unique_ptr<Graph> elaborateText(const std::string& source,
-                                     const std::vector<std::string>& args = {});
+                                     const std::vector<std::string>& args = {},
+                                     sta::dbSta* sta = nullptr);
 
 }  // namespace syn

--- a/src/syn/src/elab/error.cc
+++ b/src/syn/src/elab/error.cc
@@ -29,10 +29,11 @@ std::unique_ptr<Graph> elaborateImpl(utl::Logger* logger,
                                      std::optional<std::string> buffer);
 
 std::unique_ptr<Graph> elaborateText(const std::string& source,
-                                     const std::vector<std::string>& args)
+                                     const std::vector<std::string>& args,
+                                     sta::dbSta* sta)
 {
   utl::Logger logger;
-  return elaborateImpl(&logger, args, nullptr, source);
+  return elaborateImpl(&logger, args, sta, source);
 }
 
 }  // namespace syn

--- a/src/syn/src/flow/combinational_mapper.cc
+++ b/src/syn/src/flow/combinational_mapper.cc
@@ -490,15 +490,16 @@ ClassMatch* Mapping::allocMatches(const int n)
 
 void Mapping::collectPrimaryOutputs()
 {
-  std::set<ControlNet> primaryOutputNets;
-  std::set<std::pair<ControlNet, Net>> fixupSet;
+  std::set<ControlNet> primary_output_nets;
+  std::set<std::pair<ControlNet, Net>> fixup_set;
 
   auto registerPrimaryOutput = [&](Net net) {
     auto cnet = subject_.stripInverter(net);
-    if (isMappable(cnet.net())) {
-      primaryOutputNets.insert(cnet);
+    auto driver = subject_.graph.resolve(cnet.net()).first;
+    if (isMappable(cnet.net()) || driver->isMapped()) {
+      primary_output_nets.insert(cnet);
       if (cnet.net() != net) {
-        fixupSet.insert({cnet, net});
+        fixup_set.insert({cnet, net});
       }
     }
   };
@@ -529,8 +530,9 @@ void Mapping::collectPrimaryOutputs()
     }
   });
 
-  primary_outputs_.assign(primaryOutputNets.begin(), primaryOutputNets.end());
-  primary_output_fixups_.assign(fixupSet.begin(), fixupSet.end());
+  primary_outputs_.assign(primary_output_nets.begin(),
+                          primary_output_nets.end());
+  primary_output_fixups_.assign(fixup_set.begin(), fixup_set.end());
 }
 
 void Mapping::computeFanouts()

--- a/src/syn/src/flow/import.cc
+++ b/src/syn/src/flow/import.cc
@@ -5,6 +5,8 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <map>
+#include <string_view>
 #include <utility>
 
 #include "sta/Liberty.hh"
@@ -31,7 +33,8 @@ void importTargets(Graph& g, sta::Network* network, utl::Logger* logger)
       return;
     }
 
-    // Build expected input/output widths from liberty cell ports.
+    std::map<std::string_view, uint32_t> lib_input_offset;
+    std::map<std::string_view, uint32_t> lib_output_offset;
     uint32_t lib_input_width = 0;
     uint32_t lib_output_width = 0;
     sta::LibertyCellPortIterator port_iter(cell);
@@ -42,10 +45,14 @@ void importTargets(Graph& g, sta::Network* network, utl::Logger* logger)
       }
       sta::PortDirection* dir = port->direction();
       if (dir->isInput()) {
+        lib_input_offset[port->name()] = lib_input_width;
         lib_input_width += port->size();
       } else if (dir->isOutput()) {
+        lib_output_offset[port->name()] = lib_output_width;
         lib_output_width += port->size();
       } else if (dir->isBidirect()) {
+        lib_input_offset[port->name()] = lib_input_width;
+        lib_output_offset[port->name()] = lib_output_width;
         lib_input_width += port->size();
         lib_output_width += port->size();
       }
@@ -66,8 +73,7 @@ void importTargets(Graph& g, sta::Network* network, utl::Logger* logger)
       logger->error(utl::SYN,
                     10,
                     "importTargets: cell '{}' input width mismatch:"
-                    " Other has {} bits, Liberty has {} bits. This is an "
-                    "internal tool error.",
+                    " Verilog instantiation has {} bits, Liberty has {} bits.",
                     other->cellType(),
                     other_input_width,
                     lib_input_width);
@@ -77,26 +83,89 @@ void importTargets(Graph& g, sta::Network* network, utl::Logger* logger)
       logger->error(utl::SYN,
                     11,
                     "importTargets: cell '{}' output width mismatch:"
-                    " Other has {} bits, Liberty has {} bits. This is an "
-                    "internal tool error.",
+                    " Verilog instantiation has {} bits, Liberty has {} bits.",
                     other->cellType(),
                     other_output_width,
                     lib_output_width);
     }
 
     // Concatenate all input port values into a single Bundle.
-    Bundle inputs;
+    Bundle inputs = Bundle::sentinel(lib_input_width);
     for (auto& port : other->ports()) {
       if (port.direction == Other::Port::kInput
           || port.direction == Other::Port::kInOut) {
-        inputs = inputs.concat(port.value);
+        sta::LibertyPort* lib_port = cell->findLibertyPort(port.name);
+        if (!lib_port || !lib_input_offset.contains(port.name)) {
+          logger->error(
+              utl::SYN,
+              35,
+              "importTargets: cell '{}' Liberty definition is missing "
+              "port '{}' connected in Verilog instantiation.",
+              other->cellType(),
+              port.name);
+        }
+
+        if (((uint32_t) lib_port->size()) != port.width) {
+          logger->error(
+              utl::SYN,
+              36,
+              "importTargets: cell '{}' instantiated with mismatched width "
+              "of port '{}': {} in Verilog vs {} in Liberty",
+              other->cellType(),
+              port.name,
+              port.width,
+              lib_port->size());
+        }
+
+        uint32_t offset = lib_input_offset.at(port.name);
+        for (uint32_t i = 0; i < port.width; i++) {
+          inputs.mutableNet(offset + i) = port.value[i];
+        }
       }
     }
 
     // Create Target and replace outputs.
     BundleView old_output = g.output(other);
-    Bundle new_output = g.add<Target>(cell, std::move(inputs));
-    g.forceReplace(old_output, BundleView(new_output));
+    Bundle target_output = g.add<Target>(cell, std::move(inputs));
+    Bundle output_replacement = Bundle::sentinel(lib_output_width);
+
+    uint32_t offset = 0;
+    for (auto& port : other->ports()) {
+      if (port.direction == Other::Port::kOutput
+          || port.direction == Other::Port::kInOut) {
+        sta::LibertyPort* lib_port = cell->findLibertyPort(port.name);
+        if (!lib_port || !lib_output_offset.contains(port.name)) {
+          logger->error(
+              utl::SYN,
+              37,
+              "importTargets: cell '{}' Liberty definition is missing "
+              "port '{}' connected in Verilog instantiation.",
+              other->cellType(),
+              port.name);
+        }
+
+        if (((uint32_t) lib_port->size()) != port.width) {
+          logger->error(
+              utl::SYN,
+              38,
+              "importTargets: cell '{}' instantiated with mismatched width "
+              "of port '{}': {} in Verilog vs {} in Liberty",
+              other->cellType(),
+              port.name,
+              port.width,
+              lib_port->size());
+        }
+
+        uint32_t lib_offset = lib_output_offset.at(port.name);
+        for (uint32_t i = 0; i < port.width; i++) {
+          output_replacement.mutableNet(offset + i)
+              = target_output[lib_offset + i];
+        }
+        offset += port.width;
+      }
+    }
+
+    g.forceReplace(old_output, BundleView(output_replacement));
     g.removeInstance(
         const_cast<Instance*>(static_cast<const Instance*>(other)));
   });

--- a/src/syn/test/BUILD
+++ b/src/syn/test/BUILD
@@ -115,9 +115,12 @@ cc_test(
         "elab_testcases.h",
         "equivalence_check.h",
     ],
+    data = ["macro_test_cells.lib"],
     deps = [
+        "//src/syn",
         "//src/syn/src/elab",
         "//src/syn/src/ir",
+        "//src/tst",
         "@googletest//:gtest",
     ],
 )

--- a/src/syn/test/CMakeLists.txt
+++ b/src/syn/test/CMakeLists.txt
@@ -40,6 +40,6 @@ foreach(_t abc_test sm_test cm_test)
 endforeach()
 
 add_executable(elab_test elab_test.cc)
-target_link_libraries(elab_test ${_syn_test_libs} syn_elab syn_ir)
+target_link_libraries(elab_test ${_syn_test_libs} syn_elab syn_flow syn_ir tst)
 gtest_discover_tests(elab_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(build_and_test elab_test)

--- a/src/syn/test/cm_test.cc
+++ b/src/syn/test/cm_test.cc
@@ -209,21 +209,22 @@ TEST_P(CmTest, MapsBelowAreaAndIsEquivalent)
   // naming-only Nots that cm.cc:integrate() leaves behind.
   float area = 0.0f;
   gate->forEachInstance([&](const Instance* inst) {
-    if (inst->is<Input>() || inst->is<Output>() || inst->is<Name>()
-        || inst->is<Not>() || inst->is<TieLow>() || inst->is<TieHigh>()
-        || inst->is<TieX>()) {
-      return;
+    if (inst->isMapped()) {
+      inst->visit([&](Net fanin) {
+        auto [fanin_driver, offset] = gate->resolve(fanin);
+        if (!fanin_driver->isMapped()) {
+          std::ostringstream os;
+          gate->dumpInstance(os, fanin_driver);
+          ADD_FAILURE() << "Unexpected instance after combinational mapping: "
+                        << os.str();
+          return;
+        }
+      });
     }
-    if (!inst->is<Target>()) {
-      std::ostringstream os;
-      gate->dumpInstance(os, inst);
-      ADD_FAILURE() << "Non-Target instance survived combinational mapping in "
-                       "case "
-                    << tc.name << ": " << os.str();
-      return;
-    }
-    if (auto* t = inst->try_as<Target>()) {
-      area += t->cell()->area();
+    if (inst->is<Target>()) {
+      if (auto* t = inst->try_as<Target>()) {
+        area += t->cell()->area();
+      }
     }
   });
 

--- a/src/syn/test/elab_test.cc
+++ b/src/syn/test/elab_test.cc
@@ -11,11 +11,14 @@
 #include "driver.h"
 #include "elab_testcases.h"
 #include "equivalence_check.h"
+#include "flow/import.h"
 #include "gtest/gtest.h"
 #include "syn/ir/Bundle.h"
 #include "syn/ir/Graph.h"
 #include "syn/ir/Instance.h"
 #include "syn/ir/TritModel.h"
+#include "syn/synthesis.h"
+#include "tst/fixture.h"
 
 int main(int argc, char** argv)
 {
@@ -288,5 +291,83 @@ TEST_P(ElabSlangTest, MatchesGolden)
 INSTANTIATE_TEST_SUITE_P(Elab,
                          ElabSlangTest,
                          ::testing::ValuesIn(elabTestcases));
+
+class ElabWithMacrosTest : public tst::Fixture
+{
+ protected:
+  void SetUp() override
+  {
+    Fixture::SetUp();
+    readLiberty(getFilePath("_main/src/syn/test/macro_test_cells.lib"));
+  }
+};
+
+TEST_F(ElabWithMacrosTest, BlackboxImport)
+{
+  // Check macro connections are correct even when Verilog blackbox
+  // module does not match Liberty port order
+  auto result = syn::elaborateText(R"(
+    module top(
+      input logic clk,
+      input logic ce,
+      input logic we,
+      input logic [8:0] addr,
+      input logic [7:0] wd,
+      output logic [7:0] rd
+    );
+      fakeram_512x8 u_ram (
+        .rd_out(rd),
+        .addr_in(addr),
+        .we_in(we),
+        .wd_in(wd),
+        .clk(clk),
+        .ce_in(ce)
+      );
+    endmodule
+
+    (* blackbox *)
+    module fakeram_512x8 (
+       output logic [7:0]    rd_out,
+       input  logic [8:0]    addr_in,
+       input  logic          we_in,
+       input  logic [7:0]    wd_in,
+       input  logic          clk,
+       input  logic          ce_in
+    );
+    endmodule
+  )",
+                                   {"--top", "top"},
+                                   getSta());
+  ASSERT_TRUE(result) << "Elaboration failed";
+
+  syn::Graph& g = *result;
+  g.normalize();
+  importTargets(g, getSta()->network(), getLogger());
+  std::ostringstream os;
+  g.dump(os);
+  EXPECT_EQ(os.str(),
+            R"(%3:0 = name "clk" 0 1 %9
+%4:0 = name "ce" 0 1 %10
+%5:0 = name "we" 0 1 %11
+%6:0 = name "addr" 0 9 vector %12:9
+%7:0 = name "wd" 0 8 vector %21:8
+%8:0 = name "rd" 0 8 vector %30:8
+%9:1 = input "clk"
+%10:1 = input "ce"
+%11:1 = input "we"
+%12:9 = input "addr"
+%21:8 = input "wd"
+%29:0 = output "rd" %30:8
+%30:8 = buf %38:8
+%38:8 = target "fakeram_512x8" {
+  input "clk" = %9
+  %38:8 = output "rd_out"
+  input "we_in" = %11
+  input "ce_in" = %10
+  input "addr_in" = %12:9
+  input "wd_in" = %21:8
+}
+)");
+}
 
 }  // namespace syn

--- a/src/syn/test/macro_test_cells.lib
+++ b/src/syn/test/macro_test_cells.lib
@@ -1,0 +1,67 @@
+library(macro_test) {
+  delay_model : table_lookup;
+  time_unit : "1ns";
+  voltage_unit : "1V";
+  current_unit : "1mA";
+  capacitive_load_unit(1, pf);
+  type (fakeram_512x8_DATA) {
+    base_type : array ;
+    data_type : bit ;
+    bit_width : 8;
+    bit_from : 7;
+    bit_to : 0 ;
+    downto : true ;
+  }
+  type (fakeram_512x8_ADDRESS) {
+    base_type : array ;
+    data_type : bit ;
+    bit_width : 9;
+    bit_from : 8;
+    bit_to : 0 ;
+    downto : true ;
+  }
+  cell(fakeram_512x8) {
+    area : 171.993;
+    interface_timing : true;
+    memory() {
+      type : ram;
+      address_width : 9;
+      word_width : 8;
+    }
+    pin(clk) {
+      direction : input;
+      capacitance : 0.025;
+      clock : true;
+    }
+    bus(rd_out) {
+      bus_type : fakeram_512x8_DATA;
+      direction : output;
+      max_capacitance : 0.500;
+      memory_read() {
+        address : addr_in;
+      }
+    }
+    pin(we_in) {
+      direction : input;
+      capacitance : 0.005;
+    }
+    pin(ce_in) {
+      direction : input;
+      capacitance : 0.005;
+    }
+    bus(addr_in) {
+      bus_type : fakeram_512x8_ADDRESS;
+      direction : input;
+      capacitance : 0.005;
+    }
+    bus(wd_in) {
+      bus_type : fakeram_512x8_DATA;
+      memory_write() {
+        address : addr_in;
+        clocked_on : "clk";
+      }
+      direction : input;
+      capacitance : 0.005;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix omitted mapping for feedthrough inverters, and port order confusion if both `.lib` and `.sv` supply competing definitions for a given macro

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes #10745 #10746 #10747
