### PR TITLE
odb: add lint exception to prevent clang-tidy failure on generated code

### DIFF
--- a/src/odb/src/codeGenerator/templates/impl.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/impl.cpp.jinja
@@ -33,6 +33,9 @@ namespace odb {
 
   bool _{{klass.name}}::operator<(const _{{klass.name}}& rhs) const
   {
+    {% if klass.less_fields | length == 1 %}
+    // NOLINTBEGIN(readability-simplify-boolean-expr)
+    {% endif %}
     {% for less in klass.less_fields %}
     if ({{less.left}} >= {{less.right}}) {
       return false;
@@ -42,6 +45,9 @@ namespace odb {
     //User Code Begin <
     //User Code End <
     return true;
+    {% if klass.less_fields | length == 1 %}
+    // NOLINTEND(readability-simplify-boolean-expr)
+    {% endif %}
   }
 
   _{{klass.name}}::_{{klass.name}}(_dbDatabase* db)

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -144,11 +144,13 @@ bool _dbChip::operator==(const _dbChip& rhs) const
 
 bool _dbChip::operator<(const _dbChip& rhs) const
 {
+  // NOLINTBEGIN(readability-simplify-boolean-expr)
   if (top_ >= rhs.top_) {
     return false;
   }
 
   return true;
+  // NOLINTEND(readability-simplify-boolean-expr)
 }
 
 _dbChip::_dbChip(_dbDatabase* db)


### PR DESCRIPTION
## Summary
When a dbObject has a single member, the generated `operator<` code will trigger a clang-tidy warning:

```
warning: redundant boolean literal in conditional return statement [readability-simplify-boolean-expr]
```
That causes clang-tidy-bazel CI pipeline to fail (e.g., #10758).

With this change, clang-tidy-bazel CI should pass  for such a case.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**