### PR TITLE
syn: fix stack-use-after-return in constant fold sliceDff, revised

### DIFF
--- a/src/syn/src/flow/constant_fold.cc
+++ b/src/syn/src/flow/constant_fold.cc
@@ -448,10 +448,10 @@ static void foldCombinationals(Graph& g)
   });
 }
 
-static Bundle sliceDff(Graph& g,
-                       const Dff* original,
-                       uint32_t base,
-                       uint32_t width)
+static BundleView sliceDff(Graph& g,
+                           const Dff* original,
+                           uint32_t base,
+                           uint32_t width)
 {
   assert(width > 0);
 
@@ -575,7 +575,7 @@ static bool foldSequentials(Graph& g)
               break;
             }
           }
-          Bundle new_out_slice = sliceDff(g, dff, i, slice_width);
+          BundleView new_out_slice = sliceDff(g, dff, i, slice_width);
           for (uint32_t k = 0; k < slice_width; k++) {
             new_out[i + k] = new_out_slice[k];
           }

--- a/src/syn/src/flow/constant_fold.cc
+++ b/src/syn/src/flow/constant_fold.cc
@@ -448,10 +448,10 @@ static void foldCombinationals(Graph& g)
   });
 }
 
-static BundleView sliceDff(Graph& g,
-                           const Dff* original,
-                           uint32_t base,
-                           uint32_t width)
+static Bundle sliceDff(Graph& g,
+                       const Dff* original,
+                       uint32_t base,
+                       uint32_t width)
 {
   assert(width > 0);
 
@@ -575,7 +575,7 @@ static bool foldSequentials(Graph& g)
               break;
             }
           }
-          BundleView new_out_slice = sliceDff(g, dff, i, slice_width);
+          Bundle new_out_slice = sliceDff(g, dff, i, slice_width);
           for (uint32_t k = 0; k < slice_width; k++) {
             new_out[i + k] = new_out_slice[k];
           }

--- a/src/syn/src/ir/Bundle.cc
+++ b/src/syn/src/ir/Bundle.cc
@@ -25,6 +25,14 @@ Bundle::Bundle(BundleView bv) : tag_(kEmpty), width_(0), net_(Net::zero())
     net_ = bv[0];
     return;
   }
+
+  if (bv.isGuaranteedConsecutive()) {
+    tag_ = kConsecutive;
+    width_ = bv.width();
+    net_ = bv[0];
+    return;
+  }
+
   std::vector<Net> nets;
   nets.reserve(bv.width());
   for (uint32_t i = 0; i < bv.width(); i++) {

--- a/src/syn/src/ir/Bundle.h
+++ b/src/syn/src/ir/Bundle.h
@@ -149,21 +149,21 @@ class Bundle
 class BundleView
 {
  public:
-  BundleView(Net net) : net_(net), Bundle_(nullptr), offset_(0), width_(1) {}
+  BundleView(Net net) : net_(net), bundle_(nullptr), offset_(0), width_(1) {}
 
   BundleView(const Bundle& Bundle)
-      : net_(Net::zero()), Bundle_(&Bundle), offset_(0), width_(Bundle.width())
+      : net_(Net::zero()), bundle_(&Bundle), offset_(0), width_(Bundle.width())
   {
   }
 
   BundleView(const Bundle& Bundle, uint32_t offset, uint32_t len)
-      : net_(Net::zero()), Bundle_(&Bundle), offset_(offset), width_(len)
+      : net_(Net::zero()), bundle_(&Bundle), offset_(offset), width_(len)
   {
   }
 
   // Consecutive nets starting at base.
   BundleView(Net base, uint32_t len)
-      : net_(base), Bundle_(nullptr), offset_(0), width_(len)
+      : net_(base), bundle_(nullptr), offset_(0), width_(len)
   {
   }
 
@@ -182,8 +182,8 @@ class BundleView
 
   Net operator[](uint32_t i) const
   {
-    if (Bundle_) {
-      return (*Bundle_)[offset_ + i];
+    if (bundle_) {
+      return (*bundle_)[offset_ + i];
     }
     return Net(net_.id_ + i);
   }
@@ -211,8 +211,8 @@ class BundleView
 
   BundleView slice(uint32_t offset, uint32_t len) const
   {
-    if (Bundle_) {
-      return BundleView(*Bundle_, offset_ + offset, len);
+    if (bundle_) {
+      return BundleView(*bundle_, offset_ + offset, len);
     }
     if (len == 0) {
       return BundleView(Net::zero(), nullptr, 0, 0);
@@ -222,14 +222,19 @@ class BundleView
 
   bool isConst() const;
 
+ protected:
+  // For optimized construction of Bundle from BundleView
+  bool isGuaranteedConsecutive() const { return bundle_ == nullptr; }
+  friend class Bundle;
+
  private:
   BundleView(Net net, const Bundle* Bundle, uint32_t offset, uint32_t len)
-      : net_(net), Bundle_(Bundle), offset_(offset), width_(len)
+      : net_(net), bundle_(Bundle), offset_(offset), width_(len)
   {
   }
 
   Net net_;
-  const Bundle* Bundle_;
+  const Bundle* bundle_;
   uint32_t offset_;
   uint32_t width_;
 };

--- a/src/syn/src/ir/Graph.h
+++ b/src/syn/src/ir/Graph.h
@@ -49,9 +49,9 @@ class Graph
   Graph& operator=(const Graph&) = delete;
 
   // Add an instance to the graph.
-  // Returns the output Bundle.
+  // Returns the output BundleView.
   template <typename T, typename... Args>
-  Bundle add(Args&&... args);
+  BundleView add(Args&&... args);
 
   // Resolve a Net to its owning Instance and bit offset.
   std::pair<const Instance*, uint32_t> resolve(Net net) const;
@@ -345,7 +345,7 @@ class Graph
 };
 
 template <typename T, typename... Args>
-Bundle Graph::add(Args&&... args)
+BundleView Graph::add(Args&&... args)
 {
   size_t inst_size;
   if constexpr (requires { T::plan(args...); }) {
@@ -376,9 +376,9 @@ Bundle Graph::add(Args&&... args)
       for (uint32_t i = 1; i < output_width; ++i) {
         new (table_.pointer(id + i)) PlaceholderEntry(inst, i);
       }
-      return Bundle(Net(id), output_width);
+      return BundleView(Net(id), output_width);
     }
-    return Bundle(Net(id));
+    return BundleView(Net(id));
   }
 
   // Heap path: allocate and construct on heap.
@@ -401,9 +401,9 @@ Bundle Graph::add(Args&&... args)
   }
 
   if (output_width > 1) {
-    return Bundle(Net(first), output_width);
+    return BundleView(Net(first), output_width);
   }
-  return Bundle(Net(first));
+  return BundleView(Net(first));
 }
 
 // Dump.cc


### PR DESCRIPTION
## Summary
This is a revised fix from https://github.com/The-OpenROAD-Project/OpenROAD/pull/10768.

Since the return value of `add` represents a contiguous block of net indices we can use `BundleView` for it which is both more efficient and prevents use-after-free should the caller cast to BundleView.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix
