### PR TITLE
syn: fix stack-use-after-return in constant fold sliceDff

### DIFF
--- a/src/syn/src/flow/constant_fold.cc
+++ b/src/syn/src/flow/constant_fold.cc
@@ -448,10 +448,10 @@ static void foldCombinationals(Graph& g)
   });
 }
 
-static BundleView sliceDff(Graph& g,
-                           const Dff* original,
-                           uint32_t base,
-                           uint32_t width)
+static Bundle sliceDff(Graph& g,
+                       const Dff* original,
+                       uint32_t base,
+                       uint32_t width)
 {
   assert(width > 0);
 
@@ -575,7 +575,7 @@ static bool foldSequentials(Graph& g)
               break;
             }
           }
-          BundleView new_out_slice = sliceDff(g, dff, i, slice_width);
+          Bundle new_out_slice = sliceDff(g, dff, i, slice_width);
           for (uint32_t k = 0; k < slice_width; k++) {
             new_out[i + k] = new_out_slice[k];
           }


### PR DESCRIPTION
## Summary
`sliceDff()` in the constant-fold pass returned a non-owning `BundleView`
built from the owning `Bundle` that `Graph::add<Dff>()` returns. The implicit
`BundleView(const Bundle&)` conversion captures a pointer to that temporary,
which is destroyed when `sliceDff()` returns; `foldSequentials()` then indexes
the dangling view.

Fix: return an owning `Bundle` from `sliceDff()` and hold it as a `Bundle` at
the call site.

## Type of Change
- Bug fix

## Impact
Optimized builds tolerate the UB (`sliceDff` is inlined, so the temporary's
storage survives the read), but a DEBUG (unoptimized) build SIGSEGVs during
synthesis of larger designs that use the integrated `syn` flow (e.g.
`asap7/aes`, `asap7/jpeg`). After the fix, both a pure DEBUG build and a
`-DASAN=ON` build complete synthesis of `asap7/aes` cleanly and produce
identical output (`1_synth.odb` sha1 matches across configs). No behavior
change for optimized builds.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass (`graph_test`, `liveness_test`
      under ASan; `asap7/aes` synthesis in DEBUG and ASan).

## Related Issues
N/A
