### PR TITLE
web: add display-control overlays from parity table 2.5 (#10619)

### DIFF
--- a/src/web/src/color.h
+++ b/src/web/src/color.h
@@ -28,4 +28,9 @@ enum class FillPattern
   kDots = 4,      // dotted
 };
 
+// Selection-highlight yellow shared by the tile highlight border
+// (TileGenerator::drawHighlight) and the selection flywires
+// (request_handler's collectNetFlightLines).
+inline constexpr Color kSelectionYellow{.r = 255, .g = 255, .b = 0, .a = 255};
+
 }  // namespace web

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -97,10 +97,11 @@ export function populateDisplayControls(app, visibility, selectability,
     // memory budget, so the total is bounded no matter how many layers or
     // chiplets the design has.
     //
-    // Only the routing layers are merged.  _instances, _pins and _modules stay
-    // as their own panes: there are three of them, they carry no meaningful
-    // memory, and they have their own add/remove rules driven by Shapes and
-    // Module-view toggles which are not worth folding into the draw list.
+    // Only the routing layers are merged.  The pseudo layers (_instances,
+    // _pins, _modules and the Misc overlays below) stay as their own panes:
+    // there is a fixed handful of them, they carry no meaningful memory, and
+    // they have their own add/remove rules driven by the Shapes, Module-view
+    // and Misc toggles which are not worth folding into the draw list.
     const mergedLayerClass = app.mergeTiles ? app.MergedTileLayer : null;
     // Panes whose draw list changed during one tree update, refreshed once at
     // the end rather than per layer — a group toggle walks every node, and
@@ -158,28 +159,47 @@ export function populateDisplayControls(app, visibility, selectability,
         };
     }
 
-    // Instance borders layer (always below routing layers)
-    const instancesLayer = new WebSocketTileLayer(app.websocketManager, '_instances', {
-        zIndex: 0,
-    });
-    instancesLayer.addTo(app.map);
-    app.allLayers.push(instancesLayer);
+    // Create a pseudo-layer tile layer and register it on the app.
+    // `appProp` names the app.<prop> slot (null = anonymous); `addToMap`
+    // attaches it immediately (layers whose toggle is default-ON).
+    function addPseudoLayer(name, appProp, zIndex, addToMap) {
+        const layer = new WebSocketTileLayer(app.websocketManager, name, {
+            zIndex,
+        });
+        if (addToMap) layer.addTo(app.map);
+        if (appProp) app[appProp] = layer;
+        app.allLayers.push(layer);
+        return layer;
+    }
 
+    // The initial attach state must follow `visibility`, which was already
+    // restored from the or_visibility cookie: a hardcoded attach leaves the
+    // checkbox (rendered from `visibility`) out of sync with the map until
+    // the first toggle runs redrawAllLayers.
+
+    // Instance borders layer (always below routing layers; no toggle)
+    addPseudoLayer('_instances', null, 0, true);
     // IO pin markers layer (between instances and routing layers)
-    const pinsLayer = new WebSocketTileLayer(app.websocketManager, '_pins', {
-        zIndex: 1,
-    });
-    pinsLayer.addTo(app.map);
-    app.pinsLayer = pinsLayer;
-    app.allLayers.push(pinsLayer);
+    addPseudoLayer('_pins', 'pinsLayer', 1, visibility.pins);
+    // Module coloring overlay (Module view)
+    addPseudoLayer('_modules', 'modulesLayer', 2, visibility.module_view);
+    // Access-point markers overlay (Misc > Access Points)
+    addPseudoLayer(
+        '_access_points', 'accessPointsLayer', 1000, visibility.access_points);
+    // Manufacturing-grid dots overlay (Misc > Manufacturing grid)
+    addPseudoLayer('_mfg_grid', 'mfgGridLayer', 2, visibility.mfg_grid);
+    // GCell-grid lines overlay (topmost, GUI paint order)
+    addPseudoLayer('_gcell_grid', 'gcellGridLayer', 1002, visibility.gcell_grid);
 
-    // Module coloring overlay layer (between instances and routing layers)
-    const modulesLayer = new WebSocketTileLayer(app.websocketManager, '_modules', {
-        zIndex: 2,
-    });
-    // Don't add to map until "Module view" is enabled
-    app.modulesLayer = modulesLayer;
-    app.allLayers.push(modulesLayer);
+    // Region boundaries overlay (above access points, GUI paint order).
+    // Only created when the design has dbRegions — the layer is default-ON
+    // (Qt parity) and would otherwise issue per-viewport tile requests that
+    // always come back transparent.  (Regions created via Tcl mid-session
+    // need a page reload to appear.)
+    app.regionsLayer = null;
+    if (techData && techData.has_regions) {
+        addPseudoLayer('_regions', 'regionsLayer', 1001, visibility.regions);
+    }
 
     // --- Layers group (using CheckboxTreeModel) ---
 
