### PR TITLE
test uses private headers: make available and depend on them.

### DIFF
--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -129,7 +129,7 @@ cc_library(
         "src/ta/FlexTA.h",
     ],
     includes = ["src"],
-    visibility = ["//visibility:private"],
+    visibility = ["//src/drt/test:__pkg__"],
     deps = [
         ":base_types",
         ":db_hdrs",

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -162,7 +162,6 @@ cc_test(
         "fixture.h",
         "gcTest.cpp",
     ],
-    features = ["-layering_check"],  # TODO: acceses private headers
     includes = [
         "../src",
     ],
@@ -170,6 +169,7 @@ cc_test(
         "//src/drt",  # build_cleaner: keep for private headers
         "//src/drt:base_types",
         "//src/drt:db_hdrs",
+        "//src/drt:drt_private_hdrs",
         "//src/odb/src/db",
         "//src/utl",
         "@googletest//:gtest",
@@ -189,14 +189,15 @@ cc_test(
         "fixture.h",
         "taTest.cpp",
     ],
-    features = ["-layering_check"],  # TODO: acceses private headers
     includes = [
         "../src",
     ],
     deps = [
-        "//src/drt",
+        # drt only exports header TritonRoute.h, but we need other symbols
+        "//src/drt",  # build_cleaner: keep
         "//src/drt:base_types",
         "//src/drt:db_hdrs",
+        "//src/drt:drt_private_hdrs",
         "//src/odb/src/db",
         "//src/utl",
         "@googletest//:gtest",


### PR DESCRIPTION
But also, we do need to depend on drt as well, as we're using symbols defined there without including any of the headers. So mark as `keep` for now, so that we don't remove it.
