### PR TITLE
bazel: override yosys-slang archive source

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -159,6 +159,12 @@ archive_override(
 
 bazel_dep(name = "yosys", version = "0.62.bcr.2", dev_dependency = True)
 bazel_dep(name = "yosys-slang", version = "0.0.0", dev_dependency = True)
+archive_override(
+    module_name = "yosys-slang",
+    sha256 = "34198f2ed7b2d3175c3ce3c9fb1c6c91f28dbcfe531d97b91d6b12c48431bdef",
+    strip_prefix = "sv-elab-6760afa2c9b9ba231a9c6a9e94f0939dd39f0a20",
+    urls = ["https://github.com/povik/yosys-slang/archive/6760afa2c9b9ba231a9c6a9e94f0939dd39f0a20.tar.gz"],
+)
 
 # --- Extensions ---
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -821,8 +821,6 @@
     "https://bcr.bazel.build/modules/xorgproto/2024.1.bcr.1/source.json": "2da7b346f94c7d5bb890d8a964110b38b439bd254ad14ec3d37022a7ac9356d8",
     "https://bcr.bazel.build/modules/yaml-cpp/0.9.0/MODULE.bazel": "d0841e12e92973d7e4c97557198335788890dafa9487d6dc0f9b852053a6c5c0",
     "https://bcr.bazel.build/modules/yaml-cpp/0.9.0/source.json": "07a9973d6cee81c8bdb1902e8f90064a0ef9aa2262bffc4df2ed577956c08e1b",
-    "https://bcr.bazel.build/modules/yosys-slang/0.0.0/MODULE.bazel": "a0c2d49792cb5e49db7871aef6b1c022188fbda6023450da1d7a040ce6e02b9e",
-    "https://bcr.bazel.build/modules/yosys-slang/0.0.0/source.json": "9de60d310212a28c1fdc5a2b4260466a0fa697b79ecf2505aa1389a8cd06c30d",
     "https://bcr.bazel.build/modules/yosys/0.62.bcr.2/MODULE.bazel": "2297c50983665b308449febf965616d11c28ce70ef04829f7a4de97d5d537726",
     "https://bcr.bazel.build/modules/yosys/0.62.bcr.2/source.json": "72bf96ef1d9c881889e8e31e9a2af5f3bbbe5c18d83712e5ece7899f1d87655f",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
@@ -2521,7 +2519,7 @@
     "@@yosys-slang+//:dependency_support/slang_ext.bzl%vendored_slang_extension": {
       "general": {
         "bzlTransitiveDigest": "5QIB1e5+v5Cj2rslpyAj2M5L+l6B1BFByldLM+ewKMA=",
-        "usagesDigest": "bNfWY5+YI9i3FTlUQx6/VFcWZJN2hVi9BG7IvG4OGf4=",
+        "usagesDigest": "i6tCm4G6czTrDX7zkosKiwqamw1Y9s/ogPY7nwt3S9o=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
## Summary
- add a root archive_override for yosys-slang 0.0.0 using the currently served GitHub archive hash and strip_prefix
- update MODULE.bazel.lock after bazelisk mod deps --lockfile_mode=update

## Why
The Bazel registry entry for yosys-slang currently expects sha256-DRFhnfEPPftw+cNVokXDNpqxgIxn3JsLp6Ekq4bxIu0= and strip prefix yosys-slang-6760afa..., but GitHub now serves the archive as sha256-NBmPLtey0xdcPOPJ+xxskfKNvP5THZe5HWsSxIQxve8= with top-level directory sv-elab-6760afa.... This makes Check-Bazel-Lock fail before OpenROAD code is built.

## Testing
- bazelisk mod deps --lockfile_mode=update
- bazelisk test //:lint_bzl_test //:fmt_bzl_test