### PR TITLE
odb: Replace insert buffer scalar brackets

### DIFF
--- a/src/dbSta/test/cpp/TestReadVerilog.cpp
+++ b/src/dbSta/test/cpp/TestReadVerilog.cpp
@@ -185,4 +185,74 @@ TEST_F(TestReadVerilog, DeepDescendantModBTermCollision)
   EXPECT_EQ(txclk_modnet->getModBTerms().size(), 1u);
 }
 
+TEST_F(TestReadVerilog, EscapedBracketScalarNames)
+{
+  const testing::TestInfo* test_info
+      = testing::UnitTest::GetInstance()->current_test_info();
+  const std::string test_name
+      = std::string(test_info->test_suite_name()) + "_" + test_info->name();
+
+  readVerilogAndSetup(test_name + ".v", /*init_default_sdc=*/false);
+
+  odb::dbBTerm* raw_bterm = block_->findBTerm("foo[3]");
+  odb::dbBTerm* leading_escape_bterm = block_->findBTerm("\\foo[3]");
+  odb::dbBTerm* escaped_bterm = block_->findBTerm("foo\\[3\\]");
+  EXPECT_EQ(raw_bterm, nullptr);
+  EXPECT_EQ(leading_escape_bterm, nullptr);
+  ASSERT_NE(escaped_bterm, nullptr);
+  EXPECT_STREQ(escaped_bterm->getConstName(), "foo\\[3\\]");
+
+  odb::dbModule* child = block_->findModule("child");
+  ASSERT_NE(child, nullptr);
+
+  EXPECT_EQ(child->findModBTerm("foo[3]"), nullptr);
+  EXPECT_EQ(child->findModBTerm("\\foo[3]"), nullptr);
+  odb::dbModBTerm* escaped_modbterm = child->findModBTerm("foo\\[3\\]");
+  ASSERT_NE(escaped_modbterm, nullptr);
+
+  EXPECT_EQ(child->getModNet("foo[3]"), nullptr);
+  EXPECT_EQ(child->getModNet("\\foo[3]"), nullptr);
+  odb::dbModNet* escaped_modnet = child->getModNet("foo\\[3\\]");
+  ASSERT_NE(escaped_modnet, nullptr);
+  EXPECT_EQ(escaped_modbterm->getModNet(), escaped_modnet);
+}
+
+TEST_F(TestReadVerilog, BusBitAndEscapedScalarAreDistinct)
+{
+  const testing::TestInfo* test_info
+      = testing::UnitTest::GetInstance()->current_test_info();
+  const std::string test_name
+      = std::string(test_info->test_suite_name()) + "_" + test_info->name();
+
+  readVerilogAndSetup(test_name + ".v", /*init_default_sdc=*/false);
+
+  odb::dbBTerm* bus_bit_bterm = block_->findBTerm("foo[3]");
+  odb::dbBTerm* leading_escape_bterm = block_->findBTerm("\\foo[3]");
+  odb::dbBTerm* escaped_bterm = block_->findBTerm("foo\\[3\\]");
+  ASSERT_NE(bus_bit_bterm, nullptr);
+  EXPECT_EQ(leading_escape_bterm, nullptr);
+  ASSERT_NE(escaped_bterm, nullptr);
+  EXPECT_NE(bus_bit_bterm, escaped_bterm);
+
+  odb::dbModule* child = block_->findModule("child");
+  ASSERT_NE(child, nullptr);
+
+  odb::dbModBTerm* bus_port = child->findModBTerm("foo");
+  odb::dbModBTerm* bus_bit_port = child->findModBTerm("foo[3]");
+  odb::dbModBTerm* escaped_port = child->findModBTerm("foo\\[3\\]");
+  ASSERT_NE(bus_port, nullptr);
+  ASSERT_NE(bus_bit_port, nullptr);
+  EXPECT_EQ(child->findModBTerm("\\foo[3]"), nullptr);
+  ASSERT_NE(escaped_port, nullptr);
+  EXPECT_NE(bus_bit_port, escaped_port);
+
+  odb::dbModNet* bus_bit_modnet = child->getModNet("foo[3]");
+  odb::dbModNet* escaped_modnet = child->getModNet("foo\\[3\\]");
+  ASSERT_NE(bus_bit_modnet, nullptr);
+  EXPECT_EQ(child->getModNet("\\foo[3]"), nullptr);
+  ASSERT_NE(escaped_modnet, nullptr);
+  EXPECT_NE(bus_bit_modnet, escaped_modnet);
+  EXPECT_EQ(escaped_port->getModNet(), escaped_modnet);
+}
+
 }  // namespace sta

