### PR TITLE
grt: ensure CUGR/FastRoute paths will not call functions from the wrong engine

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -361,6 +361,7 @@ class GlobalRouter
   void applyAdjustments(int min_routing_layer, int max_routing_layer);
   // main functions
   void initCoreGrid(int max_routing_layer);
+  void mirrorGridToFastRoute(int max_routing_layer);
   void initRoutingLayers(int min_routing_layer, int max_routing_layer);
   void checkAdjacentLayersDirection(int min_routing_layer,
                                     int max_routing_layer);

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -376,6 +376,11 @@ class GlobalRouter
                            bool horizontal);
   odb::Rect getGCellRect(int x, int y);
   void initNetlist(std::vector<Net*>& nets, bool incremental = false);
+  void computeNetDegree(const std::vector<Net*>& nets,
+                        int& min_degree,
+                        int& max_degree);
+  void reportNetDegree(const std::vector<Net*>& nets);
+  void reportMacrosAndBlockages();
   std::vector<Net*> initNets(bool check_pin_placement = true);
   void initRoutingGrid(int min_routing_layer, int max_routing_layer);
   std::vector<Net*> initCUGR(int min_routing_layer, int max_routing_layer);

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -198,10 +198,12 @@ std::vector<Net*> GlobalRouter::initCUGR(int min_routing_layer,
   // Propagate the global adjustment to per-layer values that CUGR reads from
   // the tech layers; this is engine-agnostic, unlike the FastRoute edge passes.
   computeUserGlobalAdjustments(min_routing_layer, max_routing_layer);
+  reportMacrosAndBlockages();
   std::vector<Net*> nets = initNets(true);
   initialized_ = true;
   odb::PtrSet<odb::dbNet> clock_nets;
   findClockNets(nets, clock_nets);
+  reportNetDegree(nets);
 
   cugr_->setCongestionIterations(congestion_iterations_);
   cugr_->init(min_routing_layer, max_routing_layer, clock_nets);
@@ -242,6 +244,7 @@ void GlobalRouter::applyAdjustments(int min_routing_layer,
                                     int max_routing_layer)
 {
   computeObstructionsAdjustments();
+  reportMacrosAndBlockages();
   std::vector<int> track_space = grid_->getTrackPitches();
   fastroute_->initBlockedIntervals(track_space);
   // Save global resources before add adjustment by layer
@@ -1583,16 +1586,80 @@ float GlobalRouter::getNetSlack(Net* net)
   return sta_->slack(net->getDbNet(), sta::MinMax::max());
 }
 
+// Net degree (pin count) statistics over the nets that get routed; engine
+// agnostic, so both FastRoute and CUGR report the same numbers.
+void GlobalRouter::computeNetDegree(const std::vector<Net*>& nets,
+                                    int& min_degree,
+                                    int& max_degree)
+{
+  min_degree = std::numeric_limits<int>::max();
+  // Do NOT use numeric_limits<int>::min() to init this because if there are
+  // no FR nets the max degree will be big negative and cannot be used to init
+  // the vectors in FR.
+  max_degree = 1;
+  for (Net* net : nets) {
+    int pin_count = net->getNumPins();
+    int min_layer, max_layer;
+    getNetLayerRange(net->getDbNet(), min_layer, max_layer);
+    odb::dbTechLayer* max_routing_layer
+        = db_->getTech()->findRoutingLayer(max_layer);
+    if (pin_count > 1
+        && (!net->hasWires() || net->hasStackedVias(max_routing_layer))) {
+      min_degree = std::min(pin_count, min_degree);
+      max_degree = std::max(pin_count, max_degree);
+    }
+  }
+}
+
+void GlobalRouter::reportNetDegree(const std::vector<Net*>& nets)
+{
+  if (!verbose_) {
+    return;
+  }
+  int min_degree, max_degree;
+  computeNetDegree(nets, min_degree, max_degree);
+  min_degree = nets.empty() ? 0 : min_degree;
+  max_degree = nets.empty() ? 0 : max_degree;
+  logger_->info(GRT, 1, "Minimum degree: {}", min_degree);
+  logger_->info(GRT, 2, "Maximum degree: {}", max_degree);
+}
+
+// Macro and blockage counts read straight from the db; engine agnostic.
+void GlobalRouter::reportMacrosAndBlockages()
+{
+  if (!verbose_) {
+    return;
+  }
+  const int min_layer = getMinRoutingLayer();
+  const int max_layer = getMaxRoutingLayer();
+  int macros_cnt = 0;
+  int blockages_cnt = 0;
+
+  for (odb::dbObstruction* obstruction : block_->getObstructions()) {
+    const int layer = obstruction->getBBox()->getTechLayer()->getRoutingLevel();
+    if (min_layer <= layer && layer <= max_layer) {
+      blockages_cnt++;
+    }
+  }
+  for (odb::dbInst* inst : block_->getInsts()) {
+    odb::dbMaster* master = inst->getMaster();
+    if (master->isBlock()) {
+      macros_cnt++;
+    }
+    for (odb::dbBox* box : master->getObstructions()) {
+      const int layer = box->getTechLayer()->getRoutingLevel();
+      if (min_layer <= layer && layer <= max_layer) {
+        blockages_cnt++;
+      }
+    }
+  }
+  logger_->info(GRT, 3, "Macros: {}", macros_cnt);
+  logger_->info(GRT, 4, "Blockages: {}", blockages_cnt);
+}
+
 void GlobalRouter::initNetlist(std::vector<Net*>& nets, bool incremental)
 {
   pad_pins_connections_.clear();
-
-  int min_degree = std::numeric_limits<int>::max();
-  // Do NOT use numeric_limits<int>::min() to init
-  // this because if there are no FR nets the max
-  // degree will be big negative and cannot be used
-  // to init the vectors in FR.
-  int max_degree = 1;
 
   if (nets.size() > 1 && seed_ != 0) {
     std::mt19937 g;
@@ -1608,20 +1675,13 @@ void GlobalRouter::initNetlist(std::vector<Net*>& nets, bool incremental)
         = db_->getTech()->findRoutingLayer(max_layer);
     if (pin_count > 1
         && (!net->hasWires() || net->hasStackedVias(max_routing_layer))) {
-      min_degree = std::min(pin_count, min_degree);
-
-      max_degree = std::max(pin_count, max_degree);
       makeFastrouteNet(net);
     }
   }
+  int min_degree, max_degree;
+  computeNetDegree(nets, min_degree, max_degree);
   fastroute_->setMaxNetDegree(max_degree);
-
-  if (verbose_) {
-    min_degree = nets.empty() ? 0 : min_degree;
-    max_degree = nets.empty() ? 0 : max_degree;
-    logger_->info(GRT, 1, "Minimum degree: {}", min_degree);
-    logger_->info(GRT, 2, "Maximum degree: {}", max_degree);
-  }
+  reportNetDegree(nets);
 
   // Add resources for pin access in macro/pad pins after defining their on grid
   // position. It must be done only in the initialization of the tool, not
@@ -5011,17 +5071,12 @@ void GlobalRouter::computeObstructionsAdjustments()
   std::map<int, std::vector<odb::Rect>> layer_obs_map;
 
   findLayerExtensions(layer_extensions);
-  int obstructions_cnt = findObstructions(die_area);
-  obstructions_cnt
-      += findInstancesObstructions(die_area, layer_extensions, layer_obs_map);
+  findObstructions(die_area);
+  findInstancesObstructions(die_area, layer_extensions, layer_obs_map);
   findNetsObstructions(die_area);
 
   std::vector<LayerId> transition_layers = findTransitionLayers();
   adjustTransitionLayers(transition_layers, layer_obs_map);
-
-  if (verbose_) {
-    logger_->info(GRT, 4, "Blockages: {}", obstructions_cnt);
-  }
 }
 
 void GlobalRouter::findLayerExtensions(std::vector<int>& layer_extensions)
@@ -5172,7 +5227,6 @@ int GlobalRouter::findInstancesObstructions(
     const std::vector<int>& layer_extensions,
     std::map<int, std::vector<odb::Rect>>& layer_obs_map)
 {
-  int macros_cnt = 0;
   int obstructions_cnt = 0;
   int pin_out_of_die_count = 0;
   odb::dbTech* tech = db_->getTech();
@@ -5183,7 +5237,6 @@ int GlobalRouter::findInstancesObstructions(
 
     bool is_macro = false;
     if (master->isBlock()) {
-      macros_cnt++;
       is_macro = true;
       has_macros_or_pads_ = true;
     }
@@ -5304,9 +5357,6 @@ int GlobalRouter::findInstancesObstructions(
     }
   }
 
-  if (verbose_) {
-    logger_->info(GRT, 3, "Macros: {}", macros_cnt);
-  }
   return obstructions_cnt;
 }
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -155,7 +155,9 @@ void GlobalRouter::clear()
   routing_tracks_.clear();
   routing_layers_.clear();
   grid_->clear();
-  fastroute_->clear();
+  if (!use_cugr_) {
+    fastroute_->clear();
+  }
   vertical_capacities_.clear();
   horizontal_capacities_.clear();
   initialized_ = false;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1620,8 +1620,12 @@ void GlobalRouter::reportNetDegree(const std::vector<Net*>& nets)
   }
   int min_degree, max_degree;
   computeNetDegree(nets, min_degree, max_degree);
