### PR TITLE
Fix incorrect @param names in doc comments

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -451,7 +451,7 @@ class FlexPA
    * @param inst_term the instance terminal
    * @param aps Vector contaning the access points
    * @param apset Set containing access points data (auxilary)
-   * @param rec Rect limiting where the point can be
+   * @param rect Rect limiting where the point can be
    * @param layer_num access point layer
    * @param x_coords map of access point x coords
    * @param y_coords map of access point y coords

--- a/src/odb/include/odb/gdsin.h
+++ b/src/odb/include/odb/gdsin.h
@@ -96,7 +96,7 @@ class GDSReader
   /**
    * Parses a GDS Element from the GDS file
    *
-   * @param str The GDS Structure to add the GDS Element to
+   * @param structure The GDS Structure to add the GDS Element to
    */
   bool processElement(dbGDSStructure* structure);
 


### PR DESCRIPTION
### Description

Two Doxygen `@param` comments reference parameter names that do not match their function signatures:

- `odb` `GDSReader::processElement(dbGDSStructure* structure)` documents `@param str` instead of `structure`.
- `drt` `FlexPA::createMultipleAccessPoints(... const gtl::rectangle_data<frCoord>& rect ...)` documents `@param rec` instead of `rect`.

This corrects the documented names to match the signatures. Documentation-only change; no behaviour is affected.
