### PR TITLE
added layer name to min pitch message

### DIFF
--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -99,8 +99,9 @@ void Straps::checkLayerSpecifications() const
       getLogger()->error(
           utl::PDN,
           175,
-          "Pitch {:.4f} is too small for, must be atleast {:.4f}",
+          "Pitch {:.4f} is too small for {}, must be atleast {:.4f}",
           layer.dbuToMicron(pitch_),
+          layer_->getName(),
           layer.dbuToMicron(min_pitch));
     }
   }

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -99,7 +99,7 @@ void Straps::checkLayerSpecifications() const
       getLogger()->error(
           utl::PDN,
           175,
-          "Pitch {:.4f} is too small for {}, must be atleast {:.4f}",
+          "Pitch {:.4f} is too small for {}, must be at least {:.4f}",
           layer.dbuToMicron(pitch_),
           layer_->getName(),
           layer.dbuToMicron(min_pitch));


### PR DESCRIPTION
## Summary
Added missing layer name to minimum pitch message

## Type of Change
- Bug fix

## Impact
Previous message didn't indicate the layer that was failing the minimum pitch check

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] **I have signed my commits (DCO).**

## Related Issues
None