### PR TITLE
odb: build unfolded model before postRead3Dbx observers

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -520,6 +520,7 @@ void OpenRoad::read3Dbx(const std::string& filename)
 {
   odb::ThreeDBlox parser(logger_, db_, sta_);
   parser.readDbx(filename);
+  db_->constructUnfoldedModel();
   db_->triggerPostRead3Dbx(db_->getChip());
   check3DBlox();
 }

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -1212,7 +1212,6 @@ void dbDatabase::triggerPostRead3Dbx(dbChip* chip)
   for (dbDatabaseObserver* observer : db->observers_) {
     observer->postRead3Dbx(chip);
   }
-  constructUnfoldedModel();
 }
 
 void dbDatabase::triggerPostReadDb()


### PR DESCRIPTION
## Summary
build unfoldedModel before triggering callbacks

## Type of Change
- Bug fix

## Impact
NA

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
<!-- Delete next item if this PR is not a bug fix or new feature -->
- [ ] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Closes #10801
