### PR TITLE
syn: add missing library on cmake target_link_libraries

### DIFF
--- a/src/syn/test/CMakeLists.txt
+++ b/src/syn/test/CMakeLists.txt
@@ -40,6 +40,6 @@ foreach(_t abc_test sm_test cm_test)
 endforeach()
 
 add_executable(elab_test elab_test.cc)
-target_link_libraries(elab_test ${_syn_test_libs} syn_elab syn_flow syn_ir tst)
+target_link_libraries(elab_test ${_syn_test_libs} syn_elab syn_flow syn_lib syn_ir tst)
 gtest_discover_tests(elab_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(build_and_test elab_test)


### PR DESCRIPTION
## Summary
Add missing `syn_lib` on CMake's target_link_libraries.

Without this, cmake build fails with:
```
/usr/bin/ld: ../src/flow/libsyn_flow.a(combinational_mapper.cc.o): in function `syn::mapCombinationals(syn::Graph&, sta::Network*, utl::Logger*, syn::Synthesis const&)':
combinational_mapper.cc:(.text+0xbe16): undefined reference to `syn::Synthesis::dontUse(sta::LibertyCell const*) const'
/usr/bin/ld: ../src/flow/libsyn_flow.a(opt_gatefusion.cc.o): in function `syn::(anonymous namespace)::buildIndex(sta::Network*, utl::Logger*, syn::Synthesis const&)':
opt_gatefusion.cc:(.text+0x7cfa): undefined reference to `syn::Synthesis::dontUse(sta::LibertyCell const*) const'
collect2: error: ld returned 1 exit status
make[2]: *** [src/syn/test/CMakeFiles/elab_test.dir/build.make:175: src/syn/test/elab_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:15397: src/syn/test/CMakeFiles/elab_test.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs.... 
```

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
Fix CMake build.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**