@@ -1320,6 +1340,11 @@ export function populateDisplayControls(app, visibility, selectability,
         { key: 'detailed', label: 'Detailed view' },
         { key: 'rulers', label: 'Rulers' },
         { key: 'scale_bar', label: 'Scale bar' },
+        { key: 'access_points', label: 'Access Points' },
+        { key: 'regions', label: 'Regions' },
+        { key: 'mfg_grid', label: 'Manufacturing grid' },
+        { key: 'gcell_grid', label: 'GCell grid' },
+        { key: 'flywires_only', label: 'Flywires only' },
     ]});
     visTree.add({ key: 'module_view', label: 'Module view' });
     // Developer overlays.  All three are plain leaves under a visKey-less

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -101,6 +101,10 @@ const app = {
     hoverHighlightPane: 'hover-highlight-pane',
     modulesLayer: null,
     pinsLayer: null,
+    accessPointsLayer: null,
+    regionsLayer: null,
+    mfgGridLayer: null,
+    gcellGridLayer: null,
     hierarchyBrowser: null,
     focusNets: new Set(),
     routeGuideNets: new Set(),
@@ -206,6 +210,17 @@ const visibility = {
     srouting_vias: true,
     pins: true,
     pin_names: true,
+    // Access points (dbAccessPoint X markers) — off by default, matching GUI
+    access_points: false,
+    // Region (dbRegion) boundaries — on by default, matching GUI
+    regions: true,
+    // Manufacturing-grid dots — off by default, matching GUI
+    mfg_grid: false,
+    // GCell grid lines — off by default, matching GUI
+    gcell_grid: false,
+    // Flywires only (selected nets as straight driver->sink lines) —
+    // off by default, matching GUI
+    flywires_only: false,
     blockages: true,
     // Blockages
     placement_blockages: true,
@@ -484,20 +499,21 @@ function redrawAllLayers() {
     setCookie('or_selectability',
               encodeURIComponent(JSON.stringify(selectability)));
 
-    // Show/hide modules layer based on module_view visibility
-    if (app.modulesLayer) {
-        if (visibility.module_view && !app.map.hasLayer(app.modulesLayer)) {
-            app.modulesLayer.addTo(app.map);
-        } else if (!visibility.module_view && app.map.hasLayer(app.modulesLayer)) {
-            app.map.removeLayer(app.modulesLayer);
-        }
-    }
-    // Show/hide pin markers layer (controlled by Shapes > Pins)
-    if (app.pinsLayer) {
-        if (visibility.pins && !app.map.hasLayer(app.pinsLayer)) {
-            app.pinsLayer.addTo(app.map);
-        } else if (!visibility.pins && app.map.hasLayer(app.pinsLayer)) {
-            app.map.removeLayer(app.pinsLayer);
+    // Show/hide the toggleable pseudo-layer tile layers.
+    const toggleableLayers = [
+        [app.modulesLayer, visibility.module_view],   // Module view
+        [app.pinsLayer, visibility.pins],             // Shapes > Pins
+        [app.accessPointsLayer, visibility.access_points],
+        [app.regionsLayer, visibility.regions],
+        [app.mfgGridLayer, visibility.mfg_grid],
+        [app.gcellGridLayer, visibility.gcell_grid],
+    ];
+    for (const [layer, visible] of toggleableLayers) {
+        if (!layer) continue;
+        if (visible && !app.map.hasLayer(layer)) {
+            layer.addTo(app.map);
+        } else if (!visible && app.map.hasLayer(layer)) {
+            app.map.removeLayer(layer);
         }
     }
     for (const layer of app.allLayers) {

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -376,19 +376,201 @@ static boost::json::object serializeProperty(
   return o;
 }
 
-static void collectHighlightShapes(const gui::Selected& sel,
-                                   std::vector<odb::Rect>& rects,
-                                   std::vector<odb::Polygon>& polys)
+// The GUI draws the driver×sink product straight to the screen; here the
+// lines are materialized in SessionState and copied per overlay tile, so
+// cap the product to keep memory bounded on huge INOUT/fanout nets
+// (beyond this the fan is visual mush anyway).
+constexpr size_t kMaxFlywires = 4096;
+
+// Mirrors the flywire fallback of gui::NetDescriptor::highlight
+// (dbDescriptors.cpp:1766-1825): straight driver->sink lines between the
+// net's placed terminals.  When `term_boxes` is non-null, the terminal
+// pin boxes are collected in the same pass (used by the flywires-only
+// mode, which suppresses the descriptor's wire shapes).  Supply and routed
+// special nets get terminal boxes but no lines, matching the GUI.
+static void collectNetFlightLines(odb::dbNet* net,
+                                  std::vector<FlightLine>& lines,
+                                  std::vector<odb::Rect>* term_boxes = nullptr)
 {
-  rects.clear();
-  polys.clear();
+  if (!net) {
+    return;
+  }
+  // GUI parity: neither supply nets nor routed special nets get flywires;
+  // their terminal boxes are still highlighted.
+  const bool is_supply = net->getSigType().isSupply();
+  const bool lines_enabled
+      = !is_supply && (!net->isSpecial() || net->getFirstSWire() == nullptr);
+  if (!lines_enabled && term_boxes == nullptr) {
+    return;  // nothing left to collect
+  }
+
+  std::set<odb::Point> driver_locs;
+  std::set<odb::Point> sink_locs;
+  // GUI parity: the ITerms of a supply net are not highlighted at all
+  // (DbNetDescriptor::highlight guards its ITerm loop with !is_supply), while
+  // its BTerms are — hence the asymmetry with the BTerm loop below.
+  if (!is_supply) {
+    for (odb::dbITerm* iterm : net->getITerms()) {
+      if (!iterm->getInst()->getPlacementStatus().isPlaced()) {
+        continue;
+      }
+      if (term_boxes) {
+        term_boxes->push_back(iterm->getBBox());
+      }
+      if (!lines_enabled) {
+        continue;
+      }
+      odb::Point center;
+      int x = 0;
+      int y = 0;
+      if (iterm->getAvgXY(&x, &y)) {
+        center = odb::Point(x, y);
+      } else if (odb::dbBox* bbox = iterm->getInst()->getBBox()) {
+        const odb::Rect rect = bbox->getBox();
+        center = odb::Point((rect.xMax() + rect.xMin()) / 2,
+                            (rect.yMax() + rect.yMin()) / 2);
+      } else {
+        int ix = 0;
+        int iy = 0;
+        iterm->getInst()->getLocation(ix, iy);
+        center = odb::Point(ix, iy);
+      }
+      const auto iotype = iterm->getIoType();
+      if (iotype == odb::dbIoType::INPUT || iotype == odb::dbIoType::INOUT) {
+        sink_locs.insert(center);
+      }
+      if (iotype == odb::dbIoType::OUTPUT || iotype == odb::dbIoType::INOUT) {
+        driver_locs.insert(center);
+      }
+    }
+  }
+  for (odb::dbBTerm* bterm : net->getBTerms()) {
+    const auto iotype = bterm->getIoType();
+    // IO direction is from the block's perspective: an INPUT bterm
+    // drives the net (GUI is_source_bterm / is_sink_bterm).
+    const bool driver_term = iotype == odb::dbIoType::INPUT
+                             || iotype == odb::dbIoType::INOUT
+                             || iotype == odb::dbIoType::FEEDTHRU;
+    const bool sink_term = iotype == odb::dbIoType::OUTPUT
+                           || iotype == odb::dbIoType::INOUT
+                           || iotype == odb::dbIoType::FEEDTHRU;
+    for (odb::dbBPin* pin : bterm->getBPins()) {
+      const odb::Rect rect = pin->getBBox();
+      if (term_boxes) {
+        term_boxes->push_back(rect);
+      }
+      if (!lines_enabled) {
+        continue;
+      }
+      const odb::Point center((rect.xMax() + rect.xMin()) / 2,
+                              (rect.yMax() + rect.yMin()) / 2);
+      if (sink_term) {
+        sink_locs.insert(center);
+      }
+      if (driver_term) {
+        driver_locs.insert(center);
+      }
+    }
+  }
+  if (!lines_enabled) {
+    return;
+  }
+
+  for (const odb::Point& driver : driver_locs) {
+    for (const odb::Point& sink : sink_locs) {
+      if (lines.size() >= kMaxFlywires) {
+        return;
+      }
+      lines.push_back(
+          FlightLine{.p1 = driver, .p2 = sink, .color = kSelectionYellow});
+    }
+  }
+}
+
+// Collect a net's special (geometric) routing shapes.  The GUI draws these
+// unconditionally at the tail of DbNetDescriptor::highlight, i.e. also in
+// flywires-only mode, so the flywire branch below has to reproduce them.
+//
+// Reproduced rather than delegated to DbNetDescriptor because the descriptor
+// cannot be made to honor the mode from here: its gate is
+// painter.getOptions()->isFlywireHighlightOnly(), and gui::Options is a private
+// Qt-dependent interface (QColor/QFont), so a non-Qt module has no way to
+// implement it — ShapeCollector's null Options resolves to DefaultOptions,
+// which answers false.  Going through Gui::getDescriptor<odb::dbSWire*>() for
+// just the tail is no better: an unregistered descriptor makes
+// DescriptorRegistry emit GUI-0053, which is fatal, and nothing registers the
+// odb descriptors in the web unit tests.
+//
+// The shapes match DbSBoxDescriptor::highlight (dbDescriptors.cpp:5707).
+static void collectSpecialWireShapes(odb::dbNet* net,
+                                     std::vector<odb::Rect>& rects,
+                                     std::vector<odb::Polygon>& polys)
+{
+  if (!net) {
+    return;
+  }
+  for (odb::dbSWire* swire : net->getSWires()) {
+    for (odb::dbSBox* box : swire->getWires()) {
+      if (box->getDirection() == odb::dbSBox::OCTILINEAR) {
+        polys.emplace_back(box->getOct());
+      } else {
+        rects.push_back(box->getBox());
+      }
+    }
+  }
+}
+
+// Append one selection's highlight shapes.  For nets, honor the
+// "Flywires only" toggle (GUI isFlywireHighlightOnly()): replace the
+// routed wire/guide shapes with driver->sink flight lines.  With the
+// toggle off, unrouted nets still get flywires (GUI fallback — the
+// descriptor emits them via painter.drawLine, which ShapeCollector
+// drops, so they are recomputed here).
+static void appendHighlightShapes(const gui::Selected& sel,
+                                  std::vector<odb::Rect>& rects,
+                                  std::vector<odb::Polygon>& polys,
+                                  std::vector<FlightLine>& lines,
+                                  const bool flywires_only)
+{
   if (!sel) {
     return;
   }
+  // Pointer-form any_cast: DbNetDescriptor::isNet() is true for BOTH of
+  // its payload types (dbNet* and NetWithSink) — the value-form cast
+  // would throw std::bad_any_cast on the latter.  Non-dbNet* payloads
+  // fall through to the plain descriptor highlight below.
+  odb::dbNet* const* net_ptr = std::any_cast<odb::dbNet*>(&sel.getObject());
+  if (sel.isNet() && net_ptr) {
+    odb::dbNet* net = *net_ptr;
+    if (flywires_only) {
+      // Only the routed wire/guide shapes are suppressed.  Terminal pin boxes
+      // and special (geometric) routing stay visible, because the GUI draws
+      // them regardless of the flywire mode — without the SWires a selected
+      // supply net would come back with no highlight at all.
+      collectNetFlightLines(net, lines, &rects);
+      collectSpecialWireShapes(net, rects, polys);
+      return;
+    }
+    if (net && !net->getWire() && net->getGuides().empty()) {
+      collectNetFlightLines(net, lines);
+    }
+  }
   ShapeCollector collector;
   sel.highlight(collector);
-  rects = std::move(collector.rects);
-  polys = std::move(collector.polys);
+  rects.insert(rects.end(), collector.rects.begin(), collector.rects.end());
+  polys.insert(polys.end(), collector.polys.begin(), collector.polys.end());
+}
+
+static void collectHighlightShapes(const gui::Selected& sel,
+                                   std::vector<odb::Rect>& rects,
+                                   std::vector<odb::Polygon>& polys,
+                                   std::vector<FlightLine>& lines,
+                                   const bool flywires_only)
+{
+  rects.clear();
+  polys.clear();
+  lines.clear();
+  appendHighlightShapes(sel, rects, polys, lines, flywires_only);
 }
 
 // Return the 0-based position of the iterator within the selection set,
@@ -406,19 +588,53 @@ static int selectionIteratorPosition(const gui::SelectionSet& set,
 // Accumulate highlight shapes from all items in a selection set.
 static void collectMultiHighlightShapes(const gui::SelectionSet& selections,
                                         std::vector<odb::Rect>& rects,
-                                        std::vector<odb::Polygon>& polys)
+                                        std::vector<odb::Polygon>& polys,
+                                        std::vector<FlightLine>& lines,
+                                        const bool flywires_only)
 {
   rects.clear();
   polys.clear();
+  lines.clear();
   for (const auto& sel : selections) {
-    if (!sel) {
-      continue;
-    }
-    ShapeCollector collector;
-    sel.highlight(collector);
-    rects.insert(rects.end(), collector.rects.begin(), collector.rects.end());
-    polys.insert(polys.end(), collector.polys.begin(), collector.polys.end());
+    appendHighlightShapes(sel, rects, polys, lines, flywires_only);
   }
+}
+
+// The three highlight vectors and the source tag form one invariant — always
+// mutate them through these helpers (callers hold selection_mutex).  The tag
+// must follow whether anything was actually collected: claiming a source for an
+// empty selection would let a later flywires_only flip re-derive (and so
+// resurrect) a highlight the user never had.
+static void clearSelectionHighlights(SessionState& state)
+{
+  state.highlight_rects.clear();
+  state.highlight_polys.clear();
+  state.highlight_lines.clear();
+  state.highlight_source = SessionState::HighlightSource::kNone;
+}
+
+static void setSelectionHighlights(SessionState& state,
+                                   const gui::Selected& sel)
+{
+  collectHighlightShapes(sel,
+                         state.highlight_rects,
+                         state.highlight_polys,
+                         state.highlight_lines,
+                         state.flywires_only);
+  state.highlight_source = sel ? SessionState::HighlightSource::kInspected
+                               : SessionState::HighlightSource::kNone;
+}
+
+static void setSelectionSetHighlights(SessionState& state)
+{
+  collectMultiHighlightShapes(state.selection_set,
+                              state.highlight_rects,
+                              state.highlight_polys,
+                              state.highlight_lines,
+                              state.flywires_only);
+  state.highlight_source = state.selection_set.empty()
+                               ? SessionState::HighlightSource::kNone
+                               : SessionState::HighlightSource::kSelectionSet;
 }
 
 static void writeInspectPayload(boost::json::object& o,
@@ -448,8 +664,10 @@ static void writeInspectPayload(boost::json::object& o,
   }
 
   if (sel.isNet()) {
-    auto* net = std::any_cast<odb::dbNet*>(sel.getObject());
-    if (net && !net->getGuides().empty()) {
+    // Pointer-form cast: the payload may be NetWithSink (see
+    // appendHighlightShapes) — the value-form cast would throw.
+    if (odb::dbNet* const* net = std::any_cast<odb::dbNet*>(&sel.getObject());
+        net && *net && !(*net)->getGuides().empty()) {
       o["has_guides"] = 1;
     }
   }
@@ -804,8 +1022,7 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
       }
 
       // Highlight all items in the selection set.
-      collectMultiHighlightShapes(
-          state.selection_set, state.highlight_rects, state.highlight_polys);
+      setSelectionSetHighlights(state);
       state.current_inspected = inspected_sel;
 
       root["selection_count"]
@@ -860,7 +1077,7 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
       state.hover_rects.clear();
       state.timing_rects.clear();
       state.timing_lines.clear();
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
+      setSelectionHighlights(state, sel);
       if (sel) {
         if (state.current_inspected && state.current_inspected != sel) {
           state.navigation_history.push_back(state.current_inspected);
@@ -926,7 +1143,7 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
         sel = state.current_inspected;
       }
 
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
+      setSelectionHighlights(state, sel);
       can_navigate_back = !state.navigation_history.empty();
       sel_count = static_cast<int>(state.selection_set.size());
       sel_index
@@ -995,8 +1212,7 @@ static WebSocketResponse handleSelectionCycle(
         state.navigation_history.clear();
         // Restore selection-set highlights (handleInspect may have
         // replaced them with a single linked object's shapes).
-        collectMultiHighlightShapes(
-            state.selection_set, state.highlight_rects, state.highlight_polys);
+        setSelectionSetHighlights(state);
       }
       sel_index
           = selectionIteratorPosition(state.selection_set, state.selection_itr);
@@ -1101,12 +1317,15 @@ WebSocketResponse SelectHandler::handleSelectLayer(const WebSocketRequest& req,
       state.timing_rects.clear();
       state.timing_lines.clear();
       state.navigation_history.clear();
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
       state.selection_set.clear();
       if (sel) {
         state.selection_set.insert(sel);
       }
       state.selection_itr = state.selection_set.begin();
+      // Through the helper, not collectHighlightShapes directly: the highlight
+      // vectors and the source tag are one invariant, and the tag is what lets
+      // a "Flywires only" flip re-derive from the right selection.
+      setSelectionSetHighlights(state);
       state.current_inspected = sel;
       sel_count = static_cast<int>(state.selection_set.size());
       sel_index
@@ -1309,8 +1528,7 @@ WebSocketResponse SelectHandler::handleSelectFanoutBin(
           state.selection_itr = state.selection_set.begin();
         }
         // Highlight every selected net in the layout.
-        collectMultiHighlightShapes(
-            state.selection_set, state.highlight_rects, state.highlight_polys);
+        setSelectionSetHighlights(state);
         state.current_inspected = first;
 
         root["selection_count"]
@@ -2032,7 +2250,7 @@ WebSocketResponse SelectHandler::handleSchematicInspect(
       state.hover_rects.clear();
       state.timing_rects.clear();
       state.timing_lines.clear();
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
+      setSelectionHighlights(state, sel);
       state.current_inspected = sel;
       state.navigation_history.clear();
     }
@@ -2267,8 +2485,7 @@ WebSocketResponse TimingHandler::handleTimingHighlight(
       std::lock_guard<std::mutex> lock(state.selection_mutex);
       state.timing_rects = std::move(new_rects);
       state.timing_lines = std::move(new_lines);
-      state.highlight_rects.clear();
-      state.highlight_polys.clear();
+      clearSelectionHighlights(state);
     }
 
     const std::string json = "{\"ok\": true}";
@@ -2424,8 +2641,7 @@ WebSocketResponse ClockTreeHandler::handleClockTreeHighlight(
     const std::string inst_name
         = std::string(req.json.at("inst_name").as_string());
     std::lock_guard<std::mutex> lock(state.selection_mutex);
-    state.highlight_rects.clear();
-    state.highlight_polys.clear();
+    clearSelectionHighlights(state);
     state.timing_rects.clear();
     state.timing_lines.clear();
 
@@ -2666,16 +2882,32 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
 WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
                                                  SessionState& state)
 {
-  // When debug renderers are active, instance positions change between
-  // frames.  Re-derive highlight shapes from the current inspected
-  // object so the selection tracks the moving instance.
+  // Re-derive the selection highlights when either:
+  //  - the "Flywires only" toggle flipped (so the change takes effect
+  //    without re-selecting) — but only while the highlights are live: a
+  //    flip after an explicit "clear highlights" must not resurrect them;
+  //  - debug renderers are active — instance positions change between
+  //    frames, so the highlight must track the moving instance.
+  const bool flywires_only = jsonOr(req.json, "flywires_only", false);
   const bool debug_renderers = jsonOr(req.json, "debug_renderers", false);
-  if (debug_renderers) {
+  {
     std::lock_guard<std::mutex> lock(state.selection_mutex);
-    if (state.current_inspected) {
-      collectHighlightShapes(state.current_inspected,
-                             state.highlight_rects,
-                             state.highlight_polys);
+    const bool flipped = (flywires_only != state.flywires_only);
+    state.flywires_only = flywires_only;
+    const bool live
+        = state.highlight_source != SessionState::HighlightSource::kNone;
+    if ((flipped && live) || (debug_renderers && state.current_inspected)) {
+      // Re-derive from the SAME source the shapes came from.  Preferring
+      // current_inspected unconditionally would drop every other item of a
+      // shift+click multi-selection on the first flip, with no way back.  With
+      // no prior highlight the source is kNone, which only the debug-renderer
+      // disjunct can reach — there the inspected object is what to track.
+      if (state.highlight_source
+          == SessionState::HighlightSource::kSelectionSet) {
+        setSelectionSetHighlights(state);
+      } else {
+        setSelectionHighlights(state, state.current_inspected);
+      }
     }
   }
 
@@ -2691,7 +2923,9 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
         rects.end(), state.hover_rects.begin(), state.hover_rects.end());
     polys = state.highlight_polys;
     colored = state.timing_rects;
-    lines = state.timing_lines;
+    lines = state.highlight_lines;
+    lines.insert(
+        lines.end(), state.timing_lines.begin(), state.timing_lines.end());
   }
 
   // Merge DRC overlay shapes
@@ -3627,14 +3861,12 @@ WebSocketResponse DRCHandler::handleDRCHighlight(const WebSocketRequest& req,
 
       {
         std::lock_guard<std::mutex> lock(state.selection_mutex);
-        state.highlight_rects.clear();
-        state.highlight_polys.clear();
+        clearSelectionHighlights(state);
         if (sel) {
           state.hover_rects.clear();
           state.timing_rects.clear();
           state.timing_lines.clear();
-          collectHighlightShapes(
-              sel, state.highlight_rects, state.highlight_polys);
+          setSelectionHighlights(state, sel);
           state.current_inspected = sel;
           state.navigation_history.clear();
         } else {
@@ -3661,8 +3893,7 @@ WebSocketResponse DRCHandler::handleDRCHighlight(const WebSocketRequest& req,
       // Clear highlight if marker_id is -1 (deselect)
       if (marker_id == -1) {
         std::lock_guard<std::mutex> lock(state.selection_mutex);
-        state.highlight_rects.clear();
-        state.highlight_polys.clear();
+        clearSelectionHighlights(state);
       }
       root["ok"] = 0;
     }

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -166,9 +166,32 @@ struct SessionState
   std::mutex selection_mutex;
   std::vector<odb::Rect> highlight_rects;
   std::vector<odb::Polygon> highlight_polys;
+  std::vector<FlightLine> highlight_lines;  // selection flywires
   std::vector<odb::Rect> hover_rects;
   std::vector<ColoredRect> timing_rects;
   std::vector<FlightLine> timing_lines;
+  // Misc > Flywires only: highlight selected nets with straight
+  // driver->sink lines instead of their routed wire/guides (GUI
+  // isFlywireHighlightOnly() parity).
+  bool flywires_only = false;
+  // Which selection the highlight_* vectors were derived from, or kNone while
+  // they hold nothing.  A flywires_only flip has to re-derive them from the
+  // SAME source: the multi-selection normally, but a single object when the
+  // user followed an inspector link out of the selection set (handleInspect
+  // deliberately narrows the highlight to the link target).  kNone doubles as
+  // the "dismissed" state, so a flip cannot resurrect highlights the user
+  // cleared.
+  //
+  // Tracking the source is a shim over the fact that selection_set and
+  // current_inspected are two overlapping answers to "what is selected"; the
+  // Qt GUI keeps only the set and narrows it on a link follow.
+  enum class HighlightSource : uint8_t
+  {
+    kNone,
+    kInspected,
+    kSelectionSet
+  };
+  HighlightSource highlight_source = HighlightSource::kNone;
 
   std::mutex selectables_mutex;
   std::vector<gui::Selected> selectables;

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -99,6 +99,56 @@ constexpr int kMinInstNameBoxPx = 20;      // min instance pixel dim for names
 // survives on its length.
 constexpr double kMinViewablePx = 5.0;
 
+// Die/core/region outline color: Qt pen Qt::gray width 0 (drawChip,
+// renderThread.cpp:1174).
+constexpr Color kOutlineGray{.r = 128, .g = 128, .b = 128, .a = 255};
+
+// DBU -> tile-pixel conversion shared by the drawing primitives, in double.
+// Unclamped: an oblique segment must be converted through these and clipped
+// by drawLine, because saturating x and y independently (as the int
+// overloads below do) rotates the segment instead of shortening it.
+inline double toPxXd(int dbu_x, const TileFrame& frame)
+{
+  return frame.pxX(dbu_x);
+}
+
+// Y is flipped: DBU grows up, pixel rows grow down.  `dim` is the side of the
+// buffer being painted: tile_px for a plain tile, tile_px*kCoverageSupersample
+// on the supersampled render path (pass bufferDim(image) there).
+inline double toPxYd(int dbu_y, const TileFrame& frame, int dim)
+{
+  return dim - 1 - frame.pxY(dbu_y);
+}
+
+// Clamped int form, so a far-outside coordinate can't overflow the cast at
+// extreme zoom.  Only safe for POINTS (dots, glyph anchors, circle/X centres)
+// and for the corners of axis-aligned rects, where losing the exact off-tile
+// coordinate cannot tilt anything; oblique segments must use toPxXd/toPxYd.
+inline int toPxX(int dbu_x, const TileFrame& frame)
+{
+  return static_cast<int>(std::clamp(frame.pxX(dbu_x), -1.0e7, 1.0e7));
+}
+
+// Clamped int form; see toPxX for when it may be used.  Deliberately clamps the
+// offset rather than delegating to toPxYd and clamping the flipped result — the
+// two differ by `dim` once saturated.
+inline int toPxY(int dbu_y, const TileFrame& frame, int dim)
+{
+  return dim - 1
+         - static_cast<int>(std::clamp(frame.pxY(dbu_y), -1.0e7, 1.0e7));
+}
+
+// Width in buffer pixels of a line meant to read as ONE CSS pixel: the overlay
+// hairlines (die/core/region outlines, grid dots and lines).  Authoring a
+// literal 1 px is wrong twice over — it reads a third as thick as everything
+// else on a 3x display, and on the supersampled render path it fades to ~1/S
+// intensity once lanczos2Downsample decimates the buffer back.  See
+// penWidthCss for the 3 CSS px pen the gui::Painter ops default to.
+inline int hairlineCss(const TileFrame& frame)
+{
+  return std::max(1, static_cast<int>(std::lround(frame.px_per_css)));
+}
+
 }  // namespace
 
 void TileVisibility::parseFromJson(const boost::json::object& json)
@@ -154,6 +204,10 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
     {"pins",               &TileVisibility::pins,               true},
     {"pin_markers",        &TileVisibility::pin_markers,        true},
     {"pin_names",          &TileVisibility::pin_names,          true},
+    {"access_points",      &TileVisibility::access_points,      false},
+    {"regions",            &TileVisibility::regions,            true},
+    {"mfg_grid",           &TileVisibility::mfg_grid,           false},
+    {"gcell_grid",         &TileVisibility::gcell_grid,         false},
     {"inst_names",         &TileVisibility::inst_names,         true},
     {"inst_pins",          &TileVisibility::inst_pins,          true},
     {"inst_pin_names",     &TileVisibility::inst_pin_names,     true},
@@ -652,6 +706,9 @@ void TileGenerator::eagerInit()
     chiplets_cache_.clear();
     chiplets_cache_valid_ = false;
   }
+  // Overlay caches are keyed by dbBlock*, which may be stale after a
+  // design swap.
+  clearOverlayCaches();
 
   odb::dbChip* chip = db_->getChip();
   if (chip) {
@@ -719,6 +776,10 @@ void TileGenerator::onDesignChanged()
   // The geometry cache is NOT dropped here.  This hook is debounced (see
   // below), so an edit arriving while an index is already invalid never
   // reaches it — geomCache() polls Search::revision() instead, which is not.
+  // The overlay caches (access points, gcell grids) are derived from the design
+  // in the same way and an empty entry is indistinguishable from "no data" —
+  // caching the gcell grid before global_route created it would keep the
+  // overlay blank until a page reload — so they poll the revision too.
 
   // Tell connected clients to re-request (mirrors Qt's fullRepaint).  The
   // Search-level debounce (announceModified fires only on a valid→invalid
@@ -1326,6 +1387,96 @@ static odb::PtrMap<odb::dbTechLayer, Color> buildLayerColorMap(
     colors[layer] = c;
   }
   return colors;
+}
+
+void TileGenerator::clearOverlayCaches() const
+{
+  std::lock_guard lock(overlay_cache_mutex_);
+  dropOverlayCaches();
+}
+
+// Caller holds overlay_cache_mutex_.  All three caches are derived from the
+// same design state and are invalidated as a unit, so one recorded revision
+// covers them.
+void TileGenerator::dropOverlayCaches() const
+{
+  bpin_ap_cache_.clear();
+  gcell_x_cache_.clear();
+  gcell_y_cache_.clear();
+}
+
+// Caller holds overlay_cache_mutex_.  `rev` must have been read BEFORE the lock
+// was taken, so an edit landing while a cache is being built leaves the
+// recorded revision behind the live one and the next call rebuilds — the same
+// ordering geomCache() relies on.
+void TileGenerator::dropOverlayCachesIfStale(const uint64_t rev) const
+{
+  if (overlay_cache_revision_ != rev) {
+    dropOverlayCaches();
+    overlay_cache_revision_ = rev;
+  }
+}
+
+TileGenerator::BpinApList TileGenerator::bpinAccessPoints(
+    odb::dbBlock* block) const
+{
+  const uint64_t rev = search_->revision();
+  std::lock_guard lock(overlay_cache_mutex_);
+  dropOverlayCachesIfStale(rev);
+  auto [it, inserted] = bpin_ap_cache_.try_emplace(block);
+  if (inserted) {
+    auto aps = std::make_shared<std::vector<BpinAp>>();
+    for (odb::dbBTerm* term : block->getBTerms()) {
+      for (odb::dbBPin* pin : term->getBPins()) {
+        for (odb::dbAccessPoint* ap : pin->getAccessPoints()) {
+          if (ap) {
+            aps->push_back({ap->getPoint(),
+                            ap->getLayer(),
+                            term->getNet(),
+                            ap->hasAccess()});
+          }
+        }
+      }
+    }
+    it->second = std::move(aps);
+  }
+  return it->second;
+}
+
+// Shared body of gcellGridX/Y.  `fill` copies one axis out of the block's grid;
+// a pointer-to-member would be ambiguous, dbGCellGrid::getGridX/Y each having a
+// second, reference-returning overload.
+TileGenerator::GridList TileGenerator::gcellGrid(
+    odb::PtrMap<odb::dbBlock, GridList>& cache,
+    odb::dbBlock* block,
+    const std::function<void(odb::dbGCellGrid*, std::vector<int>&)>& fill) const
+{
+  const uint64_t rev = search_->revision();
+  std::lock_guard lock(overlay_cache_mutex_);
+  dropOverlayCachesIfStale(rev);
+  auto [it, inserted] = cache.try_emplace(block);
+  if (inserted) {
+    auto grid_lines = std::make_shared<std::vector<int>>();
+    if (odb::dbGCellGrid* grid = block->getGCellGrid()) {
+      fill(grid, *grid_lines);  // sorted ascending by odb
+    }
+    it->second = std::move(grid_lines);
+  }
+  return it->second;
+}
+
+TileGenerator::GridList TileGenerator::gcellGridX(odb::dbBlock* block) const
+{
+  return gcellGrid(gcell_x_cache_, block, [](auto* grid, auto& out) {
+    grid->getGridX(out);
+  });
+}
+
+TileGenerator::GridList TileGenerator::gcellGridY(odb::dbBlock* block) const
+{
+  return gcellGrid(gcell_y_cache_, block, [](auto* grid, auto& out) {
+    grid->getGridY(out);
+  });
 }
 
 const odb::PtrMap<odb::dbTechLayer, Color>& TileGenerator::getLayerColorMap(
@@ -1991,6 +2142,408 @@ const std::vector<odb::Rect>* findViaBoxes(
 
 }  // namespace
 
+void TileGenerator::outlineRectInTile(std::vector<unsigned char>& image,
+                                      const odb::Rect& r,
+                                      const Color& c,
+                                      const TileFrame& frame) const
+{
+  const odb::Rect& dbu_tile = frame.cull;
+  const int xl = r.xMin();
+  const int yl = r.yMin();
+  const int xh = r.xMax();
+  const int yh = r.yMax();
+  const int64_t pixel_xl = static_cast<int64_t>(frame.pxX(xl));
+  const int64_t pixel_yl = static_cast<int64_t>(frame.pxY(yl));
+  const int64_t pixel_xh = static_cast<int64_t>(std::ceil(frame.pxX(xh)));
+  const int64_t pixel_yh = static_cast<int64_t>(std::ceil(frame.pxY(yh)));
+
+  // frame.scale is in buffer pixels per DBU, so the clamps must follow the
+  // buffer the caller handed us: tile_px for a plain tile,
+  // tile_px*kCoverageSupersample for the supersampled render path.
+  const int dim = bufferDim(image);
+  const int loop_xl = std::clamp<int64_t>(pixel_xl, 0, dim);
+  const int loop_yl = std::clamp<int64_t>(pixel_yl, 0, dim);
+  const int loop_xh = std::clamp<int64_t>(pixel_xh, 0, dim);
+  const int loop_yh = std::clamp<int64_t>(pixel_yh, 0, dim);
+
+  const int draw_xl = std::clamp<int64_t>(pixel_xl, 0, dim - 1);
+  const int draw_yl = std::clamp<int64_t>(pixel_yl, 0, dim - 1);
+  const int draw_xh = std::clamp<int64_t>(pixel_xh, 0, dim - 1);
+  const int draw_yh = std::clamp<int64_t>(pixel_yh, 0, dim - 1);
+
+  // Thickness grows with the buffer so the edge survives decimation; each
+  // band is drawn inward from the edge to keep the rect's extent exact.
+  const int t = hairlineCss(frame);
+  if (dbu_tile.xMin() <= xl && xl <= dbu_tile.xMax()) {
+    for (int iy = loop_yl; iy < loop_yh; ++iy) {
+      for (int k = 0; k < t; ++k) {
+        setPixel(image, draw_xl + k, dim - 1 - iy, c, dim);
+      }
+    }
+  }
+  if (dbu_tile.xMin() <= xh && xh <= dbu_tile.xMax()) {
+    for (int iy = loop_yl; iy < loop_yh; ++iy) {
+      for (int k = 0; k < t; ++k) {
+        setPixel(image, draw_xh - k, dim - 1 - iy, c, dim);
+      }
+    }
+  }
+  if (dbu_tile.yMin() <= yl && yl <= dbu_tile.yMax()) {
+    for (int ix = loop_xl; ix < loop_xh; ++ix) {
+      for (int k = 0; k < t; ++k) {
+        setPixel(image, ix, dim - 1 - draw_yl - k, c, dim);
+      }
+    }
+  }
+  if (dbu_tile.yMin() <= yh && yh <= dbu_tile.yMax()) {
+    for (int ix = loop_xl; ix < loop_xh; ++ix) {
+      for (int k = 0; k < t; ++k) {
+        setPixel(image, ix, dim - 1 - draw_yh + k, c, dim);
+      }
+    }
+  }
+}
+
+// Special "_access_points" layer: dbAccessPoint markers (X).  Mirrors GUI
+// RenderThread::drawAccessPoints (renderThread.cpp:1484-1550).
+void TileGenerator::drawAccessPointsLayer(std::vector<unsigned char>& image,
+                                          odb::dbBlock* block,
+                                          const TileFrame& frame,
+                                          const TileVisibility& vis) const
+{
+  const odb::Rect& dbu_tile = frame.cull;
+  constexpr Color kApHasAccess{.r = 0, .g = 255, .b = 0, .a = 255};
+  constexpr Color kApNoAccess{.r = 255, .g = 0, .b = 0, .a = 255};
+  constexpr int kApSizeDbu = 100;             // match GUI shape_size
+  constexpr int kApHalfDbu = kApSizeDbu / 2;  // marker reach past its centre
+  const int dim = bufferDim(image);
+  // LOD: skip when the 100-DBU marker would be sub-pixel (mirror GUI).  The
+  // limit is in CSS pixels, so scale it by the buffer's px-per-CSS-px.
+  if (kApSizeDbu * frame.scale < frame.px_per_css) {
+    return;
+  }
+  const int half_px = static_cast<int>(kApSizeDbu * frame.scale / 2.0);
+  const int stroke = hairlineCss(frame);
+
+  // Cull against the tile grown by the marker's reach, not against the tile
+  // itself: the X extends half a marker past its centre, so an access point
+  // just outside this tile still paints arms into it.  Culling on the bare
+  // centre made the neighbouring tile skip the marker entirely, which chopped
+  // the X along every tile seam (PR #10806 review).  drawLine clips to the
+  // buffer, so drawing a marker centred outside the tile is safe.
+  odb::Rect ap_tile;
+  dbu_tile.bloat(kApHalfDbu, ap_tile);
+
+  // Draw one access point whose point is already in GLOBAL DBU.
+  auto draw_ap = [&](const odb::Point& pt,
+                     odb::dbTechLayer* ap_lyr,
+                     const bool has_access) {
+    if (vis.has_visible_layers && ap_lyr
+        && !vis.visible_layers.contains(ap_lyr->getName())) {
+      return;  // access point on a hidden layer
+    }
+    if (!ap_tile.intersects(pt)) {
+      return;  // viewport cull, inflated by the marker reach
+    }
+    const int px = toPxX(pt.x(), frame);
+    const int py = toPxY(pt.y(), frame, dim);
+    const Color c = has_access ? kApHasAccess : kApNoAccess;
+    drawLine(image,
+             px - half_px,
+             py - half_px,
+             px + half_px,
+             py + half_px,
+             c,
+             stroke);
+    drawLine(image,
+             px - half_px,
+             py + half_px,
+             px + half_px,
+             py - half_px,
+             c,
+             stroke);
+  };
+
+  // (a) IO pins (BPins) — global coords, no transform.  The per-block
+  // cache avoids rescanning every BTerm on every tile; holding the shared_ptr
+  // keeps the list alive across a concurrent cache clear.
+  const BpinApList bpin_aps = bpinAccessPoints(block);
+  for (const BpinAp& ap : *bpin_aps) {
+    if (ap.net && !vis.isNetVisible(ap.net)) {
+      continue;  // null-safe net filter
+    }
+    draw_ap(ap.point, ap.layer, ap.has_access);
+  }
+  // (b) Instance pins (ITerms) — translate by instance origin only.
+  //     Gate on inst_pins to mirror GUI areInstancePinsVisible().
+  //     searchInsts gets the grown tile for the same seam reason as draw_ap.
+  if (vis.inst_pins) {
+    for (odb::dbInst* inst : search_->searchInsts(block,
+                                                  ap_tile.xMin(),
+                                                  ap_tile.yMin(),
+                                                  ap_tile.xMax(),
+                                                  ap_tile.yMax())) {
+      int ox = 0;
+      int oy = 0;
+      inst->getLocation(ox, oy);
+      const odb::dbTransform xform({ox, oy});  // translation only!
+      for (odb::dbITerm* it : inst->getITerms()) {
+        for (odb::dbAccessPoint* ap : it->getPrefAccessPoints()) {
+          if (!ap) {
+            continue;
+          }
+          odb::Point pt = ap->getPoint();
+          xform.apply(pt);
+          draw_ap(pt, ap->getLayer(), ap->hasAccess());
+        }
+      }
+    }
+  }
+}
+
+// Special "_regions" layer: dbRegion boundaries as semi-transparent
+// filled rects with a 1px gray outline.  Mirrors GUI
+// RenderThread::drawRegions (renderThread.cpp:1405-1426).
+void TileGenerator::drawRegionsLayer(std::vector<unsigned char>& image,
+                                     odb::dbBlock* block,
+                                     const TileFrame& frame,
+                                     const TileVisibility& /*vis*/) const
+{
+  const odb::Rect& dbu_tile = frame.cull;
+  // GUI defaults: fill = region_color_ (0x70,0x70,0x70,0x70), outline
+  // pen = Qt::gray — same gray as the die outline (kOutlineGray).
+  constexpr Color kRegionFill{.r = 0x70, .g = 0x70, .b = 0x70, .a = 0x70};
+  for (odb::dbRegion* region : block->getRegions()) {
+    for (odb::dbBox* box : region->getBoundaries()) {
+      const odb::Rect r = box->getBox();
+      if (r.area() <= 0 || !r.overlaps(dbu_tile)) {
+        continue;
+      }
+      drawFilledRect(
+          image, toPixels(frame, r.intersect(dbu_tile)), kRegionFill);
+      // Outline: same clamped edge drawing as the die/core outline.
+      outlineRectInTile(image, r, kOutlineGray, frame);
+    }
+  }
+}
+
+// Special "_mfg_grid" layer: white dots at manufacturing-grid points.
+// Mirrors GUI RenderThread::drawManufacturingGrid (renderThread.cpp:1359-1403).
+void TileGenerator::drawMfgGridLayer(std::vector<unsigned char>& image,
+                                     odb::dbBlock* block,
+                                     const TileFrame& frame,
+                                     const TileVisibility& vis) const
+{
+  const odb::Rect& dbu_tile = frame.cull;
+  odb::dbTech* tech = block->getTech();
+  if (!tech || !tech->hasManufacturingGrid()) {
+    return;
+  }
+  const int grid = tech->getManufacturingGrid();  // DBU
+  if (grid <= 0) {
+    return;
+  }
+  const int dim = bufferDim(image);
+  // Adaptive decimation instead of the Qt behaviour of hiding the grid whenever
+  // points would be closer than kMinViewablePx.  A manufacturing grid is far
+  // finer than a die: nangate45's 10 DBU grid on a 9.3 mm die only clears a
+  // 5 px spacing at z=15, so the Qt rule makes the overlay unreachable in
+  // practice (PR #10806 review).  Here we keep the on-screen spacing at
+  // kMinViewablePx by drawing every k-th grid line: k == 1 is the exact grid
+  // once it is legible, and below that this is a SUBGRID (k*grid), not the
+  // literal manufacturing grid.
+  //
+  // k depends only on scale/dim — never on the tile — so neighbouring tiles at
+  // the same zoom agree on the same absolute lattice and the seams line up.
+  //
+  // "Detailed view" tightens the target spacing, so the lattice gets denser and
+  // lands closer to the real grid (measured on bp_quad: coverage 24% -> 37%,
+  // dot period 5 px -> 4).  It stops at 4 px rather than the 1 px the toggle
+  // uses for shapes, for two reasons:
+  //  - a grid tiles the plane, unlike sparse shapes, and the tile is Lanczos-
+  //    decimated on the way out, which spreads every dot over ~3 output px.
+  //    Below ~4 px the dots merge into a solid white sheet that hides the
+  //    design (measured at a 1 px and a 2 px target: every pixel of the tile
+  //    lit), which is worse than showing nothing.
+  //  - the target can never reach 0, because this loop is O(points in tile) —
+  //    the raw grid on a 9.3 mm die at zoom-out is ~10^11 points per tile.
+  constexpr double kDetailedGridPx = 4.0;
+  const double target_px = vis.detailed ? kDetailedGridPx : kMinViewablePx;
+  const double dbu_per_css = frame.px_per_css / frame.scale;
+  const int k = std::max(
+      1, static_cast<int>(std::ceil(target_px * dbu_per_css / grid)));
+  const int step = k * grid;
+  constexpr Color kGridDot{.r = 255, .g = 255, .b = 255, .a = 255};
+  const int dot = hairlineCss(frame);
+  // Anchor on absolute multiples of `step` (seamless across tiles).  Integer
+  // division truncates toward zero, so snap explicitly to handle negative
+  // coordinates (tile bounds include the label margin, which can go
+  // negative near the origin); the Qt version only handles positive ones.
+  int first_x = dbu_tile.xMin() / step * step;
+  if (first_x < dbu_tile.xMin()) {
+    first_x += step;
+  }
+  int last_x = dbu_tile.xMax() / step * step;
+  if (last_x > dbu_tile.xMax()) {
+    last_x -= step;
+  }
+  int first_y = dbu_tile.yMin() / step * step;
+  if (first_y < dbu_tile.yMin()) {
+    first_y += step;
+  }
+  int last_y = dbu_tile.yMax() / step * step;
+  if (last_y > dbu_tile.yMax()) {
+    last_y -= step;
+  }
+  for (int gx = first_x; gx <= last_x; gx += step) {
+    const int px = toPxX(gx, frame);
+    for (int gy = first_y; gy <= last_y; gy += step) {
+      const int py = toPxY(gy, frame, dim);
+      // One dot per grid point; `dot` px wide so it survives decimation.
+      for (int dy = 0; dy < dot; ++dy) {
+        for (int dx = 0; dx < dot; ++dx) {
+          setPixel(image, px + dx, py + dy, kGridDot, dim);
+        }
+      }
+    }
+  }
+}
+
+// Special "_gcell_grid" layer: white grid lines at GCell boundaries.
+// Mirrors GUI RenderThread::drawGCellGrid (renderThread.cpp:1304-1357).
+void TileGenerator::drawGcellGridLayer(std::vector<unsigned char>& image,
+                                       odb::dbBlock* block,
+                                       const TileFrame& frame,
+                                       const TileVisibility& /*vis*/) const
+{
+  const odb::Rect& dbu_tile = frame.cull;
+  odb::dbGCellGrid* grid = block->getGCellGrid();
+  const odb::Rect die_area = block->getDieArea();
+  if (!grid || !dbu_tile.intersects(die_area)) {
+    return;
+  }
+  const odb::Rect draw_bounds = dbu_tile.intersect(die_area);
+  constexpr Color kGridLine{.r = 255, .g = 255, .b = 255, .a = 255};
+  const int dim = bufferDim(image);
+  // Pixel range of draw_bounds inside this tile (Y flipped).
+  const int pxl = toPxX(draw_bounds.xMin(), frame);
+  const int pxh = toPxX(draw_bounds.xMax(), frame);
+  const int pyl = toPxY(draw_bounds.yMin(), frame, dim);
+  const int pyh = toPxY(draw_bounds.yMax(), frame, dim);
+
+  const int stroke = hairlineCss(frame);
+  auto draw_v = [&](const int x) {
+    if (x < draw_bounds.xMin() || draw_bounds.xMax() < x) {
+      return;
+    }
+    const int px = toPxX(x, frame);
+    drawLine(image, px, pyl, px, pyh, kGridLine, stroke);
+  };
+  auto draw_h = [&](const int y) {
+    if (y < draw_bounds.yMin() || draw_bounds.yMax() < y) {
+      return;
+    }
+    const int py = toPxY(y, frame, dim);
+    drawLine(image, pxl, py, pxh, py, kGridLine, stroke);
+  };
+
+  // Per-block cache + binary search: only visit the grid lines inside
+  // this tile instead of copying/scanning the full vectors.  Holding the
+  // shared_ptr keeps the vectors alive across a concurrent cache clear.
+  const GridList x_grid = gcellGridX(block);
+  const GridList y_grid = gcellGridY(block);
+  for (auto itx = std::ranges::lower_bound(*x_grid, draw_bounds.xMin());
+       itx != x_grid->end() && *itx <= draw_bounds.xMax();
+       ++itx) {
+    draw_v(*itx);
+  }
+  for (auto ity = std::ranges::lower_bound(*y_grid, draw_bounds.yMin());
+       ity != y_grid->end() && *ity <= draw_bounds.yMax();
+       ++ity) {
+    draw_h(*ity);
+  }
+
+  // Close the mesh at the die boundary.  The grid lines are the gcell
+  // START edges (e.g. gcd/ihp: last line at 172800 vs die 185960), so the
+  // top/right edges have no line.  The Qt GUI looks closed because it
+  // always draws the die outline separately (renderThread.cpp:1188-1191);
+  // the web viewer only draws a die outline for multi-die designs, so
+  // close the grid here.
+  draw_v(die_area.xMin());
+  draw_v(die_area.xMax());
+  draw_h(die_area.yMin());
+  draw_h(die_area.yMax());
+}
+
+/* static */
+std::vector<std::string> TileGenerator::saveImageLayerOrder(
+    const TileVisibility& vis,
+    const std::vector<std::string>& tech_layers)
+{
+  // Bottom to top, by the SAME z order the client stacks the layers in on
+  // screen (addPseudoLayer / the layer loop in display-controls.js): Leaflet
+  // paints by zIndex, so a PNG composited in any other order is not the view
+  // the user saw.  Compositing in registry order — every pseudo layer last —
+  // put the manufacturing grid over the routing and the pin markers over the
+  // tech layers.  These three mirror the client's non-pseudo values;
+  // PseudoLayerDef::z_index carries the overlays'.
+  constexpr int kInstancesZ = 0;
+  constexpr int kPinsZ = 1;
+  constexpr int kTechLayerZBase = 3;
+
+  std::vector<std::pair<int, std::string>> ordered;
+  ordered.reserve(tech_layers.size() + 2 + pseudoLayerDefs().size());
+  ordered.emplace_back(kInstancesZ, "_instances");
+  if (vis.pins) {
+    ordered.emplace_back(kPinsZ, "_pins");
+  }
+  int layer_z = kTechLayerZBase;
+  for (const std::string& name : tech_layers) {
+    ordered.emplace_back(layer_z++, name);
+  }
+  for (const PseudoLayerDef& def : pseudoLayerDefs()) {
+    if (vis.*def.flag) {
+      ordered.emplace_back(def.z_index, def.name);
+    }
+  }
+  std::ranges::stable_sort(ordered, {}, &std::pair<int, std::string>::first);
+
+  std::vector<std::string> names;
+  names.reserve(ordered.size());
+  for (auto& [z, name] : ordered) {
+    names.push_back(std::move(name));
+  }
+  return names;
+}
+
+const std::array<TileGenerator::PseudoLayerDef, 4>&
+TileGenerator::pseudoLayerDefs()
+{
+  // z_index mirrors addPseudoLayer() in display-controls.js (see
+  // saveImageLayerOrder); those values in turn follow the GUI's paint order
+  // (renderThread.cpp:1201-1298), where the manufacturing grid goes down before
+  // the routing layers and access points, regions and the gcell grid on top.
+  static const std::array<PseudoLayerDef, 4> defs = {{
+      {.name = "_access_points",
+       .flag = &TileVisibility::access_points,
+       .painter = &TileGenerator::drawAccessPointsLayer,
+       .z_index = 1000},
+      {.name = "_regions",
+       .flag = &TileVisibility::regions,
+       .painter = &TileGenerator::drawRegionsLayer,
+       .z_index = 1001},
+      {.name = "_mfg_grid",
+       .flag = &TileVisibility::mfg_grid,
+       .painter = &TileGenerator::drawMfgGridLayer,
+       .z_index = 2},
+      {.name = "_gcell_grid",
+       .flag = &TileVisibility::gcell_grid,
+       .painter = &TileGenerator::drawGcellGridLayer,
+       .z_index = 1002},
+  }};
+  return defs;
+}
+
 std::vector<unsigned char> TileGenerator::renderTileBuffer(
     const std::string& layer,
     const int z,
@@ -2122,11 +2675,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
     // frame for translation-only transforms; non-R0 orientations log
     // and skip for v1 (followup work to support full transforms).
     const std::vector<ChipletNode>& chiplet_nodes = chiplets();
-    // The die-outline overlay only makes sense in multi-die designs; in
-    // single-chip layouts there is no chiplet to demarcate, and adding
-    // it caused regressions because every "expect transparent" test
-    // started seeing a gray frame.
+    // Multi-die designs draw the die outline on EVERY layer pass (chiplet
+    // demarcation).  Single-die designs draw die+core outlines too (Qt
+    // drawChip does it unconditionally), but only on the always-rendered
+    // "_instances" pass — drawing on every pass put a gray frame on every
+    // tech-layer tile and broke every "expect transparent" test.
     const bool draw_die_outline = chiplet_nodes.size() > 1;
+    // "_instances" pass: instance borders only (no routing) + the always-on
+    // die/core outlines.
+    const bool instances_only = (layer == "_instances");
     for (const ChipletNode& node : chiplet_nodes) {
       if (!vis.isChipletVisible(node.path)) {
         continue;
@@ -2207,55 +2764,23 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
       const int pat_ox = patternAnchor(dbu_x_min, scale);
       const int pat_oy = patternAnchor(dbu_y_min, scale);
 
-      // Mirrors RenderThread::drawChip() in the Qt GUI: outline the die
-      // boundary so the chiplet shape is visible regardless of which
-      // tech layer is active. Drawn once per layer-pass on every tile,
-      // but only in multi-die designs where the demarcation is useful.
-      if (draw_die_outline) {
+      // Mirrors RenderThread::drawChip() in the Qt GUI: die outline on
+      // every layer pass in multi-die designs (chiplet demarcation), and
+      // on the _instances pass for all designs (Qt draws it always;
+      // scoping to _instances keeps tech-layer tiles transparent).
+      if (draw_die_outline || instances_only) {
         const odb::Rect die = block->getDieArea();
         if (die.area() > 0) {
-          const int xl = die.xMin();
-          const int yl = die.yMin();
-          const int xh = die.xMax();
-          const int yh = die.yMax();
-          const int64_t pixel_xl = (int64_t) ((xl - dbu_x_min) * scale);
-          const int64_t pixel_yl = (int64_t) ((yl - dbu_y_min) * scale);
-          const int64_t pixel_xh
-              = (int64_t) std::ceil((xh - dbu_x_min) * scale);
-          const int64_t pixel_yh
-              = (int64_t) std::ceil((yh - dbu_y_min) * scale);
-
-          const int loop_xl = std::clamp<int64_t>(pixel_xl, 0, super);
-          const int loop_yl = std::clamp<int64_t>(pixel_yl, 0, super);
-          const int loop_xh = std::clamp<int64_t>(pixel_xh, 0, super);
-          const int loop_yh = std::clamp<int64_t>(pixel_yh, 0, super);
-
-          const int draw_xl = std::clamp<int64_t>(pixel_xl, 0, super - 1);
-          const int draw_yl = std::clamp<int64_t>(pixel_yl, 0, super - 1);
-          const int draw_xh = std::clamp<int64_t>(pixel_xh, 0, super - 1);
-          const int draw_yh = std::clamp<int64_t>(pixel_yh, 0, super - 1);
-
-          constexpr Color die_outline{.r = 128, .g = 128, .b = 128, .a = 255};
-          if (dbu_x_min <= xl && xl <= dbu_x_max) {
-            for (int iy = loop_yl; iy < loop_yh; ++iy) {
-              setPixel(image_buffer, draw_xl, super - 1 - iy, die_outline);
-            }
-          }
-          if (dbu_x_min <= xh && xh <= dbu_x_max) {
-            for (int iy = loop_yl; iy < loop_yh; ++iy) {
-              setPixel(image_buffer, draw_xh, super - 1 - iy, die_outline);
-            }
-          }
-          if (dbu_y_min <= yl && yl <= dbu_y_max) {
-            for (int ix = loop_xl; ix < loop_xh; ++ix) {
-              setPixel(image_buffer, ix, super - 1 - draw_yl, die_outline);
-            }
-          }
-          if (dbu_y_min <= yh && yh <= dbu_y_max) {
-            for (int ix = loop_xl; ix < loop_xh; ++ix) {
-              setPixel(image_buffer, ix, super - 1 - draw_yh, die_outline);
-            }
-          }
+          outlineRectInTile(image_buffer, die, kOutlineGray, frame);
+        }
+      }
+      // Core area outline (Qt drawChip draws it right after the die).
+      // Unset core -> empty polygon -> mergeInit()-inverted rect, so
+      // check min<max explicitly rather than area()>0.
+      if (instances_only) {
+        const odb::Rect core = block->getCoreArea();
+        if (core.xMin() < core.xMax() && core.yMin() < core.yMax()) {
+          outlineRectInTile(image_buffer, core, kOutlineGray, frame);
         }
       }
 
@@ -2580,8 +3105,18 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
         }
       }
 
-      // Special "_instances" layer: only draw instance borders, no routing
-      const bool instances_only = (layer == "_instances");
+      // Self-painting pseudo layers (see pseudoLayerDefs): dispatch by
+      // name and gate on the layer's visibility flag.
+      bool pseudo_overlay = false;
+      for (const PseudoLayerDef& def : pseudoLayerDefs()) {
+        if (layer == def.name) {
+          pseudo_overlay = true;
+          if (vis.*def.flag) {
+            (this->*def.painter)(image_buffer, block, frame, vis);
+          }
+          break;
+        }
+      }
 
       // On a tech-layer tile the per-instance pass paints only master
       // obstructions (vis.blockages) and cell-pin shapes (vis.inst_pins).  It
@@ -2596,9 +3131,10 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
           = instances_only || !tech_layer
             || ((vis.blockages || vis.inst_pins) && layer_master_geom);
 
-      // "_modules" and "_pins" layers handle their own drawing above;
-      // skip all other drawing (instances, routing, etc.)
-      if (!modules_layer && !pins_layer) {
+      // Pseudo layers ("_modules", "_pins" and the overlays above) handle
+      // their own drawing; skip all other drawing (instances, routing, etc.)
+      const bool pseudo_layer = modules_layer || pins_layer || pseudo_overlay;
+      if (!pseudo_layer) {
         const auto iterm_font = fontAtlasGetFont(static_cast<int>(
             std::lround(kItermLabelFontHeight * super_per_css)));
         const int iterm_font_h = getTextHeight(iterm_font);
@@ -3428,7 +3964,7 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
           }
         }
 
-      }  // end if (!modules_layer && !pins_layer)
+      }  // end if (!pseudo_layer)
 
       if (use_local) {
         // Slow-path compositing for chiplets with non-R0 orientations.
@@ -3947,15 +4483,8 @@ void TileGenerator::saveImage(const std::string& filename,
   const int tile_span_h = (ty_max - ty_min + 1) * kTileSizeInPixel;
   std::vector<unsigned char> output(4UL * tile_span_w * tile_span_h, 0);
 
-  // Layers to render (bottom to top): _instances, tech layers, _pins.
-  std::vector<std::string> layers_to_render;
-  layers_to_render.emplace_back("_instances");
-  for (const auto& name : getLayers()) {
-    layers_to_render.push_back(name);
-  }
-  if (vis.pins) {
-    layers_to_render.emplace_back("_pins");
-  }
+  const std::vector<std::string> layers_to_render
+      = saveImageLayerOrder(vis, getLayers());
 
   // Render each tile, compositing all layers.
   for (int ty = ty_min; ty <= ty_max; ++ty) {
@@ -4235,19 +4764,6 @@ Color toTileColor(const gui::Painter::Color& c)
   };
 }
 
-inline int toPxX(int dbu_x, const TileFrame& frame)
-{
-  return static_cast<int>(frame.pxX(dbu_x));
-}
-
-// Y is flipped: DBU grows up, pixel rows grow down.  `dim` is the buffer side
-// length (tile_px = 256*dpr), not a fixed 256 — a hardcoded flip anchors the
-// overlay 256 rows from the top instead of the tile bottom on HiDPI.
-inline int toPxY(int dbu_y, const TileFrame& frame, int dim)
-{
-  return dim - 1 - static_cast<int>(frame.pxY(dbu_y));
-}
-
 }  // namespace
 
 /* static */
@@ -4318,15 +4834,13 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
         if (l->pen.color.a == 0) {
           continue;
         }
-        const int x0 = toPxX(l->p1.x(), frame);
-        const int y0 = toPxY(l->p1.y(), frame, dim);
-        const int x1 = toPxX(l->p2.x(), frame);
-        const int y1 = toPxY(l->p2.y(), frame, dim);
+        // Oblique segment: convert in double so drawLine's clip keeps the
+        // slope (see toPxXd).
         drawLine(image,
-                 x0,
-                 y0,
-                 x1,
-                 y1,
+                 toPxXd(l->p1.x(), frame),
+                 toPxYd(l->p1.y(), frame, dim),
+                 toPxXd(l->p2.x(), frame),
+                 toPxYd(l->p2.y(), frame, dim),
                  toTileColor(l->pen.color),
                  penWidthPx(l->pen, scale));
       } else if (const auto* c = std::get_if<DrawCircleOp>(&op)) {
@@ -4387,11 +4901,12 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
           for (int i = 0; i < n; ++i) {
             const odb::Point& a = p->points[i];
             const odb::Point& b = p->points[(i + 1) % n];
+            // Polygon edges are arbitrary segments — same reason as DrawLineOp.
             drawLine(image,
-                     toPxX(a.x(), frame),
-                     toPxY(a.y(), frame, dim),
-                     toPxX(b.x(), frame),
-                     toPxY(b.y(), frame, dim),
+                     toPxXd(a.x(), frame),
+                     toPxYd(a.y(), frame, dim),
+                     toPxXd(b.x(), frame),
+                     toPxYd(b.y(), frame, dim),
                      pen,
                      w);
           }
@@ -4657,15 +5172,20 @@ void TileGenerator::drawHighlight(std::vector<unsigned char>& image,
     // Semi-transparent yellow fill
     fillPolygon(image, poly, frame, fill, /*blend=*/true);
 
-    // Solid yellow border — draw each edge
+    // Solid yellow border — draw each edge.  Oblique by nature (these are the
+    // octagons of octilinear SWires), so convert in double and let drawLine
+    // clip: a vertex a whole die outside the tile overflows an int cast, and
+    // saturating it per axis would tilt the edge.
     const auto& points = poly.getPoints();
     const int n = static_cast<int>(points.size());
     for (int i = 0; i < n - 1; ++i) {
-      const int px0 = static_cast<int>(frame.pxX(points[i].x()));
-      const int py0 = dim - 1 - static_cast<int>(frame.pxY(points[i].y()));
-      const int px1 = static_cast<int>(frame.pxX(points[i + 1].x()));
-      const int py1 = dim - 1 - static_cast<int>(frame.pxY(points[i + 1].y()));
-      drawLine(image, px0, py0, px1, py1, border, penWidthCss(frame));
+      drawLine(image,
+               toPxXd(points[i].x(), frame),
+               toPxYd(points[i].y(), frame, dim),
+               toPxXd(points[i + 1].x(), frame),
+               toPxYd(points[i + 1].y(), frame, dim),
+               border,
+               penWidthCss(frame));
     }
   }
 }
@@ -4753,20 +5273,73 @@ void TileGenerator::drawColoredHighlight(std::vector<unsigned char>& image,
 
 /* static */
 void TileGenerator::drawLine(std::vector<unsigned char>& image,
-                             int x0,
-                             int y0,
-                             int x1,
-                             int y1,
+                             const double fx0,
+                             const double fy0,
+                             const double fx1,
+                             const double fy1,
                              const Color& c,
-                             int width)
+                             const int width)
 {
+  const int r = (width - 1) / 2;
+  int x0 = 0;
+  int y0 = 0;
+  int x1 = 0;
+  int y1 = 0;
+
+  // Liang-Barsky clip against the tile (with a margin for the brush
+  // radius) BEFORE running Bresenham: callers may pass endpoints far
+  // outside the tile (flywires, region edges at deep zoom) and an
+  // unclipped line iterates one step per pixel of its full length.
+  // The bound follows the buffer, like setPixel/drawFilledRect: overlay
+  // painters run on the supersampled buffer, where a hardcoded 256 would
+  // clip away everything past the first quadrant.
+  //
+  // Clipping (not saturating) is also what keeps the slope exact: the clip
+  // moves both endpoints along the segment's own parameter t, so the
+  // in-bounds result is collinear with the input no matter how far outside
+  // the tile the endpoints started.
+  {
+    const double lo = -r - 1.0;
+    const double hi = bufferDim(image) + r;
+    const double dxf = fx1 - fx0;
+    const double dyf = fy1 - fy0;
+    double t0 = 0.0;
+    double t1 = 1.0;
+    auto clip = [&t0, &t1](double p, double q) {
+      if (p == 0.0) {
+        return q >= 0.0;  // parallel: inside iff q >= 0
+      }
+      const double t = q / p;
+      if (p < 0) {
+        if (t > t1) {
+          return false;
+        }
+        t0 = std::max(t0, t);
+      } else {
+        if (t < t0) {
+          return false;
+        }
+        t1 = std::min(t1, t);
+      }
+      return true;
+    };
+    if (!clip(-dxf, fx0 - lo) || !clip(dxf, hi - fx0) || !clip(-dyf, fy0 - lo)
+        || !clip(dyf, hi - fy0)) {
+      return;  // fully outside the tile
+    }
+    // Both ends now lie inside [lo, hi], so the casts cannot overflow.
+    x1 = static_cast<int>(std::lround(fx0 + t1 * dxf));
+    y1 = static_cast<int>(std::lround(fy0 + t1 * dyf));
+    x0 = static_cast<int>(std::lround(fx0 + t0 * dxf));
+    y0 = static_cast<int>(std::lround(fy0 + t0 * dyf));
+  }
+
   // Bresenham's line algorithm
   int dx = std::abs(x1 - x0);
   int dy = std::abs(y1 - y0);
   int sx = x0 < x1 ? 1 : -1;
   int sy = y0 < y1 ? 1 : -1;
   int err = dx - dy;
-  const int r = (width - 1) / 2;
 
   while (true) {
     if (r <= 0) {
@@ -4800,15 +5373,17 @@ void TileGenerator::drawFlightLines(std::vector<unsigned char>& image,
 {
   const int dim = bufferDim(image);
   for (const auto& fl : lines) {
-    // Convert DBU to pixel coordinates
-    int px0 = static_cast<int>(frame.pxX(fl.p1.x()));
-    int py0 = dim - 1 - static_cast<int>(frame.pxY(fl.p1.y()));
-    int px1 = static_cast<int>(frame.pxX(fl.p2.x()));
-    int py1 = dim - 1 - static_cast<int>(frame.pxY(fl.p2.y()));
+    // Convert DBU to pixel coordinates in double and let drawLine clip:
+    // flywires can be far longer than a tile, and the clamped int conversion
+    // would tilt them once one axis saturated at extreme zoom.
+    const double px0 = toPxXd(fl.p1.x(), frame);
+    const double py0 = toPxYd(fl.p1.y(), frame, dim);
+    const double px1 = toPxXd(fl.p2.x(), frame);
+    const double py1 = toPxYd(fl.p2.y(), frame, dim);
 
     // Rough bounding-box check: skip if line can't cross this tile
-    int lx0 = std::min(px0, px1), lx1 = std::max(px0, px1);
-    int ly0 = std::min(py0, py1), ly1 = std::max(py0, py1);
+    const double lx0 = std::min(px0, px1), lx1 = std::max(px0, px1);
+    const double ly0 = std::min(py0, py1), ly1 = std::max(py0, py1);
     if (lx1 < 0 || lx0 >= dim || ly1 < 0 || ly0 >= dim) {
       continue;
     }
@@ -5150,6 +5725,9 @@ boost::json::object serializeTechResponse(const TileGenerator& gen)
   out["sites"] = std::move(sites);
 
   out["has_liberty"] = gen.hasSta();
+  // Lets the client skip creating the default-on "_regions" tile layer
+  // (and its per-viewport requests) when the design has no dbRegion.
+  out["has_regions"] = gen.getBlock() && !gen.getBlock()->getRegions().empty();
   // For 3DBlox designs the top dbChip is HIER and has no dbBlock; the
   // chiplet list below is still emitted so the frontend can group layers
   // by chiplet.

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <any>
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -214,6 +215,12 @@ struct TileVisibility
   bool pins = true;               // BTerm (IO pin) shapes on tech layers
   bool pin_markers = true;        // BTerm direction markers on _pins layer
   bool pin_names = true;          // BTerm name labels on _pins layer
+  bool access_points
+      = false;  // dbAccessPoint markers (X), off by default (Qt parity)
+  bool regions
+      = true;  // dbRegion boundaries overlay, on by default (Qt parity)
+  bool mfg_grid = false;  // manufacturing-grid dots, off by default (Qt parity)
+  bool gcell_grid = false;  // GCell grid lines, off by default (Qt parity)
 
   // Shapes — other per-layer geometry (not routing sub-types)
   bool blockages = true;  // master obstructions (LEF OBS)
@@ -508,6 +515,13 @@ class TileGenerator
                  double dbu_per_pixel,
                  const TileVisibility& vis) const;
 
+  // The layers saveImage composites, bottom to top.  Public so a test can pin
+  // the order down: it has to match the zIndex the client gives each layer in
+  // display-controls.js, or the saved PNG is not the view on screen.
+  static std::vector<std::string> saveImageLayerOrder(
+      const TileVisibility& vis,
+      const std::vector<std::string>& tech_layers);
+
   // Render timing path overlay (colored rects + flight lines) to PNG bytes.
   std::vector<unsigned char> renderOverlayPng(
       int width_px,
@@ -674,11 +688,16 @@ class TileGenerator
                          const Color& c,
                          int dim = -1);
 
+  // Endpoints are tile-pixel coordinates, in double so that a segment far
+  // outside the tile keeps its exact SLOPE: the clip below runs on the values
+  // as given and only its (in-bounds) result is rounded.  Converting an oblique
+  // DBU segment through the clamped toPxX/toPxY instead would saturate each
+  // axis on its own and rotate the segment — use toPxXd/toPxYd here.
   static void drawLine(std::vector<unsigned char>& image,
-                       int x0,
-                       int y0,
-                       int x1,
-                       int y1,
+                       double x0,
+                       double y0,
+                       double x1,
+                       double y1,
                        const Color& c,
                        int width = 3);
 
@@ -739,6 +758,91 @@ class TileGenerator
   std::function<void()> design_changed_cb_;
   mutable std::mutex design_changed_cb_mutex_;
   std::atomic_bool suppress_design_changed_{false};
+
+  // Per-block caches for the grid/access-point overlay layers, so tiles
+  // don't rescan all BTerms / copy the full gcell vectors on every tile.
+  // Dropped by clearOverlayCaches() from eagerInit() (design reload), and by
+  // the accessors themselves when Search::revision() has moved: a gcell grid
+  // created mid-session by global_route would otherwise stay hidden behind the
+  // empty vector cached before it, and onDesignChanged() is debounced, so it
+  // cannot be relied on to notice (see dropOverlayCachesIfStale).
+  //
+  // The accessors hand out a shared_ptr, not a reference into the map: they
+  // release overlay_cache_mutex_ on return, and a concurrent
+  // clearOverlayCaches() would destroy a referenced vector under a renderer.
+  // Ownership costs nothing on the hot path (no data is copied).
+  struct BpinAp
+  {
+    odb::Point point;
+    odb::dbTechLayer* layer;
+    odb::dbNet* net;  // may be null (unconnected bterm)
+    bool has_access;
+  };
+  using BpinApList = std::shared_ptr<const std::vector<BpinAp>>;
+  using GridList = std::shared_ptr<const std::vector<int>>;
+  BpinApList bpinAccessPoints(odb::dbBlock* block) const;
+  GridList gcellGridX(odb::dbBlock* block) const;
+  GridList gcellGridY(odb::dbBlock* block) const;
+  GridList gcellGrid(odb::PtrMap<odb::dbBlock, GridList>& cache,
+                     odb::dbBlock* block,
+                     const std::function<void(odb::dbGCellGrid*,
+                                              std::vector<int>&)>& fill) const;
+  void clearOverlayCaches() const;
+  // Both require overlay_cache_mutex_; see the definitions.
+  void dropOverlayCaches() const;
+  void dropOverlayCachesIfStale(uint64_t rev) const;
+
+  // Pseudo-layer painters used by renderTileBuffer (one per overlay).
+  // Callers gate on the visibility flag; painters handle the rest.  All
+  // share one signature so pseudoLayerDefs() can dispatch by table.
+  void drawAccessPointsLayer(std::vector<unsigned char>& image,
+                             odb::dbBlock* block,
+                             const TileFrame& frame,
+                             const TileVisibility& vis) const;
+  void drawRegionsLayer(std::vector<unsigned char>& image,
+                        odb::dbBlock* block,
+                        const TileFrame& frame,
+                        const TileVisibility& vis) const;
+  void drawMfgGridLayer(std::vector<unsigned char>& image,
+                        odb::dbBlock* block,
+                        const TileFrame& frame,
+                        const TileVisibility& vis) const;
+  void drawGcellGridLayer(std::vector<unsigned char>& image,
+                          odb::dbBlock* block,
+                          const TileFrame& frame,
+                          const TileVisibility& vis) const;
+
+  // Registry of the self-painting pseudo layers: layer name -> visibility
+  // flag -> painter -> paint order.  Single source of truth for the
+  // renderTileBuffer dispatch, the pseudo-layer guard and saveImage's
+  // layers_to_render — adding an overlay means adding one entry (plus the
+  // client layer).
+  //
+  // `z_index` is only read by saveImageLayerOrder(); see that function for why
+  // the value has to mirror the client's.
+  struct PseudoLayerDef
+  {
+    const char* name;
+    bool TileVisibility::*flag;
+    void (TileGenerator::*painter)(std::vector<unsigned char>&,
+                                   odb::dbBlock*,
+                                   const TileFrame&,
+                                   const TileVisibility&) const;
+    int z_index;
+  };
+  static const std::array<PseudoLayerDef, 4>& pseudoLayerDefs();
+  // Draw a rect's edges clamped to the tile (die/core/region outlines).
+  void outlineRectInTile(std::vector<unsigned char>& image,
+                         const odb::Rect& r,
+                         const Color& c,
+                         const TileFrame& frame) const;
+  mutable std::mutex overlay_cache_mutex_;
+  mutable odb::PtrMap<odb::dbBlock, BpinApList> bpin_ap_cache_;
+  mutable odb::PtrMap<odb::dbBlock, GridList> gcell_x_cache_;
+  mutable odb::PtrMap<odb::dbBlock, GridList> gcell_y_cache_;
+  // The Search::revision() the three caches above were built at; see
+  // dropOverlayCachesIfStale.
+  mutable uint64_t overlay_cache_revision_ = 0;
 
   static constexpr int kTileSizeInPixel = 256;
 };

--- a/src/web/src/web.tcl
+++ b/src/web/src/web.tcl
@@ -103,10 +103,14 @@ proc save_image { args } {
         }
         set key [lindex $opt 0]
         set val [lindex $opt 1]
+        # Emit real JSON booleans: TileVisibility::parseFromJson reads every
+        # field with value_to<bool>, which rejects 1/0 — and the caller catches
+        # that by discarding the WHOLE visibility object (WEB-0042), so one
+        # integer used to turn every -display_option into a no-op.
         if { $val eq "true" || $val eq "1" } {
-          set val 1
+          set val "true"
         } else {
-          set val 0
+          set val "false"
         }
         lappend pairs "\"$key\":$val"
       }

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -165,6 +165,7 @@ export function createOverlayTileLayer(visibility, app) {
             // and no longer sits exactly on the shape it highlights.
             ...tileSizeFields(currentDpr(), tileSize),
             debug_renderers: !!visibility.debug_renderers,
+            flywires_only: !!visibility.flywires_only,
         };
         // Pass visible layers so route guides respect layer visibility.
         if (app && app.visibleLayerNames) {

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -83,6 +83,54 @@ class FakeDescriptor : public gui::Descriptor
   }
 };
 
+// Minimal dbNet descriptor so tests can build a gui::Selected whose
+// isNet() is true; highlight() stands in for the wire-shape drawing of
+// the real NetDescriptor (a big rect the flywire mode must suppress).
+class FakeNetDescriptor : public gui::Descriptor
+{
+ public:
+  static constexpr int kWireRectSize = 90000;
+
+  std::string getName(const std::any& object) const override
+  {
+    return std::any_cast<odb::dbNet*>(object)->getName();
+  }
+
+  std::string getTypeName() const override { return "Net"; }
+
+  std::string getTypeName(const std::any&) const override { return "Net"; }
+
+  bool getBBox(const std::any&, odb::Rect& bbox) const override
+  {
+    bbox = odb::Rect(0, 0, kWireRectSize, kWireRectSize);
+    return true;
+  }
+
+  bool isNet(const std::any&) const override { return true; }
+
+  void visitAllObjects(
+      const std::function<void(const gui::Selected&)>&) const override
+  {
+  }
+
+  Properties getProperties(const std::any&) const override { return {}; }
+
+  gui::Selected makeSelected(const std::any& object) const override
+  {
+    return gui::Selected(object, this);
+  }
+
+  bool lessThan(const std::any& l, const std::any& r) const override
+  {
+    return std::any_cast<odb::dbNet*>(l) < std::any_cast<odb::dbNet*>(r);
+  }
+
+  void highlight(const std::any&, gui::Painter& painter) const override
+  {
+    painter.drawRect(odb::Rect(0, 0, kWireRectSize, kWireRectSize));
+  }
+};
+
 class LazyMetadataHeatMap : public gui::HeatMapDataSource
 {
  public:
@@ -164,6 +212,50 @@ class TileHandlerTest : public tst::Nangate45Fixture
     gen_ = std::make_shared<TileGenerator>(
         getDb(), /*sta=*/nullptr, getLogger());
     handler_ = std::make_unique<TileHandler>(gen_);
+  }
+
+  // Driver (buf1.Z) and sink (buf2.A) placed buffers on a new net.
+  odb::dbNet* makeConnectedNet(const char* net_name)
+  {
+    odb::dbMaster* master = lib_->findMaster("BUF_X16");
+    if (!master) {
+      return nullptr;
+    }
+    const std::string base = net_name;
+    odb::dbInst* buf1
+        = odb::dbInst::create(block_, master, (base + "_drv").c_str());
+    buf1->setLocation(10000, 10000);
+    buf1->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+    odb::dbInst* buf2
+        = odb::dbInst::create(block_, master, (base + "_snk").c_str());
+    buf2->setLocation(60000, 60000);
+    buf2->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+    odb::dbNet* net = odb::dbNet::create(block_, net_name);
+    buf1->findITerm("Z")->connect(net);
+    buf2->findITerm("A")->connect(net);
+    return net;
+  }
+
+  // Prime the highlight state the way an inspect would, so an overlay request
+  // can exercise a "Flywires only" flip against it.
+  void primeInspected(const gui::Selected& sel)
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.current_inspected = sel;
+    state_.highlight_source = SessionState::HighlightSource::kInspected;
+  }
+
+  // An overlay-tile request with the "Flywires only" toggle in a given
+  // position.
+  static WebSocketRequest overlayRequest(uint32_t id, bool flywires_only)
+  {
+    WebSocketRequest req;
+    req.id = id;
+    req.type = WebSocketRequest::kOverlayTile;
+    req.json = parseObj(flywires_only
+                            ? R"({"z":0,"x":0,"y":0,"flywires_only":true})"
+                            : R"({"z":0,"x":0,"y":0,"flywires_only":false})");
+    return req;
   }
 
   std::shared_ptr<TileGenerator> gen_;
@@ -538,6 +630,260 @@ TEST_F(TileHandlerTest, OverlayTileUsesHighlightState)
   EXPECT_FALSE(resp.payload.empty());
 }
 
+//------------------------------------------------------------------------------
+// "Flywires only" (Misc toggle) — selection flywires on the overlay
+//------------------------------------------------------------------------------
+
+TEST_F(TileHandlerTest, FlywiresOnlySuppressesWireShapes)
+{
+  odb::dbNet* net = makeConnectedNet("sig");
+  ASSERT_NE(net, nullptr);
+
+  static FakeNetDescriptor net_descriptor;
+  primeInspected(net_descriptor.makeSelected(std::any(net)));
+
+  // Toggle ON via overlay request: highlight re-derived as flywires.
+  WebSocketRequest req = overlayRequest(20, /*flywires_only=*/true);
+  auto resp = handler_->handleOverlayTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    EXPECT_FALSE(state_.highlight_lines.empty())
+        << "flywires_only should produce driver->sink lines";
+    for (const auto& r : state_.highlight_rects) {
+      EXPECT_LT(r.dx(), FakeNetDescriptor::kWireRectSize)
+          << "wire shapes must be suppressed in flywire mode";
+    }
+  }
+
+  // Toggle back OFF: unrouted net keeps its flywires (GUI fallback) and
+  // the descriptor's wire shapes are collected again.
+  req = overlayRequest(21, /*flywires_only=*/false);
+  resp = handler_->handleOverlayTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    EXPECT_FALSE(state_.highlight_lines.empty())
+        << "unrouted net keeps flywires with the toggle off (GUI parity)";
+    bool has_wire_rect = false;
+    for (const auto& r : state_.highlight_rects) {
+      has_wire_rect
+          = has_wire_rect || r.dx() == FakeNetDescriptor::kWireRectSize;
+    }
+    EXPECT_TRUE(has_wire_rect)
+        << "descriptor wire shapes should return when the toggle is off";
+  }
+}
+
+TEST_F(TileHandlerTest, FlywiresToggleDoesNotResurrectClearedHighlights)
+{
+  odb::dbNet* net = makeConnectedNet("sig2");
+  ASSERT_NE(net, nullptr);
+
+  static FakeNetDescriptor net_descriptor;
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.current_inspected = net_descriptor.makeSelected(std::any(net));
+    // Simulate an explicit "clear highlights" that kept the inspected
+    // object (e.g. DRC clear): vectors empty, highlights inactive.
+  }
+
+  WebSocketRequest req = overlayRequest(23, /*flywires_only=*/true);
+  auto resp = handler_->handleOverlayTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.highlight_lines.empty())
+      << "toggle flip must not resurrect cleared highlights";
+  EXPECT_TRUE(state_.highlight_rects.empty());
+}
+
+TEST_F(TileHandlerTest, NonNetPayloadWithIsNetDoesNotThrow)
+{
+  // A descriptor may report isNet()==true while its payload is NOT a
+  // plain dbNet* (e.g. DbNetDescriptor::NetWithSink).  The collector
+  // must fall back to the generic highlight path instead of throwing
+  // std::bad_any_cast.
+  class FakeNetWithSinkDescriptor : public FakeNetDescriptor
+  {
+   public:
+    std::string getName(const std::any&) const override { return "nws"; }
+    void highlight(const std::any&, gui::Painter& painter) const override
+    {
+      painter.drawRect(odb::Rect(0, 0, 1000, 1000));
+    }
+  };
+  static FakeNetWithSinkDescriptor descriptor;
+  // Payload is an int — any_cast<odb::dbNet*> by value would throw.
+  primeInspected(descriptor.makeSelected(std::any(42)));
+
+  WebSocketRequest req = overlayRequest(24, /*flywires_only=*/true);
+  auto resp = handler_->handleOverlayTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.highlight_lines.empty());
+  EXPECT_FALSE(state_.highlight_rects.empty())
+      << "non-dbNet payload should use the generic highlight path";
+}
+
+TEST_F(TileHandlerTest, FlywiresSkipSupplyNets)
+{
+  odb::dbMaster* master = lib_->findMaster("BUF_X16");
+  ASSERT_NE(master, nullptr);
+  odb::dbInst* buf1 = odb::dbInst::create(block_, master, "buf1");
+  buf1->setLocation(10000, 10000);
+  buf1->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  odb::dbNet* pwr = odb::dbNet::create(block_, "VDD");
+  pwr->setSigType(odb::dbSigType::POWER);
+  buf1->findITerm("A")->connect(pwr);
+
+  static FakeNetDescriptor net_descriptor;
+  primeInspected(net_descriptor.makeSelected(std::any(pwr)));
+
+  WebSocketRequest req = overlayRequest(22, /*flywires_only=*/true);
+  auto resp = handler_->handleOverlayTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.highlight_lines.empty())
+      << "supply nets must not get flywires (GUI parity)";
+}
+
+// A "Flywires only" flip must re-derive the highlight from the SAME selection
+// it came from.  Preferring current_inspected (which a click sets to the LAST
+// object hit) silently dropped every other member of a shift+click
+// multi-selection on the first flip, and flipping back did not restore them
+// (reported on the PR #10806 review).
+TEST_F(TileHandlerTest, FlywiresFlipPreservesMultiSelection)
+{
+  odb::dbNet* net_a = makeConnectedNet("multi_a");
+  odb::dbNet* net_b = makeConnectedNet("multi_b");
+  ASSERT_NE(net_a, nullptr);
+  ASSERT_NE(net_b, nullptr);
+
+  static FakeNetDescriptor net_descriptor;
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    // As after two shift+clicks: both nets selected, the second one inspected.
+    state_.selection_set.insert(net_descriptor.makeSelected(std::any(net_a)));
+    state_.selection_set.insert(net_descriptor.makeSelected(std::any(net_b)));
+    state_.selection_itr = state_.selection_set.begin();
+    state_.current_inspected = net_descriptor.makeSelected(std::any(net_b));
+    state_.highlight_source = SessionState::HighlightSource::kSelectionSet;
+  }
+
+  // Each net has one driver and one sink, so one flywire per net.
+  WebSocketRequest req = overlayRequest(25, /*flywires_only=*/true);
+  ASSERT_EQ(handler_->handleOverlayTile(req, state_).type,
+            WebSocketResponse::kPng);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    EXPECT_EQ(state_.highlight_lines.size(), 2u)
+        << "both selected nets must keep their flywires across the flip";
+  }
+
+  // ... and flipping back keeps both, too (the unrouted-net fallback).
+  req = overlayRequest(26, /*flywires_only=*/false);
+  ASSERT_EQ(handler_->handleOverlayTile(req, state_).type,
+            WebSocketResponse::kPng);
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.highlight_lines.size(), 2u)
+      << "un-toggling must not narrow the selection either";
+}
+
+// The other half of the invariant: when the user followed an inspector link out
+// of the selection set, handleInspect deliberately narrowed the highlight to
+// that one object, so a flip must NOT widen it back to the whole set.
+TEST_F(TileHandlerTest, FlywiresFlipAfterLinkFollowKeepsSingleObject)
+{
+  odb::dbNet* net_a = makeConnectedNet("link_a");
+  odb::dbNet* net_b = makeConnectedNet("link_b");
+  odb::dbNet* linked = makeConnectedNet("link_target");
+  ASSERT_NE(net_a, nullptr);
+  ASSERT_NE(net_b, nullptr);
+  ASSERT_NE(linked, nullptr);
+
+  static FakeNetDescriptor net_descriptor;
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.selection_set.insert(net_descriptor.makeSelected(std::any(net_a)));
+    state_.selection_set.insert(net_descriptor.makeSelected(std::any(net_b)));
+    state_.selection_itr = state_.selection_set.end();
+    state_.current_inspected = net_descriptor.makeSelected(std::any(linked));
+    state_.highlight_source = SessionState::HighlightSource::kInspected;
+  }
+
+  WebSocketRequest req = overlayRequest(27, /*flywires_only=*/true);
+  ASSERT_EQ(handler_->handleOverlayTile(req, state_).type,
+            WebSocketResponse::kPng);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.highlight_lines.size(), 1u)
+      << "the link target's highlight must not grow into the selection set";
+}
+
+// "Flywires only" suppresses the routed wire/guide shapes, NOT the special
+// (geometric) routing: the GUI draws SWires at the tail of
+// DbNetDescriptor::highlight regardless of the mode.
+TEST_F(TileHandlerTest, FlywiresOnlyKeepsSpecialWireShapes)
+{
+  odb::dbNet* net = makeConnectedNet("special_sig");
+  ASSERT_NE(net, nullptr);
+  net->setSpecial();
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  odb::dbSWire* swire = odb::dbSWire::create(net, odb::dbWireType::ROUTED);
+  ASSERT_NE(swire, nullptr);
+  odb::dbSBox::create(
+      swire, metal1, 20000, 20000, 30000, 21000, odb::dbWireShapeType::NONE);
+
+  static FakeNetDescriptor net_descriptor;
+  primeInspected(net_descriptor.makeSelected(std::any(net)));
+
+  WebSocketRequest req = overlayRequest(28, /*flywires_only=*/true);
+  ASSERT_EQ(handler_->handleOverlayTile(req, state_).type,
+            WebSocketResponse::kPng);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.highlight_lines.empty())
+      << "a routed special net gets no flywires (GUI parity)";
+  const auto& rects = state_.highlight_rects;
+  EXPECT_NE(std::ranges::find(rects, odb::Rect(20000, 20000, 30000, 21000)),
+            rects.end())
+      << "the SWire shape must survive flywires-only mode";
+}
+
+// Same for supply nets, which is the worst case of the bug: their flywires AND
+// their ITerm boxes are suppressed by GUI parity, so before the fix a selected
+// power net came back with no highlight at all.
+TEST_F(TileHandlerTest, FlywiresOnlySupplyNetKeepsShapes)
+{
+  odb::dbNet* pwr = odb::dbNet::create(block_, "VDD_swire");
+  pwr->setSigType(odb::dbSigType::POWER);
+  pwr->setSpecial();
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  odb::dbSWire* swire = odb::dbSWire::create(pwr, odb::dbWireType::ROUTED);
+  ASSERT_NE(swire, nullptr);
+  odb::dbSBox::create(
+      swire, metal1, 0, 40000, 100000, 41000, odb::dbWireShapeType::NONE);
+
+  static FakeNetDescriptor net_descriptor;
+  primeInspected(net_descriptor.makeSelected(std::any(pwr)));
+
+  WebSocketRequest req = overlayRequest(29, /*flywires_only=*/true);
+  ASSERT_EQ(handler_->handleOverlayTile(req, state_).type,
+            WebSocketResponse::kPng);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.highlight_lines.empty())
+      << "supply nets must not get flywires (GUI parity)";
+  EXPECT_FALSE(state_.highlight_rects.empty())
+      << "a selected supply net must still be highlighted by its SWires";
+}
+
 TEST_F(TileHandlerTest, HeatMapsReturnsMetadata)
 {
   gui::registerBuiltinHeatMapSources(/*sta=*/nullptr, getLogger());
@@ -792,6 +1138,31 @@ TEST_F(SelectHandlerTest, InspectInvalidIdReturnsError)
 
   std::string json = payloadStr(resp);
   EXPECT_NE(json.find("\"error\""), std::string::npos);
+}
+
+// An inspect that resolves to nothing clears the highlight vectors, so it must
+// also clear the source tag.  Leaving it set let a later "Flywires only" flip
+// re-derive the highlight from the stale current_inspected — resurrecting
+// exactly what the tag exists to keep dismissed.
+TEST_F(SelectHandlerTest, InvalidInspectDoesNotPrimeHighlights)
+{
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.current_inspected = makeFakeSelected(&fake_current_);
+    state_.highlight_source = SessionState::HighlightSource::kInspected;
+  }
+
+  WebSocketRequest req;
+  req.id = 30;
+  req.type = WebSocketRequest::kInspect;
+  req.json = parseObj(R"({"select_id":999})");
+  ASSERT_EQ(handler_->handleInspect(req, state_).type,
+            WebSocketResponse::kJson);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.highlight_rects.empty());
+  EXPECT_EQ(state_.highlight_source, SessionState::HighlightSource::kNone)
+      << "an empty selection must not leave the highlights primed";
 }
 
 TEST_F(SelectHandlerTest, HoverInvalidIdReturnsOkZeroCount)

