### PR TITLE
Fix writability of 1_synth.sdc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -151,6 +151,7 @@ archive_override(
     patch_strip = 1,
     patches = [
         "//bazel/bazel-orfs-patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
+        "//bazel/bazel-orfs-patches:0036-fix-sdc-readonly.patch",
     ],
     sha256 = "8325c6755215857a87a84db078d47dfbb2dfcbef70eaf0dd376fe5a7a363cd58",
     strip_prefix = "OpenROAD-flow-scripts-" + ORFS_COMMIT,

--- a/bazel/bazel-orfs-patches/0036-fix-sdc-readonly.patch
+++ b/bazel/bazel-orfs-patches/0036-fix-sdc-readonly.patch
@@ -1,0 +1,8 @@
+--- a/flow/scripts/synth_odb.tcl.orig	2026-07-05 16:03:40.847972593 +0200
++++ b/flow/scripts/synth_odb.tcl	2026-07-05 16:03:40.850477641 +0200
+@@ -30,4 +30,5 @@
+ # the user could have dependencies, such as sourcing util.tcl,
+ # which are read in here and a canonicalized version is written
+ # out by OpenSTA that has no dependencies.
++catch {exec chmod +w $::env(RESULTS_DIR)/1_synth.sdc}
+ orfs_write_sdc $::env(RESULTS_DIR)/1_synth.sdc


### PR DESCRIPTION
The `1_synth.sdc` is copied from a template from the bazel input files, which are read-only. The `exec cp` then will copy the file which then is still read-only, thus the subsequent write will fail.

Make the file writable.

(this was discovered attempting to run in an RBE environment where the readonlyness of the inputs is very strict).
