### PR TITLE
Add "Macros to be placed" count to MPL design-data summary

### DIFF
--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -130,7 +130,7 @@ void ClusteringEngine::init()
 
   tree_->io_pads = getIOPads();
 
-  reportDesignData();
+  reportDesignData(unfixed_macros.size());
 }
 
 bool ClusteringEngine::movableCellsFitInMacroPlacementArea() const
@@ -280,7 +280,7 @@ std::vector<odb::dbInst*> ClusteringEngine::getIOPads() const
   return io_pads;
 }
 
-void ClusteringEngine::reportDesignData()
+void ClusteringEngine::reportDesignData(size_t num_macros_to_place)
 {
   const odb::Rect& die = block_->getDieArea();
   logger_->report(
@@ -306,6 +306,7 @@ void ClusteringEngine::reportDesignData()
       "\tNumber of std cell instances: {}\n"
       "\tArea of std cell instances: {:.2f}\n"
       "\tNumber of macros: {}\n"
+      "\tMacros to be placed: {}\n"
       "\tArea of macros: {:.2f}\n"
       "\tBase halo (L, B, R, T): ({:.2f}, {:.2f}, {:.2f}, {:.2f})\n"
       "\tArea of macros with halos: {:.2f}\n"
@@ -317,6 +318,7 @@ void ClusteringEngine::reportDesignData()
       design_metrics_->getNumStdCell(),
       block_->dbuAreaToMicrons(design_metrics_->getStdCellArea()),
       design_metrics_->getNumMacro(),
+      num_macros_to_place,
       block_->dbuAreaToMicrons(design_metrics_->getMacroArea()),
       block_->dbuToMicrons(base_halo_.left),
       block_->dbuToMicrons(base_halo_.bottom),

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/src/mpl/src/clusterEngine.h
+++ b/src/mpl/src/clusterEngine.h
@@ -148,7 +148,7 @@ class ClusteringEngine
   int64_t computeMacroWithHaloArea(
       const std::vector<odb::dbInst*>& unfixed_macros);
   std::vector<odb::dbInst*> getIOPads() const;
-  void reportDesignData();
+  void reportDesignData(size_t num_macros_to_place);
   void createRoot();
   void setBaseThresholds();
   void createIOClusters();

--- a/src/mpl/src/clusterEngine.h
+++ b/src/mpl/src/clusterEngine.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/src/mpl/test/boundary_push1.ok
+++ b/src/mpl/test/boundary_push1.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 4
+	Macros to be placed: 4
 	Area of macros: 40000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 40000.00

--- a/src/mpl/test/centralization1.ok
+++ b/src/mpl/test/centralization1.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (302.10, 301.00),  Floorplan Area: (0.00, 0.00) (302.10, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/clocked_macro.ok
+++ b/src/mpl/test/clocked_macro.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 43000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 43000.00

--- a/src/mpl/test/fixed_covers.ok
+++ b/src/mpl/test/fixed_covers.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 2
+	Macros to be placed: 1
 	Area of macros: 20000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/fixed_ios1.ok
+++ b/src/mpl/test/fixed_ios1.ok
@@ -9,6 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/fixed_macros1.ok
+++ b/src/mpl/test/fixed_macros1.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 2
+	Macros to be placed: 1
 	Area of macros: 20000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/fixed_macros2.ok
+++ b/src/mpl/test/fixed_macros2.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 15.40) (220.02,
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.80
 	Number of macros: 2
+	Macros to be placed: 1
 	Area of macros: 20000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/guides1.ok
+++ b/src/mpl/test/guides1.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/guides2.ok
+++ b/src/mpl/test/guides2.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 10
+	Macros to be placed: 10
 	Area of macros: 166000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 166000.00

--- a/src/mpl/test/halos1.ok
+++ b/src/mpl/test/halos1.ok
@@ -6,6 +6,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 2
+	Macros to be placed: 2
 	Area of macros: 20000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 22650.00

--- a/src/mpl/test/halos2.ok
+++ b/src/mpl/test/halos2.ok
@@ -6,6 +6,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 2
+	Macros to be placed: 2
 	Area of macros: 20000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 22782.00

--- a/src/mpl/test/halos3.ok
+++ b/src/mpl/test/halos3.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (250.00, 250.00),  Floorplan Area: (9.00, 9.80) (249.92, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (12.00, 6.00, 12.00, 6.00)
 	Area of macros with halos: 13888.00

--- a/src/mpl/test/halos4.ok
+++ b/src/mpl/test/halos4.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (250.00, 250.00),  Floorplan Area: (9.00, 9.80) (249.92, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (16.00, 8.00, 4.00, 2.00)
 	Area of macros with halos: 13200.00

--- a/src/mpl/test/io_constraints1.ok
+++ b/src/mpl/test/io_constraints1.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints10.ok
+++ b/src/mpl/test/io_constraints10.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints2.ok
+++ b/src/mpl/test/io_constraints2.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints3.ok
+++ b/src/mpl/test/io_constraints3.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 200
 	Area of std cell instances: 904.40
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints4.ok
+++ b/src/mpl/test/io_constraints4.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.80
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints5.ok
+++ b/src/mpl/test/io_constraints5.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.80
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints6.ok
+++ b/src/mpl/test/io_constraints6.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints7.ok
+++ b/src/mpl/test/io_constraints7.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints8.ok
+++ b/src/mpl/test/io_constraints8.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_constraints9.ok
+++ b/src/mpl/test/io_constraints9.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/io_pads1.ok
+++ b/src/mpl/test/io_pads1.ok
@@ -9,6 +9,7 @@ Die Area: (0.00, 0.00) (290.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/keep_clustering_data.ok
+++ b/src/mpl/test/keep_clustering_data.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/macro_only.ok
+++ b/src/mpl/test/macro_only.ok
@@ -7,6 +7,7 @@ Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 10
+	Macros to be placed: 10
 	Area of macros: 166000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 166000.00

--- a/src/mpl/test/macros_without_pins1.ok
+++ b/src/mpl/test/macros_without_pins1.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.80
 	Number of macros: 2
+	Macros to be placed: 1
 	Area of macros: 20000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/mixed_ios1.ok
+++ b/src/mpl/test/mixed_ios1.ok
@@ -9,6 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/orientation_improve1.ok
+++ b/src/mpl/test/orientation_improve1.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/orientation_improve2.ok
+++ b/src/mpl/test/orientation_improve2.ok
@@ -8,6 +8,7 @@ Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/orientation_improve3.ok
+++ b/src/mpl/test/orientation_improve3.ok
@@ -9,6 +9,7 @@ Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00

--- a/src/mpl/test/placement_blockages1.ok
+++ b/src/mpl/test/placement_blockages1.ok
@@ -6,6 +6,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Number of std cell instances: 150
 	Area of std cell instances: 678.30
 	Number of macros: 1
+	Macros to be placed: 1
 	Area of macros: 10000.00
 	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00


### PR DESCRIPTION
## Summary

`ClusteringEngine::reportDesignData()` already reports the **total** macro count (`Number of macros`), which counts every block instance — fixed and unfixed. It did not surface how many macros MPL will actually **place** (the unfixed macros).

This adds a `Macros to be placed` line to the summary, printed right next to the existing total so the two numbers are easy to compare. For designs with fixed macros the two values differ (e.g. `fixed_macros1`: 2 total, 1 to place).

## Implementation

- `ClusteringEngine::reportDesignData()` now takes the unfixed-macro count, already collected in `init()` as `unfixed_macros`, and prints it as one new `logger_->report()` line.
- Logging-only change: no new Tcl flags / env vars, and deterministic (iteration over `block_->getInsts()` is in stable DB order).

## Testing

- Regenerated the affected MPL test goldens (the new line is the only change in each).
- `bazel test //src/mpl/test/...` — 39 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)