-  min_degree = nets.empty() ? 0 : min_degree;
-  max_degree = nets.empty() ? 0 : max_degree;
+  // No routable net passed the degree filter; report zeros instead of the
+  // sentinel min_degree.
+  if (nets.empty() || min_degree == std::numeric_limits<int>::max()) {
+    min_degree = 0;
+    max_degree = 0;
+  }
   logger_->info(GRT, 1, "Minimum degree: {}", min_degree);
   logger_->info(GRT, 2, "Maximum degree: {}", max_degree);
 }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1441,8 +1441,9 @@ std::vector<RoutePt> GlobalRouter::findOnGridPositions(
         pos_on_grid = grid_->getPositionOnGrid(rect_middle);
         // if a macro/pad pin is unreachable due to not having enough resources
         // at its on grid position, get the position closest to the macro/pad
-        // boundary to ensure routability
-        if (pin.isConnectedToPadOrMacro()
+        // boundary to ensure routability. CUGR has no FastRoute edge capacities
+        // to query, so it skips this heuristic and routes from the center.
+        if (!use_cugr_ && pin.isConnectedToPadOrMacro()
             && !isPinReachable(pin, pos_on_grid)) {
           pos_on_grid = grid_->getPositionOnGrid(
               pin.getPositionNearInstEdge(pin_box, rect_middle));

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -180,7 +180,6 @@ std::vector<Net*> GlobalRouter::initNets(bool check_pin_placement)
   if (check_pin_placement) {
     checkPinPlacement();
   }
-  initNetlist(nets);
   return nets;
 }
 
@@ -190,14 +189,15 @@ void GlobalRouter::initRoutingGrid(int min_routing_layer, int max_routing_layer)
   reportLayerSettings(min_routing_layer, max_routing_layer);
   initRoutingTracks(max_routing_layer);
   initCoreGrid(max_routing_layer);
-  computeObstructionsAdjustments();
-  computeUserGlobalAdjustments(min_routing_layer, max_routing_layer);
 }
 
 std::vector<Net*> GlobalRouter::initCUGR(int min_routing_layer,
                                          int max_routing_layer)
 {
   initRoutingGrid(min_routing_layer, max_routing_layer);
+  // Propagate the global adjustment to per-layer values that CUGR reads from
+  // the tech layers; this is engine-agnostic, unlike the FastRoute edge passes.
+  computeUserGlobalAdjustments(min_routing_layer, max_routing_layer);
   std::vector<Net*> nets = initNets(true);
   initialized_ = true;
   odb::PtrSet<odb::dbNet> clock_nets;
@@ -222,6 +222,7 @@ std::vector<Net*> GlobalRouter::initFastRoute(int min_routing_layer,
   reportLayerSettings(min_routing_layer, max_routing_layer);
   initRoutingTracks(max_routing_layer);
   initCoreGrid(max_routing_layer);
+  mirrorGridToFastRoute(max_routing_layer);
   setCapacities(min_routing_layer, max_routing_layer);
 
   applyAdjustments(min_routing_layer, max_routing_layer);
@@ -231,6 +232,7 @@ std::vector<Net*> GlobalRouter::initFastRoute(int min_routing_layer,
   fastroute_->initEdgesCapacityPerLayer();
 
   std::vector<Net*> nets = initNets(check_pin_placement);
+  initNetlist(nets);
 
   initialized_ = true;
   return nets;
@@ -291,12 +293,25 @@ NetRouteMap GlobalRouter::getPartialRoutes()
   NetRouteMap net_routes;
   // TODO: still need to fix this during incremental grt
   if (is_incremental_) {
+    // Source partial routes from the active engine; CUGR has no FastRoute
+    // trees.
+    NetRouteMap cugr_routes;
+    if (use_cugr_) {
+      cugr_routes = cugr_->getRoutes();
+    }
     for (const auto& [db_net, net] : db_net_map_) {
       // Do not add local nets, as they are not routed in incremental grt.
       if (routes_[db_net].empty() && !net->isLocal()) {
-        GRoute route;
-        net_routes.insert({db_net, route});
-        fastroute_->getPlanarRoute(db_net, net_routes[db_net]);
+        if (use_cugr_) {
+          auto it = cugr_routes.find(db_net);
+          if (it != cugr_routes.end() && !it->second.empty()) {
+            net_routes[db_net] = it->second;
+          }
+        } else {
+          GRoute route;
+          net_routes.insert({db_net, route});
+          fastroute_->getPlanarRoute(db_net, net_routes[db_net]);
+        }
       }
     }
   } else {
@@ -409,7 +424,6 @@ void GlobalRouter::startIncremental()
 void GlobalRouter::endIncremental(bool save_guides)
 {
   is_incremental_ = true;
-  fastroute_->setResistanceAware(resistance_aware_);
   updateDirtyRoutes(save_guides);
   grouter_cbk_->removeOwner();
   delete grouter_cbk_;
@@ -499,8 +513,10 @@ void GlobalRouter::finishGlobalRouting(bool save_guides)
   }
 
   if (is_congested_) {
-    // Suggest adjustment value
-    suggestAdjustment();
+    // suggestAdjustment relies on FastRoute congestion data.
+    if (!use_cugr_) {
+      suggestAdjustment();
+    }
     // CUGR overflow is downgraded to a warning even without -allow_congestion,
     // since it produces good results on detailed routing.
     if (allow_congestion_ || use_cugr_) {
@@ -769,7 +785,14 @@ void GlobalRouter::initCoreGrid(int max_routing_layer)
 {
   initGrid(max_routing_layer);
   findTrackPitches(max_routing_layer);
+}
 
+// Mirror the engine-agnostic grid into FastRoute's structures. Only the
+// FastRoute path needs this; CUGR maintains its own grid.
+void GlobalRouter::mirrorGridToFastRoute(int max_routing_layer)
+{
+  fastroute_->setRegularX(grid_->isPerfectRegularX());
+  fastroute_->setRegularY(grid_->isPerfectRegularY());
   fastroute_->setLowerLeft(grid_->getXMin(), grid_->getYMin());
   fastroute_->setTileSize(grid_->getTileSize());
   fastroute_->setGridsAndLayers(
@@ -2522,6 +2545,7 @@ void GlobalRouter::initGridAndNets()
     initRoutingLayers(min_layer, max_layer);
     initRoutingTracks(max_layer);
     initCoreGrid(max_layer);
+    mirrorGridToFastRoute(max_layer);
     setCapacities(min_layer, max_layer);
     applyAdjustments(min_layer, max_layer);
   }
@@ -4349,9 +4373,6 @@ void GlobalRouter::initGrid(int max_layer)
 
   bool perfect_regular_x = (x_grids * tile_size) == dx;
   bool perfect_regular_y = (y_grids * tile_size) == dy;
-
-  fastroute_->setRegularX(perfect_regular_x);
-  fastroute_->setRegularY(perfect_regular_y);
 
   int num_layers = routing_layers_.size();
   if (max_layer > -1) {
@@ -6262,6 +6283,8 @@ std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)
   }
 
   std::vector<Net*> dirty_nets;
+
+  fastroute_->setResistanceAware(resistance_aware_);
 
   if (!initialized_) {
     int min_layer, max_layer;


### PR DESCRIPTION
## Summary
Isolate the CUGR global-routing engine from the FastRoute engine so that running one never invokes the other's initialization or routing functions. Previously the `use_cugr` path still fell through FastRoute-only setup (grid mirroring, FastRoute netlist build, edge/regularity setup, resistance-aware/suggest-adjustment calls) that CUGR neither needs nor reads.

Key changes:
- Extract FastRoute grid mirroring into `mirrorGridToFastRoute()`, called only from `initFastRoute`/`initGridAndNets`; `initCoreGrid`/`initGrid` are now engine-agnostic.
- Move `initNetlist()` out of the shared `initNets()` into the FastRoute path.
- Relocate `setResistanceAware` into the FastRoute branch of `updateDirtyRoutes`, guard `suggestAdjustment`, and skip `fastroute_->clear()` on the CUGR path.
- `getPartialRoutes()` now sources incremental partial routes from CUGR instead of `fastroute_->getPlanarRoute()`, so incremental CUGR parasitics estimation sees real routes rather than empty FastRoute trees.
- Keep `computeUserGlobalAdjustments` on the CUGR path (it is engine-agnostic: it propagates the global adjustment into the per-layer tech-layer values CUGR reads); the FastRoute-only obstruction pass stays out of the CUGR path.
- Report net degree and macro/blockage counts for CUGR via engine-agnostic helpers, so those diagnostics are emitted from a single shared code path for both engines.

After these changes, neither the full-route nor the incremental flow of one engine executes any init/routing function of the other; the only shared presence is that both engine objects are still constructed.

## Type of Change
- Bug fix
- Refactoring

## Impact
- No QoR change for non-incremental routing: guides are identical for both engines.
- Incremental CUGR parasitics now use real CUGR routes instead of empty FastRoute trees, which can shift slack-driven critical-net selection (a correctness improvement on the incremental path).
- CUGR still emits the macro/blockage/net-degree diagnostics; log output is unchanged.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**