--- a/src/dbSta/test/cpp/TestReadVerilog_BusBitAndEscapedScalarAreDistinct.v
+++ b/src/dbSta/test/cpp/TestReadVerilog_BusBitAndEscapedScalarAreDistinct.v
@@ -1,0 +1,29 @@
+module top (foo,
+    \foo[3] ,
+    out_bus,
+    out_scalar);
+ input [7:0] foo;
+ input \foo[3] ;
+ output out_bus;
+ output out_scalar;
+
+ child u_child (.foo(foo),
+    .\foo[3] (\foo[3] ),
+    .out_bus(out_bus),
+    .out_scalar(out_scalar));
+endmodule
+
+module child (foo,
+    \foo[3] ,
+    out_bus,
+    out_scalar);
+ input [7:0] foo;
+ input \foo[3] ;
+ output out_bus;
+ output out_scalar;
+
+ BUF_X1 bus_load (.A(foo[3]),
+    .Z(out_bus));
+ BUF_X1 scalar_load (.A(\foo[3] ),
+    .Z(out_scalar));
+endmodule

--- a/src/dbSta/test/cpp/TestReadVerilog_EscapedBracketScalarNames.v
+++ b/src/dbSta/test/cpp/TestReadVerilog_EscapedBracketScalarNames.v
@@ -1,0 +1,17 @@
+module top (\foo[3] ,
+    out);
+ input \foo[3] ;
+ output out;
+
+ child u_child (.\foo[3] (\foo[3] ),
+    .out(out));
+endmodule
+
+module child (\foo[3] ,
+    out);
+ input \foo[3] ;
+ output out;
+
+ BUF_X1 load (.A(\foo[3] ),
+    .Z(out));
+endmodule