--- a/src/web/test/cpp/TestSaveImage.cpp
+++ b/src/web/test/cpp/TestSaveImage.cpp
@@ -109,6 +109,18 @@ class SaveImageTest : public tst::Nangate45Fixture
     return false;
   }
 
+  static size_t countNonTransparentPixels(
+      const std::vector<unsigned char>& rgba)
+  {
+    size_t count = 0;
+    for (size_t i = 3; i < rgba.size(); i += 4) {
+      if (rgba[i] > 0) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
   std::unique_ptr<TileGenerator> tile_gen_;
   std::vector<std::string> output_files_;
 };
@@ -233,9 +245,15 @@ TEST_F(SaveImageTest, VisibilityPinsOff)
   auto pixels_on = decodePngFile(path_on, w1, h1);
   auto pixels_off = decodePngFile(path_off, w2, h2);
 
+  // The die and core outlines are drawn unconditionally on the _instances
+  // pass (Qt drawChip parity), so the "pins off" image is never fully
+  // transparent.  What the toggle must guarantee is that hiding pins only
+  // ever takes pixels away — every BTerm shape and marker disappears and
+  // nothing new is drawn in their place.
   EXPECT_TRUE(hasNonTransparentPixel(pixels_on))
       << "BTerm shapes should appear with vis.pins=true";
-  EXPECT_FALSE(hasNonTransparentPixel(pixels_off))
+  EXPECT_LT(countNonTransparentPixels(pixels_off),
+            countNonTransparentPixels(pixels_on))
       << "BTerm shapes should be hidden with vis.pins=false";
 }
 
