### PR TITLE
pdn: do not consider the strap width in the halo check.

### DIFF
--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -1792,20 +1792,6 @@ void InstanceGrid::checkHalo() const
     return;
   }
 
-  // Followpin straps may extend half their width past the row boundary, so
-  // grow the rows by that amount before testing for an overlap.
-  int row_bloat = 0;
-  for (Grid* grid : getDomain()->getPDNGen()->getGrids()) {
-    if (this == grid) {
-      continue;
-    }
-    for (const auto& strap : grid->getStraps()) {
-      if (strap->type() == GridComponent::kFollowpin) {
-        row_bloat = std::max(strap->getWidth() / 2, row_bloat);
-      }
-    }
-  }
-
   const odb::Rect inst_box = inst_->getBBox()->getBox();
   const odb::Rect halo_box = applyHalo(inst_box, true, true, true);
 
@@ -1815,8 +1801,7 @@ void InstanceGrid::checkHalo() const
   std::vector<odb::Rect> overlapping_rows;
   std::string first_row;
   for (auto* row : getBlock()->getRows()) {
-    const odb::Rect row_box
-        = row->getBBox().bloat(row_bloat, odb::Orientation2D::Vertical);
+    const odb::Rect row_box = row->getBBox();
     if (!halo_box.overlaps(row_box) || inst_box.overlaps(row_box)) {
       continue;
     }

--- a/src/pdn/test/sky130_spm_halo_too_big.ok
+++ b/src/pdn/test/sky130_spm_halo_too_big.ok
@@ -9,5 +9,5 @@ The NOWIREEXTENSIONATPIN statement will be ignored. See file sky130_spm/delayed_
 [INFO ODB-0131]     Created 309 components and 668 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 804 connections.
 [INFO ODB-0133]     Created 20 nets and 49 connections.
-[ERROR PDN-0008] macro - dsa\[0\] halo overlaps row ROW_1_2 (and 20 other row(s)); reduce the halo to at most "10.0000 10.0000 5.3750 6.3150".
+[ERROR PDN-0008] macro - dsa\[0\] halo overlaps row ROW_1_2 (and 20 other row(s)); reduce the halo to at most "10.0000 10.0000 5.3750 6.5550".
 PDN-0008


### PR DESCRIPTION
Restores the previous semantics.
