### PR TITLE
odb: makeNewNetName must avoid instance name collisions

### DIFF
--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -3883,7 +3883,15 @@ std::string dbBlock::makeNewNetName(const dbModule* parent,
   auto exists = [this, scope, corresponding_flat_net](const char* name) {
     if (scope != nullptr) {
       const char* base = getBaseName(name);
-      if (scope->getModNet(base) || scope->findModBTerm(base)) {
+      // A net/port name must also be unique against instance names in the
+      // scope: a net/port and an instance cannot share a name in one Verilog
+      // scope.  OpenROAD can promote an anonymous net ("_NNNNN_") to a
+      // module boundary port, and yosys/ABC name anonymous cells "_NNNNN_"
+      // too, so without this check the promoted port collides with a leaf or
+      // hierarchical instance of the same name -- illegal Verilog that
+      // Verilator rejects with "Instance has the same name as port".
+      if (scope->getModNet(base) || scope->findModBTerm(base)
+          || scope->findModInst(base) || scope->findDbInst(base)) {
         return true;
       }
     }

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -291,6 +291,39 @@ TEST_F(ModuleFixture, test_find_modinst)
   auto minst2 = odb::dbModInst::create(master1, master2, "minst2");
   EXPECT_EQ(block_->findModInst("minst1/minst2"), minst2);
 }
+
+// makeNewNetName must not hand out a name that already belongs to an
+// instance in the scope: a net/port and an instance cannot share a name in
+// one Verilog scope.  OpenROAD promotes anonymous nets ("_NNNNN_") to
+// module boundary ports, and yosys/ABC name anonymous cells "_NNNNN_" too,
+// so without an instance-name check the promoted port collides with a leaf
+// or hierarchical instance -- illegal Verilog ("Instance has the same name
+// as port").
+TEST_F(ModuleFixture, makeNewNetName_avoids_instance_collision)
+{
+  auto top = block_->getTopModule();
+  ASSERT_NE(top, nullptr);
+
+  // Leaf (dbInst) collision: an instance named "_42_" exists in scope.
+  dbInst::create(block_, lib_->findMaster("and2"), "_42_");
+  std::string leaf = block_->makeNewNetName(
+      top, "_42_", dbNameUniquifyType::IF_NEEDED_WITH_UNDERSCORE);
+  EXPECT_STRNE(block_->getBaseName(leaf.c_str()), "_42_")
+      << "net name must not collide with leaf instance '_42_'";
+
+  // Hierarchical (dbModInst) collision: a module instance named "_99_".
+  auto master = dbModule::create(block_, "anon_master");
+  dbModInst::create(top, master, "_99_");
+  std::string hier = block_->makeNewNetName(
+      top, "_99_", dbNameUniquifyType::IF_NEEDED_WITH_UNDERSCORE);
+  EXPECT_STRNE(block_->getBaseName(hier.c_str()), "_99_")
+      << "net name must not collide with module instance '_99_'";
+
+  // No collision: a fresh name is returned unchanged.
+  std::string fresh = block_->makeNewNetName(
+      top, "no_collision_here", dbNameUniquifyType::IF_NEEDED_WITH_UNDERSCORE);
+  EXPECT_STREQ(block_->getBaseName(fresh.c_str()), "no_collision_here");
+}
 class DetailedFixture : public SimpleDbFixture
 {
  protected:


### PR DESCRIPTION
### Problem

`dbBlock::makeNewNetName` uniquifies a new net/port name against ModNets, ModBTerms, and flat nets in the scope — but **not** against instance names. A net/port and an instance cannot share a name in one Verilog scope.

OpenROAD's hierarchical flow promotes some anonymous nets (`_NNNNN_`) to module boundary ports, and yosys/ABC name anonymous cells `_NNNNN_` too. So a promoted boundary port can be handed a name already owned by a leaf (`dbInst`) or hierarchical (`dbModInst`) instance in the same module. `write_verilog` then emits a module containing both a port and an instance of the same name — illegal Verilog that Verilator rejects with:

```
%Error: Instance has the same name as port: ...
```

breaking gate-level (e.g. SAIF) simulation of the placed netlist.

### Fix

Extend the collision check in `makeNewNetName`'s `exists` lambda to also reject names matching a `dbModInst` or `dbInst` in the scope (`findModInst` / `findDbInst`), so the generated name is uniquified (suffixed) when it would otherwise collide with an instance. The change is conservative — it only makes generated names *more* unique.

This is a sibling to the naming-correctness discussion in parallaxsw/OpenSTA#453 ("the problem is in the upstream name"): the fix belongs in OpenROAD's name generation, not in a `write_verilog` post-pass.

### Testing

- New `TestModule.makeNewNetName_avoids_instance_collision` regression covers the leaf-instance (`dbInst`) collision, the hierarchical-instance (`dbModInst`) collision, and the no-collision passthrough. Confirmed to fail without the fix and pass with it.
- `//src/odb/test/cpp:TestModule` and `//src/rsz/test:TestInsertBuffer` (which exercises `makeNewNetName` heavily, including the existing ModBTerm-collision regression) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)