### PR TITLE
dbSta: check LEF pins against Liberty

### DIFF
--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -105,8 +105,10 @@ cc_library(
         "include",
     ],
     deps = [
+        ":dbNetwork",
         ":dbSta",
         "//src/odb/src/db",
+        "//src/sta:opensta_lib",
         "//src/utl",
     ],
 )

--- a/src/dbSta/include/db_sta/IpChecker.hh
+++ b/src/dbSta/include/db_sta/IpChecker.hh
@@ -30,6 +30,7 @@ namespace sta {
 // LEF-CHK-009: Pin geometry presence
 // LEF-CHK-010a: Pin minimum width (perpendicular to routing direction)
 // LEF-CHK-010b: Pin minimum area
+// LEF/LIB-CHK-012: LEF macros and signal pins exist in Liberty
 
 class IpChecker
 {
@@ -87,6 +88,9 @@ class IpChecker
 
   // LEF-CHK-010b: Pin minimum area
   void checkPinMinArea(odb::dbMaster* master);
+
+  // LEF/LIB-CHK-012: LEF macros and signal pins exist in Liberty
+  void checkLibertyPinPresence(odb::dbMaster* master);
 
   // Helper: Check if a pin shape has at least one accessible edge
   bool hasAccessibleEdge(odb::dbMaster* master,

--- a/src/dbSta/src/IpChecker.cc
+++ b/src/dbSta/src/IpChecker.cc
@@ -9,15 +9,19 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
 
+#include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
 #include "odb/PtrSetMap.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "sta/Liberty.hh"
+#include "sta/NetworkClass.hh"
 #include "utl/Logger.h"
 
 namespace sta {
@@ -121,6 +125,7 @@ void IpChecker::checkLefMaster(odb::dbMaster* master)
   checkPinGeometryPresence(master);            // LEF-CHK-009
   checkPinMinDimensions(master);               // LEF-CHK-010a
   checkPinMinArea(master);                     // LEF-CHK-010b
+  checkLibertyPinPresence(master);             // LEF/LIB-CHK-012
 }
 
 // LEF-CHK-001: Macro dimensions aligned to manufacturing grid
@@ -689,6 +694,50 @@ void IpChecker::checkPinMinArea(odb::dbMaster* master)
           warning_count_++;
         }
       }
+    }
+  }
+}
+
+// LEF/LIB-CHK-012: LEF macros and signal pins exist in Liberty.
+void IpChecker::checkLibertyPinPresence(odb::dbMaster* master)
+{
+  if (sta_ == nullptr) {
+    return;
+  }
+
+  dbNetwork* network = sta_->getDbNetwork();
+  if (network == nullptr) {
+    return;
+  }
+
+  std::unique_ptr<LibertyLibraryIterator> lib_iter{
+      network->libertyLibraryIterator()};
+  if (!lib_iter->hasNext()) {
+    return;
+  }
+
+  const std::string master_name = master->getName();
+  LibertyCell* liberty_cell = network->findLibertyCell(master_name);
+  if (liberty_cell == nullptr) {
+    logger_->warn(
+        utl::CHK, 120, "LEF macro {} missing Liberty cell", master_name);
+    warning_count_++;
+    return;
+  }
+
+  for (odb::dbMTerm* mterm : master->getMTerms()) {
+    if (mterm->getSigType().isSupply()) {
+      continue;
+    }
+
+    if (liberty_cell->findLibertyPort(mterm->getName()) == nullptr) {
+      logger_->warn(utl::CHK,
+                    121,
+                    "Pin {}/{} missing from Liberty cell {}",
+                    master_name,
+                    mterm->getName(),
+                    liberty_cell->name());
+      warning_count_++;
     }
   }
 }

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -83,6 +83,10 @@ ALL_TESTS = [
     "write_verilog9_hier",
 ]
 
+PASSFAIL_TESTS = [
+    "check_ip_liberty_pins",
+]
+
 filegroup(
     name = "regression_resources",
     srcs = [
@@ -288,16 +292,18 @@ filegroup(
             ],
         }.get(test_name, []),
     )
