### PR TITLE
etc: Use _execute for bison download to get log only on failure as for others.

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -357,7 +357,8 @@ _install_bison() {
                     fi
                 done
                 if [[ ${success} -ne 1 ]]; then
-                    (error "Could not download bison-${BISON_VERSION}.tar.gz from any mirror.")
+                    warn "Could not download bison-${BISON_VERSION}.tar.gz from any mirror."
+                    return 1
                 fi
             }
             _execute "Downloading Bison" _download_bison

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -338,26 +338,29 @@ _install_bison() {
     if [[ "${bison_installed_version}" != "${BISON_VERSION}" ]]; then
         (
             cd "${BASE_DIR}"
-            local mirrors=(
-                "https://ftp.gnu.org/gnu/bison"
-                "https://ftpmirror.gnu.org/bison"
-                "https://mirrors.kernel.org/gnu/bison"
-                "https://mirrors.dotsrc.org/gnu/bison"
-            )
-            local success=0
-            for mirror in "${mirrors[@]}"; do
-                local url="${mirror}/bison-${BISON_VERSION}.tar.gz"
-                log "Trying to download bison from: $url"
-                if wget $OPT_NOCERT "$url"; then
-                    success=1
-                    break
-                else
-                    warn "Failed to download from $mirror"
+            _download_bison() {
+                local mirrors=(
+                    "https://ftp.gnu.org/gnu/bison"
+                    "https://ftpmirror.gnu.org/bison"
+                    "https://mirrors.kernel.org/gnu/bison"
+                    "https://mirrors.dotsrc.org/gnu/bison"
+                )
+                local success=0
+                for mirror in "${mirrors[@]}"; do
+                    local url="${mirror}/bison-${BISON_VERSION}.tar.gz"
+                    log "Trying to download bison from: $url"
+                    if wget $OPT_NOCERT "$url"; then
+                        success=1
+                        break
+                    else
+                        warn "Failed to download from $mirror"
+                    fi
+                done
+                if [[ ${success} -ne 1 ]]; then
+                    (error "Could not download bison-${BISON_VERSION}.tar.gz from any mirror.")
                 fi
-            done
-            if [[ ${success} -ne 1 ]]; then
-                error "Could not download bison-${BISON_VERSION}.tar.gz from any mirror."
-            fi
+            }
+            _execute "Downloading Bison" _download_bison
             _verify_checksum "${BISON_CHECKSUM}" "bison-${BISON_VERSION}.tar.gz" || error "Bison checksum failed."
             _execute "Extracting Bison..." tar xf "bison-${BISON_VERSION}.tar.gz"
             cd "bison-${BISON_VERSION}"


### PR DESCRIPTION
On success:
`[INFO] Downloading Bison ✔`

On failure:
```
INFO] Downloading Bison ✖
[INFO] Trying to download bison from: https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz
--2026-06-29 15:53:34--  https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz
Resolving ftp.gnu.org (ftp.gnu.org)... failed: Name or service not known.
wget: unable to resolve host address ‘ftp.gnu.org’
[WARNING] Failed to download from https://ftp.gnu.org/gnu/bison
[INFO] Trying to download bison from: https://ftpmirror.gnu.org/bison/bison-3.8.2.tar.gz
--2026-06-29 15:53:34--  https://ftpmirror.gnu.org/bison/bison-3.8.2.tar.gz
Resolving ftpmirror.gnu.org (ftpmirror.gnu.org)... failed: Name or service not known.
wget: unable to resolve host address ‘ftpmirror.gnu.org’
[WARNING] Failed to download from https://ftpmirror.gnu.org/bison
[INFO] Trying to download bison from: https://mirrors.kernel.org/gnu/bison/bison-3.8.2.tar.gz
--2026-06-29 15:53:34--  https://mirrors.kernel.org/gnu/bison/bison-3.8.2.tar.gz
Resolving mirrors.kernel.org (mirrors.kernel.org)... failed: Name or service not known.
wget: unable to resolve host address ‘mirrors.kernel.org’
[WARNING] Failed to download from https://mirrors.kernel.org/gnu/bison
[INFO] Trying to download bison from: https://mirrors.dotsrc.org/gnu/bison/bison-3.8.2.tar.gz
--2026-06-29 15:53:34--  https://mirrors.dotsrc.org/gnu/bison/bison-3.8.2.tar.gz
Resolving mirrors.dotsrc.org (mirrors.dotsrc.org)... failed: Name or service not known.
wget: unable to resolve host address ‘mirrors.dotsrc.org’
[WARNING] Failed to download from https://mirrors.dotsrc.org/gnu/bison
[ERROR] Could not download bison-3.8.2.tar.gz from any mirror.
[ERROR] Failed to execute: _download_bison
```