### PR TITLE
odb, rcx: add set_extraction_rules_file command and deprecate -ext_model_file .tcl option

### DIFF
--- a/src/odb/README.md
+++ b/src/odb/README.md
@@ -490,6 +490,25 @@ add_3dblox_alignment_marker_rule
 | `-tolerance` | Maximum allowed center-to-center misalignment in microns. Must be positive. Defaults to 0 (exact alignment required). |
 | `-relative_orientations` | Optional Tcl list of allowed orientations of master_b relative to master_a (e.g. `{R0 MY}`). When omitted, orientations are not constrained. |
 
+### Set Extraction Rules File
+
+Sets the path to the parasitics extraction rules file. For a design in which
+multiple technologies are used, the user must specify the technology for which
+they want to set the rules path.
+
+```tcl
+set_extraction_rules_file
+    [-tech tech_name]
+    rules_file
+```
+
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-tech` | Technology for which to set the extraction rules path. |
+| `rules_file` | Path to the extraction rules file. |
+
 ## Regression tests
 
 There are a set of regression tests in `./test`. For more information, refer to this [section](../../README.md#regression-tests). 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7592,8 +7592,6 @@ class dbDatabase : public dbObject
 
   dbChip* findChip(const char* name) const;
 
-  bool hasHierarchicalChip() const;
-
   dbSet<dbProperty> getProperties() const;
 
   dbSet<dbChipInst> getChipInsts() const;
@@ -7620,6 +7618,8 @@ class dbDatabase : public dbObject
 
   void setHierarchy(bool value);
   bool hasHierarchy() const;
+
+  bool hasHierarchicalChip() const;
 
   void setTopChip(dbChip* chip);
   ///

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -5889,6 +5889,10 @@ class dbTech : public dbObject
   ///
   std::string getName();
 
+  void setExtractionRulesFile(const std::string& path);
+
+  std::string getExtractionRulesFile();
+
   ///
   /// Get the Database units per micron.
   ///
@@ -7587,6 +7591,8 @@ class dbDatabase : public dbObject
   dbSet<dbChip> getChips() const;
 
   dbChip* findChip(const char* name) const;
+
+  bool hasHierarchicalChip() const;
 
   dbSet<dbProperty> getProperties() const;
 

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -704,6 +704,17 @@ dbChip* dbDatabase::findChip(const char* name) const
   return (dbChip*) obj->chip_hash_.find(name);
 }
 
+bool dbDatabase::hasHierarchicalChip() const
+{
+  for (dbChip* chip : getChips()) {
+    if (chip->getChipType() == dbChip::ChipType::HIER) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 dbSet<dbProperty> dbDatabase::getProperties() const
 {
   _dbDatabase* obj = (_dbDatabase*) this;

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -704,17 +704,6 @@ dbChip* dbDatabase::findChip(const char* name) const
   return (dbChip*) obj->chip_hash_.find(name);
 }
 
-bool dbDatabase::hasHierarchicalChip() const
-{
-  for (dbChip* chip : getChips()) {
-    if (chip->getChipType() == dbChip::ChipType::HIER) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 dbSet<dbProperty> dbDatabase::getProperties() const
 {
   _dbDatabase* obj = (_dbDatabase*) this;
@@ -932,6 +921,17 @@ bool dbDatabase::hasHierarchy() const
 {
   const _dbDatabase* db = reinterpret_cast<const _dbDatabase*>(this);
   return db->hierarchy_;
+}
+
+bool dbDatabase::hasHierarchicalChip() const
+{
+  for (dbChip* chip : getChips()) {
+    if (chip->getChipType() == dbChip::ChipType::HIER) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void dbDatabase::read(std::istream& file)

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 134;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 135;  // Current revision number
+
+// Revision where dbTech::extraction_rules_file_ was added
+inline constexpr uint32_t kSchemaTechExtractionRulesFile = 135;
 
 // Revision where the per-corner child-block feature for parasitics was removed
 inline constexpr uint32_t kSchemaRemovePerCornerBlock = 134;

--- a/src/odb/src/db/dbTech.cpp
+++ b/src/odb/src/db/dbTech.cpp
@@ -86,6 +86,10 @@ bool _dbTech::operator==(const _dbTech& rhs) const
     return false;
   }
 
+  if (extraction_rules_file_ != rhs.extraction_rules_file_) {
+    return false;
+  }
+
   if (via_cnt_ != rhs.via_cnt_) {
     return false;
   }
@@ -330,6 +334,7 @@ dbOStream& operator<<(dbOStream& stream, const _dbTech& tech)
   stream << NamedTable("cell_edge_spacing_tbl_", tech.cell_edge_spacing_tbl_);
   stream << *tech.name_cache_;
   stream << tech.via_hash_;
+  stream << tech.extraction_rules_file_;
   return stream;
 }
 
@@ -381,6 +386,9 @@ dbIStream& operator>>(dbIStream& stream, _dbTech& tech)
   }
   stream >> *tech.name_cache_;
   stream >> tech.via_hash_;
+  if (db->isSchema(kSchemaTechExtractionRulesFile)) {
+    stream >> tech.extraction_rules_file_;
+  }
 
   return stream;
 }
@@ -389,6 +397,18 @@ std::string dbTech::getName()
 {
   auto tech = (_dbTech*) this;
   return tech->name_;
+}
+
+void dbTech::setExtractionRulesFile(const std::string& path)
+{
+  _dbTech* tech = (_dbTech*) this;
+  tech->extraction_rules_file_ = path;
+}
+
+std::string dbTech::getExtractionRulesFile()
+{
+  _dbTech* tech = (_dbTech*) this;
+  return tech->extraction_rules_file_;
 }
 
 double _dbTech::getLefVersion() const

--- a/src/odb/src/db/dbTech.h
+++ b/src/odb/src/db/dbTech.h
@@ -73,6 +73,7 @@ class _dbTech : public _dbObject
  public:
   // PERSISTANT-MEMBERS
   std::string name_;
+  std::string extraction_rules_file_;
   int via_cnt_;
   int layer_cnt_;
   int rlayer_cnt_;

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1210,6 +1210,32 @@ proc add_3dblox_alignment_marker_rule { args } {
   }
 }
 
+sta::define_cmd_args "set_extraction_rules_file" {
+    [-tech tech_name] rules_file
+}
+
+proc set_extraction_rules_file { args } {
+  sta::parse_key_args "set_extraction_rules_file" args \
+    keys {-tech} flags {}
+  sta::check_argc_eq1 "set_extraction_rules_file" $args
+
+  set db [ord::get_db]
+  if { [info exists keys(-tech)] } {
+    set tech [$db findTech $keys(-tech)]
+  } elseif { [$db hasHierarchicalChip] } {
+    utl::error ODB 478 "Could not set extraction rules file.\
+      Use -tech to specify a technology in a 3D design."
+  } else {
+    set tech [$db getTech]
+  }
+
+  if { $tech == "NULL" } {
+    utl::error ODB 477 "Could not set extraction rules file. Tech not found."
+  }
+
+  $tech setExtractionRulesFile $args
+}
+
 namespace eval odb {
 proc resolve_master { cell { lib_name "" } } {
   set db [ord::get_db]

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1233,7 +1233,7 @@ proc set_extraction_rules_file { args } {
     utl::error ODB 477 "Could not set extraction rules file. Tech not found."
   }
 
-  $tech setExtractionRulesFile $args
+  $tech setExtractionRulesFile [lindex $args 0]
 }
 
 namespace eval odb {

--- a/src/odb/test/odb_readme_msgs_check.ok
+++ b/src/odb/test/odb_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 22,        Desc: 22,        Syn: 22,        Options: 22,        Args: 22
+Names: 23,        Desc: 23,        Syn: 23,        Options: 23,        Args: 23
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.

--- a/src/rcx/README.md
+++ b/src/rcx/README.md
@@ -50,7 +50,7 @@ returned.
 
 ```tcl
 extract_parasitics
