### PR TITLE
bazel: stub ld.lld's libxml2.so.2 via toolchains_llvm; add etc/bazel-hermetic

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -103,6 +103,23 @@ git_override(
 ## Downstream consumers must configure their own C++ toolchain.
 bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 
+# Prebuilt LLVM ld.lld dynamically links libxml2.so.2; hosts whose libxml2
+# is 2.14+ (soname libxml2.so.16 — Ubuntu 25.10+, Arch, Fedora 41+) cannot
+# run it. This override adds `libxml2_stub` support to toolchains_llvm,
+# which writes a stub lib/libxml2.so.2 into the downloaded distribution
+# (see llvm.toolchain below). Feature PR with details and verification:
+# https://github.com/bazel-contrib/toolchains_llvm/pull/795
+#
+# LLVM release binaries link libxml2 statically starting with LLVM 23.1.0
+# (scheduled 2026-08-25). Once this project moves to LLVM >= 23.1.0, delete
+# this override and the libxml2_stub attribute.
+archive_override(
+    module_name = "toolchains_llvm",
+    sha256 = "a13800df1525a710f770a95cd083318063b2afa599e6cb5ecc910f80e0bc78a5",
+    strip_prefix = "toolchains_llvm-5ccf76e92b5404f21bdb825e5f3ef4bd44e28cd7",
+    urls = ["https://github.com/bazel-contrib/toolchains_llvm/archive/5ccf76e92b5404f21bdb825e5f3ef4bd44e28cd7.tar.gz"],
+)
+
 # --- Dev dependencies (not propagated to downstream consumers) ---
 
 bazel_dep(name = "aspect_rules_lint", version = "2.5.2", dev_dependency = True)
@@ -168,6 +185,9 @@ llvm = use_extension(
     dev_dependency = True,
 )
 llvm.toolchain(
+    # Stub out ld.lld's libxml2.so.2 dependency; see the toolchains_llvm
+    # archive_override above.
+    libxml2_stub = True,
     llvm_version = "20.1.8",
 )
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -458,6 +458,8 @@
     "https://bcr.bazel.build/modules/grpc/1.69.0/source.json": "82e5cd0eeed569909ff42fd6946b813c8b69fc71a6b075ccebef224937e19215",
     "https://bcr.bazel.build/modules/harfbuzz/11.0.1.bcr.1/MODULE.bazel": "4b0942d58350d56889a7b84348dd9b83ed02845a301c1197c55e1be16a97779b",
     "https://bcr.bazel.build/modules/harfbuzz/11.0.1.bcr.1/source.json": "91f26cabe47d52379cf596809c66e3238f53fb417d5b9e237ee999cc93d7956f",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.4.3/MODULE.bazel": "9c20052fd3f1fb767c48b78c1bbc46f501a4ca69d14558429d1234e68e449f68",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.4.3/source.json": "e8c54d81e72633fb6f1d23c7e2d44e0b39b1caef2a256141136a2f63e6204b78",
     "https://bcr.bazel.build/modules/highs/1.11.0/MODULE.bazel": "f820e7fc99bd332d5133502c49f3ff35c754566ae593b4cf5c91931c8d122f9b",
     "https://bcr.bazel.build/modules/highs/1.11.0/source.json": "122976647568ee73c10d15078f4554624ce9c390ee3d9f2a5dcb0b95b63a782b",
     "https://bcr.bazel.build/modules/icu/76.1.bcr.3/MODULE.bazel": "0af631e5c94380fcf75cc779cd4d66352fb23deba224f6ac0d3f32933b5698d4",
@@ -625,7 +627,6 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.18/MODULE.bazel": "4460ec36adc8f722a6a2a4ac9374cb91f2acebadaa93fc37966129afb3dece87",
     "https://bcr.bazel.build/modules/rules_cc/0.2.18/source.json": "abad668ff2fd63ada1ac49bf386d37e27048b89a3465a6fd968bb832b00a09d3",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.2/MODULE.bazel": "a0656c5a8ff7f76bb1319ebf301bab9d94da5b48894cac25a14ed115f9dd0884",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
@@ -803,8 +804,6 @@
     "https://bcr.bazel.build/modules/tcl_lang/9.0.2.bcr.1/source.json": "fac478c17b901d1b168339ed49881e5883fac98bb9397586300d3ca2ed5cefa8",
     "https://bcr.bazel.build/modules/tcmalloc/0.0.0-20250927-12f2552/MODULE.bazel": "b702a6b6806b1041d84918c5098b765b204261647f8cb3e75e0f439106b65ddd",
     "https://bcr.bazel.build/modules/tcmalloc/0.0.0-20250927-12f2552/source.json": "a6f5da61dd65e3f2f7380b4f52dd4b0f771a5b6ba9db7b46be7c28c52bc7af58",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.5.0/MODULE.bazel": "31c7077ef64bafdf2dfb46d4bca321b4e8f143b00ac68b2c31f5ff0c91044b60",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.5.0/source.json": "aecbd0eea924f27bf8d33d3823f1427e1eddc826ff96425e4304b0d7ad6d7ffa",
     "https://bcr.bazel.build/modules/upb/0.0.0-20211020-160625a/MODULE.bazel": "6cced416be2dc5b9c05efd5b997049ba795e5e4e6fafbe1624f4587767638928",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
@@ -2439,83 +2438,27 @@
         ]
       }
     },