@@ -303,6 +321,57 @@ TEST_F(SaveImageTest, MultipleLayersComposited)
   unsigned w = 0, h = 0;
   auto pixels = decodePngFile(path, w, h);
   EXPECT_TRUE(hasNonTransparentPixel(pixels));
+}
+
+// ─── Composition order ───────────────────────────────────────────────────────
+
+// saveImage must composite in the same z order Leaflet stacks the layers in on
+// screen (display-controls.js addPseudoLayer), otherwise the saved PNG is not
+// the view the user was looking at.  Before the fix every pseudo layer was
+// appended after the tech layers, which put the manufacturing grid over the
+// routing and the pin markers over the tech layers (PR #10806 review).
+//
+// Asserted on the layer list rather than on pixels: every layer here is
+// semi-transparent, so a dot drawn over the routing still blends with it and no
+// pixel test can tell the two orders apart reliably.
+TEST_F(SaveImageTest, LayerCompositionOrderMatchesClientZIndex)
+{
+  const std::vector<std::string> tech_layers = {"metal1", "metal2"};
+  TileVisibility vis;
+  vis.pins = true;
+  vis.mfg_grid = true;
+  vis.access_points = true;
+  vis.regions = true;
+  vis.gcell_grid = true;
+
+  // zIndex on screen: _instances 0, _pins 1, _mfg_grid 2, tech layers 3.., then
+  // _access_points 1000, _regions 1001, _gcell_grid 1002.
+  const std::vector<std::string> expected = {"_instances",
+                                             "_pins",
+                                             "_mfg_grid",
+                                             "metal1",
+                                             "metal2",
+                                             "_access_points",
+                                             "_regions",
+                                             "_gcell_grid"};
+  EXPECT_EQ(TileGenerator::saveImageLayerOrder(vis, tech_layers), expected);
+}
+
+TEST_F(SaveImageTest, LayerCompositionOrderHonorsVisibility)
+{
+  const std::vector<std::string> tech_layers = {"metal1"};
+  TileVisibility vis;
+  vis.pins = false;
+  // `regions` is the one overlay that defaults ON (Qt parity), so turn the
+  // whole set off explicitly rather than relying on the defaults.
+  vis.regions = false;
+  vis.mfg_grid = false;
+  vis.access_points = false;
+  vis.gcell_grid = false;
+
+  EXPECT_EQ(TileGenerator::saveImageLayerOrder(vis, tech_layers),
+            (std::vector<std::string>{"_instances", "metal1"}))
+      << "hidden overlays must not be composited at all";
 }
 
 }  // namespace

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -384,6 +384,38 @@ class TileGeneratorTest : public tst::Nangate45Fixture
     return false;
   }
 
