### PR TITLE
dbSta: escape brackets in scalar net/port names (not bus selects)

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -532,6 +532,13 @@ class dbNetwork : public ConcreteNetwork
   // path-qualified one stored in ODB.
   static std::string stripParentPrefix(const std::string& name);
 
+  // If name parses as a clean (unescaped) bus member "prefix[idx]" but
+  // scope declares no actual bus named "prefix", return the name with the
+  // brackets escaped ("prefix\[idx\]") so STA treats it as a scalar escaped
+  // identifier rather than a bus select.  Otherwise return name unchanged.
+  std::string escapeBracketsIfScalar(const std::string& name,
+                                     odb::dbModule* scope) const;
+
   std::set<const Cell*> hier_modules_;
   std::set<const Port*> concrete_ports_;
   std::unique_ptr<dbEditHierarchy> hierarchy_editor_;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -76,6 +76,7 @@ Recommended conclusion: use map for concrete cells. They are invariant.
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/ObjectId.hh"
+#include "sta/ParseBus.hh"
 #include "sta/PatternMatch.hh"
 #include "sta/PortDirection.hh"
 #include "sta/Search.hh"
@@ -803,6 +804,43 @@ std::string dbNetwork::stripParentPrefix(const std::string& name)
   return name;
 }
 
+std::string dbNetwork::escapeBracketsIfScalar(const std::string& name,
+                                              odb::dbModule* scope) const
+{
+  if (scope == nullptr) {
+    return name;
+  }
+  bool is_bus = false;
+  std::string bus_name;
+  int index = 0;
+  parseBusName(name, '[', ']', pathEscape(), is_bus, bus_name, index);
+  // Not a clean bus member (no brackets, or the brackets are already
+  // escaped) -- nothing to do.
+  if (!is_bus) {
+    return name;
+  }
+  // Only a per-bit scalar *terminal* can be misrendered: it is declared as a
+  // module port (so portVerilogName escapes its brackets) yet referenced as a
+  // net (so netVerilogName would emit a bus select on an undeclared bus).  A
+  // genuine bus select has no module boundary terminal of the bracketed name,
+  // so leave it alone.
+  if (scope->findModBTerm(name.c_str()) == nullptr) {
+    return name;
+  }
+  // A real bus member carries a sibling bus aggregate dbModBTerm named after
+  // the bus prefix (see Verilog2db::makeModBTerms); the brackets then denote a
+  // genuine bus select and must stay unescaped.
+  dbModBTerm* aggregate = scope->findModBTerm(bus_name.c_str());
+  if (aggregate && aggregate->isBusPort()) {
+    return name;
+  }
+  // Per-bit escaped-scalar signal (e.g. produced by partition synthesis or
+  // repair_design buffer insertion) whose name merely happens to contain
+  // brackets.  Escape them so write_verilog emits "\prefix[idx] " instead of
+  // a bus select on an undeclared bus.
+  return escapeChars(name, '[', ']', '\0', pathEscape());
+}
+
 std::string dbNetwork::name(const Port* port) const
 {
   if (isConcretePort(port)) {
@@ -826,6 +864,9 @@ std::string dbNetwork::name(const Port* port) const
 
   if (hasHierarchy()) {
     name = stripParentPrefix(name);
+  }
+  if (modbterm) {
+    name = escapeBracketsIfScalar(name, modbterm->getParent());
   }
   return name;
 }
@@ -1879,7 +1920,7 @@ std::string dbNetwork::name(const Net* net) const
   // Note the fall through: if we have a dnet which has a
   // little modnet friend, we use the modnet name.
   if (modnet) {
-    name = modnet->getName();
+    name = escapeBracketsIfScalar(modnet->getName(), modnet->getParent());
   }
   if (dnet || modnet) {
     return name;

--- a/src/dbSta/test/cpp/TestDbSta.cc
+++ b/src/dbSta/test/cpp/TestDbSta.cc
@@ -331,4 +331,65 @@ TEST_F(TestDbSta, StalePrevPath)
       << pre_pin_name << " after=" << post_pin_name;
 }
 
+// Regression test for dbNetwork name escaping of scalar signals whose
+// name merely contains brackets.
+//
+// Background (parallaxsw/OpenSTA#453): partition synthesis and
+// repair_design buffer insertion can produce single-bit "escaped-scalar"
+// signals like "\foo[7] " -- the brackets are literal name characters, not
+// a bus subscript, and no bus "foo" is declared.  If dbNetwork hands STA
+// the bare name "foo[7]", write_verilog emits a bus select on an
+// undeclared bus and Verilator rejects it ("Illegal bit or array select").
+//
+// jjcherry56 (STA maintainer): "The problem is in the upstream name.
+// foo[7] should be foo\[7\] if it is not doing a bus select."  So
+// dbNetwork::name() must return the ESCAPED form for such scalars, while
+// leaving genuine bus members (which always carry a sibling bus-aggregate
+// modBTerm) unescaped.
+TEST_F(TestDbSta, EscapeScalarBracketName)
+{
+  readVerilogAndSetup("TestDbSta_0.v");
+
+  odb::dbModule* top = block_->getTopModule();
+  ASSERT_NE(top, nullptr);
+
+  // (1) Standalone scalar port whose name contains literal brackets.
+  // No bus aggregate "foo" exists, so the brackets must be escaped.
+  odb::dbModBTerm* scalar_bterm = odb::dbModBTerm::create(top, "foo[7]");
+  ASSERT_NE(scalar_bterm, nullptr);
+  Port* scalar_port = db_network_->dbToSta(scalar_bterm);
+  ASSERT_NE(scalar_port, nullptr);
+  EXPECT_EQ(db_network_->name(scalar_port), "foo\\[7\\]");
+
+  // (2) Scalar net sharing its name with a scalar boundary port: the port
+  // declaration escapes the brackets, so the net reference must too.
+  odb::dbModBTerm::create(top, "bar[3]");
+  odb::dbModNet* scalar_net = odb::dbModNet::create(top, "bar[3]");
+  ASSERT_NE(scalar_net, nullptr);
+  Net* sta_net = db_network_->dbToSta(scalar_net);
+  ASSERT_NE(sta_net, nullptr);
+  EXPECT_EQ(db_network_->name(sta_net), "bar\\[3\\]");
+
+  // (3) Genuine bus member must NOT be escaped: a sibling bus-aggregate
+  // modBTerm "vec" (isBusPort) marks "vec[2]" as a real bus select.
+  odb::dbModBTerm* bus_agg = odb::dbModBTerm::create(top, "vec");
+  ASSERT_NE(bus_agg, nullptr);
+  odb::dbBusPort* busport = odb::dbBusPort::create(top, bus_agg, 3, 0);
+  bus_agg->setBusPort(busport);
+  odb::dbModBTerm* bus_member = odb::dbModBTerm::create(top, "vec[2]");
+  ASSERT_NE(bus_member, nullptr);
+  Port* member_port = db_network_->dbToSta(bus_member);
+  ASSERT_NE(member_port, nullptr);
+  EXPECT_EQ(db_network_->name(member_port), "vec[2]");
+
+  // A genuine bus-member net must likewise stay unescaped so the bus select
+  // is preserved (regression guard: top-level bus bits have no per-bit
+  // modBTerm, so they are never escaped either).
+  odb::dbModNet* member_net = odb::dbModNet::create(top, "vec[2]");
+  ASSERT_NE(member_net, nullptr);
+  Net* sta_member_net = db_network_->dbToSta(member_net);
+  ASSERT_NE(sta_member_net, nullptr);
+  EXPECT_EQ(db_network_->name(sta_member_net), "vec[2]");
+}
+
 }  // namespace sta