-    "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
+    "@@toolchains_llvm+//toolchain/extensions:distributions.bzl%llvm_distributions": {
       "general": {
-        "bzlTransitiveDigest": "SFT0LhY0ioB2PsbncmTCGyGh8M0OtAJ2fCq0fHtf7ps=",
-        "usagesDigest": "ZuaBuvEE8efZLVQ2tR8Vbv3podpYbZjO703SKYIAb4g=",
+        "bzlTransitiveDigest": "gCdXpBt3HBBc280OILOFheHmO7lXWXJYnPgYiTtyapI=",
+        "usagesDigest": "3B/1Qf38oum/lRpBvi3mnJwV6XMAQF+4//DH0B29rNA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "llvm_toolchain_llvm": {
-            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
+          "llvm_distributions_data": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain/internal:distributions_repo.bzl%llvm_distributions_repo",
             "attributes": {
-              "alternative_llvm_sources": [],
-              "auth_patterns": {},
-              "distribution": "auto",
-              "exec_arch": "",
-              "exec_os": "",
-              "extra_llvm_distributions": {},
-              "libclang_rt": {},
-              "llvm_mirror": "",
-              "llvm_version": "20.1.8",
-              "llvm_versions": {},
-              "netrc": "",
-              "sha256": {},
-              "strip_prefix": {},
-              "urls": {}
-            }
-          },
-          "llvm_toolchain": {
-            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
-            "attributes": {
-              "absolute_paths": false,
-              "archive_flags": {},
-              "compile_flags": {},
-              "conly_flags": {},
-              "coverage_compile_flags": {},
-              "coverage_link_flags": {},
-              "cxx_builtin_include_directories": {},
-              "cxx_flags": {},
-              "cxx_standard": {},
-              "dbg_compile_flags": {},
-              "exec_arch": "",
-              "exec_os": "",
-              "extra_exec_compatible_with": {},
-              "extra_target_compatible_with": {},
-              "fastbuild_compile_flags": {},
-              "link_flags": {},
-              "link_libs": {},
-              "llvm_versions": {
-                "": "20.1.8"
-              },
-              "opt_compile_flags": {},
-              "opt_link_flags": {},
-              "stdlib": {},
-              "target_settings": {},
-              "unfiltered_compile_flags": {},
-              "toolchain_roots": {},
-              "sysroot": {}
+              "srcs": [
+                "@@toolchains_llvm+//toolchain/distributions:pre_github.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:github_legacy.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:github.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:extra.jsonc"
+              ]
             }
           }
         },