-    [-ext_model_file filename]      
+    [-ext_model_file filename]
     [-corner cornerIndex]
     [-corner_cnt count]            
     [-max_res ohms]               
@@ -70,7 +70,7 @@ extract_parasitics
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-ext_model_file` | Specify the Extraction Rules file used for the extraction. |
+| `-ext_model_file` | Deprecated. Use the `set_extraction_rules_file` command instead. |
 | `-corner cornerIndex` | Corner to extract.  Default -1. |
 | `-corner_cnt` | Defines the number of corners used during the parasitic extraction. |
 | `-max_res` | Combines resistors in series up to the threshold value. |

--- a/src/rcx/src/OpenRCX.tcl
+++ b/src/rcx/src/OpenRCX.tcl
@@ -83,9 +83,13 @@ proc extract_parasitics { args } {
 
   set ext_model_file ""
   if { [info exists keys(-ext_model_file)] } {
-    utl::warn RCX 514 "-ext_model_file is deprecated, use\
-                       set_extraction_rules_file instead."
-    set_extraction_rules_file $keys(-ext_model_file)
+    utl::warn RCX 514 "The -ext_model_file option is deprecated. Use\
+                       set_extraction_rules_file command instead."
+
+    # We may have multiple technologies loaded, so use the current block's
+    # tech to prevent an error resolving an ambiguous default tech.
+    set tech [[ord::get_db_block] getTech]
+    set_extraction_rules_file -tech [$tech getName] $keys(-ext_model_file)
   }
 
   set corner_cnt 1

--- a/src/rcx/src/OpenRCX.tcl
+++ b/src/rcx/src/OpenRCX.tcl
@@ -83,7 +83,9 @@ proc extract_parasitics { args } {
 
   set ext_model_file ""
   if { [info exists keys(-ext_model_file)] } {
-    set ext_model_file $keys(-ext_model_file)
+    utl::warn RCX 514 "-ext_model_file is deprecated, use\
+                       set_extraction_rules_file instead."
+    set_extraction_rules_file $keys(-ext_model_file)
   }
 
   set corner_cnt 1

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -216,6 +216,11 @@ void Ext::extract(ExtractOptions options)
 
   odb::orderWires(logger_, block);
 
+  std::string rules_file = block->getTech()->getExtractionRulesFile();
+  if (!rules_file.empty()) {
+    options.ext_model_file = rules_file.c_str();
+  }
+
   _ext->set_debug_nets(options.debug_net);
 
   _ext->_lef_res = options.lef_res;

--- a/src/rcx/test/45_gcd.py
+++ b/src/rcx/test/45_gcd.py
@@ -17,9 +17,10 @@ via_45.set_resistance(tech)
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-rcx_aux.extract_parasitics(
-    design, ext_model_file="45_patterns.rules", max_res=0, coupling_threshold=0.1
-)
+db_tech = tech.getTech()
+db_tech.setExtractionRulesFile("45_patterns.rules")
+
+rcx_aux.extract_parasitics(design, max_res=0, coupling_threshold=0.1)
 
 spef_file = helpers.make_result_file("45_gcd.spef")
 rcx_aux.write_spef(design, filename=spef_file, nets=test_nets)

--- a/src/rcx/test/45_gcd.tcl
+++ b/src/rcx/test/45_gcd.tcl
@@ -10,7 +10,8 @@ read_def 45_gcd.def
 source 45_via_resistance.tcl
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file 45_patterns.rules -max_res 0 \
+set_extraction_rules_file 45_patterns.rules
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1
 
 set spef_file [make_result_file 45_gcd.spef]

--- a/src/rcx/test/coordinates.py
+++ b/src/rcx/test/coordinates.py
@@ -17,9 +17,10 @@ via_45.set_resistance(tech)
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-rcx_aux.extract_parasitics(
-    design, ext_model_file="45_patterns.rules", max_res=0, coupling_threshold=0.1
-)
+db_tech = tech.getTech()
+db_tech.setExtractionRulesFile("45_patterns.rules")
+
+rcx_aux.extract_parasitics(design, max_res=0, coupling_threshold=0.1)
 
 spef_file = helpers.make_result_file("coordinates.spef")
 rcx_aux.write_spef(design, filename=spef_file, nets=test_nets, coordinates=True)

--- a/src/rcx/test/coordinates.tcl
+++ b/src/rcx/test/coordinates.tcl
@@ -10,7 +10,8 @@ read_def coordinates.def
 source 45_via_resistance.tcl
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file 45_patterns.rules -max_res 0 \
+set_extraction_rules_file 45_patterns.rules
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1
 
 set spef_file [make_result_file coordinates.spef]

--- a/src/rcx/test/ext_pattern.py
+++ b/src/rcx/test/ext_pattern.py
@@ -11,9 +11,11 @@ design.readDef("generate_pattern.defok")
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
+db_tech = tech.getTech()
+db_tech.setExtractionRulesFile("ext_pattern.rules")
+
 rcx_aux.extract_parasitics(
     design,
-    ext_model_file="ext_pattern.rules",
     cc_model=12,
     max_res=0,
     context_depth=10,

--- a/src/rcx/test/ext_pattern.tcl
+++ b/src/rcx/test/ext_pattern.tcl
@@ -6,7 +6,8 @@ read_lef sky130hs/sky130hs.tlef
 read_def generate_pattern.defok
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file ext_pattern.rules -cc_model 12 \
+set_extraction_rules_file ext_pattern.rules
+extract_parasitics -cc_model 12 \
   -max_res 0 -context_depth 10 -coupling_threshold 0.1
 
 set spef_file [make_result_file ext_pattern.spef]

--- a/src/rcx/test/gcd.py
+++ b/src/rcx/test/gcd.py
@@ -18,9 +18,10 @@ design.evalTclString("source sky130hs/sky130hs.rc")
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-rcx_aux.extract_parasitics(
-    design, ext_model_file="ext_pattern.rules", max_res=0, coupling_threshold=0.1
-)
+db_tech = tech.getTech()
+db_tech.setExtractionRulesFile("ext_pattern.rules")
+
+rcx_aux.extract_parasitics(design, max_res=0, coupling_threshold=0.1)
 
 spef_file = helpers.make_result_file("gcd.spef")
 rcx_aux.write_spef(design, filename=spef_file, nets=test_nets)

--- a/src/rcx/test/gcd.tcl
+++ b/src/rcx/test/gcd.tcl
@@ -12,7 +12,8 @@ read_def gcd.def
 source sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file ext_pattern.rules -max_res 0 \
+set_extraction_rules_file ext_pattern.rules
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1
 
 set spef_file [make_result_file gcd.spef]

--- a/src/rcx/test/names.tcl
+++ b/src/rcx/test/names.tcl
@@ -33,7 +33,8 @@ detailed_route -verbose 0
 
 # Extract
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $rcx_rules_file
+set_extraction_rules_file $rcx_rules_file
+extract_parasitics
 
 set spef_file [make_result_file names.spef]
 write_spef $spef_file

--- a/src/rcx/test/net_name_consistency.tcl
+++ b/src/rcx/test/net_name_consistency.tcl
@@ -30,7 +30,8 @@ read_def -floorplan_initialize $test_name.def
 
 # Extract RC from the routed DEF fixture.
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $rcx_rules_file
+set_extraction_rules_file $rcx_rules_file
+extract_parasitics
 
 # Write Verilog
 set verilog_file [make_result_file $test_name.v]

--- a/src/rcx/test/no_merging.tcl
+++ b/src/rcx/test/no_merging.tcl
@@ -12,7 +12,8 @@ read_def gcd.def
 source sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file ext_pattern.rules -no_merge_via_res -max_res 0.0
+set_extraction_rules_file ext_pattern.rules
+extract_parasitics -no_merge_via_res -max_res 0.0
 
 set spef_file [make_result_file no_merging.spef]
 write_spef $spef_file

--- a/src/rcx/test/rcx_aux.py
+++ b/src/rcx/test/rcx_aux.py
@@ -28,9 +28,21 @@ def extract_parasitics(
     dbg=0
 ):
 
+    if ext_model_file is not None:
+        utl.warn(
+            utl.RCX,
+            514,
+            "The ext_model_file option is deprecated. Use "
+            "set_extraction_rules_file command instead.",
+        )
+
+        # We may have multiple technologies loaded, so use the current block's
+        # tech to prevent an error resolving an ambiguous default tech.
+        db_tech = design.getBlock().getTech()
+        db_tech.setExtractionRulesFile(ext_model_file)
+
     opts = rcx.ExtractOptions()
 
-    opts.ext_model_file = ext_model_file
     opts.corner_cnt = corner_cnt
     opts.corner = corner
     opts.max_res = max_res

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_3corners.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_3corners.tcl
@@ -14,7 +14,8 @@ source $test_dir/sky130hs/sky130hs.rc
 define_process_corner -ext_model_index 0 min
 define_process_corner -ext_model_index 1 typ
 define_process_corner -ext_model_index 2 max
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_3corners_define_list.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_3corners_define_list.tcl
@@ -13,7 +13,8 @@ source $test_dir/sky130hs/sky130hs.rc
 get_model_corners -ext_model_file $model_v2
 define_rcx_corners -corner_list "min typ max"
 
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_3corners_undefined.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_3corners_undefined.tcl
@@ -18,7 +18,8 @@ source $test_dir/sky130hs/sky130hs.rc
 # get_model_corners -ext_model_file $model_v2
 # define_rcx_corners -corner_list "max typ min"
 
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_0.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_0.tcl
@@ -13,7 +13,8 @@ source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 MAX
 # define_process_corner -ext_model_index 2 MAX1
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_0_2.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_0_2.tcl
@@ -19,7 +19,8 @@ source $test_dir/sky130hs/sky130hs.rc
 define_process_corner -ext_model_index 0 min
 define_process_corner -ext_model_index 2 max
 
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_1.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_1.tcl
@@ -12,7 +12,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 1 max
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_2.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_2.tcl
@@ -12,7 +12,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 2 MAX1
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_2_1.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/gcd_corners_2_1.tcl
@@ -13,7 +13,8 @@ source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 2 MAX1
 define_process_corner -ext_model_index 1 MAX2
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/v1_gcd_3corners_define_list.tcl
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/v1_gcd_3corners_define_list.tcl
@@ -13,7 +13,8 @@ source $test_dir/sky130hs/sky130hs.rc
 get_model_corners -ext_model_file $model_v1
 define_rcx_corners -corner_list "min typ max"
 
-extract_parasitics -ext_model_file $model_v1 -max_res 0 \
+set_extraction_rules_file $model_v1
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -skip_over_cell
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v1_model_v2.tcl
+++ b/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v1_model_v2.tcl
@@ -16,7 +16,8 @@ source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
 define_process_corner -ext_model_index 1 Y
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1 -version 1.0
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v1_model_v2_1.tcl
+++ b/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v1_model_v2_1.tcl
@@ -15,7 +15,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1 -version 1.0
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v2_model_v1.tcl
+++ b/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v2_model_v1.tcl
@@ -16,7 +16,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -max_res 0 \
+set_extraction_rules_file $model_v1
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1 -version 2.0 -skip_over_cell
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v2_model_v2.tcl
+++ b/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v2_model_v2.tcl
@@ -19,7 +19,8 @@ source $test_dir/sky130hs/sky130hs.rc
 get_model_corners -ext_model_file $model_v2
 define_rcx_corners -corner_list "max typ min"
 
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0 -skip_over_cell -dbg 2
 # different test: extract_parasitics -ext_model_file $model_v2 \
 #   -max_res 0 -coupling_threshold 0.1 -version 2.0

--- a/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v2_model_v2_overcell.tcl
+++ b/src/rcx/test/rcx_v2/flow/gcd/scripts/gcd_flow_v2_model_v2_overcell.tcl
@@ -19,7 +19,8 @@ source $test_dir/sky130hs/sky130hs.rc
 get_model_corners -ext_model_file $model_v2
 define_rcx_corners -corner_list "max typ min"
 
-extract_parasitics -ext_model_file $model_v2 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.001 -version 2.0
 # different test: extract_parasitics -ext_model_file $model_v2 \
 #   -max_res 0 -coupling_threshold 0.1 -version 2.0

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_flow_v2_model_v1_no_via_merge.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_flow_v2_model_v1_no_via_merge.tcl
@@ -16,7 +16,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -max_res 0 \
+set_extraction_rules_file $model_v1
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1 -version 2.0 -skip_over_cell -no_merge_via_res
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_lef_rc.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_lef_rc.tcl
@@ -14,7 +14,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -coupling_threshold 0.1 \
+set_extraction_rules_file $model_v1
+extract_parasitics -coupling_threshold 0.1 \
   -version 2.0 -skip_over_cell -max_res 0 -lef_rc
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_lef_rc_max_res_0.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_lef_rc_max_res_0.tcl
@@ -14,7 +14,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -coupling_threshold 0.1 \
+set_extraction_rules_file $model_v1
+extract_parasitics -coupling_threshold 0.1 \
   -version 2.0 -skip_over_cell -no_merge_via_res -max_res 0 -lef_rc
 
 write_spef $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_0.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_0.tcl
@@ -16,7 +16,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -max_res 0 \
+set_extraction_rules_file $model_v1
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1 -version 2.0 -skip_over_cell -max_res 0
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_0_no_via_merge.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_0_no_via_merge.tcl
@@ -16,7 +16,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -coupling_threshold 0.1 \
+set_extraction_rules_file $model_v1
+extract_parasitics -coupling_threshold 0.1 \
   -version 2.0 -skip_over_cell -no_merge_via_res -max_res 0
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_10.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_10.tcl
@@ -16,7 +16,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -max_res 0 \
+set_extraction_rules_file $model_v1
+extract_parasitics -max_res 0 \
   -coupling_threshold 0.1 -version 2.0 -skip_over_cell -max_res 10
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_500.tcl
+++ b/src/rcx/test/rcx_v2/flow/options/scripts/gcd_v2_v1_max_res_500.tcl
@@ -16,7 +16,8 @@ read_def $test_dir/gcd.def
 source $test_dir/sky130hs/sky130hs.rc
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file $model_v1 -coupling_threshold 0.1 \
+set_extraction_rules_file $model_v1
+extract_parasitics -coupling_threshold 0.1 \
   -version 2.0 -skip_over_cell -max_res 500
 
 set spef_file $test_case.spef

--- a/src/rcx/test/rcx_v2/flow/patterns/scripts/ext_patterns_flow_v2_model_v2.tcl
+++ b/src/rcx/test/rcx_v2/flow/patterns/scripts/ext_patterns_flow_v2_model_v2.tcl
@@ -7,7 +7,8 @@ read_def $test_dir/generate_pattern.defok
 
 get_model_corners -ext_model_file $model_v2
 define_rcx_corners -corner_list "max typ min"
-extract_parasitics -ext_model_file $model_v2 -cc_model 12 -max_res 0 \
+set_extraction_rules_file $model_v2
+extract_parasitics -cc_model 12 -max_res 0 \
   -context_depth 10 -coupling_threshold 0.1 -version 2.0 -dbg 1
 
 set test_nets "3 48 92 193 200 243 400 521 671"

--- a/src/rcx/test/short_resover.tcl
+++ b/src/rcx/test/short_resover.tcl
@@ -9,7 +9,8 @@ read_lef sky130hs/sky130hs_std_cell.lef
 read_def gcd.def
 
 define_process_corner -ext_model_index 0 X
-extract_parasitics -ext_model_file short_resover.rules
+set_extraction_rules_file short_resover.rules
+extract_parasitics
 
 set spef_file [make_result_file short_resover.spef]
 write_spef $spef_file


### PR DESCRIPTION
## Summary
Beginning of the work for 3D RCX.

Currently, there's no way to specify multiple rules. The changes here alters where the rules path is stored from RCX internals to ODB so that we can have a command that allows specifying the rules for each technology used in the 3D design.

The idea here is that blocks with the same technology may share the same rules so we don't need to re-parse them during parasitics extraction.

## Type of Change
- New feature
- Documentation update

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