--- a/src/odb/src/db/dbInsertBuffer.cpp
+++ b/src/odb/src/db/dbInsertBuffer.cpp
@@ -24,6 +24,25 @@
 
 namespace odb {
 
+static std::string replaceBracketsWithUnderscores(std::string_view name)
+{
+  std::string sanitized_name;
+  sanitized_name.reserve(name.size());
+
+  for (size_t i = 0; i < name.size(); i++) {
+    const char ch = name[i];
+    if (ch == '\\' && i + 1 < name.size()
+        && (name[i + 1] == '[' || name[i + 1] == ']')) {
+      sanitized_name += '_';
+      i++;
+      continue;
+    }
+    sanitized_name += (ch == '[' || ch == ']') ? '_' : ch;
+  }
+
+  return sanitized_name;
+}
+
 dbInsertBuffer::dbInsertBuffer(dbNet* net)
     : net_(net),
       block_(net ? net->getBlock() : nullptr),
@@ -495,6 +514,12 @@ dbNet* dbInsertBuffer::createNewFlatNet(
     new_net_uniquify = dbNameUniquifyType::IF_NEEDED;
   }
 
+  if (bterm == nullptr) {
+    // New split nets are scalar wires. Keep their generated names easy to read
+    // by replacing bracket characters before ODB stores the name.
+    new_net_name = replaceBracketsWithUnderscores(new_net_name);
+  }
+
   // Create a new net
   dbNet* new_net = dbNet::create(
       block_, new_net_name.c_str(), new_net_uniquify, target_module_);
@@ -513,7 +538,10 @@ std::string dbInsertBuffer::makeUniqueHierName(const dbModule* module,
                                                const std::string& base_name,
                                                const char* suffix) const
 {
-  std::string name = (suffix == nullptr) ? base_name : base_name + suffix;
+  // insertBuffer only punches scalar hierarchy ports, never bus ports.
+  std::string scalar_base_name = replaceBracketsWithUnderscores(base_name);
+  std::string name
+      = (suffix == nullptr) ? scalar_base_name : scalar_base_name + suffix;
   std::string full = block_->makeNewNetName(
       module, name.c_str(), dbNameUniquifyType::IF_NEEDED_WITH_UNDERSCORE);
   return std::string(block_->getBaseName(full.c_str()));

--- a/src/rsz/test/cpp/TestInsertBuffer.cpp
+++ b/src/rsz/test/cpp/TestInsertBuffer.cpp
@@ -3371,4 +3371,103 @@ TEST_F(TestInsertBuffer, BeforeLoads_Case34)
   writeAndCompareVerilogOutputFile(test_name, test_name + "_post.v");
 }
 
+TEST_F(TestInsertBuffer, BusBitModNetName)
+{
+  const auto* test_info = testing::UnitTest::GetInstance()->current_test_info();
+  const std::string test_name
+      = std::string(test_info->test_suite_name()) + "_" + test_info->name();
+
+  int num_warning = 0;
+  readVerilogAndSetup(test_name + "_pre.v");
+
+  dbMaster* buf_master = db_->findMaster("BUF_X4");
+  ASSERT_NE(buf_master, nullptr);
+
+  dbModule* sub_mod = block_->findModule("SUB");
+  ASSERT_NE(sub_mod, nullptr);
+
+  EXPECT_NE(block_->findBTerm("foo[3]"), nullptr);
+  EXPECT_EQ(block_->findBTerm("\\foo[3]"), nullptr);
+  EXPECT_NE(sub_mod->findModBTerm("foo[3]"), nullptr);
+  EXPECT_EQ(sub_mod->findModBTerm("foo\\[3\\]"), nullptr);
+  EXPECT_EQ(sub_mod->getModNet("foo[3]1"), nullptr);
+  EXPECT_EQ(sub_mod->getModNet("foo\\[3\\]"), nullptr);
+
+  dbNet* flat_net = block_->findNet("foo[3]");
+  ASSERT_NE(flat_net, nullptr);
+  dbITerm* load0_a = block_->findITerm("sub0/load0/A");
+  ASSERT_NE(load0_a, nullptr);
+  ASSERT_EQ(load0_a->getNet(), flat_net);
+  dbITerm* load1_a = block_->findITerm("sub0/child0/load1/A");
+  ASSERT_NE(load1_a, nullptr);
+  ASSERT_EQ(load1_a->getNet(), flat_net);
+
+  odb::PtrSet<dbObject> load_pins;
+  load_pins.insert(load0_a);
+  load_pins.insert(load1_a);
+
+  dbInst* new_buf
+      = flat_net->insertBufferBeforeLoads(load_pins,
+                                          buf_master,
+                                          nullptr,
+                                          "split",
+                                          "foo[3]",
+                                          dbNameUniquifyType::IF_NEEDED,
+                                          false);
+  ASSERT_NE(new_buf, nullptr);
+
+  sta_->updateTiming(true);
+  num_warning = db_network_->checkAxioms();
+  num_warning += sta_->checkSanity();
+  EXPECT_EQ(num_warning, 0);
+
+  std::string mod_net_names;
+  for (dbModNet* mod_net : sub_mod->getModNets()) {
+    if (!mod_net_names.empty()) {
+      mod_net_names += ", ";
+    }
+    mod_net_names += mod_net->getConstName();
+  }
+
+  EXPECT_NE(sub_mod->getModNet("foo_3_"), nullptr)
+      << "The split net is a scalar wire, so bracket characters should be "
+         "replaced in the stored dbModNet name. Existing dbModNet names: "
+      << mod_net_names;
+
+  writeAndCompareVerilogOutputFile(test_name, test_name + "_post.v");
+}
+
+TEST_F(TestInsertBuffer, BusBitBTermName)
+{
+  dbMaster* buf_master = db_->findMaster("BUF_X4");
+  ASSERT_NE(buf_master, nullptr);
+
+  dbNet* orig_net = dbNet::create(block_, "orig");
+  ASSERT_NE(orig_net, nullptr);
+  dbBTerm* bterm = dbBTerm::create(orig_net, "foo[3]");
+  ASSERT_NE(bterm, nullptr);
+  bterm->setIoType(dbIoType::OUTPUT);
+  bterm->connect(orig_net);
+
+  dbInst* drvr = dbInst::create(block_, db_->findMaster("LOGIC0_X1"), "drvr");
+  ASSERT_NE(drvr, nullptr);
+  dbITerm* drvr_z = drvr->findITerm("Z");
+  ASSERT_NE(drvr_z, nullptr);
+  drvr_z->connect(orig_net);
+
+  dbInst* new_buf
+      = orig_net->insertBufferBeforeLoad(bterm, buf_master, nullptr, "output");
+  ASSERT_NE(new_buf, nullptr);
+
+  dbITerm* buf_z = new_buf->findITerm("Z");
+  ASSERT_NE(buf_z, nullptr);
+  dbNet* buf_out_net = buf_z->getNet();
+  ASSERT_NE(buf_out_net, nullptr);
+
+  EXPECT_EQ(bterm->getNet(), buf_out_net);
+  EXPECT_STREQ(buf_out_net->getConstName(), "foo[3]")
+      << "BTerm-derived net names must preserve the port name for Verilog "
+         "compatibility.";
+}
+
 }  // namespace odb