### PR DESCRIPTION
### Problem

`write_verilog` emits bus-select syntax (`foo[7]`) for any net/port whose name parses as a clean, unescaped bus member. That is correct when `foo` is a declared bus (`input [hi:lo] foo;` / `wire [hi:lo] foo;`), but **wrong** for a single-bit *escaped-scalar* signal declared as `input \foo[7] ;` with no bus declaration.

The two name renderers disagree on such a name:
- `portVerilogName` escapes the brackets → the port dcl is `input \foo[7] ;`
- `netVerilogName` treats them as a bus subscript → the reference is `foo[7]`

Verilator then implicitly declares a 1-bit `logic foo` and rejects the bit-select:

```
%Error: Illegal bit or array select; type does not have a bit range
```

These per-bit escaped-scalar boundary signals arise from partition synthesis and from `repair_design` buffer insertion across module boundaries.

### Fix

Following the upstream guidance on parallaxsw/OpenSTA#453 — *"The problem is in the upstream name. foo[7] should be foo\\[7\\] if it is not doing a bus select."* — this fixes the name `dbNetwork` hands to STA rather than patching the writer.

`dbNetwork::name(const Port*)` / `name(const Net*)` now escape the brackets of a clean bus-member name **only when**, in the owning module:
1. a per-bit module boundary terminal (`dbModBTerm`) of that exact name exists (positive evidence it is a scalar port, not a pure bus select), **and**
2. the bus prefix has no bus-aggregate `dbModBTerm` (`isBusPort()`).

Genuine bus members are left untouched: sub-module bus bits carry a sibling bus aggregate, and top-level bus bits have no per-bit `dbModBTerm` at all, so neither path escapes them. This is the bracket analogue of the recent escaped-slash fix in `dbNetwork::name(Port*)` / `stripParentPrefix` (`hier_escape_port`).

This supersedes the write-side workaround proposed in parallaxsw/OpenSTA#453.

### Testing

- New `dbsta_unittest` regression `TestDbSta.EscapeScalarBracketName`: covers scalar port escaping, scalar-net escaping (net sharing a name with a scalar boundary port), and the genuine bus-member negative cases (member port and member net stay unescaped). Confirmed to fail without the fix and pass with it.
- Full `//src/dbSta/test:all` (74 tests) and `//src/rsz/test:all` (254 tests) pass — including the hierarchical write-verilog goldens (`hierwrite`, `hier3`, `hierclock`) that exercise real top-level and sub-module buses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)