### PR TITLE
(DO NOT MERGE) rsz: Add escaped scalar port hierarchy regression

### DIFF
--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -254,6 +254,7 @@ PASSFAIL_TESTS = [
     # NOTE: cpp_tests excluded - it's a CMake-specific wrapper script that expects
     # build directory structure not compatible with Bazel
     # "cpp_tests",
+    "repair_design_escape_scalar_port_verilog_hier",
     "repair_setup_legacy_mt",
     "repair_setup_mt1",
 ]

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -236,6 +236,7 @@ or_integration_tests(
     measured_vt_swap
     repair_fanout7_skip_pin_swap
   PASSFAIL_TESTS
+    repair_design_escape_scalar_port_verilog_hier
     repair_setup_legacy_mt
     repair_setup_mt1
     cpp_tests

--- a/src/rsz/test/repair_design_escape_scalar_port_verilog_hier.tcl
+++ b/src/rsz/test/repair_design_escape_scalar_port_verilog_hier.tcl
@@ -1,0 +1,141 @@
+# repair_design buffering must preserve escaped scalar bracket ports from
+# Verilog when the design is linked through hierarchical flow.
+source "helpers.tcl"
+
+set test_name repair_design_escape_scalar_port_verilog_hier
+set input_name repair_design_escape_scalar_port_verilog_hier
+set top_scalar_port {foo\[7\]}
+set mod_scalar_port {bar\[3\]}
+set top_output_port {out\[0\]}
+set mod_output_port {out\[1\]}
+set load_count 35
+
+proc place_inst { inst_name x y } {
+  set inst [[ord::get_db_block] findInst $inst_name]
+  $inst setLocation $x $y
+  $inst setOrient R0
+  $inst setPlacementStatus PLACED
+}
+
+proc place_bterm { bterm_name layer_name x y } {
+  set block [ord::get_db_block]
+  set tech [ord::get_db_tech]
+  set bterm [$block findBTerm $bterm_name]
+  set layer [$tech findLayer $layer_name]
+  set bpin [odb::dbBPin_create $bterm]
+  $bpin setPlacementStatus PLACED
+  odb::dbBox_create $bpin $layer $x $y [expr { $x + 100 }] [expr { $y + 100 }]
+}
+
+read_liberty repair_fanout4.lib
+read_lef Nangate45/Nangate45.lef
+read_verilog "${input_name}.v"
+link_design -hier top
+
+set child_mod [[ord::get_db_block] findModule child]
+set mod_bterm [$child_mod findModBTerm $mod_scalar_port]
+if { $mod_bterm == "NULL" } {
+  utl::error RSZ 999 \
+    "hierarchical read_verilog did not create dbModBTerm \\bar[3]"
+}
+set mod_out_bterm [$child_mod findModBTerm $mod_output_port]
+if { $mod_out_bterm == "NULL" } {
+  utl::error RSZ 999 \
+    "hierarchical read_verilog did not create dbModBTerm \\out[1]"
+}
+
+initialize_floorplan \
+  -die_area {0 0 30 40} \
+  -core_area {0 0 30 40} \
+  -site FreePDK45_38x28_10R_NP_162NW_34O
+
+# Place the escaped scalar top port and its fanout loads without using DEF.
+place_bterm $top_scalar_port metal1 0 1000
+place_bterm $top_output_port metal1 29000 1000
+place_inst u_child/out_driver 25000 1000
+for { set i 0 } { $i < $load_count } { incr i } {
+  set x [expr { ($i % 5) * 5000 }]
+  set y [expr { ($i / 5) * 5000 }]
+  place_inst u_child/load$i $x $y
+}
+
+set_max_fanout 3 [current_design]
+set_driving_cell -lib_cell BUF_X1 [all_inputs]
+set_load 100 [get_ports $top_output_port]
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal1
+estimate_parasitics -placement
+
+report_check_types -max_fanout
+
+repair_design
+report_check_types -max_fanout
+
+set verilog_file [make_result_file "${test_name}.v"]
+write_verilog $verilog_file
+report_file $verilog_file
+
+set stream [open $verilog_file r]
+set verilog_text [read $stream]
+close $stream
+
+set has_buffering [regexp {BUF_X1 fanout[0-9]+} $verilog_text]
+set has_escaped_top_decl [regexp {input \\foo\[7\] ;} $verilog_text]
+set has_escaped_mod_decl [regexp {input \\bar\[3\] ;} $verilog_text]
+set has_escaped_top_out_decl [regexp {output \\out\[0\] ;} $verilog_text]
+set has_escaped_mod_out_decl [regexp {output \\out\[1\] ;} $verilog_text]
+set has_escaped_mod_ref [regexp {\(\.A\(\\bar\[3\] \)} $verilog_text]
+set has_escaped_mod_inst_ref [regexp {\.\\bar\[3\] \(\\foo\[7\] \)} $verilog_text]
+set has_escaped_mod_out_inst_ref [regexp {\.\\out\[1\] \(net[0-9]+\)} $verilog_text]
+set has_escaped_output_buffer 0
+if { [regexp {\.\\out\[1\] \((net[0-9]+)\)} $verilog_text -> output_net] } {
+  set output_buffer_pattern [format \
+    {BUF_X1 wire[0-9]+ \(\.A\(%s\),\n    \.Z\(\\out\[0\] \)\)} \
+    $output_net]
+  set has_escaped_output_buffer [regexp $output_buffer_pattern $verilog_text]
+}
+set has_bad_bus_port_decl [regexp {input \[7:7\] foo;} $verilog_text]
+set has_bad_mod_bus_port_decl [regexp {input \[3:3\] bar;} $verilog_text]
+set has_bad_out_bus_port_decl [regexp {output \[0:0\] out;} $verilog_text]
+set has_bad_mod_out_bus_port_decl [regexp {output \[1:1\] out;} $verilog_text]
+set has_bad_bus_select_ref [regexp {\(\.A\(foo\[7\]\)} $verilog_text]
+set has_bad_mod_bus_select_ref [regexp {\(\.A\(bar\[3\]\)} $verilog_text]
+set has_bad_out_bus_select_ref [regexp {\(\.Z\(out\[1\]\)} $verilog_text]
+
+if { !$has_buffering } {
+  utl::error RSZ 999 "repair_design did not buffer the escaped scalar port"
+}
+if { !$has_escaped_top_decl } {
+  utl::error RSZ 999 \
+    "write_verilog did not preserve escaped scalar top port \\foo[7]"
+}
+if { !$has_escaped_top_out_decl } {
+  utl::error RSZ 999 \
+    "write_verilog did not preserve escaped scalar top output port \\out[0]"
+}
+if {
+  !$has_escaped_mod_decl || !$has_escaped_mod_ref
+  || !$has_escaped_mod_inst_ref
+} {
+  utl::error RSZ 999 \
+    "write_verilog did not preserve escaped scalar module port \\bar[3]"
+}
+if {
+  !$has_escaped_mod_out_decl || !$has_escaped_mod_out_inst_ref
+  || !$has_escaped_output_buffer
+} {
+  utl::error RSZ 999 \
+    "repair_design did not buffer escaped scalar module output port \\out[1]"
+}
+if {
+  $has_bad_bus_port_decl || $has_bad_mod_bus_port_decl
+  || $has_bad_out_bus_port_decl || $has_bad_mod_out_bus_port_decl
+  || $has_bad_bus_select_ref || $has_bad_mod_bus_select_ref
+  || $has_bad_out_bus_select_ref
+} {
+  utl::error RSZ 999 \
+    "write_verilog emitted bus syntax for an escaped scalar bracket port"
+}
+
+puts "pass"

--- a/src/rsz/test/repair_design_escape_scalar_port_verilog_hier.v
+++ b/src/rsz/test/repair_design_escape_scalar_port_verilog_hier.v
@@ -1,0 +1,86 @@
+module child (\bar[3] , \out[1] );
+  input \bar[3] ;
+  output \out[1] ;
+
+  wire z0;
+  wire z1;
+  wire z2;
+  wire z3;
+  wire z4;
+  wire z5;
+  wire z6;
+  wire z7;
+  wire z8;
+  wire z9;
+  wire z10;
+  wire z11;
+  wire z12;
+  wire z13;
+  wire z14;
+  wire z15;
+  wire z16;
+  wire z17;
+  wire z18;
+  wire z19;
+  wire z20;
+  wire z21;
+  wire z22;
+  wire z23;
+  wire z24;
+  wire z25;
+  wire z26;
+  wire z27;
+  wire z28;
+  wire z29;
+  wire z30;
+  wire z31;
+  wire z32;
+  wire z33;
+  wire z34;
+
+  BUF_X1 out_driver (.A(\bar[3] ), .Z(\out[1] ));
+
+  BUF_X1 load0 (.A(\bar[3] ), .Z(z0));
+  BUF_X1 load1 (.A(\bar[3] ), .Z(z1));
+  BUF_X1 load2 (.A(\bar[3] ), .Z(z2));
+  BUF_X1 load3 (.A(\bar[3] ), .Z(z3));
+  BUF_X1 load4 (.A(\bar[3] ), .Z(z4));
+  BUF_X1 load5 (.A(\bar[3] ), .Z(z5));
+  BUF_X1 load6 (.A(\bar[3] ), .Z(z6));
+  BUF_X1 load7 (.A(\bar[3] ), .Z(z7));
+  BUF_X1 load8 (.A(\bar[3] ), .Z(z8));
+  BUF_X1 load9 (.A(\bar[3] ), .Z(z9));
+  BUF_X1 load10 (.A(\bar[3] ), .Z(z10));
+  BUF_X1 load11 (.A(\bar[3] ), .Z(z11));
+  BUF_X1 load12 (.A(\bar[3] ), .Z(z12));
+  BUF_X1 load13 (.A(\bar[3] ), .Z(z13));
+  BUF_X1 load14 (.A(\bar[3] ), .Z(z14));
+  BUF_X1 load15 (.A(\bar[3] ), .Z(z15));
+  BUF_X1 load16 (.A(\bar[3] ), .Z(z16));
+  BUF_X1 load17 (.A(\bar[3] ), .Z(z17));
+  BUF_X1 load18 (.A(\bar[3] ), .Z(z18));
+  BUF_X1 load19 (.A(\bar[3] ), .Z(z19));
+  BUF_X1 load20 (.A(\bar[3] ), .Z(z20));
+  BUF_X1 load21 (.A(\bar[3] ), .Z(z21));
+  BUF_X1 load22 (.A(\bar[3] ), .Z(z22));
+  BUF_X1 load23 (.A(\bar[3] ), .Z(z23));
+  BUF_X1 load24 (.A(\bar[3] ), .Z(z24));
+  BUF_X1 load25 (.A(\bar[3] ), .Z(z25));
+  BUF_X1 load26 (.A(\bar[3] ), .Z(z26));
+  BUF_X1 load27 (.A(\bar[3] ), .Z(z27));
+  BUF_X1 load28 (.A(\bar[3] ), .Z(z28));
+  BUF_X1 load29 (.A(\bar[3] ), .Z(z29));
+  BUF_X1 load30 (.A(\bar[3] ), .Z(z30));
+  BUF_X1 load31 (.A(\bar[3] ), .Z(z31));
+  BUF_X1 load32 (.A(\bar[3] ), .Z(z32));
+  BUF_X1 load33 (.A(\bar[3] ), .Z(z33));
+  BUF_X1 load34 (.A(\bar[3] ), .Z(z34));
+endmodule
+
+module top (\foo[7] , \out[0] );
+  input \foo[7] ;
+  output \out[0] ;
+
+  child u_child (.\bar[3] (\foo[7] ),
+                 .\out[1] (\out[0] ));
+endmodule


### PR DESCRIPTION
Adds an rsz regression for escaped scalar bracket ports in hierarchical repair_design flow.
Covers both top-level dbBTerm \foo[7] and child-module dbModBTerm \bar[3] through write_verilog.
