### PR TITLE
dbSta: check LEF/Liberty pin consistency

### DIFF
--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -105,8 +105,10 @@ cc_library(
         "include",
     ],
     deps = [
+        ":dbNetwork",
         ":dbSta",
         "//src/odb/src/db",
+        "//src/sta:opensta_lib",
         "//src/utl",
     ],
 )

--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -119,8 +119,10 @@ cc_library(
         "include",
     ],
     deps = [
+        ":dbNetwork",
         ":dbSta",
         "//src/odb/src/db",
+        "//src/sta:opensta_lib",
         "//src/utl",
     ],
 )

--- a/src/dbSta/include/db_sta/IpChecker.hh
+++ b/src/dbSta/include/db_sta/IpChecker.hh
@@ -8,6 +8,10 @@
 #include "odb/db.h"
 #include "odb/geom.h"
 
+namespace sta {
+class dbSta;
+}  // namespace sta
+
 namespace utl {
 class Logger;
 }  // namespace utl
@@ -26,11 +30,13 @@ namespace sta {
 // LEF-CHK-009: Pin geometry presence
 // LEF-CHK-010a: Pin minimum width (perpendicular to routing direction)
 // LEF-CHK-010b: Pin minimum area
+// LEF/LIB-CHK-011: Pin direction matches Liberty
+// LEF/LIB-CHK-012: LEF macros and signal pins exist in Liberty
 
 class IpChecker
 {
  public:
-  IpChecker(odb::dbDatabase* db, utl::Logger* logger);
+  IpChecker(odb::dbDatabase* db, dbSta* sta, utl::Logger* logger);
 
   // Configuration
   void setMaxPolygons(int max) { max_polygons_ = max; }
@@ -84,6 +90,9 @@ class IpChecker
   // LEF-CHK-010b: Pin minimum area
   void checkPinMinArea(odb::dbMaster* master);
 
+  // LEF/LIB-CHK-011-012: Check Liberty pin presence and direction
+  void checkLibertyPins(odb::dbMaster* master);
+
   // Helper: Check if a pin shape has at least one accessible edge
   bool hasAccessibleEdge(odb::dbMaster* master,
                          const odb::Rect& pin_rect,
@@ -91,6 +100,7 @@ class IpChecker
 
   // Member variables
   odb::dbDatabase* db_;
+  dbSta* sta_;
   utl::Logger* logger_;
 
   // Configuration

--- a/src/dbSta/src/IpChecker.cc
+++ b/src/dbSta/src/IpChecker.cc
@@ -9,21 +9,92 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
 
+#include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
 #include "odb/PtrSetMap.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "sta/Liberty.hh"
+#include "sta/NetworkClass.hh"
+#include "sta/PortDirection.hh"
 #include "utl/Logger.h"
 
 namespace sta {
 
-IpChecker::IpChecker(odb::dbDatabase* db, utl::Logger* logger)
-    : db_(db), logger_(logger)
+namespace {
+
+enum class PinDirection
+{
+  input,
+  output,
+  inout,
+};
+
+bool getLefPinDirection(odb::dbMTerm* mterm, PinDirection& direction)
+{
+  switch (mterm->getIoType().getValue()) {
+    case odb::dbIoType::INPUT:
+      direction = PinDirection::input;
+      return true;
+    case odb::dbIoType::OUTPUT:
+      direction = PinDirection::output;
+      return true;
+    case odb::dbIoType::INOUT:
+      direction = PinDirection::inout;
+      return true;
+    case odb::dbIoType::FEEDTHRU:
+      return false;
+  }
+  return false;
+}
+
+bool getLibertyPinDirection(LibertyPort* port, PinDirection& direction)
+{
+  PortDirection* port_direction = port->direction();
+  if (port_direction == nullptr || port_direction->isUnknown()
+      || port_direction->isPowerGround() || port_direction->isInternal()) {
+    return false;
+  }
+
+  if (port_direction->isInput()) {
+    direction = PinDirection::input;
+    return true;
+  }
+  if (port_direction->isOutput() || port_direction->isTristate()) {
+    direction = PinDirection::output;
+    return true;
+  }
+  if (port_direction->isBidirect()) {
+    direction = PinDirection::inout;
+    return true;
+  }
+
+  return false;
+}
+
+const char* directionName(PinDirection direction)
+{
+  switch (direction) {
+    case PinDirection::input:
+      return "input";
+    case PinDirection::output:
+      return "output";
+    case PinDirection::inout:
+      return "inout";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+IpChecker::IpChecker(odb::dbDatabase* db, dbSta* sta, utl::Logger* logger)
+    : db_(db), sta_(sta), logger_(logger)
 {
 }
 
@@ -121,6 +192,7 @@ void IpChecker::checkLefMaster(odb::dbMaster* master)
   checkPinGeometryPresence(master);            // LEF-CHK-009
   checkPinMinDimensions(master);               // LEF-CHK-010a
   checkPinMinArea(master);                     // LEF-CHK-010b
+  checkLibertyPins(master);                    // LEF/LIB-CHK-011-012
 }
 
 // LEF-CHK-001: Macro dimensions aligned to manufacturing grid
@@ -689,6 +761,74 @@ void IpChecker::checkPinMinArea(odb::dbMaster* master)
           warning_count_++;
         }
       }
+    }
+  }
+}
+
+// LEF/LIB-CHK-011-012: Check Liberty pin presence and direction.
+void IpChecker::checkLibertyPins(odb::dbMaster* master)
+{
+  if (sta_ == nullptr) {
+    return;
+  }
+
+  dbNetwork* network = sta_->getDbNetwork();
+  if (network == nullptr) {
+    return;
+  }
+
+  std::unique_ptr<LibertyLibraryIterator> lib_iter{
+      network->libertyLibraryIterator()};
+  if (!lib_iter->hasNext()) {
+    return;
+  }
+
+  const std::string master_name = master->getName();
+  LibertyCell* liberty_cell = network->findLibertyCell(master_name);
+  if (liberty_cell == nullptr) {
+    logger_->warn(
+        utl::CHK, 120, "LEF macro {} missing Liberty cell", master_name);
+    warning_count_++;
+    return;
+  }
+
+  for (odb::dbMTerm* mterm : master->getMTerms()) {
+    if (mterm->getSigType().isSupply()) {
+      continue;
+    }
+
+    LibertyPort* liberty_port = liberty_cell->findLibertyPort(mterm->getName());
+    if (liberty_port == nullptr) {
+      logger_->warn(utl::CHK,
+                    121,
+                    "Pin {}/{} missing from Liberty cell {}",
+                    master_name,
+                    mterm->getName(),
+                    liberty_cell->name());
+      warning_count_++;
+      continue;
+    }
+
+    PinDirection lef_direction;
+    if (!getLefPinDirection(mterm, lef_direction)) {
+      continue;
+    }
+
+    PinDirection liberty_direction;
+    if (!getLibertyPinDirection(liberty_port, liberty_direction)) {
+      continue;
+    }
+
+    if (lef_direction != liberty_direction) {
+      logger_->warn(utl::CHK,
+                    111,
+                    "Pin {}/{} direction mismatch between LEF ({}) and "
+                    "Liberty ({})",
+                    master_name,
+                    mterm->getName(),
+                    directionName(lef_direction),
+                    directionName(liberty_direction));
+      warning_count_++;
     }
   }
 }

--- a/src/dbSta/src/IpChecker.cc
+++ b/src/dbSta/src/IpChecker.cc
@@ -9,21 +9,92 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
 
+#include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
 #include "odb/PtrSetMap.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "sta/Liberty.hh"
+#include "sta/NetworkClass.hh"
+#include "sta/PortDirection.hh"
 #include "utl/Logger.h"
 
 namespace sta {
 
-IpChecker::IpChecker(odb::dbDatabase* db, utl::Logger* logger)
-    : db_(db), logger_(logger)
+namespace {
+
+enum class PinDirection
+{
+  kInput,
+  kOutput,
+  kInOut,
+};
+
+static bool getLefPinDirection(odb::dbMTerm* mterm, PinDirection& direction)
+{
+  switch (mterm->getIoType().getValue()) {
+    case odb::dbIoType::INPUT:
+      direction = PinDirection::kInput;
+      return true;
+    case odb::dbIoType::OUTPUT:
+      direction = PinDirection::kOutput;
+      return true;
+    case odb::dbIoType::INOUT:
+      direction = PinDirection::kInOut;
+      return true;
+    case odb::dbIoType::FEEDTHRU:
+      return false;
+  }
+  return false;
+}
+
+static bool getLibertyPinDirection(LibertyPort* port, PinDirection& direction)
+{
+  PortDirection* port_direction = port->direction();
+  if (port_direction == nullptr || port_direction->isUnknown()
+      || port_direction->isPowerGround() || port_direction->isInternal()) {
+    return false;
+  }
+
+  if (port_direction->isInput()) {
+    direction = PinDirection::kInput;
+    return true;
+  }
+  if (port_direction->isOutput() || port_direction->isTristate()) {
+    direction = PinDirection::kOutput;
+    return true;
+  }
+  if (port_direction->isBidirect()) {
+    direction = PinDirection::kInOut;
+    return true;
+  }
+
+  return false;
+}
+
+static const char* directionName(PinDirection direction)
+{
+  switch (direction) {
+    case PinDirection::kInput:
+      return "input";
+    case PinDirection::kOutput:
+      return "output";
+    case PinDirection::kInOut:
+      return "inout";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+IpChecker::IpChecker(odb::dbDatabase* db, dbSta* sta, utl::Logger* logger)
+    : db_(db), sta_(sta), logger_(logger)
 {
 }
 
@@ -121,6 +192,7 @@ void IpChecker::checkLefMaster(odb::dbMaster* master)
   checkPinGeometryPresence(master);            // LEF-CHK-009
   checkPinMinDimensions(master);               // LEF-CHK-010a
   checkPinMinArea(master);                     // LEF-CHK-010b
+  checkLibertyPins(master);                    // LEF/LIB-CHK-011-012
 }
 
 // LEF-CHK-001: Macro dimensions aligned to manufacturing grid
@@ -689,6 +761,74 @@ void IpChecker::checkPinMinArea(odb::dbMaster* master)
           warning_count_++;
         }
       }
+    }
+  }
+}
+
+// LEF/LIB-CHK-011-012: Check Liberty pin presence and direction.
+void IpChecker::checkLibertyPins(odb::dbMaster* master)
+{
+  if (sta_ == nullptr) {
+    return;
+  }
+
+  dbNetwork* network = sta_->getDbNetwork();
+  if (network == nullptr) {
+    return;
+  }
+
+  std::unique_ptr<LibertyLibraryIterator> lib_iter{
+      network->libertyLibraryIterator()};
+  if (!lib_iter->hasNext()) {
+    return;
+  }
+
+  const std::string master_name = master->getName();
+  LibertyCell* liberty_cell = network->findLibertyCell(master_name);
+  if (liberty_cell == nullptr) {
+    logger_->warn(
+        utl::CHK, 120, "LEF macro {} missing Liberty cell", master_name);
+    warning_count_++;
+    return;
+  }
+
+  for (odb::dbMTerm* mterm : master->getMTerms()) {
+    if (mterm->getSigType().isSupply()) {
+      continue;
+    }
+
+    LibertyPort* liberty_port = liberty_cell->findLibertyPort(mterm->getName());
+    if (liberty_port == nullptr) {
+      logger_->warn(utl::CHK,
+                    121,
+                    "Pin {}/{} missing from Liberty cell {}",
+                    master_name,
+                    mterm->getName(),
+                    liberty_cell->name());
+      warning_count_++;
+      continue;
+    }
+
+    PinDirection lef_direction;
+    if (!getLefPinDirection(mterm, lef_direction)) {
+      continue;
+    }
+
+    PinDirection liberty_direction;
+    if (!getLibertyPinDirection(liberty_port, liberty_direction)) {
+      continue;
+    }
+
+    if (lef_direction != liberty_direction) {
+      logger_->warn(utl::CHK,
+                    111,
+                    "Pin {}/{} direction mismatch between LEF ({}) and "
+                    "Liberty ({})",
+                    master_name,
+                    mterm->getName(),
+                    directionName(lef_direction),
+                    directionName(liberty_direction));
+      warning_count_++;
     }
   }
 }

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -324,9 +324,10 @@ check_ip_cmd(const char* master_name,
 {
   ord::OpenRoad* openroad = ord::getOpenRoad();
   odb::dbDatabase* db = openroad->getDb();
+  sta::dbSta* sta = openroad->getSta();
   utl::Logger* logger = openroad->getLogger();
 
-  sta::IpChecker checker(db, logger);
+  sta::IpChecker checker(db, sta, logger);
   checker.setMaxPolygons(max_polygons);
   checker.setVerbose(verbose);
 

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -332,9 +332,10 @@ check_ip_cmd(const char* master_name,
 {
   ord::OpenRoad* openroad = ord::getOpenRoad();
   odb::dbDatabase* db = openroad->getDb();
+  sta::dbSta* sta = openroad->getSta();
   utl::Logger* logger = openroad->getLogger();
 
-  sta::IpChecker checker(db, logger);
+  sta::IpChecker checker(db, sta, logger);
   checker.setMaxPolygons(max_polygons);
   checker.setVerbose(verbose);
 

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -83,6 +83,10 @@ ALL_TESTS = [
     "write_verilog9_hier",
 ]
 
+PASSFAIL_TESTS = [
+    "check_ip_liberty_pins",
+]
+
 filegroup(
     name = "regression_resources",
     srcs = [
@@ -288,16 +292,18 @@ filegroup(
             ],
         }.get(test_name, []),
     )
-    for test_name in ALL_TESTS
+    for test_name in ALL_TESTS + PASSFAIL_TESTS
 ]
 
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
+        check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )
-    for test_name in ALL_TESTS
+    for test_name in ALL_TESTS + PASSFAIL_TESTS
 ]
 
 cc_test(

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -106,6 +106,10 @@ ALL_TESTS = [
     "write_verilog9_hier",
 ]
 
+PASSFAIL_TESTS = [
+    "check_ip_liberty_pins",
+]
+
 filegroup(
     name = "regression_resources",
     srcs = [
@@ -340,16 +344,18 @@ filegroup(
             ],
         }.get(test_name, []),
     )
-    for test_name in ALL_TESTS
+    for test_name in ALL_TESTS + PASSFAIL_TESTS
 ]
 
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
+        check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )
-    for test_name in ALL_TESTS
+    for test_name in ALL_TESTS + PASSFAIL_TESTS
 ]
 
 cc_test(

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -71,6 +71,8 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+  PASSFAIL_TESTS
+    check_ip_liberty_pins
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -76,6 +76,8 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+  PASSFAIL_TESTS
+    check_ip_liberty_pins
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/check_ip_liberty_pins.lef
+++ b/src/dbSta/test/check_ip_liberty_pins.lef
@@ -1,0 +1,138 @@
+VERSION 5.8 ;
+BUSBITCHARS "[]" ;
+DIVIDERCHAR "/" ;
+
+UNITS
+  DATABASE MICRONS 1000 ;
+END UNITS
+
+MANUFACTURINGGRID 0.005 ;
+
+LAYER M1
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.200 ;
+  WIDTH 0.100 ;
+  AREA 0.020 ;
+END M1
+
+MACRO lef_lib_pins_match
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.500 0.500 0.700 0.700 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_pins_match
+
+MACRO lef_lib_pin_missing
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.500 0.500 0.700 0.700 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_pin_missing
+
+MACRO lef_lib_cell_missing
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.500 0.500 0.700 0.700 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_cell_missing
+
+MACRO lef_lib_direction_mismatch
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_direction_mismatch
+
+END LIBRARY

--- a/src/dbSta/test/check_ip_liberty_pins.lib
+++ b/src/dbSta/test/check_ip_liberty_pins.lib
@@ -1,0 +1,48 @@
+library (check_ip_liberty_pins) {
+  delay_model : table_lookup;
+  capacitive_load_unit (1,pf);
+  current_unit : "1A";
+  pulling_resistance_unit : "1kohm";
+  time_unit : "1ns";
+  voltage_unit : "1V";
+
+  cell (lef_lib_pins_match) {
+    area : 1;
+    pin (A) {
+      capacitance : 0.001;
+      direction : input;
+    }
+    pin (Z) {
+      direction : output;
+      function : "A";
+    }
+    pg_pin (VDD) {
+      pg_type : primary_power;
+      voltage_name : VDD;
+    }
+  }
+
+  cell (lef_lib_pin_missing) {
+    area : 1;
+    pin (A) {
+      capacitance : 0.001;
+      direction : input;
+    }
+    pg_pin (VDD) {
+      pg_type : primary_power;
+      voltage_name : VDD;
+    }
+  }
+
+  cell (lef_lib_direction_mismatch) {
+    area : 1;
+    pin (A) {
+      direction : output;
+      function : "1";
+    }
+    pg_pin (VDD) {
+      pg_type : primary_power;
+      voltage_name : VDD;
+    }
+  }
+}

--- a/src/dbSta/test/check_ip_liberty_pins.tcl
+++ b/src/dbSta/test/check_ip_liberty_pins.tcl
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, The OpenROAD Authors
+
+source "helpers.tcl"
+
+read_lef check_ip_liberty_pins.lef
+
+proc expect_check_ip_pass { master_name } {
+  if { [catch { check_ip -master $master_name } err] } {
+    puts "FAIL: expected $master_name to pass: $err"
+    exit 1
+  }
+}
+
+proc expect_check_ip_fail { master_name } {
+  if { ![catch { check_ip -master $master_name } err] } {
+    puts "FAIL: expected $master_name to fail"
+    exit 1
+  }
+}
+
+expect_check_ip_pass lef_lib_cell_missing
+
+read_liberty check_ip_liberty_pins.lib
+
+expect_check_ip_pass lef_lib_pins_match
+expect_check_ip_fail lef_lib_pin_missing
+expect_check_ip_fail lef_lib_cell_missing
+expect_check_ip_fail lef_lib_direction_mismatch
+
+puts "pass"


### PR DESCRIPTION
## Summary
- check that a LEF BLOCK macro has a matching Liberty cell once Liberty data is loaded
- report non-supply LEF pins missing from the matching Liberty cell
- compare LEF and Liberty pin directions in the same traversal
- keep LEF-only check_ip behavior unchanged when no Liberty library is loaded
- cover matching pins, missing cells, missing ports, direction mismatches, and the no-Liberty case

Related to #4872. Supersedes #10821.

## Tests
- clang-format --dry-run --Werror on the changed C++ files
- git diff --check
- bazelisk build --config=lint //src/dbSta:dbSta //src/dbSta:IpChecker
- bazelisk test //src/dbSta/test:check_ip_liberty_pins-tcl_test
- bazelisk test //src/dbSta/test:all (75 targets passed)
- bazelisk build --stamp //:openroad