--- a/src/rsz/test/cpp/TestInsertBuffer_BusBitModNetName_post.v
+++ b/src/rsz/test/cpp/TestInsertBuffer_BusBitModNetName_post.v
@@ -1,0 +1,58 @@
+module top (out0,
+    out1,
+    out2,
+    foo);
+ output out0;
+ output out1;
+ output out2;
+ input [7:0] foo;
+
+
+ SUB sub0 (.foo({foo[7],
+    foo[6],
+    foo[5],
+    foo[4],
+    foo[3],
+    foo[2],
+    foo[1],
+    foo[0]}),
+    .out0(out0),
+    .out1(out1),
+    .out2(out2));
+endmodule
+module CHILD (foo,
+    Z);
+ input [7:0] foo;
+ output Z;
+
+
+ BUF_X1 load1 (.A(foo[3]),
+    .Z(Z));
+endmodule
+module SUB (foo,
+    out0,
+    out1,
+    out2);
+ input [7:0] foo;
+ output out0;
+ output out1;
+ output out2;
+
+ wire foo_3_;
+
+ CHILD child0 (.foo({foo[7],
+    foo[6],
+    foo[5],
+    foo[4],
+    foo_3_,
+    foo[2],
+    foo[1],
+    foo[0]}),
+    .Z(out1));
+ BUF_X1 load0 (.A(foo_3_),
+    .Z(out0));
+ BUF_X1 load2 (.A(foo[3]),
+    .Z(out2));
+ BUF_X4 split (.A(foo[3]),
+    .Z(foo_3_));
+endmodule

--- a/src/rsz/test/cpp/TestInsertBuffer_BusBitModNetName_pre.v
+++ b/src/rsz/test/cpp/TestInsertBuffer_BusBitModNetName_pre.v
@@ -1,0 +1,41 @@
+module top (foo,
+    out0,
+    out1,
+    out2);
+ input [7:0] foo;
+ output out0;
+ output out1;
+ output out2;
+
+
+ SUB sub0 (.foo(foo),
+    .out0(out0),
+    .out1(out1),
+    .out2(out2));
+endmodule
+module SUB (foo,
+    out0,
+    out1,
+    out2);
+ input [7:0] foo;
+ output out0;
+ output out1;
+ output out2;
+
+
+ BUF_X1 load0 (.A(foo[3]),
+    .Z(out0));
+ CHILD child0 (.foo(foo),
+    .Z(out1));
+ BUF_X1 load2 (.A(foo[3]),
+    .Z(out2));
+endmodule
+module CHILD (foo,
+    Z);
+ input [7:0] foo;
+ output Z;
+
+
+ BUF_X1 load1 (.A(foo[3]),
+    .Z(Z));
+endmodule


### PR DESCRIPTION
## Summary
- Insert buffer can create a new port and a modnet with bracket characters in their names. But it creates bracket escaping issue.
- To cope with the issue, replaced bracket characters with underscores in generated insert buffer scalar hierarchy port and split-net names.  --> **No more escaping complexity**.
- Insert buffer does not create a new bus port. So this bracket replacement is safe.

## Problem
- Insert buffer hierarchy port punching can generate scalar names derived from bus-bit-like flat net names.
- Preserving raw brackets or escaped brackets in generated scalar names is harder to read and can still confuse name-only consumers.

## Solution
- Add `replaceBracketsWithUnderscores` for generated scalar names.
- Apply it to generated hierarchy port names and generated split flat-net names before ODB stores them.

## Impact
- A generated scalar name derived from `foo[3]` is stored and emitted as `foo_3_`.