+  static size_t countNonTransparentPixels(
+      const std::vector<unsigned char>& rgba)
+  {
+    size_t count = 0;
+    for (size_t i = 3; i < rgba.size(); i += 4) {
+      if (rgba[i] > 0) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  // Return true if any visible pixel is NOT the gray die/core outline
+  // ({128,128,128,255}) drawn on the _instances pass.
+  // True if any visible pixel isn't part of the always-on die/core outline.
+  // The outline is neutral gray (kOutlineGray); alpha is NOT checked because
+  // tiles are rasterized supersampled and Lanczos-decimated, so edge pixels
+  // come back with partial coverage (observed 64..197) while the RGB stays
+  // 128,128,128.
+  static bool hasNonOutlinePixel(const std::vector<unsigned char>& rgba)
+  {
+    for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+      if (rgba[i + 3] == 0) {
+        continue;
+      }
+      if (rgba[i] != 128 || rgba[i + 1] != 128 || rgba[i + 2] != 128) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   odb::dbInst* placeInst(const char* master_name,
                          const char* inst_name,
                          int x,
@@ -483,6 +515,28 @@ class TileGeneratorTest : public tst::Nangate45Fixture
     const std::vector<unsigned char> off = decodePng(
         tile_gen_->generateHeatMapTile(*heatmap_, zoom, x, y), width, height);
     return textPixels(on, off, axis);
+  }
+
+  // Create an IO pin (net+bterm+bpin box on metal1) carrying one
+  // dbAccessPoint at (2000,2000) with access granted.  Returns nullptr
+  // if metal1 is missing.
+  odb::dbAccessPoint* makeMetal1AccessPoint()
+  {
+    odb::dbNet* net = odb::dbNet::create(block_, "ap_pin");
+    odb::dbBTerm* bterm = odb::dbBTerm::create(net, "ap_pin");
+    bterm->setIoType(odb::dbIoType::INPUT);
+    odb::dbBPin* bpin = odb::dbBPin::create(bterm);
+    odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+    if (!metal1) {
+      return nullptr;
+    }
+    odb::dbBox::create(bpin, metal1, 1900, 1900, 2100, 2100);
+    bpin->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+    odb::dbAccessPoint* ap = odb::dbAccessPoint::create(bpin);
+    ap->setPoint(odb::Point(2000, 2000));
+    ap->setLayer(metal1);
+    ap->setAccess(true, odb::dbDirection::EAST);
+    return ap;
   }
 
   std::unique_ptr<TileGenerator> tile_gen_;
@@ -1668,7 +1722,9 @@ TEST_F(TileGeneratorTest, StdcellVisibilityFilter)
   auto png = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
   unsigned w = 0, h = 0;
   auto pixels = decodePng(png, w, h);
-  EXPECT_FALSE(hasNonTransparentPixel(pixels));
+  // The _instances pass always draws the gray die/core outline (Qt
+  // parity); with stdcells hidden nothing else may be visible.
+  EXPECT_FALSE(hasNonOutlinePixel(pixels));
 }
 
 TEST_F(TileGeneratorTest, IsNetVisibleRespectsSignalType)
@@ -1963,6 +2019,724 @@ TEST_F(TileGeneratorTest, InstPinNamesRendered)
   auto pixels_no_pins = decodePng(png_no_pins, w, h);
   EXPECT_FALSE(hasNonTransparentPixel(pixels_no_pins))
       << "ITerm labels should not render when inst_pins is false";
+}
+
+//------------------------------------------------------------------------------
+// Access-point overlay tests (_access_points pseudo-layer)
+//------------------------------------------------------------------------------
+
+// One table-driven test for the overlay visibility flags: default value,
+// explicit set, and omitted-key fallback (same table shape as kFields).
+TEST_F(TileGeneratorTest, OverlayFlagsParsedFromJson)
+{
+  struct FlagCase
+  {
+    const char* key;
+    bool TileVisibility::*field;
+    bool default_val;
+  };
+  const FlagCase cases[] = {
+      {"access_points", &TileVisibility::access_points, false},
+      {"regions", &TileVisibility::regions, true},
+      {"mfg_grid", &TileVisibility::mfg_grid, false},
+      {"gcell_grid", &TileVisibility::gcell_grid, false},
+  };
+  for (const auto& c : cases) {
+    TileVisibility vis_default;
+    EXPECT_EQ(vis_default.*c.field, c.default_val) << c.key;
+
+    // Explicitly set to the opposite of the default.
+    TileVisibility vis_set;
+    const std::string json = std::string("{\"") + c.key
+                             + "\":" + (c.default_val ? "false" : "true") + "}";
+    vis_set.parseFromJson(parseObj(json));
+    EXPECT_EQ(vis_set.*c.field, !c.default_val) << c.key;
+
+    // Omitting the key falls back to the default.
+    TileVisibility vis_omitted;
+    vis_omitted.parseFromJson(parseObj(R"({"pins":true})"));
+    EXPECT_EQ(vis_omitted.*c.field, c.default_val) << c.key;
+  }
+}
+
+TEST_F(TileGeneratorTest, AccessPointsOverlayGatedByFlag)
+{
+  // Small die so the fixed 100-DBU marker is well above the sub-pixel LOD.
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+
+  ASSERT_NE(makeMetal1AccessPoint(), nullptr);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  unsigned w = 0, h = 0;
+
+  // access_points=true → marker rendered.
+  TileVisibility vis_on;
+  vis_on.stdcells = false;
+  vis_on.access_points = true;
+  auto png_on = tile_gen_->generateTile("_access_points", 0, 0, 0, vis_on);
+  auto pixels_on = decodePng(png_on, w, h);
+  EXPECT_TRUE(hasNonTransparentPixel(pixels_on))
+      << "Access-point marker should render when vis.access_points is true";
+
+  // access_points=false → nothing on the pseudo-layer.
+  TileVisibility vis_off;
+  vis_off.stdcells = false;
+  vis_off.access_points = false;
+  auto png_off = tile_gen_->generateTile("_access_points", 0, 0, 0, vis_off);
+  auto pixels_off = decodePng(png_off, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels_off))
+      << "Access points should be hidden when vis.access_points is false";
+}
+
+TEST_F(TileGeneratorTest, AccessPointsRespectLayerVisibility)
+{
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+
+  ASSERT_NE(makeMetal1AccessPoint(), nullptr);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  unsigned w = 0, h = 0;
+
+  // visible_layers = ["metal1"] → the metal1 access point renders.
+  TileVisibility vis_m1;
+  vis_m1.stdcells = false;
+  vis_m1.parseFromJson(
+      parseObj(R"({"access_points":true,"visible_layers":["metal1"]})"));
+  auto png_m1 = tile_gen_->generateTile("_access_points", 0, 0, 0, vis_m1);
+  auto pixels_m1 = decodePng(png_m1, w, h);
+  EXPECT_TRUE(hasNonTransparentPixel(pixels_m1))
+      << "AP on metal1 should render when metal1 is visible";
+
+  // visible_layers = ["metal5"] → the metal1 access point is hidden.
+  TileVisibility vis_m5;
+  vis_m5.stdcells = false;
+  vis_m5.parseFromJson(
+      parseObj(R"({"access_points":true,"visible_layers":["metal5"]})"));
+  auto png_m5 = tile_gen_->generateTile("_access_points", 0, 0, 0, vis_m5);
+  auto pixels_m5 = decodePng(png_m5, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels_m5))
+      << "AP on metal1 should be hidden when only metal5 is visible";
+}
+
+//------------------------------------------------------------------------------
+// Region overlay tests (_regions pseudo-layer)
+//------------------------------------------------------------------------------
+
+TEST_F(TileGeneratorTest, RegionsOverlayGatedByFlag)
+{
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+  // Anchor the block bbox (getBounds uses content, not the die area).
+  placeInst("BUF_X16", "buf1", 0, 0);
+
+  odb::dbRegion* region = odb::dbRegion::create(block_, "test_dom");
+  ASSERT_NE(region, nullptr);
+  odb::dbBox::create(region, 1000, 1000, 3000, 3000);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  unsigned w = 0, h = 0;
+
+  // regions=true → boundary rendered on the _regions pseudo-layer.
+  TileVisibility vis_on;
+  vis_on.stdcells = false;
+  vis_on.regions = true;
+  auto png_on = tile_gen_->generateTile("_regions", 0, 0, 0, vis_on);
+  auto pixels_on = decodePng(png_on, w, h);
+  EXPECT_TRUE(hasNonTransparentPixel(pixels_on))
+      << "Region boundary should render when vis.regions is true";
+
+  // regions=false → nothing on the pseudo-layer.
+  TileVisibility vis_off;
+  vis_off.stdcells = false;
+  vis_off.regions = false;
+  auto png_off = tile_gen_->generateTile("_regions", 0, 0, 0, vis_off);
+  auto pixels_off = decodePng(png_off, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels_off))
+      << "Regions should be hidden when vis.regions is false";
+}
+
+TEST_F(TileGeneratorTest, RegionsSkipZeroAreaBoundaries)
+{
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+  placeInst("BUF_X16", "buf1", 0, 0);
+
+  // Degenerate boundary (zero width) must be skipped (GUI parity:
+  // drawRegions only draws boundaries with area() > 0).
+  odb::dbRegion* region = odb::dbRegion::create(block_, "empty_dom");
+  ASSERT_NE(region, nullptr);
+  odb::dbBox::create(region, 2000, 1000, 2000, 3000);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.regions = true;
+  auto png = tile_gen_->generateTile("_regions", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels))
+      << "Zero-area region boundaries should not be drawn";
+}
+
+//------------------------------------------------------------------------------
+// Manufacturing-grid overlay tests (_mfg_grid pseudo-layer)
+//------------------------------------------------------------------------------
+
+TEST_F(TileGeneratorTest, MfgGridGatedByFlagAndLod)
+{
+  // Nangate45 fixture LEF has MANUFACTURINGGRID 0.0050 (= 10 DBU).
+  ASSERT_TRUE(getDb()->getTech()->hasManufacturingGrid());
+  placeInst("BUF_X16", "buf1", 0, 0);  // anchor block bbox
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  unsigned w = 0, h = 0;
+
+  // Deep zoom (z=5): grid spacing >= 5 px → dots rendered.
+  TileVisibility vis_on;
+  vis_on.stdcells = false;
+  vis_on.mfg_grid = true;
+  auto png_on = tile_gen_->generateTile("_mfg_grid", 5, 0, 0, vis_on);
+  auto pixels_on = decodePng(png_on, w, h);
+  EXPECT_TRUE(hasNonTransparentPixel(pixels_on))
+      << "Grid dots should render at deep zoom when vis.mfg_grid is true";
+
+  // Same zoom, flag off → transparent.
+  TileVisibility vis_off;
+  vis_off.stdcells = false;
+  vis_off.mfg_grid = false;
+  auto png_off = tile_gen_->generateTile("_mfg_grid", 5, 0, 0, vis_off);
+  auto pixels_off = decodePng(png_off, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels_off))
+      << "Grid dots should be hidden when vis.mfg_grid is false";
+}
+
+// Mirrors kMinViewablePx in tile_generator.cpp (the on-screen spacing the
+// decimation keeps between grid dots).
+constexpr int kMinViewablePxForTest = 5;
+
+// The marker must survive tile seams.  Culling access points on their CENTRE
+// made the neighbouring tile skip the marker entirely, so the X was chopped
+// along every seam (reported on the PR #10806 review).
+//
+// The access point sits JUST INSIDE the left tile, close enough to the seam
+// that the right leg of its X reaches into the right tile.  The right tile does
+// not contain the centre, so with the old centre-based cull it came back empty
+// — which is exactly the truncated X from the report.  (Placing the point
+// exactly on the seam would not test anything: Rect::intersects is inclusive on
+// edges, so every neighbouring tile would "contain" it and draw.)
+TEST_F(TileGeneratorTest, AccessPointXCompleteAcrossTileSeams)
+{
+  constexpr int kExtent = 4000;  // anchors the block bbox → z=1 seam at 2000
+  constexpr int kApX = 1990;     // 10 DBU left of the seam; marker reach is 50
+  constexpr int kApY = 1000;
+  block_->setDieArea(odb::Rect(0, 0, kExtent, kExtent));
+  odb::dbMaster* m = lib_->findMaster("INV_X1");
+  ASSERT_NE(m, nullptr);
+  placeInst("INV_X1", "anchor_ll", 0, 0);
+  placeInst("INV_X1",
+            "anchor_ur",
+            kExtent - static_cast<int>(m->getWidth()),
+            kExtent - static_cast<int>(m->getHeight()));
+
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  odb::dbNet* net = odb::dbNet::create(block_, "seam_pin");
+  odb::dbBTerm* bterm = odb::dbBTerm::create(net, "seam_pin");
+  bterm->setIoType(odb::dbIoType::INPUT);
+  odb::dbBPin* bpin = odb::dbBPin::create(bterm);
+  odb::dbBox::create(bpin, metal1, kApX - 20, kApY - 20, kApX + 20, kApY + 20);
+  bpin->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  odb::dbAccessPoint* ap = odb::dbAccessPoint::create(bpin);
+  ASSERT_NE(ap, nullptr);
+  ap->setPoint(odb::Point(kApX, kApY));
+  ap->setLayer(metal1);
+  ap->setAccess(true, odb::dbDirection::EAST);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+  const odb::Rect b = tile_gen_->getBounds();
+  const int seam = (b.xMin() + b.xMax()) / 2;
+  ASSERT_GT(kApX, seam - 50)
+      << "access point must be within marker reach of the "
+         "seam for this test to mean anything";
+  ASSERT_LT(kApX, seam) << "access point must sit inside the LEFT tile";
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.access_points = true;
+
+  auto green_px = [&](int tx) {
+    unsigned w = 0;
+    unsigned h = 0;
+    auto px = decodePng(
+        tile_gen_->generateTile("_access_points", 1, tx, 1, vis), w, h);
+    int n = 0;
+    for (size_t i = 0; i + 3 < px.size(); i += 4) {
+      if (px[i + 3] > 0 && px[i] == 0 && px[i + 1] == 255 && px[i + 2] == 0) {
+        ++n;
+      }
+    }
+    return n;
+  };
+  EXPECT_GT(green_px(0), 0)
+      << "left tile (owns the centre) must draw the marker";
+  EXPECT_GT(green_px(1), 0)
+      << "right tile drew nothing: the leg crossing the seam is being dropped, "
+         "so the X renders chopped";
+}
+
+// Below the legibility limit the overlay DECIMATES instead of hiding (this
+// replaces the old Qt-parity behaviour of showing nothing: a manufacturing grid
+// is so much finer than a die that the Qt rule made the overlay unreachable in
+// practice — see the PR #10806 review).  What is drawn there is a subgrid.
+TEST_F(TileGeneratorTest, MfgGridDecimatesBelowLodInsteadOfHiding)
+{
+  ASSERT_TRUE(getDb()->getTech()->hasManufacturingGrid());
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  // z=0: whole design in one tile, so the raw 10 DBU grid is far below one
+  // pixel — the old code returned an empty tile here.
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.mfg_grid = true;
+  unsigned w = 0;
+  unsigned h = 0;
+  auto pixels
+      = decodePng(tile_gen_->generateTile("_mfg_grid", 0, 0, 0, vis), w, h);
+  ASSERT_TRUE(hasNonTransparentPixel(pixels))
+      << "the grid must stay reachable at zoom-out via decimation";
+
+  // And it must be a readable lattice, not a smear: consecutive dot columns
+  // have to sit at least ~kMinViewablePx apart.
+  const int iw = static_cast<int>(w);
+  std::set<int> cols;
+  for (int y = 0; y < static_cast<int>(h); ++y) {
+    for (int x = 0; x < iw; ++x) {
+      if (pixels[(static_cast<size_t>(y) * iw + x) * 4 + 3] > 0) {
+        cols.insert(x);
+      }
+    }
+  }
+  ASSERT_GE(cols.size(), 2u) << "expected several dot columns";
+  // Measure the PERIOD between dots (distance between the starts of runs of
+  // contiguous lit columns), not the gap between lit columns: each dot is
+  // itself a couple of pixels wide, so the gap understates the spacing.
+  std::vector<int> run_starts;
+  int prev = -2;
+  for (const int c : cols) {
+    if (c != prev + 1) {
+      run_starts.push_back(c);
+    }
+    prev = c;
+  }
+  ASSERT_GE(run_starts.size(), 2u) << "expected at least two dot columns";
+  int min_period = iw;
+  for (size_t i = 1; i < run_starts.size(); ++i) {
+    min_period = std::min(min_period, run_starts[i] - run_starts[i - 1]);
+  }
+  EXPECT_GE(min_period, static_cast<int>(kMinViewablePxForTest))
+      << "dot period is " << min_period
+      << " px — that is a smear, not a readable grid";
+}
+
+// "Detailed view" tightens the decimation target from kMinViewablePx (5 px) to
+// kDetailedGridPx (4 px), so the lattice gets denser and closer to the real
+// manufacturing grid — mirroring what the toggle already does to shapes.  It
+// deliberately stops short of a 1 px target: that lights every pixel of the
+// tile, and the raw grid's loop is O(points in tile), unbounded at zoom-out.
+TEST_F(TileGeneratorTest, MfgGridDenserUnderDetailedView)
+{
+  ASSERT_TRUE(getDb()->getTech()->hasManufacturingGrid());
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  auto dots = [&](bool detailed) {
+    TileVisibility vis;
+    vis.stdcells = false;
+    vis.mfg_grid = true;
+    vis.detailed = detailed;
+    unsigned w = 0;
+    unsigned h = 0;
+    auto px
+        = decodePng(tile_gen_->generateTile("_mfg_grid", 0, 0, 0, vis), w, h);
+    return static_cast<int>(countNonTransparentPixels(px));
+  };
+  const int off = dots(false);
+  const int on = dots(true);
+  ASSERT_GT(off, 0) << "baseline grid must be visible via decimation";
+  EXPECT_GT(on, off) << "detailed view must draw a denser lattice (" << on
+                     << " vs " << off << " dots)";
+  // Denser must still be a lattice: with a tighter target the dots merge into a
+  // solid sheet that hides the design, so cap the coverage well below full.
+  const int tile_px = kTileSize * kTileSize;
+  EXPECT_LT(on, tile_px / 2)
+      << "detailed grid covers " << on << " of " << tile_px
+      << " pixels — that is a solid sheet, not a grid";
+}
+
+// The decimation step must depend only on the zoom, never on the tile, or
+// neighbouring tiles would land on different lattices and the seam would jump.
+TEST_F(TileGeneratorTest, MfgGridLatticeIsSeamlessAcrossTiles)
+{
+  ASSERT_TRUE(getDb()->getTech()->hasManufacturingGrid());
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.mfg_grid = true;
+
+  // Two horizontally adjacent tiles at the same zoom.  Their dot rows must
+  // coincide: same absolute lattice, so the same y positions light up.
+  unsigned w = 0;
+  unsigned h = 0;
+  auto left
+      = decodePng(tile_gen_->generateTile("_mfg_grid", 1, 0, 0, vis), w, h);
+  auto right
+      = decodePng(tile_gen_->generateTile("_mfg_grid", 1, 1, 0, vis), w, h);
+  const int iw = static_cast<int>(w);
+  auto rows = [&](const std::vector<unsigned char>& px) {
+    std::set<int> r;
+    for (int y = 0; y < static_cast<int>(h); ++y) {
+      for (int x = 0; x < iw; ++x) {
+        if (px[(static_cast<size_t>(y) * iw + x) * 4 + 3] > 0) {
+          r.insert(y);
+          break;
+        }
+      }
+    }
+    return r;
+  };
+  const std::set<int> lr = rows(left);
+  const std::set<int> rr = rows(right);
+  ASSERT_FALSE(lr.empty());
+  ASSERT_FALSE(rr.empty());
+  EXPECT_EQ(lr, rr)
+      << "dot rows differ between adjacent tiles — the lattice is "
+         "tile-dependent and the seam will visibly jump";
+}
+
+//------------------------------------------------------------------------------
+// Die / core outline tests (_instances pass, always on — Qt parity)
+//------------------------------------------------------------------------------
+
+TEST_F(TileGeneratorTest, DieAndCoreOutlinesOnInstancesLayer)
+{
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+  block_->setCoreArea(odb::Rect(500, 500, 3500, 3500));
+  placeInst("BUF_X16", "buf1", 0, 0);  // anchor block bbox
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  // Everything hidden — only the die/core outlines may remain.
+  TileVisibility vis;
+  vis.stdcells = false;
+  auto png = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+
+  EXPECT_TRUE(hasNonTransparentPixel(pixels))
+      << "Die/core outlines should be drawn on the _instances pass";
+  EXPECT_FALSE(hasNonOutlinePixel(pixels))
+      << "Only the gray outline color may be visible";
+
+  // Two nested frames -> some row crosses 4 vertical outline pixels
+  // (die left/right + core left/right).  Find a row with >= 4 gray pixels.
+  // Alpha varies with the decimation coverage, so only the RGB is matched.
+  int max_gray_in_row = 0;
+  for (unsigned yy = 0; yy < h; ++yy) {
+    int gray = 0;
+    for (unsigned xx = 0; xx < w; ++xx) {
+      const size_t i = 4UL * (yy * w + xx);
+      if (pixels[i] == 128 && pixels[i + 1] == 128 && pixels[i + 2] == 128
+          && pixels[i + 3] > 0) {
+        ++gray;
+      }
+    }
+    max_gray_in_row = std::max(max_gray_in_row, gray);
+  }
+  EXPECT_GE(max_gray_in_row, 4)
+      << "Expected die + core vertical edges crossing the same row";
+}
+
+TEST_F(TileGeneratorTest, NoOutlineOnTechLayerTiles)
+{
+  // Guard against the regression that motivated the original multi-die-only
+  // gating: tech-layer tiles must stay transparent (no gray frame).
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+  block_->setCoreArea(odb::Rect(500, 500, 3500, 3500));
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.routing = false;
+  vis.special_nets = false;
+  vis.pins = false;
+  vis.inst_pins = false;
+  vis.blockages = false;
+  auto png = tile_gen_->generateTile("metal1", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels))
+      << "Tech-layer tiles must not carry the die/core outline";
+}
+
+//------------------------------------------------------------------------------
+// GCell-grid overlay tests (_gcell_grid pseudo-layer)
+//------------------------------------------------------------------------------
+
+TEST_F(TileGeneratorTest, GcellGridGatedByFlag)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);  // anchor block bbox
+
+  // Create a GCell grid the same way grt does (absolute-DBU patterns).
+  odb::dbGCellGrid* grid = odb::dbGCellGrid::create(block_);
+  ASSERT_NE(grid, nullptr);
+  grid->addGridPatternX(0, 5, 1000);
+  grid->addGridPatternY(0, 5, 1000);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  unsigned w = 0, h = 0;
+
+  // No LOD: grid lines render even at z=0 (unlike the mfg grid).
+  TileVisibility vis_on;
+  vis_on.stdcells = false;
+  vis_on.gcell_grid = true;
+  auto png_on = tile_gen_->generateTile("_gcell_grid", 0, 0, 0, vis_on);
+  auto pixels_on = decodePng(png_on, w, h);
+  EXPECT_TRUE(hasNonTransparentPixel(pixels_on))
+      << "GCell grid lines should render when vis.gcell_grid is true";
+
+  // Flag off → transparent.
+  TileVisibility vis_off;
+  vis_off.stdcells = false;
+  vis_off.gcell_grid = false;
+  auto png_off = tile_gen_->generateTile("_gcell_grid", 0, 0, 0, vis_off);
+  auto pixels_off = decodePng(png_off, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels_off))
+      << "GCell grid should be hidden when vis.gcell_grid is false";
+}
+
+TEST_F(TileGeneratorTest, GcellGridClosedAtDieBoundary)
+{
+  // The dbGCellGrid stores only the gcell START edges, so the top/right
+  // die edges have no grid line.  The web renderer must close the mesh at
+  // the die boundary (the Qt GUI gets this from its separate die outline).
+  block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
+  placeInst("BUF_X16", "buf1", 0, 0);  // bbox ~7000 DBU wide, die inside tile
+
+  odb::dbGCellGrid* grid = odb::dbGCellGrid::create(block_);
+  ASSERT_NE(grid, nullptr);
+  // Single interior line per axis at 2000 — far from the die top/right.
+  grid->addGridPatternX(2000, 1, 1);
+  grid->addGridPatternY(2000, 1, 1);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.gcell_grid = true;
+  auto png = tile_gen_->generateTile("_gcell_grid", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+
+  // Count rows containing a long horizontal run of white pixels: expect 3
+  // (die bottom edge, interior line at y=2000, die top edge).  Vertical
+  // lines only contribute isolated pixels per row, so a >=20px run filter
+  // isolates the horizontal lines.
+  // A single 1-CSS-px line lands on more than one output row: the tile is
+  // rasterized supersampled and Lanczos-decimated, which spreads each line
+  // over ~3 rows with partial alpha.  Count contiguous BANDS of such rows,
+  // not the rows themselves.
+  int bands = 0;
+  bool in_band = false;
+  for (unsigned yy = 0; yy < h; ++yy) {
+    int run = 0, best = 0;
+    for (unsigned xx = 0; xx < w; ++xx) {
+      const size_t i = 4UL * (yy * w + xx);
+      // Alpha varies with the decimation coverage; match the RGB only.
+      const bool white = pixels[i] == 255 && pixels[i + 1] == 255
+                         && pixels[i + 2] == 255 && pixels[i + 3] > 0;
+      run = white ? run + 1 : 0;
+      best = std::max(best, run);
+    }
+    const bool row_has_line = best >= 20;
+    if (row_has_line && !in_band) {
+      ++bands;
+    }
+    in_band = row_has_line;
+  }
+  EXPECT_EQ(bands, 3)
+      << "Expected bottom edge + interior line + top edge horizontal lines";
+}
+
+TEST_F(TileGeneratorTest, GcellGridAbsentWithoutGrid)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);
+  // No dbGCellGrid created (pre-global-route design) → nothing to draw.
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.gcell_grid = true;
+  auto png = tile_gen_->generateTile("_gcell_grid", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels))
+      << "GCell grid layer should be empty when the block has no grid";
+}
+
+// The per-block gcell cache is only correct as long as the grid it copied is
+// unchanged, so it must be dropped on a design change, not only on a design
+// reload.  Rerouting a live session changes the grid (global_route replaces the
+// patterns), and before the fix the overlay kept drawing the OLD lattice until
+// the page was reloaded (reported on the PR #10806 review).
+TEST_F(TileGeneratorTest, GcellGridCacheInvalidatedOnDesignChange)
+{
+  constexpr int kExtent = 10000;
+  block_->setDieArea(odb::Rect(0, 0, kExtent, kExtent));
+  placeInst("BUF_X16", "buf1", 0, 0);
+
+  // A coarse grid: 2 lines per axis.
+  odb::dbGCellGrid* grid = odb::dbGCellGrid::create(block_);
+  ASSERT_NE(grid, nullptr);
+  grid->addGridPatternX(0, 2, 5000);
+  grid->addGridPatternY(0, 2, 5000);
+
+  makeTileGen();
+  tile_gen_->eagerInit();  // also installs the design-changed hook
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.gcell_grid = true;
+
+  // First render copies the coarse grid into the cache.
+  unsigned w = 0, h = 0;
+  auto pixels_before
+      = decodePng(tile_gen_->generateTile("_gcell_grid", 0, 0, 0, vis), w, h);
+  const size_t lit_before = countNonTransparentPixels(pixels_before);
+  ASSERT_GT(lit_before, 0u) << "the coarse grid should be drawn";
+
+  // Reroute: a much finer grid, plus the routing whose odb callback is what
+  // announces the design change (Search::inDbSWireCreate -> clearShapes ->
+  // on_modified).  Dropping the PNG cache alone is not enough here — the
+  // overlay cache still holds the coarse lattice.
+  grid->addGridPatternX(0, 40, 250);
+  grid->addGridPatternY(0, 40, 250);
+
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  odb::dbNet* net = odb::dbNet::create(block_, "grt_special");
+  net->setSpecial();
+  odb::dbSWire* swire = odb::dbSWire::create(net, odb::dbWireType::ROUTED);
+  ASSERT_NE(swire, nullptr);
+  odb::dbSBox::create(
+      swire, metal1, 0, 0, 1000, 100, odb::dbWireShapeType::NONE);
+
+  auto pixels_after
+      = decodePng(tile_gen_->generateTile("_gcell_grid", 0, 0, 0, vis), w, h);
+  EXPECT_GT(countNonTransparentPixels(pixels_after), lit_before)
+      << "the re-created, denser grid must replace the cached one";
+}
+
+// toPxX/toPxY saturate each axis on its own, so feeding them a segment whose
+// endpoints are far outside the tile used to CHANGE ITS SLOPE (only one axis
+// clipped) instead of shortening it.  Flight lines therefore have to go through
+// the double conversion + drawLineF (reported on the PR #10806 review).
+TEST_F(TileGeneratorTest, FlywireSlopePreservedAtExtremeZoom)
+{
+  constexpr int kSpan = 100000;
+  block_->setDieArea(odb::Rect(0, 0, kSpan, kSpan));
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  // Pick an exact DBU point on the bounds' diagonal, then ask for the tile that
+  // contains it — aiming at a fixed tile index instead would not work, because
+  // beyond z~17 a tile is narrower than one DBU and an odb::Point cannot be
+  // placed inside a chosen one.
+  //
+  // The segment must be SHALLOW, not diagonal: saturating both axes at the same
+  // +/-1e7 turns any segment into a 45-degree one, so a 45-degree input is the
+  // single slope the old conversion happened to get right.  Here dy is an
+  // eighth of dx, and both endpoints are far enough out (~10^8 px at z=15) that
+  // both axes used to saturate.
+  constexpr int kZoom = 15;
+  constexpr int kSlopeDivisor = 8;
+  const odb::Rect bounds = tile_gen_->getBounds();
+  const int num_tiles = 1 << kZoom;
+  const double tile_dbu = bounds.maxDXDY() / static_cast<double>(num_tiles);
+  // Offsets are relative to the bounds, which follow the block BBox (and so the
+  // instance above), not the die area.
+  const int diag_offset = bounds.maxDXDY() / 4;
+  const int far = 100 * bounds.maxDXDY();
+  const odb::Point on_diagonal(bounds.xMin() + diag_offset,
+                               bounds.yMin() + diag_offset);
+  // Same index on both axes, so the tile origin is on the bounds' diagonal too.
+  const int tile_idx = static_cast<int>(diag_offset / tile_dbu);
+  ASSERT_LT(tile_idx, num_tiles);
+  const std::vector<FlightLine> lines
+      = {FlightLine{.p1 = odb::Point(on_diagonal.x() - far,
+                                     on_diagonal.y() - far / kSlopeDivisor),
+                    .p2 = odb::Point(on_diagonal.x() + far,
+                                     on_diagonal.y() + far / kSlopeDivisor),
+                    .color = Color{.r = 255, .g = 255, .b = 0, .a = 255}}};
+
+  // Leaflet y counts from the top, hence the flip on the y index only.
+  auto png = tile_gen_->generateOverlayTile(kZoom,
+                                            tile_idx,
+                                            num_tiles - 1 - tile_idx,
+                                            /*highlight_rects=*/{},
+                                            /*highlight_polys=*/{},
+                                            /*colored_rects=*/{},
+                                            lines);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  ASSERT_GT(w, 0u);
+
+  // The segment crosses the whole tile, so it must span the full width while
+  // rising only about 1/kSlopeDivisor of it.  A rotated (45-degree) segment
+  // would span both dimensions equally.
+  int min_x = static_cast<int>(w);
+  int max_x = -1;
+  int min_y = static_cast<int>(h);
+  int max_y = -1;
+  for (unsigned yy = 0; yy < h; ++yy) {
+    for (unsigned xx = 0; xx < w; ++xx) {
+      if (pixels[4UL * (yy * w + xx) + 3] == 0) {
+        continue;
+      }
+      min_x = std::min(min_x, static_cast<int>(xx));
+      max_x = std::max(max_x, static_cast<int>(xx));
+      min_y = std::min(min_y, static_cast<int>(yy));
+      max_y = std::max(max_y, static_cast<int>(yy));
+    }
+  }
+  ASSERT_GE(max_x, 0) << "the flywire must cross the requested tile";
+  const int x_span = max_x - min_x + 1;
+  const int y_span = max_y - min_y + 1;
+  EXPECT_GT(x_span, static_cast<int>(w) / 2)
+      << "the segment should run across the tile";
+  // Half-way between the true ratio (1/8) and the rotated one (1/1).
+  EXPECT_LT(y_span * 4, x_span)
+      << "the segment's slope must survive the DBU->pixel conversion";
 }
 
 TEST_F(TileGeneratorTest, InvalidLayerProducesValidPng)