-    for test_name in ALL_TESTS
+    for test_name in ALL_TESTS + PASSFAIL_TESTS
 ]
 
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
+        check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )
-    for test_name in ALL_TESTS
+    for test_name in ALL_TESTS + PASSFAIL_TESTS
 ]
 
 cc_test(

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -71,6 +71,8 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+  PASSFAIL_TESTS
+    check_ip_liberty_pins
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/check_ip_liberty_pins.lef
+++ b/src/dbSta/test/check_ip_liberty_pins.lef
@@ -1,0 +1,115 @@
+VERSION 5.8 ;
+BUSBITCHARS "[]" ;
+DIVIDERCHAR "/" ;
+
+UNITS
+  DATABASE MICRONS 1000 ;
+END UNITS
+
+MANUFACTURINGGRID 0.005 ;
+
+LAYER M1
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.200 ;
+  WIDTH 0.100 ;
+  AREA 0.020 ;
+END M1
+
+MACRO lef_lib_pins_match
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.500 0.500 0.700 0.700 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_pins_match
+
+MACRO lef_lib_pin_missing
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.500 0.500 0.700 0.700 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_pin_missing
+
+MACRO lef_lib_cell_missing
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SIZE 1.000 BY 1.000 ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.100 0.100 0.300 0.300 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNAMODEL OXIDE1 ;
+    PORT
+      LAYER M1 ;
+      RECT 0.500 0.500 0.700 0.700 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER M1 ;
+      RECT 0.000 0.000 1.000 0.200 ;
+    END
+  END VDD
+END lef_lib_cell_missing
+
+END LIBRARY

--- a/src/dbSta/test/check_ip_liberty_pins.lib
+++ b/src/dbSta/test/check_ip_liberty_pins.lib
@@ -1,0 +1,36 @@
+library (check_ip_liberty_pins) {
+  delay_model : table_lookup;
+  capacitive_load_unit (1,pf);
+  current_unit : "1A";
+  pulling_resistance_unit : "1kohm";
+  time_unit : "1ns";
+  voltage_unit : "1V";
+
+  cell (lef_lib_pins_match) {
+    area : 1;
+    pin (A) {
+      capacitance : 0.001;
+      direction : input;
+    }
+    pin (Z) {
+      direction : output;
+      function : "A";
+    }
+    pg_pin (VDD) {
+      pg_type : primary_power;
+      voltage_name : VDD;
+    }
+  }
+
+  cell (lef_lib_pin_missing) {
+    area : 1;
+    pin (A) {
+      capacitance : 0.001;
+      direction : input;
+    }
+    pg_pin (VDD) {
+      pg_type : primary_power;
+      voltage_name : VDD;
+    }
+  }
+}

--- a/src/dbSta/test/check_ip_liberty_pins.tcl
+++ b/src/dbSta/test/check_ip_liberty_pins.tcl
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, The OpenROAD Authors
+
+source "helpers.tcl"
+
+read_lef check_ip_liberty_pins.lef
+read_liberty check_ip_liberty_pins.lib
+
+proc expect_check_ip_pass { master_name } {
+  if { [catch { check_ip -master $master_name } err] } {
+    puts "FAIL: expected $master_name to pass: $err"
+    exit 1
+  }
+}
+
+proc expect_check_ip_fail { master_name } {
+  if { ![catch { check_ip -master $master_name } err] } {
+    puts "FAIL: expected $master_name to fail"
+    exit 1
+  }
+}
+
+expect_check_ip_pass lef_lib_pins_match
+expect_check_ip_fail lef_lib_pin_missing
+expect_check_ip_fail lef_lib_cell_missing
+
+puts "pass"


### PR DESCRIPTION
## Summary
- add `LEF/LIB-CHK-012` to warn when a LEF non-supply pin is missing from the matching Liberty cell
- keep the check conditional on a matching Liberty cell so LEF-only IP checks do not become noisy
- register a focused pass/fail regression fixture in both Bazel and CMake

Related to #4872.

## Tests
- PASS: `git diff --check`
- PASS: `bazelisk build --jobs=4 --local_cpu_resources=4 //src/dbSta:IpChecker`
- BLOCKED: `bazelisk test --jobs=4 --local_cpu_resources=4 //src/dbSta/test:check_ip_liberty_pins-tcl_test` on the Ubuntu 22.04 GCP VM fails before test execution while linking `openroad` with unresolved `__isoc23_*` glibc symbols from the Bazel LLVM/sysroot toolchain.
