### PR TITLE
syn: link syn_lib into npn_test to resolve Synthesis::dontUse

### DIFF
--- a/src/syn/test/CMakeLists.txt
+++ b/src/syn/test/CMakeLists.txt
@@ -33,7 +33,7 @@ gtest_discover_tests(liveness_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 add_dependencies(build_and_test liveness_test)
 
 add_executable(npn_test npn_test.cc)
-target_link_libraries(npn_test GTest::gtest syn_flow)
+target_link_libraries(npn_test GTest::gtest syn_flow syn_lib syn_ir)
 gtest_discover_tests(npn_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(build_and_test npn_test)
 


### PR DESCRIPTION
## Summary
Small fix of missing `syn_lib syn_ir` into CMake's target_link_libraries.

## Type of Change
- Bug fix

## Impact
Fix CMake build.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**