@@ -2292,7 +3066,8 @@ TEST_F(RowRenderingTest, RowHiddenWhenSiteNotVisible)
   auto png = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
   unsigned w = 0, h = 0;
   auto pixels = decodePng(png, w, h);
-  EXPECT_FALSE(hasNonTransparentPixel(pixels))
+  // Ignore the always-on gray die/core outline (Qt parity).
+  EXPECT_FALSE(hasNonOutlinePixel(pixels))
       << "Row should be hidden when its site is not in the visibility list";
 }
 
@@ -2812,13 +3587,24 @@ TEST_F(MoireArrayTest, BumpArrayBelowThresholdCulledUniformlyAcrossTileSeam)
   const int iw = static_cast<int>(w);
   const int ih = static_cast<int>(h);
 
+  // The _instances pass also draws the always-on gray die/core outline (Qt
+  // drawChip parity).  That isn't array coverage, so exclude it: neutral
+  // gray at any alpha (the supersampled render is decimated, so outline
+  // pixels come back with partial coverage).
+  auto is_array_pixel = [](const unsigned char* p) {
+    if (p[3] == 0) {
+      return false;
+    }
+    return p[0] != 128 || p[1] != 128 || p[2] != 128;
+  };
+
   auto coverage = [&](const std::vector<unsigned char>& px, int xa, int xb) {
     int nz = 0;
     int tot = 0;
     for (int y = 0; y < ih; ++y) {
       for (int x = xa; x < xb; ++x) {
         ++tot;
-        if (px[(static_cast<size_t>(y) * iw + x) * 4 + 3] > 0) {
+        if (is_array_pixel(&px[(static_cast<size_t>(y) * iw + x) * 4])) {
           ++nz;
         }
       }
@@ -2836,13 +3622,13 @@ TEST_F(MoireArrayTest, BumpArrayBelowThresholdCulledUniformlyAcrossTileSeam)
   for (int y = 0; y < ih; ++y) {
     for (int x = iw - 4; x < iw; ++x) {  // left tile, right edge
       ++seam_tot;
-      if (left[(static_cast<size_t>(y) * iw + x) * 4 + 3] > 0) {
+      if (is_array_pixel(&left[(static_cast<size_t>(y) * iw + x) * 4])) {
         ++seam_nz;
       }
     }
     for (int x = 0; x < 4; ++x) {  // right tile, left edge
       ++seam_tot;
-      if (right[(static_cast<size_t>(y) * iw + x) * 4 + 3] > 0) {
+      if (is_array_pixel(&right[(static_cast<size_t>(y) * iw + x) * 4])) {
         ++seam_nz;
       }
     }


### PR DESCRIPTION
Addresses a portion of https://github.com/The-OpenROAD-Project/OpenROAD/issues/10619


### 2.5 Display controls — overlays, grids & misc

| Feature | GUI | Web | Status |
|---|---|---|---|
| **Access points** | `drawAccessPoints` | `drawAccessPointsLayer()` (`_access_points` layer, green/red X, `inst_pins` gate, sub-pixel LOD) | ❌ → ✅ |
| **Regions (dbRegion)** | `drawRegions` | `drawRegionsLayer()` (`_regions` layer, default-on, gated by `has_regions` in the tech response) | ❌ → ✅ |
| **Manufacturing grid** | `drawManufacturingGrid` | `drawMfgGridLayer()` (absolute grid multiples, 5px-per-point LOD) | ❌ → ✅ |
| **GCell grid** | `drawGCellGrid` | `drawGcellGridLayer()` (clipped to die, mesh closed at the die boundary) | ❌ → ✅ |
| **Flywires / flywires-only** | `isFlywireHighlightOnly()` | `collectNetFlightLines()` + `flywires_only` toggle; unrouted nets now show flywires with the toggle off (GUI fallback parity) | ❌ → ✅ |
| **Die / core outline** (related) | `drawChip` | always drawn on the `_instances` pass for single-die designs | ❌ → ✅ |
| **Detailed view** | yes | — | ❌ |
| **Focused-nets guides** toggle | yes | guides via inspector, no global toggle | 🟡 |
| **Highlight selected** | yes | selection highlight always on, no gate | 🟡 |
| Module view | yes | `_modules` layer | ✅ |
| Scale bar | yes | client-side | 🟡 |
| Background color | yes | theme-driven | 🟡 |
| Save/restore display state via Tcl | `save/restore_display_controls` | cookies only | ❌ |


