### PR TITLE
Make file_to_string invocation more robust.

### DIFF
--- a/bazel/tcl_encode_or.bzl
+++ b/bazel/tcl_encode_or.bzl
@@ -48,9 +48,9 @@ tcl_encode = rule(
             doc = "Files to be wrapped.",
         ),
         "_encode_script": attr.label(
-            default = "//etc:file_to_string",
+            default = "//etc:file_to_string.py",
             executable = True,
-            allow_files = True,
+            allow_single_file = [".py"],
             cfg = "exec",
         ),
     },

--- a/etc/BUILD
+++ b/etc/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 package(features = ["layering_check"])
 
@@ -7,16 +7,8 @@ exports_files(
         "whittle.py",
         "whittle_cleanup.tcl",
         "whittle_cut.tcl",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-py_binary(
-    name = "file_to_string",
-    srcs = [
         "file_to_string.py",
     ],
-    main = "file_to_string.py",
     visibility = ["//visibility:public"],
 )
 

--- a/src/stt/BUILD
+++ b/src/stt/BUILD
@@ -18,10 +18,9 @@ genrule(
         "src/flt/etc/POST9.dat",
     ],
     outs = ["src/flt/etc/POST9.cpp"],
-    cmd = "$(execpath //etc:file_to_string) --inputs $(location src/flt/etc/POST9.dat) --output \"$@\" --varname post9 --namespace stt::flt",
-    tools = [
-        "//etc:file_to_string",
-    ],
+    cmd = "$(PYTHON3) $(execpath //etc:file_to_string.py) --inputs $(location src/flt/etc/POST9.dat) --output \"$@\" --varname post9 --namespace stt::flt",
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tools = ["//etc:file_to_string.py"],
 )
 
 genrule(
@@ -30,10 +29,9 @@ genrule(
         "src/flt/etc/POWV9.dat",
     ],
     outs = ["src/flt/etc/POWV9.cpp"],
-    cmd = "$(execpath //etc:file_to_string) --inputs $(location src/flt/etc/POWV9.dat) --output \"$@\" --varname powv9 --namespace stt::flt",
-    tools = [
-        "//etc:file_to_string",
-    ],
+    cmd = "$(PYTHON3) $(execpath //etc:file_to_string.py) --inputs $(location src/flt/etc/POWV9.dat) --output \"$@\" --varname powv9 --namespace stt::flt",
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tools = ["//etc:file_to_string.py"],
 )
 
 cc_library(


### PR DESCRIPTION
Using `py_binary()` will emit a driver script in front of the actual script; depending on flags the user chooses, this can be in Python or could also be a shell script. This can create trouble if we then attempt to invoke that shell script with a python interpreter in tcl_encode_or.

Since this is a simple one-file script, always invoke it with the existing Python interpreter witout detour, making the whole situation more robust.
