### PR TITLE
Fix the broken slang alias.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -250,7 +250,7 @@ alias(
     visibility = ["//visibility:public"],
 )
 """,
-    path = "bazel",
+    path = "bazel/slang-compat",
 )
 
 # --- Overrides ---

--- a/bazel/slang-compat/README
+++ b/bazel/slang-compat/README
@@ -1,0 +1,3 @@
+Placeholder directory for the @slang alias build
+file to internally manifest.
+(see MODULE.bazel, new_local_repository(name="slang"))


### PR DESCRIPTION
It was using a path 'bazel/', but that path already exists in the main project, so bazel ended up symlinking to that directory. Unclear how that ever worked, or if bazel internally worked around the glitch, but this should fix it.
