### PR TITLE
update tests to remove name collision

### DIFF
--- a/src/rsz/test/clone_flat.tcl
+++ b/src/rsz/test/clone_flat.tcl
@@ -2,7 +2,7 @@
 source "helpers.tcl"
 source "hi_fanout.tcl"
 
-set def_filename [make_result_file "repair_fanout7.def"]
+set def_filename [make_result_file "clone_flat.def"]
 # Gates we want to eventually NAND2_X4, NAND3_X4, NAND4_X4
 
 write_clone_test_def $def_filename NAND2_X4 150

--- a/src/rsz/test/repair_fanout7.tcl
+++ b/src/rsz/test/repair_fanout7.tcl
@@ -8,6 +8,9 @@ if { ![info exists def_filename] } {
 if { ![info exists repair_args] } {
   set repair_args {}
 }
+if { ![info exists eqy_test_name] } {
+  set eqy_test_name "repair_fanout7"
+}
 # Gates we want to eventually NAND2_X4, NAND3_X4, NAND4_X4
 
 write_clone_test_def $def_filename NAND2_X4 150
@@ -37,9 +40,9 @@ estimate_parasitics -placement
 
 # Repair the high fanout net hopefully with gate cloning code.
 report_worst_slack -max
-write_verilog_for_eqy repair_fanout7 before "None"
+write_verilog_for_eqy $eqy_test_name before "None"
 repair_timing -setup -repair_tns 100 -verbose {*}$repair_args
-run_equivalence_test repair_fanout7 \
+run_equivalence_test $eqy_test_name \
   -lib_dir ./Nangate45/work_around_yosys/ \
   -remove_cells "None"
 report_worst_slack -max

--- a/src/rsz/test/repair_fanout7_multi.tcl
+++ b/src/rsz/test/repair_fanout7_multi.tcl
@@ -1,4 +1,5 @@
 source "helpers.tcl"
 set def_filename [make_result_file "repair_fanout7_multi.def"]
 set repair_args [list -max_repairs_per_pass 10]
+set eqy_test_name "repair_fanout7_multi"
 source "repair_fanout7.tcl"

--- a/src/rsz/test/repair_fanout7_skip_pin_swap.tcl
+++ b/src/rsz/test/repair_fanout7_skip_pin_swap.tcl
@@ -3,7 +3,7 @@ source "helpers.tcl"
 source "hi_fanout.tcl"
 
 if { ![info exists def_filename] } {
-  set def_filename [make_result_file "repair_fanout7.def"]
+  set def_filename [make_result_file "repair_fanout7_skip_pin_swap.def"]
 }
 if { ![info exists repair_args] } {
   set repair_args {}
@@ -37,9 +37,9 @@ estimate_parasitics -placement
 
 # Repair the high fanout net hopefully with gate cloning code.
 report_worst_slack -max
-write_verilog_for_eqy repair_fanout7 before "None"
+write_verilog_for_eqy repair_fanout7_skip_pin_swap before "None"
 repair_timing -setup -repair_tns 100 -verbose -skip_pin_swap {*}$repair_args
-run_equivalence_test repair_fanout7 \
+run_equivalence_test repair_fanout7_skip_pin_swap \
   -lib_dir ./Nangate45/work_around_yosys/ \
   -remove_cells "None"
 report_worst_slack -max


### PR DESCRIPTION
## Summary
Helper run_equivalence_test <tag> writes results/<tag>_before.v, <tag>_after.v, <tag>.eqy, <tag>_output/; so eqy tag collides same as def filename.
  Changes:

  1. clone_flat.tcl: repair_fanout7.def to clone_flat.def.
  2. repair_fanout7_skip_pin_swap.tcl: same collision, twice.
    - Default def: repair_fanout7.def to repair_fanout7_skip_pin_swap.def
    - eqy tag in write_verilog_for_eqy + run_equivalence_test: repair_fanout7 to repair_fanout7_skip_pin_swap
  3. repair_fanout7.tcl: eqy tag hardcoded but script sourced by repair_fanout7_multi.tcl - both wrote results/repair_fanout7_before.v etc. Parameterized with existing guard pattern:
 ```
 if { ![info exists eqy_test_name] } {
    set eqy_test_name "repair_fanout7"
  }
```
 and write_verilog_for_eqy $eqy_test_name ..., run_equivalence_test $eqy_test_name ....
  4. repair_fanout7_multi.tcl: added set eqy_test_name "repair_fanout7_multi" before sourcing.

  Golden .ok files unaffected - eqy pass message generic ("Repair timing output passed/skipped equivalence test"), no tag in logs. Standalone repair_fanout7.tcl behavior unchanged (defaults  match old names).

## Type of Change
- Regression

## Impact
N/A

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

