### PR TITLE
bazel: pass git to lint scripts in fix_lint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -666,6 +666,7 @@ sh_binary(
         "$(rootpath @buildifier_prebuilt//:buildifier)",
         "$(rootpath //bazel:bzl_lint_test.sh)",
         "$(rootpath @buildifier_prebuilt//:buildifier)",
+        "$(rootpath @git)",
     ],
     data = [
         "MODULE.bazel",
@@ -677,5 +678,6 @@ sh_binary(
         "//bazel:tclfmt",
         "//bazel:tclint",
         "@buildifier_prebuilt//:buildifier",
+        "@git",
     ],
 )

--- a/bazel/fix_lint.sh
+++ b/bazel/fix_lint.sh
@@ -10,11 +10,11 @@ export BUILD_WORKSPACE_DIRECTORY="${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
 
 # TCL: auto-format then lint
 "$1" "$2"
-"$3" "$4" || rc=$?
+"$3" "$4" "$9" || rc=$?
 
 # Bazel: auto-format then lint
 "$5" "$6"
-"$7" "$8" || rc=$?
+"$7" "$8" "$9" || rc=$?
 
 git -C "$BUILD_WORKSPACE_DIRECTORY" status
 

--- a/bazel/fix_lint.sh
+++ b/bazel/fix_lint.sh
@@ -6,17 +6,27 @@
 # that file-discovery logic is not duplicated (DRY).
 set -euo pipefail
 
+TCL_TIDY_SH="$1"
+TCLFMT="$2"
+TCL_LINT_SH="$3"
+TCLINT="$4"
+BZL_TIDY_SH="$5"
+BZL_FMT_BUILDIFIER="$6"
+BZL_LINT_SH="$7"
+BZL_LINT_BUILDIFIER="$8"
+GIT="$9"
+
 export BUILD_WORKSPACE_DIRECTORY="${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
 
 # TCL: auto-format then lint
-"$1" "$2"
-"$3" "$4" "$9" || rc=$?
+"${TCL_TIDY_SH}" "${TCLFMT}"
+"${TCL_LINT_SH}" "${TCLINT}" "${GIT}" || rc=$?
 
 # Bazel: auto-format then lint
-"$5" "$6"
-"$7" "$8" "$9" || rc=$?
+"${BZL_TIDY_SH}" "${BZL_FMT_BUILDIFIER}"
+"${BZL_LINT_SH}" "${BZL_LINT_BUILDIFIER}" "${GIT}" || rc=$?
 
-git -C "$BUILD_WORKSPACE_DIRECTORY" status
+"${GIT}" -C "$BUILD_WORKSPACE_DIRECTORY" status
 
 if [ "${rc:-0}" -ne 0 ]; then
     echo "Error: lint violations remain that require manual fixes." >&2


### PR DESCRIPTION
`bazelisk run //:fix_lint` has been failing with `bazel/tcl_lint_test.sh: line 10: $2: unbound variable`: the lint scripts take the git binary as their second argument (their `sh_test` wrappers pass `$(rootpath @git)`), but the `//:fix_lint` driver invoked them with only the lint tool. Pass `$(rootpath @git)` through.

## Verification

`bazelisk run //:fix_lint` completes with both lint passes running (verified on top of #10812, since the prebuilt `ld.lld` used by current master cannot start on an Ubuntu 26.04 host without `libxml2.so.2` — the failure #10812 addresses).

## Type of Change

- Bug fix (build infrastructure)

- [x] I have run the relevant tests and they pass
- [x] My code follows the repository's formatting guidelines
- [x] **I have signed my commits (DCO).**