-        "recordedRepoMappingEntries": [
-          [
-            "toolchains_llvm+",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
-          [
-            "toolchains_llvm+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "toolchains_llvm+",
-            "toolchains_llvm",
-            "toolchains_llvm+"
-          ]
-        ]
+        "recordedRepoMappingEntries": []
       }
     },
     "@@yosys-slang+//:dependency_support/slang_ext.bzl%vendored_slang_extension": {

--- a/etc/bazel-hermetic
+++ b/etc/bazel-hermetic
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Launch bazel in a pruned environment so that toolchains and tools the
+# build is supposed to provide hermetically cannot be picked up from the
+# host. This is a ratchet, not a proof: it removes host compilers,
+# linkers and interpreters from PATH and disables Bazel's local C++
+# toolchain autodetection, but the C++ toolchain still compiles against
+# the host glibc sysroot (/usr/include, /usr/lib), and Bazel itself,
+# a JVM-independent binary, comes from the host.
+#
+# Usage: etc/bazel-hermetic <command> [args...]
+#    e.g. etc/bazel-hermetic build //:openroad
+#
+# The allowlist below is the contract for what the build may use from the
+# host. Grow it only with a comment stating which repository rule or
+# action needs the entry and why bazel cannot provide it.
+set -euo pipefail
+
+# Base shell utilities: repository rules (patch_cmds, configure scripts of
+# module extensions) run through /bin/sh and expect a POSIX userland.
+ALLOWED_TOOLS=(
+  bash sh env
+  basename dirname readlink realpath pwd
+  cat cp ln ls mkdir mktemp mv rm rmdir touch chmod stat find
+  cut grep head sed sort tail tr uniq wc od printf true false test expr sleep
+  awk                # module extension configure steps
+  diff cmp patch     # single_version_override / archive_override patches
+  tar gzip bzip2 xz zstd unzip  # archive extraction fallbacks
+  uname id hostname date which getconf nproc
+  git                # tools/workspace_status.sh embeds version info
+  gh                 # optional; used by some developer workflows
+)
+
+TOOLBOX=$(mktemp -d "${TMPDIR:-/tmp}/bazel-hermetic.XXXXXX")
+trap 'rm -rf "${TOOLBOX}"' EXIT
+
+for tool in "${ALLOWED_TOOLS[@]}"; do
+  if path=$(command -v -- "${tool}" 2>/dev/null); then
+    ln -s "${path}" "${TOOLBOX}/${tool}" 2>/dev/null || true
+  fi
+done
+
+# The bazel binary itself. bazelisk is often a node or shell wrapper whose
+# interpreter must not leak into the pruned PATH, so resolve the real ELF
+# binary it manages (~/.cache/bazelisk) instead of symlinking the wrapper.
+BAZEL=$(command -v bazelisk || command -v bazel) ||
+  { echo >&2 "bazel-hermetic: no bazel or bazelisk on PATH"; exit 1; }
+if [[ $(head -c 4 "$(readlink -f "${BAZEL}")") != $'\x7fELF' ]]; then
+  version=$("${BAZEL}" --version | awk '{print $2}')
+  arch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x86_64/')
+  meta="${HOME}/.cache/bazelisk/downloads/metadata/bazelbuild/bazel-${version}-linux-${arch}"
+  real="${HOME}/.cache/bazelisk/downloads/sha256/$(cat "${meta}" 2>/dev/null)/bin/bazel"
+  [[ -x ${real} ]] ||
+    { echo >&2 "bazel-hermetic: ${BAZEL} is a wrapper and no real bazel-${version} found under ~/.cache/bazelisk"; exit 1; }
+  BAZEL=${real}
+fi
+ln -s "${BAZEL}" "${TOOLBOX}/bazel"
+
+if [[ $# -eq 0 ]]; then
+  echo >&2 "usage: etc/bazel-hermetic [startup flags] <command> [args...]"
+  exit 1
+fi
+
+# Leading --flags are bazel startup options (e.g. --output_base=...).
+startup_flags=()
+while [[ $# -gt 0 && $1 == --* ]]; do
+  startup_flags+=("$1")
+  shift
+done
+if [[ $# -eq 0 ]]; then
+  echo >&2 "usage: etc/bazel-hermetic [startup flags] <command> [args...]"
+  exit 1
+fi
+command=$1
+shift
+
+# Flags only exist on build-ish commands; startup flags go before the command.
+extra_flags=()
+case "${command}" in
+  build|test|run|cquery|aquery|coverage|fetch|vendor|sync|mod)
+    extra_flags=(
+      # Fail local C++ toolchain autodetection instead of silently using
+      # /usr/bin/gcc; the hermetic toolchain must win resolution anyway.
+      "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+      # Repository rules and actions see only the allowlisted tools.
+      "--repo_env=PATH=${TOOLBOX}"
+      "--action_env=PATH=${TOOLBOX}"
+    )
+    ;;
+esac
+
+# --nosystem_rc/--nohome_rc: only the workspace .bazelrc applies, so host-
+# specific configuration (e.g. remote caches) cannot mask missing hermeticity.
+exec env -i \
+  HOME="${HOME}" \
+  USER="${USER:-$(id -un)}" \
+  LOGNAME="${LOGNAME:-$(id -un)}" \
+  TERM="${TERM:-dumb}" \
+  LANG=C.UTF-8 \
+  PATH="${TOOLBOX}" \
+  "${TOOLBOX}/bazel" --nosystem_rc --nohome_rc "${startup_flags[@]}" "${command}" "${extra_flags[@]}" "$@"


### PR DESCRIPTION
Fresh approach replacing #9809.

## Problem

Prebuilt LLVM `ld.lld` dynamically links `libxml2.so.2` (used only for Windows COFF manifest merging). libxml2 2.14 changed its soname to `libxml2.so.16`, so on Ubuntu 25.10+/Arch/Fedora 41+ `ld.lld` cannot start without host workarounds (`libxml2-dev` + `sudo ln`), and with a compatibility symlink every link action prints `no version information available`. Upstream: llvm/llvm-project#138225.

## Change

- Consume bazel-contrib/toolchains_llvm#795 by commit hash (`archive_override`): a new `libxml2_stub` attribute writes a stub `lib/libxml2.so.2` into the downloaded LLVM distribution, where `ld.lld`'s `RUNPATH` (`$ORIGIN/../lib`) finds it ahead of any system path. The stub bytes are assembled in pure Starlark and written with `rctx.file` — **no host compiler, linker, python or shell is executed to produce it**, and generation is identical from any host OS (macOS hosts and remote execution included).
- `etc/bazel-hermetic`: launches bazel with an allowlisted PATH (no host compilers/linkers/interpreters), `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1`, and only the workspace bazelrc. Builds fail instead of silently reaching for host toolchains the build should provide. Known boundary, documented in the script: the C++ toolchain still compiles against the host glibc sysroot.

## Expiry

LLVM release binaries link libxml2 statically starting with LLVM 23.1.0 (scheduled 2026-08-25; llvm-project commits 70cf763a42d5, 4d7c1c6b08c0). When this project moves to LLVM >= 23.1.0, delete the `archive_override` and the `libxml2_stub` attribute. The stub is inert the moment binaries stop requesting libxml2.

## Verification

On Ubuntu 26.04 (no usable system libxml2.so.2, no `libxml2-dev`):

- `etc/bazel-hermetic build //src/utl:utl` — compiles and links (409 actions) with `gcc`, `cc`, `clang`, `ld`, `python3` all absent from PATH and local C++ toolchain detection disabled; zero libxml2 diagnostics in the log.
- `readelf -V` on the generated stub shows the `LIBXML2_2.4.30` / `LIBXML2_2.6.0` version definitions; `ld.lld --version` is silent.
- Full-build evidence on a pristine host follows in a comment.

## Type of Change

- Bug fix (build infrastructure)

- [x] I have verified that the local build succeeds
- [x] My code follows the repository's formatting guidelines
- [x] **I have signed my commits (DCO).**