### PR TITLE
Gpl: add support for non-rectangular regions

### DIFF
--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -795,6 +795,11 @@ void PlacerBaseCommon::init()
              block->dbuToMicrons(die_.coreUx()),
              block->dbuToMicrons(die_.coreUy()));
 
+  log_->info(GPL,
+             16,
+             "Core area:                  {:10.3f} um^2",
+             block->dbuAreaToMicrons(die_.coreArea()));
+
   // insts fill with real instances
   dbSet<dbInst> db_insts = block->getInsts();
   instStor_.reserve(db_insts.size());

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1090,8 +1090,10 @@ PlacerBase::~PlacerBase()
 void PlacerBase::init(bool check_density)
 {
   die_ = pbCommon_->getDie();
+  odb::dbRegion* region = nullptr;
   if (group_ != nullptr) {
-    auto boundaries = group_->getRegion()->getBoundaries();
+    region = group_->getRegion();
+    auto boundaries = region->getBoundaries();
 
     if (!boundaries.empty()) {
       region_bbox_.mergeInit();
@@ -1105,6 +1107,7 @@ void PlacerBase::init(bool check_density)
       region_area_ = die_.coreArea();
     }
   } else {
+    region = nullptr;
     region_bbox_
         = odb::Rect(die_.coreLx(), die_.coreLy(), die_.coreUx(), die_.coreUy());
     region_area_ = die_.coreArea();
@@ -1124,30 +1127,41 @@ void PlacerBase::init(bool check_density)
       continue;
     }
 
-    odb::dbGroup* db_inst_group = db_inst->getGroup();
-    if (group_ == nullptr) {
-      if (db_inst_group
-          && db_inst_group->getType() != odb::dbGroupType::VISUAL_DEBUG) {
-        continue;
-      }
-    } else {
-      if (!db_inst_group || db_inst_group != group_
-          || db_inst_group->getType() == odb::dbGroupType::VISUAL_DEBUG) {
-        continue;
-      }
-    }
-
     if (inst->isFixed()) {
       // Check whether fixed instance is
-      // within the corearea
+      // within the region
       //
-      // outside of corearea is none of RePlAce's business
-      if (isCoreAreaOverlap(die_, *inst)) {
-        fixedInsts_.push_back(inst);
-        nonPlaceInsts_.push_back(inst);
-        nonPlaceInstsArea_ += getOverlapWithCoreArea(die_, *inst);
+      // outside of region is none of RePlAce's business
+      int64_t overlap_area = 0;
+      if (!region || region->getBoundaries().empty()) {
+        if (isCoreAreaOverlap(die_, *inst)) {
+          overlap_area = getOverlapWithCoreArea(die_, *inst);
+        }
+      } else {
+        overlap_area = region->getOverlapArea(db_inst->getBBox()->getBox());
       }
+
+      if (overlap_area == 0) {
+        continue;
+      }
+      fixedInsts_.push_back(inst);
+      nonPlaceInsts_.push_back(inst);
+      nonPlaceInstsArea_ += overlap_area;
     } else {
+      // Movable instances
+      odb::dbGroup* db_inst_group = db_inst->getGroup();
+      if (group_ == nullptr) {
+        if (db_inst_group
+            && db_inst_group->getType() != odb::dbGroupType::VISUAL_DEBUG) {
+          continue;
+        }
+      } else {
+        if (!db_inst_group || db_inst_group != group_
+            || db_inst_group->getType() == odb::dbGroupType::VISUAL_DEBUG) {
+          continue;
+        }
+      }
+
       placeInsts_.push_back(inst);
       int64_t instArea = inst->getArea();
       placeInstsArea_ += instArea;
@@ -1188,8 +1202,8 @@ void PlacerBase::initInstsForUnusableSites()
 {
   dbSet<dbRow> rows = db_->getChip()->getBlock()->getRows();
 
-  int64_t siteCountX = (die_.coreUx() - die_.coreLx()) / siteSizeX_;
-  int64_t siteCountY = (die_.coreUy() - die_.coreLy()) / siteSizeY_;
+  int64_t siteCountX = region_bbox_.dx() / siteSizeX_;
+  int64_t siteCountY = region_bbox_.dy() / siteSizeY_;
 
   enum SiteInfo
   {
@@ -1214,11 +1228,19 @@ void PlacerBase::initInstsForUnusableSites()
     for (dbRow* row : rows) {
       Rect rect = row->getBBox();
 
-      std::pair<int, int> pairX = getMinMaxIdx(
-          rect.xMin(), rect.xMax(), die_.coreLx(), siteSizeX_, 0, siteCountX);
+      std::pair<int, int> pairX = getMinMaxIdx(rect.xMin(),
+                                               rect.xMax(),
+                                               region_bbox_.xMin(),
+                                               siteSizeX_,
+                                               0,
+                                               siteCountX);
 
-      std::pair<int, int> pairY = getMinMaxIdx(
-          rect.yMin(), rect.yMax(), die_.coreLy(), siteSizeY_, 0, siteCountY);
+      std::pair<int, int> pairY = getMinMaxIdx(rect.yMin(),
+                                               rect.yMax(),
+                                               region_bbox_.yMin(),
+                                               siteSizeY_,
+                                               0,
+                                               siteCountY);
 
       for (int i = pairX.first; i < pairX.second; i++) {
         for (int j = pairY.first; j < pairY.second; j++) {
@@ -1236,22 +1258,53 @@ void PlacerBase::initInstsForUnusableSites()
 
           std::pair<int, int> pairX = getMinMaxIdx(rect.xMin(),
                                                    rect.xMax(),
-                                                   die_.coreLx(),
+                                                   region_bbox_.xMin(),
                                                    siteSizeX_,
                                                    0,
                                                    siteCountX);
 
           std::pair<int, int> pairY = getMinMaxIdx(rect.yMin(),
                                                    rect.yMax(),
-                                                   die_.coreLy(),
+                                                   region_bbox_.yMin(),
                                                    siteSizeY_,
                                                    0,
                                                    siteCountY);
 
           for (int i = pairX.first; i < pairX.second; i++) {
             for (int j = pairY.first; j < pairY.second; j++) {
-              siteGrid[(j * siteCountX) + i] = Blocked;
+              siteGrid[(j * siteCountX) + i] = SiteInfo::Blocked;
             }
+          }
+        }
+      }
+    }
+  } else {
+    // Initialization for non-rectangular regions
+    auto boundaries = group_->getRegion()->getBoundaries();
+    if (boundaries.size() > 1) {
+      // First, block everything
+      std::ranges::fill(siteGrid, SiteInfo::Blocked);
+
+      for (auto boundary : boundaries) {
+        Rect rect = boundary->getBox();
+        std::pair<int, int> pairX = getMinMaxIdx(rect.xMin(),
+                                                 rect.xMax(),
+                                                 region_bbox_.xMin(),
+                                                 siteSizeX_,
+                                                 0,
+                                                 siteCountX);
+
+        std::pair<int, int> pairY = getMinMaxIdx(rect.yMin(),
+                                                 rect.yMax(),
+                                                 region_bbox_.yMin(),
+                                                 siteSizeY_,
+                                                 0,
+                                                 siteCountY);
+
+        // Then, unblock only the placeable areas
+        for (int i = pairX.first; i < pairX.second; i++) {
+          for (int j = pairY.first; j < pairY.second; j++) {
+            siteGrid[(j * siteCountX) + i] = SiteInfo::Row;
           }
         }
       }
@@ -1270,11 +1323,19 @@ void PlacerBase::initInstsForUnusableSites()
       continue;
     }
     dbBox* bbox = blockage->getBBox();
-    std::pair<int, int> pairX = getMinMaxIdx(
-        bbox->xMin(), bbox->xMax(), die_.coreLx(), siteSizeX_, 0, siteCountX);
+    std::pair<int, int> pairX = getMinMaxIdx(bbox->xMin(),
+                                             bbox->xMax(),
+                                             region_bbox_.xMin(),
+                                             siteSizeX_,
+                                             0,
+                                             siteCountX);
 
-    std::pair<int, int> pairY = getMinMaxIdx(
-        bbox->yMin(), bbox->yMax(), die_.coreLy(), siteSizeY_, 0, siteCountY);
+    std::pair<int, int> pairY = getMinMaxIdx(bbox->yMin(),
+                                             bbox->yMax(),
+                                             region_bbox_.yMin(),
+                                             siteSizeY_,
+                                             0,
+                                             siteCountY);
 
     float filler_density = (100 - blockage->getMaxDensity()) / 100;
     int cells = 0;
@@ -1327,13 +1388,13 @@ void PlacerBase::initInstsForUnusableSites()
 
       std::pair<int, int> pairX = getMinMaxIdx(box.xMin() - halo.xMin(),
                                                box.xMax() + halo.xMax(),
-                                               die_.coreLx(),
+                                               region_bbox_.xMin(),
                                                siteSizeX_,
                                                0,
                                                siteCountX);
       std::pair<int, int> pairY = getMinMaxIdx(box.yMin() - halo.yMin(),
                                                box.yMax() + halo.yMax(),
-                                               die_.coreLy(),
+                                               region_bbox_.yMin(),
                                                siteSizeY_,
                                                0,
                                                siteCountY);
@@ -1354,9 +1415,9 @@ void PlacerBase::initInstsForUnusableSites()
     }
 
     std::pair<int, int> pairX = getMinMaxIdx(
-        inst->lx(), inst->ux(), die_.coreLx(), siteSizeX_, 0, siteCountX);
+        inst->lx(), inst->ux(), region_bbox_.xMin(), siteSizeX_, 0, siteCountX);
     std::pair<int, int> pairY = getMinMaxIdx(
-        inst->ly(), inst->uy(), die_.coreLy(), siteSizeY_, 0, siteCountY);
+        inst->ly(), inst->uy(), region_bbox_.yMin(), siteSizeY_, 0, siteCountY);
     for (int i = pairX.first; i < pairX.second; i++) {
       for (int j = pairY.first; j < pairY.second; j++) {
         siteGrid[(j * siteCountX) + i] = FixedInst;
@@ -1385,10 +1446,10 @@ void PlacerBase::initInstsForUnusableSites()
           i++;
         }
         int endX = i;
-        Instance dummy_gcell(die_.coreLx() + (siteSizeX_ * startX),
-                             die_.coreLy() + (siteSizeY_ * j),
-                             die_.coreLx() + (siteSizeX_ * endX),
-                             die_.coreLy() + (siteSizeY_ * (j + 1)));
+        Instance dummy_gcell(region_bbox_.xMin() + (siteSizeX_ * startX),
+                             region_bbox_.yMin() + (siteSizeY_ * j),
+                             region_bbox_.xMin() + (siteSizeX_ * endX),
+                             region_bbox_.yMin() + (siteSizeY_ * (j + 1)));
         instStor_.push_back(dummy_gcell);
       }
     }
@@ -1436,10 +1497,10 @@ void PlacerBase::printInfo(bool check_density) const
              13,
              "{:10} ( {:6.3f} {:6.3f} ) ( {:6.3f} {:6.3f} ) um",
              "Core BBox:",
-             block->dbuToMicrons(die_.coreLx()),
-             block->dbuToMicrons(die_.coreLy()),
-             block->dbuToMicrons(die_.coreUx()),
-             block->dbuToMicrons(die_.coreUy()));
+             block->dbuToMicrons(region_bbox_.xMin()),
+             block->dbuToMicrons(region_bbox_.yMin()),
+             block->dbuToMicrons(region_bbox_.xMax()),
+             block->dbuToMicrons(region_bbox_.yMax()));
 
   float util = static_cast<float>(placeInstsArea_)
                / (region_area_ - nonPlaceInstsArea_) * 100;

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1100,6 +1100,8 @@ void PlacerBase::init(bool check_density)
       for (auto boundary : boundaries) {
         region_bbox_.merge(boundary->getBox());
       }
+      region_bbox_ = region_bbox_.intersect(odb::Rect(
+          die_.coreLx(), die_.coreLy(), die_.coreUx(), die_.coreUy()));
       region_area_ = region_bbox_.area();
     } else {
       region_bbox_ = odb::Rect(

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1489,7 +1489,7 @@ void PlacerBase::printInfo(bool check_density) const
 
   log_->info(GPL,
              12,
-             "{:10} ( {:6.3f} {:6.3f} ) ( {:6.3f} {:6.3f} ) um",
+             "{:15} ( {:6.3f} {:6.3f} ) ( {:6.3f} {:6.3f} ) um",
              "Die BBox:",
              block->dbuToMicrons(die_.dieLx()),
              block->dbuToMicrons(die_.dieLy()),
@@ -1497,8 +1497,8 @@ void PlacerBase::printInfo(bool check_density) const
              block->dbuToMicrons(die_.dieUy()));
   log_->info(GPL,
              13,
-             "{:10} ( {:6.3f} {:6.3f} ) ( {:6.3f} {:6.3f} ) um",
-             "Core BBox:",
+             "{:15} ( {:6.3f} {:6.3f} ) ( {:6.3f} {:6.3f} ) um",
+             "Placement BBox:",
              block->dbuToMicrons(region_bbox_.xMin()),
              block->dbuToMicrons(region_bbox_.yMin()),
              block->dbuToMicrons(region_bbox_.xMax()),
@@ -1507,10 +1507,6 @@ void PlacerBase::printInfo(bool check_density) const
   float util = static_cast<float>(placeInstsArea_)
                / (region_area_ - nonPlaceInstsArea_) * 100;
 
-  log_->info(GPL,
-             16,
-             "Core area:                  {:10.3f} um^2",
-             block->dbuAreaToMicrons(die_.coreArea()));
   log_->info(GPL,
              14,
              "Region name: {}.",

--- a/src/gpl/test/ar01.ok
+++ b/src/gpl/test/ar01.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  1.140  1.120 ) ( 29.260 41.720 ) um
+[INFO GPL-0016] Core area:                    1141.672 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/ar01.ok
+++ b/src/gpl/test/ar01.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.400 42.840 ) um
-[INFO GPL-0013] Core BBox: (  1.140  1.120 ) ( 29.260 41.720 ) um
-[INFO GPL-0016] Core area:                    1141.672 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.400 42.840 ) um
+[INFO GPL-0013] Placement BBox: (  1.140  1.120 ) ( 29.260 41.720 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                  1141.672 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/ar02.ok
+++ b/src/gpl/test/ar02.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  1.140  1.120 ) ( 44.080 27.720 ) um
+[INFO GPL-0016] Core area:                    1142.204 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/ar02.ok
+++ b/src/gpl/test/ar02.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 45.220 28.840 ) um
-[INFO GPL-0013] Core BBox: (  1.140  1.120 ) ( 44.080 27.720 ) um
-[INFO GPL-0016] Core area:                    1142.204 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 45.220 28.840 ) um
+[INFO GPL-0013] Placement BBox: (  1.140  1.120 ) ( 44.080 27.720 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                  1142.204 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/cluster_place01.ok
+++ b/src/gpl/test/cluster_place01.ok
@@ -18,9 +18,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 36.290 35.840 ) um
-[INFO GPL-0013] Core BBox: (  1.140  1.120 ) ( 35.150 34.720 ) um
-[INFO GPL-0016] Core area:                    1142.736 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 36.290 35.840 ) um
+[INFO GPL-0013] Placement BBox: (  1.140  1.120 ) ( 35.150 34.720 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                  1142.736 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/cluster_place01.ok
+++ b/src/gpl/test/cluster_place01.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  1.140  1.120 ) ( 35.150 34.720 ) um
+[INFO GPL-0016] Core area:                    1142.736 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/convergence01.ok
+++ b/src/gpl/test/convergence01.ok
@@ -19,6 +19,7 @@
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.054  0.270 ) um
 [INFO GPL-0004] CoreBBox: (  0.486  0.540 ) ( 11.502 11.340 ) um
+[INFO GPL-0016] Core area:                     118.973 um^2
 [INFO GPL-0036] Movable instances area:         15.528 um^2
 [INFO GPL-0037] Total instances area:           17.860 um^2
 [INFO GPL-0035] Pin density area adjust:        -1.121 um^2

--- a/src/gpl/test/convergence01.ok
+++ b/src/gpl/test/convergence01.ok
@@ -29,9 +29,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     98
 [INFO GPL-0011] Number of pins:                    227
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 12.000 12.000 ) um
-[INFO GPL-0013] Core BBox: (  0.486  0.540 ) ( 11.502 11.340 ) um
-[INFO GPL-0016] Core area:                     118.973 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 12.000 12.000 ) um
+[INFO GPL-0013] Placement BBox: (  0.486  0.540 ) ( 11.502 11.340 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   118.973 um^2
 [INFO GPL-0017] Fixed instances area:            2.333 um^2

--- a/src/gpl/test/core01.ok
+++ b/src/gpl/test/core01.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 36.290 35.840 ) um
-[INFO GPL-0013] Core BBox: (  1.140  1.120 ) ( 35.150 34.720 ) um
-[INFO GPL-0016] Core area:                    1142.736 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 36.290 35.840 ) um
+[INFO GPL-0013] Placement BBox: (  1.140  1.120 ) ( 35.150 34.720 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                  1142.736 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/core01.ok
+++ b/src/gpl/test/core01.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  1.140  1.120 ) ( 35.150 34.720 ) um
+[INFO GPL-0016] Core area:                    1142.736 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -13,6 +13,7 @@ pad : 2 -> 1.030
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -23,9 +23,8 @@ pad : 2 -> 1.030
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/diverge01.ok
+++ b/src/gpl/test/diverge01.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/diverge01.ok
+++ b/src/gpl/test/diverge01.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/error01.ok
+++ b/src/gpl/test/error01.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/error01.ok
+++ b/src/gpl/test/error01.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/incremental01.ok
+++ b/src/gpl/test/incremental01.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/incremental01.ok
+++ b/src/gpl/test/incremental01.ok
@@ -18,9 +18,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/nograd01.ok
+++ b/src/gpl/test/nograd01.ok
@@ -18,9 +18,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     12
 [INFO GPL-0011] Number of pins:                     12
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 120.000 120.000 ) um
-[INFO GPL-0013] Core BBox: ( 10.044 10.260 ) ( 109.998 109.890 ) um
-[INFO GPL-0016] Core area:                    9958.417 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 120.000 120.000 ) um
+[INFO GPL-0013] Placement BBox: ( 10.044 10.260 ) ( 109.998 109.890 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                  9958.417 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/nograd01.ok
+++ b/src/gpl/test/nograd01.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.054  0.270 ) um
 [INFO GPL-0004] CoreBBox: ( 10.044 10.260 ) ( 109.998 109.890 ) um
+[INFO GPL-0016] Core area:                    9958.417 um^2
 [INFO GPL-0036] Movable instances area:          0.437 um^2
 [INFO GPL-0037] Total instances area:            0.437 um^2
 [INFO GPL-0035] Pin density area adjust:         0.000 um^2

--- a/src/gpl/test/region01.ok
+++ b/src/gpl/test/region01.ok
@@ -30,6 +30,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.460  2.720 ) um
 [INFO GPL-0004] CoreBBox: (  2.300  2.720 ) ( 375.360 375.360 ) um
+[INFO GPL-0016] Core area:                  139017.078 um^2
 [INFO GPL-0036] Movable instances area:       6974.189 um^2
 [INFO GPL-0037] Total instances area:         6974.189 um^2
 [INFO GPL-0035] Pin density area adjust:       477.053 um^2

--- a/src/gpl/test/region01.ok
+++ b/src/gpl/test/region01.ok
@@ -40,9 +40,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                   103
 [INFO GPL-0010] Number of nets:                    666
 [INFO GPL-0011] Number of pins:                   2059
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 377.475 377.475 ) um
-[INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 375.360 375.360 ) um
-[INFO GPL-0016] Core area:                  139017.078 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 377.475 377.475 ) um
+[INFO GPL-0013] Placement BBox: (  2.300  2.720 ) ( 375.360 375.360 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                139017.078 um^2
 [INFO GPL-0017] Fixed instances area:        68045.261 um^2
@@ -57,9 +56,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    666
 [INFO GPL-0011] Number of pins:                   2059
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 377.475 377.475 ) um
-[INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 375.360 375.360 ) um
-[INFO GPL-0016] Core area:                  139017.078 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 377.475 377.475 ) um
+[INFO GPL-0013] Placement BBox: ( 40.000 40.000 ) ( 250.000 150.000 ) um
 [INFO GPL-0014] Region name: spm_inst_0_domain.
 [INFO GPL-0015] Region area:                 23100.000 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
@@ -74,9 +72,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    666
 [INFO GPL-0011] Number of pins:                   2059
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 377.475 377.475 ) um
-[INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 375.360 375.360 ) um
-[INFO GPL-0016] Core area:                  139017.078 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 377.475 377.475 ) um
+[INFO GPL-0013] Placement BBox: ( 40.000 210.000 ) ( 250.000 320.000 ) um
 [INFO GPL-0014] Region name: spm_inst_1_domain.
 [INFO GPL-0015] Region area:                 23100.000 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-obs.ok
+++ b/src/gpl/test/simple01-obs.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple01-obs.ok
+++ b/src/gpl/test/simple01-obs.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                   406
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:          218.652 um^2

--- a/src/gpl/test/simple01-rd.ok
+++ b/src/gpl/test/simple01-rd.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-rd.ok
+++ b/src/gpl/test/simple01-rd.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple01-ref.ok
+++ b/src/gpl/test/simple01-ref.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-ref.ok
+++ b/src/gpl/test/simple01-ref.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple01-skip-io.ok
+++ b/src/gpl/test/simple01-skip-io.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1068
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-skip-io.ok
+++ b/src/gpl/test/simple01-skip-io.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple01-td-net-percentage.ok
+++ b/src/gpl/test/simple01-td-net-percentage.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-td-net-percentage.ok
+++ b/src/gpl/test/simple01-td-net-percentage.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-td-repair.ok
+++ b/src/gpl/test/simple01-td-repair.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-td-repair.ok
+++ b/src/gpl/test/simple01-td-repair.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-td-tune.ok
+++ b/src/gpl/test/simple01-td-tune.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-td-tune.ok
+++ b/src/gpl/test/simple01-td-tune.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-td.ok
+++ b/src/gpl/test/simple01-td.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-td.ok
+++ b/src/gpl/test/simple01-td.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-uniform.ok
+++ b/src/gpl/test/simple01-uniform.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-uniform.ok
+++ b/src/gpl/test/simple01-uniform.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple01-vcts-clamp.ok
+++ b/src/gpl/test/simple01-vcts-clamp.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-vcts-clamp.ok
+++ b/src/gpl/test/simple01-vcts-clamp.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-vcts-noclk.ok
+++ b/src/gpl/test/simple01-vcts-noclk.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-vcts-noclk.ok
+++ b/src/gpl/test/simple01-vcts-noclk.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-vcts-userlat.ok
+++ b/src/gpl/test/simple01-vcts-userlat.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-vcts-userlat.ok
+++ b/src/gpl/test/simple01-vcts-userlat.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01-vcts.ok
+++ b/src/gpl/test/simple01-vcts.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    356
 [INFO GPL-0011] Number of pins:                   1106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01-vcts.ok
+++ b/src/gpl/test/simple01-vcts.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        553.280 um^2
 [INFO GPL-0037] Total instances area:          553.280 um^2
 [INFO GPL-0035] Pin density area adjust:        47.712 um^2

--- a/src/gpl/test/simple01.ok
+++ b/src/gpl/test/simple01.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple01.ok
+++ b/src/gpl/test/simple01.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple02-rd.ok
+++ b/src/gpl/test/simple02-rd.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple02-rd.ok
+++ b/src/gpl/test/simple02-rd.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple02.ok
+++ b/src/gpl/test/simple02.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     1
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.266 um^2

--- a/src/gpl/test/simple02.ok
+++ b/src/gpl/test/simple02.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple03-rd.ok
+++ b/src/gpl/test/simple03-rd.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple03-rd.ok
+++ b/src/gpl/test/simple03-rd.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple03.ok
+++ b/src/gpl/test/simple03.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple03.ok
+++ b/src/gpl/test/simple03.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple04-rd.ok
+++ b/src/gpl/test/simple04-rd.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple04-rd.ok
+++ b/src/gpl/test/simple04-rd.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple04.ok
+++ b/src/gpl/test/simple04.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple04.ok
+++ b/src/gpl/test/simple04.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple05.ok
+++ b/src/gpl/test/simple05.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  1.900  1.400 ) (  7.980  7.000 ) um
+[INFO GPL-0016] Core area:                      34.048 um^2
 [INFO GPL-0036] Movable instances area:          1.862 um^2
 [INFO GPL-0037] Total instances area:            1.862 um^2
 [INFO GPL-0035] Pin density area adjust:         0.000 um^2

--- a/src/gpl/test/simple05.ok
+++ b/src/gpl/test/simple05.ok
@@ -18,9 +18,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                      2
 [INFO GPL-0011] Number of pins:                      4
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 10.000 10.000 ) um
-[INFO GPL-0013] Core BBox: (  1.900  1.400 ) (  7.980  7.000 ) um
-[INFO GPL-0016] Core area:                      34.048 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 10.000 10.000 ) um
+[INFO GPL-0013] Placement BBox: (  1.900  1.400 ) (  7.980  7.000 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                    34.048 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple06.ok
+++ b/src/gpl/test/simple06.ok
@@ -17,9 +17,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                    364
 [INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple06.ok
+++ b/src/gpl/test/simple06.ok
@@ -7,6 +7,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:        569.772 um^2
 [INFO GPL-0037] Total instances area:          569.772 um^2
 [INFO GPL-0035] Pin density area adjust:        49.963 um^2

--- a/src/gpl/test/simple07.ok
+++ b/src/gpl/test/simple07.ok
@@ -12,6 +12,7 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.460  2.720 ) um
 [INFO GPL-0004] CoreBBox: (  5.520 10.880 ) ( 28.520 43.520 ) um
+[INFO GPL-0016] Core area:                     750.720 um^2
 [INFO GPL-0036] Movable instances area:          3.754 um^2
 [INFO GPL-0037] Total instances area:          102.598 um^2
 [INFO GPL-0035] Pin density area adjust:         0.000 um^2

--- a/src/gpl/test/simple07.ok
+++ b/src/gpl/test/simple07.ok
@@ -22,9 +22,8 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                      2
 [INFO GPL-0011] Number of pins:                      4
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 34.165 54.885 ) um
-[INFO GPL-0013] Core BBox: (  5.520 10.880 ) ( 28.520 43.520 ) um
-[INFO GPL-0016] Core area:                     750.720 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 34.165 54.885 ) um
+[INFO GPL-0013] Placement BBox: (  5.520 10.880 ) ( 28.520 43.520 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   750.720 um^2
 [INFO GPL-0017] Fixed instances area:           98.845 um^2

--- a/src/gpl/test/simple08.ok
+++ b/src/gpl/test/simple08.ok
@@ -12,6 +12,7 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.460  2.720 ) um
 [INFO GPL-0004] CoreBBox: (  5.520 10.880 ) ( 28.520 43.520 ) um
+[INFO GPL-0016] Core area:                     750.720 um^2
 [INFO GPL-0036] Movable instances area:          3.754 um^2
 [INFO GPL-0037] Total instances area:          102.598 um^2
 [INFO GPL-0035] Pin density area adjust:         0.000 um^2

--- a/src/gpl/test/simple08.ok
+++ b/src/gpl/test/simple08.ok
@@ -22,9 +22,8 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                      2
 [INFO GPL-0011] Number of pins:                      4
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 34.165 54.885 ) um
-[INFO GPL-0013] Core BBox: (  5.520 10.880 ) ( 28.520 43.520 ) um
-[INFO GPL-0016] Core area:                     750.720 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 34.165 54.885 ) um
+[INFO GPL-0013] Placement BBox: (  5.520 10.880 ) ( 28.520 43.520 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   750.720 um^2
 [INFO GPL-0017] Fixed instances area:           98.845 um^2

--- a/src/gpl/test/simple09.ok
+++ b/src/gpl/test/simple09.ok
@@ -18,9 +18,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                      2
 [INFO GPL-0011] Number of pins:                      4
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                   953.876 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/simple09.ok
+++ b/src/gpl/test/simple09.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
+[INFO GPL-0016] Core area:                     953.876 um^2
 [INFO GPL-0036] Movable instances area:          1.862 um^2
 [INFO GPL-0037] Total instances area:            1.862 um^2
 [INFO GPL-0035] Pin density area adjust:         0.000 um^2

--- a/src/gpl/test/simple10.ok
+++ b/src/gpl/test/simple10.ok
@@ -12,6 +12,7 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.460  2.720 ) um
 [INFO GPL-0004] CoreBBox: ( 10.120 10.880 ) ( 7989.740 7988.640 ) um
+[INFO GPL-0016] Core area:                  63659493.251 um^2
 [INFO GPL-0036] Movable instances area:          3.754 um^2
 [INFO GPL-0037] Total instances area:          117.613 um^2
 [INFO GPL-0035] Pin density area adjust:         0.000 um^2

--- a/src/gpl/test/simple10.ok
+++ b/src/gpl/test/simple10.ok
@@ -22,9 +22,8 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                      2
 [INFO GPL-0011] Number of pins:                      4
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 8000.000 8000.000 ) um
-[INFO GPL-0013] Core BBox: ( 10.120 10.880 ) ( 7989.740 7988.640 ) um
-[INFO GPL-0016] Core area:                  63659493.251 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 8000.000 8000.000 ) um
+[INFO GPL-0013] Placement BBox: ( 10.120 10.880 ) ( 7989.740 7988.640 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                63659493.251 um^2
 [INFO GPL-0017] Fixed instances area:           53.802 um^2

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -5109,6 +5109,11 @@ class dbRegion : public dbObject
   dbSet<dbBox> getBoundaries();
 
   ///
+  /// Get the overlap area between the region and a rectangle
+  ///
+  int64_t getOverlapArea(const Rect& r);
+
+  ///
   /// Add this instance to the region
   ///
   void addInst(dbInst* inst);

--- a/src/odb/src/db/dbRegion.cpp
+++ b/src/odb/src/db/dbRegion.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "dbBlock.h"
 #include "dbBox.h"

--- a/src/odb/src/db/dbRegion.cpp
+++ b/src/odb/src/db/dbRegion.cpp
@@ -25,6 +25,7 @@
 #include "odb/dbBlockCallBackObj.h"
 #include "odb/dbSet.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 
 namespace odb {
 
@@ -182,6 +183,30 @@ dbSet<dbBox> dbRegion::getBoundaries()
   return dbSet<dbBox>(region, block->box_itr_);
 }
 
+int64_t dbRegion::getOverlapArea(const Rect& r)
+{
+  auto boundaries = getBoundaries();
+  std::vector<Rect> intersections;
+  int64_t area = 0;
+  if (!boundaries.empty()) {
+    for (auto bound : boundaries) {
+      Rect intersection;
+      bound->getBox().intersection(r, intersection);
+      intersections.push_back(intersection);
+      area += intersection.area();
+    }
+  }
+  // Remove overlapping area between boundaries
+  for (auto i = 0; i < intersections.size(); i++) {
+    for (auto j = i + 1; j < intersections.size(); j++) {
+      Rect intersection;
+      intersections[i].intersection(r, intersections[j]);
+      area -= intersection.area();
+    }
+  }
+  return area;
+}
+
 void dbRegion::addInst(dbInst* inst_)
 {
   _dbRegion* region = (_dbRegion*) this;
@@ -237,6 +262,7 @@ void dbRegion::removeInst(dbInst* inst_)
 
   inst->region_ = 0;
 }
+
 void dbRegion::removeGroup(dbGroup* group)
 {
   _dbRegion* region = (_dbRegion*) this;

--- a/src/odb/test/replace_hier_mod1.ok
+++ b/src/odb/test/replace_hier_mod1.ok
@@ -20,6 +20,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
+[INFO GPL-0016] Core area:                   47872.020 um^2
 [INFO GPL-0036] Movable instances area:         60.382 um^2
 [INFO GPL-0037] Total instances area:           60.382 um^2
 [INFO GPL-0035] Pin density area adjust:        -5.299 um^2
@@ -150,6 +151,7 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
+[INFO GPL-0016] Core area:                   47872.020 um^2
 [INFO GPL-0036] Movable instances area:         59.850 um^2
 [INFO GPL-0037] Total instances area:           59.850 um^2
 [INFO GPL-0035] Pin density area adjust:        -5.299 um^2
@@ -334,6 +336,7 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
+[INFO GPL-0016] Core area:                   47872.020 um^2
 [INFO GPL-0036] Movable instances area:         60.382 um^2
 [INFO GPL-0037] Total instances area:           60.382 um^2
 [INFO GPL-0035] Pin density area adjust:        -5.299 um^2
@@ -548,6 +551,7 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
+[INFO GPL-0016] Core area:                   47872.020 um^2
 [INFO GPL-0036] Movable instances area:         59.850 um^2
 [INFO GPL-0037] Total instances area:           59.850 um^2
 [INFO GPL-0035] Pin density area adjust:        -5.299 um^2

--- a/src/odb/test/replace_hier_mod1.ok
+++ b/src/odb/test/replace_hier_mod1.ok
@@ -30,9 +30,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     11
 [INFO GPL-0011] Number of pins:                     38
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 40.000 1200.000 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
-[INFO GPL-0016] Core area:                   47872.020 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 40.000 1200.000 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                 47872.020 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
@@ -161,9 +160,8 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     11
 [INFO GPL-0011] Number of pins:                     38
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 40.000 1200.000 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
-[INFO GPL-0016] Core area:                   47872.020 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 40.000 1200.000 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                 47872.020 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
@@ -346,9 +344,8 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     11
 [INFO GPL-0011] Number of pins:                     38
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 40.000 1200.000 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
-[INFO GPL-0016] Core area:                   47872.020 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 40.000 1200.000 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                 47872.020 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
@@ -561,9 +558,8 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     11
 [INFO GPL-0011] Number of pins:                     38
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 40.000 1200.000 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
-[INFO GPL-0016] Core area:                   47872.020 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 40.000 1200.000 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 39.900 1199.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                 47872.020 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/test/upf_aes.ok
+++ b/test/upf_aes.ok
@@ -22,6 +22,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.460  2.720 ) um
 [INFO GPL-0004] CoreBBox: ( 30.360 32.640 ) ( 969.680 968.320 ) um
+[INFO GPL-0016] Core area:                  878902.938 um^2
 [INFO GPL-0036] Movable instances area:     368817.475 um^2
 [INFO GPL-0037] Total instances area:       368817.475 um^2
 [INFO GPL-0035] Pin density area adjust:     51093.513 um^2

--- a/test/upf_aes.ok
+++ b/test/upf_aes.ok
@@ -966,25 +966,39 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1012] Total routability artificial inflation: 6746.89 (+1.61%)
 [INFO GPL-1013] Total timing-driven delta area: -27258.16 (-6.49%)
 [INFO GPL-1014] Final placement area: 399399.72 (-4.88%)
-[INFO DPL-0006] Core area: 878902.94 um^2, Instances area: 341550.07 um^2, Utilization: 38.9%
+[INFO DPL-0006] Core area: 878902.94 um^2
+[INFO DPL-0007] Movable instances area: 341550.07 um^2
+[INFO DPL-0008] Fixed instances area within core: 0.00 um^2
+[INFO DPL-0009] Utilization: 38.9%
 [INFO DPL-0005] Diamond search max displacement: +/- 1413 sites horizontally, +/- 238 rows vertically.
-[INFO DPL-1101] Legalizing using diamond search.
-Movements Summary
----------------------------------------
-Total cells:                   16929
-Diamond Move Success:          16929 (100.00%)
-Diamond Move Failure:              0
-Rip-up and replace Success:        0 (  0.00% of diamond failures)
-Rip-up and replace Failure:        0
-Total Placement Failures:          0
----------------------------------------
+[INFO DPL-1102] Legalizing using negotiation legalizer.
+[INFO DPL-1103] Negotiation base search window: +/-20 sites horizontally, +/-5 rows vertically 
+	Automatic search window extension enabled.
+	Search window extendable up to the max displacement cap of +/-1413 sites, +/-238 rows near walls.
+[INFO DPL-1104] NegotiationLegalizer DRC penalty: 5.
+[INFO DPL-0392] Negotiation cell height distribution (1 unique row-count(s)):
+[INFO DPL-0393]   height 1 row(s): 45715 cells
+          |      Total |  Illegal |  Illegal
+Iteration | Violations |    Cells |    Sites
+---------------------------------------------
+        0 |        198 |       148 |        50
+        1 |        131 |       131 |         0
+        2 |        131 |       131 |         0
+        3 |        131 |       131 |         0
+        4 |        131 |       131 |         0
+[WARNING DPL-0700] Negotiation phase 1: violations stuck at 131 for 3 consecutive iterations.
+Using old diamond search for 131 remaining illegal cells.
+diamond recovery: recovered 131/131 stuck cells.
+Negotiation phase 2: isolation point active, 1000 iterations.
+      400 |          0 |         0 |         0
+Negotiation phase 2 converged at iteration 0.
 Placement Analysis
 ---------------------------------
-total displacement     105480.2 u
-average displacement        2.3 u
+total displacement     159153.3 u
+average displacement        3.5 u
 max displacement          636.0 u
 original HPWL         3007148.2 u
-legalized HPWL        3117557.6 u
+legalized HPWL        3135498.6 u
 delta HPWL                    4 %
 
 Detailed placement improvement.
@@ -1002,56 +1016,57 @@ Detailed placement improvement.
 [INFO DPL-0312] Found 0 edge spacing violations and 0 padding violations.
 [INFO DPL-0303] Running algorithm for independent set matching.
 [INFO DPL-0300] Set matching objective is wirelength.
-[INFO DPL-0301] Pass   1 of matching; objective is 3.117910e+09.
-[INFO DPL-0301] Pass   2 of matching; objective is 3.058705e+09.
-[INFO DPL-0302] End of matching; objective is 3.045506e+09, improvement is 2.32 percent.
+[INFO DPL-0301] Pass   1 of matching; objective is 3.135771e+09.
+[INFO DPL-0301] Pass   2 of matching; objective is 3.075786e+09.
+[INFO DPL-0302] End of matching; objective is 3.062543e+09, improvement is 2.34 percent.
 [INFO DPL-0303] Running algorithm for global swaps.
-[INFO DPL-0306] Pass   1 of global swaps; hpwl is 2.939838e+09.
-[INFO DPL-0306] Pass   2 of global swaps; hpwl is 2.889527e+09.
-[INFO DPL-0306] Pass   3 of global swaps; hpwl is 2.860291e+09.
-[INFO DPL-0306] Pass   4 of global swaps; hpwl is 2.841017e+09.
-[INFO DPL-0307] End of global swaps; objective is 2.841017e+09, improvement is 6.71 percent.
+[INFO DPL-0306] Pass   1 of global swaps; hpwl is 2.942839e+09.
+[INFO DPL-0306] Pass   2 of global swaps; hpwl is 2.889985e+09.
+[INFO DPL-0306] Pass   3 of global swaps; hpwl is 2.858345e+09.
+[INFO DPL-0306] Pass   4 of global swaps; hpwl is 2.838475e+09.
+[INFO DPL-0307] End of global swaps; objective is 2.838475e+09, improvement is 7.32 percent.
 [INFO DPL-0303] Running algorithm for vertical swaps.
-[INFO DPL-0308] Pass   1 of vertical swaps; hpwl is 2.813716e+09.
-[INFO DPL-0309] End of vertical swaps; objective is 2.813716e+09, improvement is 0.96 percent.
+[INFO DPL-0308] Pass   1 of vertical swaps; hpwl is 2.809214e+09.
+[INFO DPL-0308] Pass   2 of vertical swaps; hpwl is 2.791465e+09.
+[INFO DPL-0309] End of vertical swaps; objective is 2.791465e+09, improvement is 1.66 percent.
 [INFO DPL-0303] Running algorithm for reordering.
-[INFO DPL-0304] Pass   1 of reordering; objective is 2.785118e+09.
-[INFO DPL-0304] Pass   2 of reordering; objective is 2.768384e+09.
-[INFO DPL-0305] End of reordering; objective is 2.768384e+09, improvement is 1.61 percent.
+[INFO DPL-0304] Pass   1 of reordering; objective is 2.761612e+09.
+[INFO DPL-0304] Pass   2 of reordering; objective is 2.745415e+09.
+[INFO DPL-0305] End of reordering; objective is 2.745415e+09, improvement is 1.65 percent.
 [INFO DPL-0303] Running algorithm for random improvement.
 [INFO DPL-0324] Random improver is using random generator.
 [INFO DPL-0325] Random improver is using hpwl objective.
 [INFO DPL-0326] Random improver cost string is (a).
 [INFO DPL-0332] End of pass, Generator random called 914300 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 914300, swaps 272252, moves 641425 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.759646e+09, Scratch cost 2.685537e+09, Incremental cost 2.685537e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.685537e+09.
-[INFO DPL-0327] Pass   1 of random improver; improvement in cost is 2.69 percent.
+[INFO DPL-0335] Generator random, Cumulative attempts 914300, swaps 285313, moves 628179 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.736541e+09, Scratch cost 2.667794e+09, Incremental cost 2.667794e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.667794e+09.
+[INFO DPL-0327] Pass   1 of random improver; improvement in cost is 2.51 percent.
 [INFO DPL-0332] End of pass, Generator random called 914300 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 1828600, swaps 553849, moves 1273248 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.685537e+09, Scratch cost 2.637342e+09, Incremental cost 2.637342e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.637342e+09.
-[INFO DPL-0327] Pass   2 of random improver; improvement in cost is 1.79 percent.
+[INFO DPL-0335] Generator random, Cumulative attempts 1828600, swaps 577753, moves 1249022 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.667794e+09, Scratch cost 2.622367e+09, Incremental cost 2.622367e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.622367e+09.
+[INFO DPL-0327] Pass   2 of random improver; improvement in cost is 1.70 percent.
 [INFO DPL-0332] End of pass, Generator random called 914300 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 2742900, swaps 845943, moves 1894392 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.637342e+09, Scratch cost 2.597091e+09, Incremental cost 2.597091e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.597091e+09.
-[INFO DPL-0327] Pass   3 of random improver; improvement in cost is 1.53 percent.
+[INFO DPL-0335] Generator random, Cumulative attempts 2742900, swaps 878964, moves 1860888 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.622367e+09, Scratch cost 2.585620e+09, Incremental cost 2.585620e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.585620e+09.
+[INFO DPL-0327] Pass   3 of random improver; improvement in cost is 1.40 percent.
 [INFO DPL-0332] End of pass, Generator random called 914300 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 3657200, swaps 1148298, moves 2505102 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.597091e+09, Scratch cost 2.563627e+09, Incremental cost 2.563627e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.563627e+09.
-[INFO DPL-0327] Pass   4 of random improver; improvement in cost is 1.29 percent.
+[INFO DPL-0335] Generator random, Cumulative attempts 3657200, swaps 1189637, moves 2462958 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.585620e+09, Scratch cost 2.552909e+09, Incremental cost 2.552909e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.552909e+09.
+[INFO DPL-0327] Pass   4 of random improver; improvement in cost is 1.27 percent.
 [INFO DPL-0332] End of pass, Generator random called 914300 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 4571500, swaps 1458823, moves 3107387 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.563627e+09, Scratch cost 2.533726e+09, Incremental cost 2.533726e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.533726e+09.
-[INFO DPL-0327] Pass   5 of random improver; improvement in cost is 1.17 percent.
-[INFO DPL-0328] End of random improver; improvement is 8.186575 percent.
+[INFO DPL-0335] Generator random, Cumulative attempts 4571500, swaps 1509177, moves 3055860 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.552909e+09, Scratch cost 2.524037e+09, Incremental cost 2.524037e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.524037e+09.
+[INFO DPL-0327] Pass   5 of random improver; improvement in cost is 1.13 percent.
+[INFO DPL-0328] End of random improver; improvement is 7.765439 percent.
 [INFO DPL-0380] Cell flipping.
 [INFO DPL-0382] Changed 0 cell orientations for row compatibility.
-[INFO DPL-0383] Performed 12818 cell flips.
-[INFO DPL-0384] End of flipping; objective is 2.523988e+09, improvement is 0.73 percent.
+[INFO DPL-0383] Performed 12794 cell flips.
+[INFO DPL-0384] End of flipping; objective is 2.514323e+09, improvement is 0.72 percent.
 [INFO DPL-0313] Found 0 cells in wrong regions.
 [INFO DPL-0315] Found 0 row alignment problems.
 [INFO DPL-0314] Found 0 site alignment problems.
@@ -1059,8 +1074,8 @@ Detailed placement improvement.
 [INFO DPL-0312] Found 0 edge spacing violations and 0 padding violations.
 Detailed Improvement Results
 ------------------------------------------
-Original HPWL          3117557.6 u ( 2036579.9,  1080977.6)
-Final HPWL             2524139.9 u ( 1630894.0,   893245.8)
-Delta HPWL                 -19.0 % (     -19.9,      -17.4)
+Original HPWL          3135498.6 u ( 2026661.4,  1108837.2)
+Final HPWL             2514494.1 u ( 1621128.8,   893365.3)
+Delta HPWL                 -19.8 % (     -20.0,      -19.4)
 
 No differences found.

--- a/test/upf_aes.ok
+++ b/test/upf_aes.ok
@@ -32,9 +32,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                   344
 [INFO GPL-0010] Number of nets:                  51671
 [INFO GPL-0011] Number of pins:                 199034
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1000.000 1000.000 ) um
-[INFO GPL-0013] Core BBox: ( 30.360 32.640 ) ( 969.680 968.320 ) um
-[INFO GPL-0016] Core area:                  878902.938 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1000.000 1000.000 ) um
+[INFO GPL-0013] Placement BBox: ( 30.360 32.640 ) ( 969.680 968.320 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                878902.938 um^2
 [INFO GPL-0017] Fixed instances area:       595260.902 um^2
@@ -49,14 +48,13 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  51671
 [INFO GPL-0011] Number of pins:                 199034
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1000.000 1000.000 ) um
-[INFO GPL-0013] Core BBox: ( 30.360 32.640 ) ( 969.680 968.320 ) um
-[INFO GPL-0016] Core area:                  878902.938 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1000.000 1000.000 ) um
+[INFO GPL-0013] Placement BBox: ( 30.360 32.640 ) ( 650.000 490.000 ) um
 [INFO GPL-0014] Region name: PD_AES_1.
-[INFO GPL-0015] Region area:                285200.000 um^2
+[INFO GPL-0015] Region area:                283398.550 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
 [INFO GPL-0018] Movable instances area:     137986.283 um^2
-[INFO GPL-0019] Utilization:                    48.382 %
+[INFO GPL-0019] Utilization:                    48.690 %
 [INFO GPL-0020] Standard cells area:        137986.283 um^2
 [INFO GPL-0021] Large instances area:            0.000 um^2
 [INFO GPL-0032] ---- Initialize Region: PD_AES_2
@@ -66,14 +64,13 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  51671
 [INFO GPL-0011] Number of pins:                 199034
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1000.000 1000.000 ) um
-[INFO GPL-0013] Core BBox: ( 30.360 32.640 ) ( 969.680 968.320 ) um
-[INFO GPL-0016] Core area:                  878902.938 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1000.000 1000.000 ) um
+[INFO GPL-0013] Placement BBox: ( 30.360 510.000 ) ( 650.000 968.320 ) um
 [INFO GPL-0014] Region name: PD_AES_2.
-[INFO GPL-0015] Region area:                285200.000 um^2
+[INFO GPL-0015] Region area:                283993.405 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
 [INFO GPL-0018] Movable instances area:     137986.283 um^2
-[INFO GPL-0019] Utilization:                    48.382 %
+[INFO GPL-0019] Utilization:                    48.588 %
 [INFO GPL-0020] Standard cells area:        137986.283 um^2
 [INFO GPL-0021] Large instances area:            0.000 um^2
 [INFO GPL-0005] ---- Execute Conjugate Gradient Initial Placement.
@@ -89,1265 +86,914 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0029] Bin size (W * H):       7.338 *  7.310 um
 [INFO GPL-0030] Number of bins:                  16384
 [INFO GPL-0033] ---- Initialize Nesterov Region: PD_AES_1
-[INFO GPL-0023] Placement target density:       0.4938
+[INFO GPL-0023] Placement target density:       0.4969
 [INFO GPL-0024] Movable insts average area:      8.183 um^2
-[INFO GPL-0025] Ideal bin area:                 16.571 um^2
-[INFO GPL-0026] Ideal bin count:                 17210
-[INFO GPL-0027] Total bin area:             285200.000 um^2
+[INFO GPL-0025] Ideal bin area:                 16.469 um^2
+[INFO GPL-0026] Ideal bin count:                 17208
+[INFO GPL-0027] Total bin area:             283398.550 um^2
 [INFO GPL-0028] Bin count (X, Y):         128 ,    128
-[INFO GPL-0029] Bin size (W * H):       4.844 *  3.594 um
+[INFO GPL-0029] Bin size (W * H):       4.841 *  3.573 um
 [INFO GPL-0030] Number of bins:                  16384
 [INFO GPL-0033] ---- Initialize Nesterov Region: PD_AES_2
-[INFO GPL-0023] Placement target density:       0.4938
+[INFO GPL-0023] Placement target density:       0.4959
 [INFO GPL-0024] Movable insts average area:      8.183 um^2
-[INFO GPL-0025] Ideal bin area:                 16.571 um^2
-[INFO GPL-0026] Ideal bin count:                 17210
-[INFO GPL-0027] Total bin area:             285200.000 um^2
+[INFO GPL-0025] Ideal bin area:                 16.503 um^2
+[INFO GPL-0026] Ideal bin count:                 17209
+[INFO GPL-0027] Total bin area:             283993.405 um^2
 [INFO GPL-0028] Bin count (X, Y):         128 ,    128
-[INFO GPL-0029] Bin size (W * H):       4.844 *  3.594 um
+[INFO GPL-0029] Bin size (W * H):       4.841 *  3.581 um
 [INFO GPL-0030] Number of bins:                  16384
 [INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-        0 |   0.9998 |  5.793855e+05 |   +0.00% |  1.31e-14 |      
-        0 |   0.9972 |  5.793855e+05 |   +0.00% |  2.91e-15 |  (PD_AES_1)
-        0 |   0.9971 |  5.793855e+05 |   +0.00% |  2.36e-15 |  (PD_AES_2)
-       10 |   0.9998 |  7.172369e+05 |  +23.79% |  2.08e-14 |      
-       10 |   0.9672 |  7.172369e+05 |  +23.79% |  4.61e-15 |  (PD_AES_1)
-       10 |   0.9720 |  7.172369e+05 |  +23.79% |  3.75e-15 |  (PD_AES_2)
-       20 |   0.9998 |  7.206311e+05 |   +0.47% |  3.37e-14 |      
-       20 |   0.9680 |  7.206311e+05 |   +0.47% |  7.49e-15 |  (PD_AES_1)
-       20 |   0.9682 |  7.206311e+05 |   +0.47% |  6.08e-15 |  (PD_AES_2)
-       30 |   0.9998 |  6.855499e+05 |   -4.87% |  5.49e-14 |      
-       30 |   0.9701 |  6.855499e+05 |   -4.87% |  1.22e-14 |  (PD_AES_1)
-       30 |   0.9706 |  6.855499e+05 |   -4.87% |  9.91e-15 |  (PD_AES_2)
-       40 |   0.9998 |  6.684118e+05 |   -2.50% |  8.95e-14 |      
-       40 |   0.9698 |  6.684118e+05 |   -2.50% |  1.99e-14 |  (PD_AES_1)
-       40 |   0.9710 |  6.684118e+05 |   -2.50% |  1.61e-14 |  (PD_AES_2)
-       50 |   0.9998 |  6.475392e+05 |   -3.12% |  1.46e-13 |      
-       50 |   0.9710 |  6.475392e+05 |   -3.12% |  3.24e-14 |  (PD_AES_1)
-       50 |   0.9717 |  6.475392e+05 |   -3.12% |  2.63e-14 |  (PD_AES_2)
-       60 |   0.9998 |  6.221209e+05 |   -3.93% |  2.37e-13 |      
-       60 |   0.9715 |  6.221209e+05 |   -3.93% |  5.27e-14 |  (PD_AES_1)
-       60 |   0.9722 |  6.221209e+05 |   -3.93% |  4.28e-14 |  (PD_AES_2)
-       70 |   0.9998 |  5.977787e+05 |   -3.91% |  3.87e-13 |      
-       70 |   0.9721 |  5.977787e+05 |   -3.91% |  8.58e-14 |  (PD_AES_1)
-       70 |   0.9735 |  5.977787e+05 |   -3.91% |  6.97e-14 |  (PD_AES_2)
-       80 |   0.9998 |  5.738810e+05 |   -4.00% |  6.30e-13 |      
-       80 |   0.9730 |  5.738810e+05 |   -4.00% |  1.40e-13 |  (PD_AES_1)
-       80 |   0.9745 |  5.738810e+05 |   -4.00% |  1.14e-13 |  (PD_AES_2)
-       90 |   0.9998 |  5.514201e+05 |   -3.91% |  1.03e-12 |      
-       90 |   0.9745 |  5.514201e+05 |   -3.91% |  2.28e-13 |  (PD_AES_1)
-       90 |   0.9758 |  5.514201e+05 |   -3.91% |  1.85e-13 |  (PD_AES_2)
-      100 |   0.9998 |  5.331812e+05 |   -3.31% |  1.67e-12 |      
-      100 |   0.9756 |  5.331812e+05 |   -3.31% |  3.71e-13 |  (PD_AES_1)
-      100 |   0.9758 |  5.331812e+05 |   -3.31% |  3.01e-13 |  (PD_AES_2)
-      110 |   0.9998 |  5.206564e+05 |   -2.35% |  2.72e-12 |      
-      110 |   0.9759 |  5.206564e+05 |   -2.35% |  6.04e-13 |  (PD_AES_1)
-      110 |   0.9759 |  5.206564e+05 |   -2.35% |  4.91e-13 |  (PD_AES_2)
-      120 |   0.9998 |  5.145984e+05 |   -1.16% |  4.43e-12 |      
-      120 |   0.9757 |  5.145984e+05 |   -1.16% |  9.84e-13 |  (PD_AES_1)
-      120 |   0.9746 |  5.145984e+05 |   -1.16% |  8.00e-13 |  (PD_AES_2)
-      130 |   0.9998 |  5.167807e+05 |   +0.42% |  7.22e-12 |      
-      130 |   0.9735 |  5.167807e+05 |   +0.42% |  1.60e-12 |  (PD_AES_1)
-      130 |   0.9724 |  5.167807e+05 |   +0.42% |  1.30e-12 |  (PD_AES_2)
-      140 |   0.9998 |  5.327825e+05 |   +3.10% |  1.17e-11 |      
-      140 |   0.9682 |  5.327825e+05 |   +3.10% |  2.61e-12 |  (PD_AES_1)
-      140 |   0.9681 |  5.327825e+05 |   +3.10% |  2.12e-12 |  (PD_AES_2)
-      150 |   0.9998 |  5.686016e+05 |   +6.72% |  1.91e-11 |      
-      150 |   0.9581 |  5.686016e+05 |   +6.72% |  4.23e-12 |  (PD_AES_1)
-      150 |   0.9613 |  5.686016e+05 |   +6.72% |  3.44e-12 |  (PD_AES_2)
-      160 |   0.9989 |  6.295772e+05 |  +10.72% |  3.08e-11 |      
-      160 |   0.9421 |  6.295772e+05 |  +10.72% |  6.85e-12 |  (PD_AES_1)
-      160 |   0.9505 |  6.295772e+05 |  +10.72% |  5.56e-12 |  (PD_AES_2)
-      170 |   0.9861 |  7.186336e+05 |  +14.15% |  4.98e-11 |      
-      170 |   0.9236 |  7.186336e+05 |  +14.15% |  1.11e-11 |  (PD_AES_1)
-      170 |   0.9347 |  7.186336e+05 |  +14.15% |  8.98e-12 |  (PD_AES_2)
-      180 |   0.9577 |  8.298941e+05 |  +15.48% |  8.01e-11 |      
-      180 |   0.9020 |  8.298941e+05 |  +15.48% |  1.78e-11 |  (PD_AES_1)
-      180 |   0.9165 |  8.298941e+05 |  +15.48% |  1.45e-11 |  (PD_AES_2)
-      190 |   0.9282 |  9.545709e+05 |  +15.02% |  1.29e-10 |      
-      190 |   0.8811 |  9.545709e+05 |  +15.02% |  2.86e-11 |  (PD_AES_1)
-      190 |   0.8962 |  9.545709e+05 |  +15.02% |  2.32e-11 |  (PD_AES_2)
-      200 |   0.8941 |  1.068179e+06 |  +11.90% |  2.07e-10 |      
-      200 |   0.8576 |  1.068179e+06 |  +11.90% |  4.60e-11 |  (PD_AES_1)
-      200 |   0.8737 |  1.068179e+06 |  +11.90% |  3.74e-11 |  (PD_AES_2)
-      210 |   0.8532 |  1.167604e+06 |   +9.31% |  3.34e-10 |      
-      210 |   0.8393 |  1.167604e+06 |   +9.31% |  7.41e-11 |  (PD_AES_1)
-      210 |   0.8567 |  1.167604e+06 |   +9.31% |  6.02e-11 |  (PD_AES_2)
-      220 |   0.8268 |  1.248430e+06 |   +6.92% |  5.39e-10 |      
-      220 |   0.8220 |  1.248430e+06 |   +6.92% |  1.20e-10 |  (PD_AES_1)
-      220 |   0.8366 |  1.248430e+06 |   +6.92% |  9.72e-11 |  (PD_AES_2)
-      230 |   0.7855 |  1.305909e+06 |   +4.60% |  8.72e-10 |      
-      230 |   0.8047 |  1.305909e+06 |   +4.60% |  1.94e-10 |  (PD_AES_1)
-      230 |   0.8178 |  1.305909e+06 |   +4.60% |  1.57e-10 |  (PD_AES_2)
-      240 |   0.7524 |  1.356341e+06 |   +3.86% |  1.41e-09 |      
-      240 |   0.7844 |  1.356341e+06 |   +3.86% |  3.13e-10 |  (PD_AES_1)
-      240 |   0.7988 |  1.356341e+06 |   +3.86% |  2.55e-10 |  (PD_AES_2)
-      250 |   0.7095 |  1.408788e+06 |   +3.87% |  2.29e-09 |      
-      250 |   0.7601 |  1.408788e+06 |   +3.87% |  5.08e-10 |  (PD_AES_1)
-      250 |   0.7753 |  1.408788e+06 |   +3.87% |  4.12e-10 |  (PD_AES_2)
-      260 |   0.6640 |  1.473820e+06 |   +4.62% |  3.70e-09 |      
-      260 |   0.7325 |  1.473820e+06 |   +4.62% |  8.21e-10 |  (PD_AES_1)
-      260 |   0.7497 |  1.473820e+06 |   +4.62% |  6.67e-10 |  (PD_AES_2)
-      270 |   0.6038 |  1.523316e+06 |   +3.36% |  5.99e-09 |      
-      270 |   0.7037 |  1.523316e+06 |   +3.36% |  1.33e-09 |  (PD_AES_1)
-      270 |   0.7277 |  1.523316e+06 |   +3.36% |  1.08e-09 |  (PD_AES_2)
-      280 |   0.5487 |  1.576061e+06 |   +3.46% |  9.70e-09 |      
-      280 |   0.6773 |  1.576061e+06 |   +3.46% |  2.15e-09 |  (PD_AES_1)
-      280 |   0.7017 |  1.576061e+06 |   +3.46% |  1.75e-09 |  (PD_AES_2)
+        0 |   0.9998 |  5.793867e+05 |   +0.00% |  1.31e-14 |      
+        0 |   0.9967 |  5.793867e+05 |   +0.00% |  2.24e-15 |  (PD_AES_1)
+        0 |   0.9965 |  5.793867e+05 |   +0.00% |  2.28e-15 |  (PD_AES_2)
+       10 |   0.9998 |  7.169869e+05 |  +23.75% |  2.08e-14 |      
+       10 |   0.9669 |  7.169869e+05 |  +23.75% |  3.55e-15 |  (PD_AES_1)
+       10 |   0.9716 |  7.169869e+05 |  +23.75% |  3.62e-15 |  (PD_AES_2)
+       20 |   0.9998 |  7.205004e+05 |   +0.49% |  3.38e-14 |      
+       20 |   0.9677 |  7.205004e+05 |   +0.49% |  5.76e-15 |  (PD_AES_1)
+       20 |   0.9677 |  7.205004e+05 |   +0.49% |  5.87e-15 |  (PD_AES_2)
+       30 |   0.9998 |  6.854302e+05 |   -4.87% |  5.50e-14 |      
+       30 |   0.9698 |  6.854302e+05 |   -4.87% |  9.38e-15 |  (PD_AES_1)
+       30 |   0.9703 |  6.854302e+05 |   -4.87% |  9.56e-15 |  (PD_AES_2)
+       40 |   0.9998 |  6.682730e+05 |   -2.50% |  8.96e-14 |      
+       40 |   0.9697 |  6.682730e+05 |   -2.50% |  1.53e-14 |  (PD_AES_1)
+       40 |   0.9707 |  6.682730e+05 |   -2.50% |  1.56e-14 |  (PD_AES_2)
+       50 |   0.9998 |  6.474033e+05 |   -3.12% |  1.46e-13 |      
+       50 |   0.9707 |  6.474033e+05 |   -3.12% |  2.49e-14 |  (PD_AES_1)
+       50 |   0.9713 |  6.474033e+05 |   -3.12% |  2.54e-14 |  (PD_AES_2)
+       60 |   0.9998 |  6.219679e+05 |   -3.93% |  2.38e-13 |      
+       60 |   0.9712 |  6.219679e+05 |   -3.93% |  4.05e-14 |  (PD_AES_1)
+       60 |   0.9719 |  6.219679e+05 |   -3.93% |  4.13e-14 |  (PD_AES_2)
+       70 |   0.9998 |  5.976034e+05 |   -3.92% |  3.87e-13 |      
+       70 |   0.9719 |  5.976034e+05 |   -3.92% |  6.60e-14 |  (PD_AES_1)
+       70 |   0.9732 |  5.976034e+05 |   -3.92% |  6.73e-14 |  (PD_AES_2)
+       80 |   0.9998 |  5.737051e+05 |   -4.00% |  6.31e-13 |      
+       80 |   0.9731 |  5.737051e+05 |   -4.00% |  1.08e-13 |  (PD_AES_1)
+       80 |   0.9742 |  5.737051e+05 |   -4.00% |  1.10e-13 |  (PD_AES_2)
+       90 |   0.9998 |  5.511722e+05 |   -3.93% |  1.03e-12 |      
+       90 |   0.9747 |  5.511722e+05 |   -3.93% |  1.75e-13 |  (PD_AES_1)
+       90 |   0.9754 |  5.511722e+05 |   -3.93% |  1.79e-13 |  (PD_AES_2)
+      100 |   0.9998 |  5.328446e+05 |   -3.33% |  1.67e-12 |      
+      100 |   0.9761 |  5.328446e+05 |   -3.33% |  2.85e-13 |  (PD_AES_1)
+      100 |   0.9757 |  5.328446e+05 |   -3.33% |  2.91e-13 |  (PD_AES_2)
+      110 |   0.9998 |  5.200642e+05 |   -2.40% |  2.73e-12 |      
+      110 |   0.9767 |  5.200642e+05 |   -2.40% |  4.65e-13 |  (PD_AES_1)
+      110 |   0.9759 |  5.200642e+05 |   -2.40% |  4.74e-13 |  (PD_AES_2)
+      120 |   0.9998 |  5.135844e+05 |   -1.25% |  4.44e-12 |      
+      120 |   0.9767 |  5.135844e+05 |   -1.25% |  7.57e-13 |  (PD_AES_1)
+      120 |   0.9744 |  5.135844e+05 |   -1.25% |  7.72e-13 |  (PD_AES_2)
+      130 |   0.9998 |  5.148915e+05 |   +0.25% |  7.23e-12 |      
+      130 |   0.9755 |  5.148915e+05 |   +0.25% |  1.23e-12 |  (PD_AES_1)
+      130 |   0.9724 |  5.148915e+05 |   +0.25% |  1.26e-12 |  (PD_AES_2)
+      140 |   0.9998 |  5.284186e+05 |   +2.63% |  1.18e-11 |      
+      140 |   0.9715 |  5.284186e+05 |   +2.63% |  2.01e-12 |  (PD_AES_1)
+      140 |   0.9683 |  5.284186e+05 |   +2.63% |  2.05e-12 |  (PD_AES_2)
+      150 |   0.9998 |  5.609439e+05 |   +6.16% |  1.91e-11 |      
+      150 |   0.9631 |  5.609439e+05 |   +6.16% |  3.26e-12 |  (PD_AES_1)
+      150 |   0.9616 |  5.609439e+05 |   +6.16% |  3.32e-12 |  (PD_AES_2)
+      160 |   0.9989 |  6.178410e+05 |  +10.14% |  3.09e-11 |      
+      160 |   0.9507 |  6.178410e+05 |  +10.14% |  5.27e-12 |  (PD_AES_1)
+      160 |   0.9508 |  6.178410e+05 |  +10.14% |  5.38e-12 |  (PD_AES_2)
+      170 |   0.9852 |  7.034715e+05 |  +13.86% |  4.99e-11 |      
+      170 |   0.9322 |  7.034715e+05 |  +13.86% |  8.51e-12 |  (PD_AES_1)
+      170 |   0.9350 |  7.034715e+05 |  +13.86% |  8.68e-12 |  (PD_AES_2)
+      180 |   0.9567 |  8.112721e+05 |  +15.32% |  8.04e-11 |      
+      180 |   0.9142 |  8.112721e+05 |  +15.32% |  1.37e-11 |  (PD_AES_1)
+      180 |   0.9174 |  8.112721e+05 |  +15.32% |  1.40e-11 |  (PD_AES_2)
+      190 |   0.9260 |  9.350837e+05 |  +15.26% |  1.29e-10 |      
+      190 |   0.8929 |  9.350837e+05 |  +15.26% |  2.20e-11 |  (PD_AES_1)
+      190 |   0.8968 |  9.350837e+05 |  +15.26% |  2.25e-11 |  (PD_AES_2)
+      200 |   0.8923 |  1.049719e+06 |  +12.26% |  2.08e-10 |      
+      200 |   0.8719 |  1.049719e+06 |  +12.26% |  3.54e-11 |  (PD_AES_1)
+      200 |   0.8742 |  1.049719e+06 |  +12.26% |  3.61e-11 |  (PD_AES_2)
+      210 |   0.8513 |  1.150921e+06 |   +9.64% |  3.35e-10 |      
+      210 |   0.8516 |  1.150921e+06 |   +9.64% |  5.71e-11 |  (PD_AES_1)
+      210 |   0.8566 |  1.150921e+06 |   +9.64% |  5.82e-11 |  (PD_AES_2)
+      220 |   0.8241 |  1.233293e+06 |   +7.16% |  5.40e-10 |      
+      220 |   0.8348 |  1.233293e+06 |   +7.16% |  9.21e-11 |  (PD_AES_1)
+      220 |   0.8368 |  1.233293e+06 |   +7.16% |  9.39e-11 |  (PD_AES_2)
+      230 |   0.7847 |  1.291974e+06 |   +4.76% |  8.74e-10 |      
+      230 |   0.8185 |  1.291974e+06 |   +4.76% |  1.49e-10 |  (PD_AES_1)
+      230 |   0.8189 |  1.291974e+06 |   +4.76% |  1.52e-10 |  (PD_AES_2)
+      240 |   0.7508 |  1.343806e+06 |   +4.01% |  1.42e-09 |      
+      240 |   0.7959 |  1.343806e+06 |   +4.01% |  2.41e-10 |  (PD_AES_1)
+      240 |   0.7993 |  1.343806e+06 |   +4.01% |  2.46e-10 |  (PD_AES_2)
+      250 |   0.7080 |  1.392842e+06 |   +3.65% |  2.29e-09 |      
+      250 |   0.7765 |  1.392842e+06 |   +3.65% |  3.91e-10 |  (PD_AES_1)
+      250 |   0.7758 |  1.392842e+06 |   +3.65% |  3.99e-10 |  (PD_AES_2)
+      260 |   0.6610 |  1.459664e+06 |   +4.80% |  3.71e-09 |      
+      260 |   0.7515 |  1.459664e+06 |   +4.80% |  6.32e-10 |  (PD_AES_1)
+      260 |   0.7503 |  1.459664e+06 |   +4.80% |  6.45e-10 |  (PD_AES_2)
+      270 |   0.6006 |  1.510257e+06 |   +3.47% |  6.01e-09 |      
+      270 |   0.7250 |  1.510257e+06 |   +3.47% |  1.02e-09 |  (PD_AES_1)
+      270 |   0.7276 |  1.510257e+06 |   +3.47% |  1.04e-09 |  (PD_AES_2)
+      280 |   0.5430 |  1.560874e+06 |   +3.35% |  9.73e-09 |      
+      280 |   0.6998 |  1.560874e+06 |   +3.35% |  1.66e-09 |  (PD_AES_1)
+      280 |   0.7025 |  1.560874e+06 |   +3.35% |  1.69e-09 |  (PD_AES_2)
 [INFO GPL-0100] Timing-driven iteration 1/2, virtual: false.
-[INFO GPL-0101]    Iter: 284, overflow: 0.632, keep resizer changes at: 1, HPWL: 1595343099
+[INFO GPL-0101]    Iter: 285, overflow: 0.634, keep resizer changes at: 1, HPWL: 1586520753
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |     51674
-    final |     +0.0% |       0 |       5 |             1 |         0
+    final |     +0.0% |       0 |       4 |             1 |         0
 ---------------------------------------------------------------------
 [INFO RSZ-0034] Found 1 slew violations.
-[INFO RSZ-0038] Inserted 5 buffers in 1 nets.
+[INFO RSZ-0038] Inserted 4 buffers in 1 nets.
    Iter   |    Area   | Removed | Inserted |   Pins
           |           | Buffers | Buffers  | Remaining
 -------------------------------------------------------
         0 |     +0.0% |       0 |        0 |     43794
-     4300 |     -0.1% |     126 |       44 |     39494
-     8600 |     -0.1% |     126 |       44 |     35194
-    12900 |     -0.1% |     126 |       44 |     30894
-    17200 |     -0.1% |     140 |       47 |     26594
-    21500 |     -0.1% |     140 |       47 |     22294
-    25800 |     -0.1% |     154 |       49 |     17994
-    30100 |     -0.1% |     154 |       49 |     13694
-    34400 |     -0.3% |     314 |       49 |      9394
-    38700 |     -1.1% |    1396 |      233 |      5094
-    43000 |     -7.1% |    5898 |      674 |       794
-    final |     -9.4% |    7435 |      846 |         0
+     4300 |     -0.1% |     126 |       46 |     39494
+     8600 |     -0.1% |     126 |       46 |     35194
+    12900 |     -0.1% |     126 |       46 |     30894
+    17200 |     -0.1% |     140 |       49 |     26594
+    21500 |     -0.1% |     140 |       49 |     22294
+    25800 |     -0.1% |     154 |       52 |     17994
+    30100 |     -0.1% |     154 |       52 |     13694
+    34400 |     -0.3% |     314 |       52 |      9394
+    38700 |     -1.1% |    1396 |      236 |      5094
+    43000 |     -7.0% |    5898 |      681 |       794
+    final |     -9.4% |    7435 |      853 |         0
 -------------------------------------------------------
 [INFO GPL-0106] Timing-driven: worst slack 0
-[INFO GPL-0107] Timing-driven: repair_design delta area: -34438.027 um^2 (-23.93%)
-[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: -6584 (-12.81%)
-[INFO GPL-0109] Timing-driven: repair_design, gcells created: 851, deleted: 7435
-[INFO GPL-0110] Timing-driven: new target density: 0.39605132
+[INFO GPL-0107] Timing-driven: repair_design delta area: -34425.516 um^2 (-23.92%)
+[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: -6578 (-12.80%)
+[INFO GPL-0109] Timing-driven: repair_design, gcells created: 857, deleted: 7435
+[INFO GPL-0110] Timing-driven: new target density: 0.39609542
 [INFO GPL-0107] Timing-driven: repair_design delta area: 0.000 um^2 (+0.00%)
-[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: -6584 (-12.81%)
+[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: -6578 (-12.80%)
 [INFO GPL-0109] Timing-driven: repair_design, gcells created: 0, deleted: 0
-[INFO GPL-0110] Timing-driven: new target density: 0.49382284
+[INFO GPL-0110] Timing-driven: new target density: 0.4968983
 [INFO GPL-0107] Timing-driven: repair_design delta area: 0.000 um^2 (+0.00%)
-[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: -6584 (-12.81%)
+[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: -6578 (-12.80%)
 [INFO GPL-0109] Timing-driven: repair_design, gcells created: 0, deleted: 0
-[INFO GPL-0110] Timing-driven: new target density: 0.49382284
-[INFO GPL-0038] Routability snapshot saved at iter = 288
-      287 |   0.5965 |  1.508923e+06 |          |           |      
+[INFO GPL-0110] Timing-driven: new target density: 0.4958784
+[INFO GPL-0038] Routability snapshot saved at iter = 290
+      289 |   0.5914 |  1.556006e+06 |          |           |      
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      290 |   0.5295 |  1.562053e+06 |   -0.89% |  1.55e-08 |      
-      290 |   0.5996 |  1.562053e+06 |   -0.89% |  3.43e-09 |  (PD_AES_1)
-      290 |   0.6344 |  1.562053e+06 |   -0.89% |  2.79e-09 |  (PD_AES_2)
-      300 |   0.4786 |  1.539955e+06 |   -1.41% |  2.51e-08 |      
-      300 |   0.5622 |  1.539955e+06 |   -1.41% |  5.57e-09 |  (PD_AES_1)
-      300 |   0.5987 |  1.539955e+06 |   -1.41% |  4.52e-09 |  (PD_AES_2)
-      310 |   0.4230 |  1.555466e+06 |   +1.01% |  4.07e-08 |      
-      310 |   0.5103 |  1.555466e+06 |   +1.01% |  9.04e-09 |  (PD_AES_1)
-      310 |   0.5549 |  1.555466e+06 |   +1.01% |  7.35e-09 |  (PD_AES_2)
-      320 |   0.3704 |  1.617823e+06 |   +4.01% |  6.59e-08 |      
-      320 |   0.4392 |  1.617823e+06 |   +4.01% |  1.46e-08 |  (PD_AES_1)
-      320 |   0.4892 |  1.617823e+06 |   +4.01% |  1.19e-08 |  (PD_AES_2)
-      330 |   0.3289 |  1.708332e+06 |   +5.59% |  1.02e-07 |      
-      330 |   0.3550 |  1.708332e+06 |   +5.59% |  2.36e-08 |  (PD_AES_1)
-      330 |   0.4057 |  1.708332e+06 |   +5.59% |  1.92e-08 |  (PD_AES_2)
-      340 |   0.3045 |  1.776607e+06 |   +4.00% |  1.50e-07 |      
-      340 |   0.2931 |  1.776607e+06 |   +4.00% |  3.53e-08 |  (PD_AES_1)
-      340 |   0.3190 |  1.776607e+06 |   +4.00% |  3.04e-08 |  (PD_AES_2)
+      290 |   0.5085 |  1.561268e+06 |   +0.03% |  1.55e-08 |      
+      290 |   0.6340 |  1.561268e+06 |   +0.03% |  2.64e-09 |  (PD_AES_1)
+      290 |   0.6292 |  1.561268e+06 |   +0.03% |  2.69e-09 |  (PD_AES_2)
+      300 |   0.4717 |  1.538433e+06 |   -1.46% |  2.51e-08 |      
+      300 |   0.5969 |  1.538433e+06 |   -1.46% |  4.28e-09 |  (PD_AES_1)
+      300 |   0.5926 |  1.538433e+06 |   -1.46% |  4.37e-09 |  (PD_AES_2)
+      310 |   0.4176 |  1.550943e+06 |   +0.81% |  4.08e-08 |      
+      310 |   0.5508 |  1.550943e+06 |   +0.81% |  6.96e-09 |  (PD_AES_1)
+      310 |   0.5514 |  1.550943e+06 |   +0.81% |  7.10e-09 |  (PD_AES_2)
+      320 |   0.3657 |  1.602496e+06 |   +3.32% |  6.62e-08 |      
+      320 |   0.4910 |  1.602496e+06 |   +3.32% |  1.13e-08 |  (PD_AES_1)
+      320 |   0.4889 |  1.602496e+06 |   +3.32% |  1.15e-08 |  (PD_AES_2)
+      330 |   0.3281 |  1.686638e+06 |   +5.25% |  1.02e-07 |      
+      330 |   0.4105 |  1.686638e+06 |   +5.25% |  1.82e-08 |  (PD_AES_1)
+      330 |   0.4044 |  1.686638e+06 |   +5.25% |  1.86e-08 |  (PD_AES_2)
+      340 |   0.3025 |  1.762922e+06 |   +4.52% |  1.49e-07 |      
+      340 |   0.3269 |  1.762922e+06 |   +4.52% |  2.88e-08 |  (PD_AES_1)
+      340 |   0.3206 |  1.762922e+06 |   +4.52% |  2.94e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 1
-[INFO GPL-0041] Total routing overflow: 18.0979
-[INFO GPL-0042] Number of overflowed tiles: 303 (1.46%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.1139
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0804
-[INFO GPL-0045] Average top 2.0% routing congestion: 1.0402
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9746
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0971
-[INFO GPL-0048] Routing congestion (1.0971) lower than previous minimum (1e+30). Updating minimum.
-[INFO GPL-0086] Inflated area:                 130.147 um^2 (+0.10%)
+[INFO GPL-0041] Total routing overflow: 18.0438
+[INFO GPL-0042] Number of overflowed tiles: 312 (1.50%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.1169
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0808
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0409
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9739
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0988
+[INFO GPL-0048] Routing congestion (1.0988) lower than previous minimum (1e+30). Updating minimum.
+[INFO GPL-0086] Inflated area:                 131.254 um^2 (+0.10%)
 [INFO GPL-0052] Placement target density:       0.3961
 [INFO GPL-0076] Removing fillers, count: Before: 364, After: 348 (-4.40%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2836.413, After: 2704.400 (-4.65%)
-[INFO GPL-0078] Removed fillers count: 16, area removed: 124.340 um^2. Remaining area to be compensated by modifying density: 5.806 um^2
-[INFO GPL-0086] Inflated area:                 612.435 um^2 (+0.49%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 365, After: 287 (-21.37%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2851.990, After: 2239.883 (-21.46%)
-[INFO GPL-0078] Removed fillers count: 78, area removed: 608.749 um^2. Remaining area to be compensated by modifying density: 3.687 um^2
-[INFO GPL-0086] Inflated area:                1138.565 um^2 (+0.92%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 365, After: 220 (-39.73%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2851.990, After: 1716.984 (-39.80%)
-[INFO GPL-0078] Removed fillers count: 145, area removed: 1131.648 um^2. Remaining area to be compensated by modifying density: 6.916 um^2
+[INFO GPL-0078] Removed fillers count: 16, area removed: 124.340 um^2. Remaining area to be compensated by modifying density: 6.913 um^2
+[INFO GPL-0086] Inflated area:                 909.858 um^2 (+0.73%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 363, After: 247 (-31.96%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2833.967, After: 1927.705 (-31.98%)
+[INFO GPL-0078] Removed fillers count: 116, area removed: 905.319 um^2. Remaining area to be compensated by modifying density: 4.539 um^2
+[INFO GPL-0086] Inflated area:                 888.372 um^2 (+0.71%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 363, After: 250 (-31.13%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2839.915, After: 1951.118 (-31.30%)
+[INFO GPL-0078] Removed fillers count: 113, area removed: 881.905 um^2. Remaining area to be compensated by modifying density: 6.467 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
 [INFO GPL-0060] Total filler area:            2704.400 um^2 (-4.65%)
-[INFO GPL-0061] Total non-inflated area:    139531.023 um^2 (-0.00%)
-[INFO GPL-0062] Total inflated area:        139661.170 um^2 (-0.00%)
+[INFO GPL-0061] Total non-inflated area:    139544.642 um^2 (-0.00%)
+[INFO GPL-0062] Total inflated area:        139675.896 um^2 (-0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2239.883 um^2 (-21.46%)
-[INFO GPL-0061] Total non-inflated area:    127240.560 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127852.996 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1716.984 um^2 (-39.80%)
-[INFO GPL-0061] Total non-inflated area:    127243.790 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        128382.355 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140820.251 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            1927.705 um^2 (-31.98%)
+[INFO GPL-0061] Total non-inflated area:    127225.804 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        128135.662 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4969
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            1951.118 um^2 (-31.30%)
+[INFO GPL-0061] Total non-inflated area:    127227.732 um^2 (-0.00%)
+[INFO GPL-0062] Total inflated area:        128116.104 um^2 (-0.00%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      350 |   0.5200 |  1.558796e+06 |  -12.26% |  1.85e-08 |      
-      350 |   0.5895 |  1.558796e+06 |  -12.26% |  4.10e-09 |  (PD_AES_1)
-      350 |   0.6219 |  1.558796e+06 |  -12.26% |  3.33e-09 |  (PD_AES_2)
-      360 |   0.4662 |  1.536415e+06 |   -1.44% |  2.72e-08 |      
-      360 |   0.5528 |  1.536415e+06 |   -1.44% |  6.03e-09 |  (PD_AES_1)
-      360 |   0.5933 |  1.536415e+06 |   -1.44% |  4.90e-09 |  (PD_AES_2)
-      370 |   0.4221 |  1.551558e+06 |   +0.99% |  3.99e-08 |      
-      370 |   0.5111 |  1.551558e+06 |   +0.99% |  8.86e-09 |  (PD_AES_1)
-      370 |   0.5578 |  1.551558e+06 |   +0.99% |  7.20e-09 |  (PD_AES_2)
-      380 |   0.3823 |  1.601008e+06 |   +3.19% |  5.86e-08 |      
-      380 |   0.4556 |  1.601008e+06 |   +3.19% |  1.30e-08 |  (PD_AES_1)
-      380 |   0.5064 |  1.601008e+06 |   +3.19% |  1.06e-08 |  (PD_AES_2)
-      390 |   0.3442 |  1.668368e+06 |   +4.21% |  8.58e-08 |      
-      390 |   0.3922 |  1.668368e+06 |   +4.21% |  1.90e-08 |  (PD_AES_1)
-      390 |   0.4415 |  1.668368e+06 |   +4.21% |  1.55e-08 |  (PD_AES_2)
-      400 |   0.3132 |  1.731351e+06 |   +3.78% |  1.26e-07 |      
-      400 |   0.3262 |  1.731351e+06 |   +3.78% |  2.79e-08 |  (PD_AES_1)
-      400 |   0.3699 |  1.731351e+06 |   +3.78% |  2.27e-08 |  (PD_AES_2)
+      350 |   0.5280 |  1.553777e+06 |  -11.86% |  1.81e-08 |      
+      350 |   0.6321 |  1.553777e+06 |  -11.86% |  3.08e-09 |  (PD_AES_1)
+      350 |   0.6277 |  1.553777e+06 |  -11.86% |  3.14e-09 |  (PD_AES_2)
+      360 |   0.4668 |  1.524102e+06 |   -1.91% |  2.66e-08 |      
+      360 |   0.5990 |  1.524102e+06 |   -1.91% |  4.53e-09 |  (PD_AES_1)
+      360 |   0.5954 |  1.524102e+06 |   -1.91% |  4.62e-09 |  (PD_AES_2)
+      370 |   0.4187 |  1.535384e+06 |   +0.74% |  3.91e-08 |      
+      370 |   0.5585 |  1.535384e+06 |   +0.74% |  6.67e-09 |  (PD_AES_1)
+      370 |   0.5596 |  1.535384e+06 |   +0.74% |  6.80e-09 |  (PD_AES_2)
+      380 |   0.3788 |  1.581181e+06 |   +2.98% |  5.74e-08 |      
+      380 |   0.5122 |  1.581181e+06 |   +2.98% |  9.78e-09 |  (PD_AES_1)
+      380 |   0.5067 |  1.581181e+06 |   +2.98% |  9.98e-09 |  (PD_AES_2)
+      390 |   0.3431 |  1.644336e+06 |   +3.99% |  8.41e-08 |      
+      390 |   0.4521 |  1.644336e+06 |   +3.99% |  1.43e-08 |  (PD_AES_1)
+      390 |   0.4471 |  1.644336e+06 |   +3.99% |  1.46e-08 |  (PD_AES_2)
+      400 |   0.3125 |  1.709357e+06 |   +3.95% |  1.23e-07 |      
+      400 |   0.3828 |  1.709357e+06 |   +3.95% |  2.10e-08 |  (PD_AES_1)
+      400 |   0.3774 |  1.709357e+06 |   +3.95% |  2.14e-08 |  (PD_AES_2)
+      410 |   0.2889 |  1.761465e+06 |   +3.05% |  1.81e-07 |      
+      410 |   0.3188 |  1.761465e+06 |   +3.05% |  3.08e-08 |  (PD_AES_1)
+      410 |   0.3143 |  1.761465e+06 |   +3.05% |  3.14e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 2
-[INFO GPL-0041] Total routing overflow: 9.4928
-[INFO GPL-0042] Number of overflowed tiles: 206 (0.99%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0748
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0456
-[INFO GPL-0045] Average top 2.0% routing congestion: 1.0108
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9526
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0602
-[INFO GPL-0048] Routing congestion (1.0602) lower than previous minimum (1.097). Updating minimum.
-[INFO GPL-0086] Inflated area:                  30.816 um^2 (+0.02%)
+[INFO GPL-0041] Total routing overflow: 12.2061
+[INFO GPL-0042] Number of overflowed tiles: 240 (1.16%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0911
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0580
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0209
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9594
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0746
+[INFO GPL-0048] Routing congestion (1.0746) lower than previous minimum (1.099). Updating minimum.
+[INFO GPL-0086] Inflated area:                  53.440 um^2 (+0.04%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 348, After: 345 (-0.86%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2704.400, After: 2681.086 (-0.86%)
-[INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 7.502 um^2
-[INFO GPL-0086] Inflated area:                 276.927 um^2 (+0.22%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 287, After: 252 (-12.20%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2239.883, After: 1966.727 (-12.20%)
-[INFO GPL-0078] Removed fillers count: 35, area removed: 273.157 um^2. Remaining area to be compensated by modifying density: 3.770 um^2
-[INFO GPL-0086] Inflated area:                 479.412 um^2 (+0.38%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 220, After: 159 (-27.73%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1716.984, After: 1240.911 (-27.73%)
-[INFO GPL-0078] Removed fillers count: 61, area removed: 476.073 um^2. Remaining area to be compensated by modifying density: 3.339 um^2
+[INFO GPL-0076] Removing fillers, count: Before: 348, After: 342 (-1.72%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2704.400, After: 2657.773 (-1.72%)
+[INFO GPL-0078] Removed fillers count: 6, area removed: 46.628 um^2. Remaining area to be compensated by modifying density: 6.813 um^2
+[INFO GPL-0086] Inflated area:                 495.917 um^2 (+0.40%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 247, After: 184 (-25.51%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 1927.705, After: 1436.023 (-25.51%)
+[INFO GPL-0078] Removed fillers count: 63, area removed: 491.682 um^2. Remaining area to be compensated by modifying density: 4.235 um^2
+[INFO GPL-0086] Inflated area:                 455.035 um^2 (+0.36%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 250, After: 192 (-23.20%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 1951.118, After: 1498.459 (-23.20%)
+[INFO GPL-0078] Removed fillers count: 58, area removed: 452.659 um^2. Remaining area to be compensated by modifying density: 2.376 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2681.086 um^2 (-0.86%)
-[INFO GPL-0061] Total non-inflated area:    139538.525 um^2 (+0.01%)
-[INFO GPL-0062] Total inflated area:        139569.341 um^2 (+0.01%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2657.773 um^2 (-1.72%)
+[INFO GPL-0061] Total non-inflated area:    139551.455 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139604.895 um^2 (+0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1966.727 um^2 (-12.20%)
-[INFO GPL-0061] Total non-inflated area:    127244.331 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127521.258 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1240.911 um^2 (-27.73%)
-[INFO GPL-0061] Total non-inflated area:    127247.129 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127726.541 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140820.251 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            1436.023 um^2 (-25.51%)
+[INFO GPL-0061] Total non-inflated area:    127230.039 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127725.956 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4969
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            1498.459 um^2 (-23.20%)
+[INFO GPL-0061] Total non-inflated area:    127230.108 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127685.143 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      410 |   0.5122 |  1.566567e+06 |   -9.52% |  1.41e-08 |      
-      410 |   0.6088 |  1.566567e+06 |   -9.52% |  3.13e-09 |  (PD_AES_1)
-      410 |   0.6468 |  1.566567e+06 |   -9.52% |  2.54e-09 |  (PD_AES_2)
-      420 |   0.4950 |  1.538281e+06 |   -1.81% |  2.07e-08 |      
-      420 |   0.5753 |  1.538281e+06 |   -1.81% |  4.60e-09 |  (PD_AES_1)
-      420 |   0.6109 |  1.538281e+06 |   -1.81% |  3.74e-09 |  (PD_AES_2)
-      430 |   0.4540 |  1.534575e+06 |   -0.24% |  3.05e-08 |      
-      430 |   0.5409 |  1.534575e+06 |   -0.24% |  6.77e-09 |  (PD_AES_1)
-      430 |   0.5822 |  1.534575e+06 |   -0.24% |  5.50e-09 |  (PD_AES_2)
-      440 |   0.4107 |  1.564158e+06 |   +1.93% |  4.48e-08 |      
-      440 |   0.4944 |  1.564158e+06 |   +1.93% |  9.94e-09 |  (PD_AES_1)
-      440 |   0.5419 |  1.564158e+06 |   +1.93% |  8.08e-09 |  (PD_AES_2)
-      450 |   0.3693 |  1.623457e+06 |   +3.79% |  6.57e-08 |      
-      450 |   0.4359 |  1.623457e+06 |   +3.79% |  1.46e-08 |  (PD_AES_1)
-      450 |   0.4883 |  1.623457e+06 |   +3.79% |  1.18e-08 |  (PD_AES_2)
-      460 |   0.3345 |  1.690778e+06 |   +4.15% |  9.62e-08 |      
-      460 |   0.3717 |  1.690778e+06 |   +4.15% |  2.14e-08 |  (PD_AES_1)
-      460 |   0.4212 |  1.690778e+06 |   +4.15% |  1.73e-08 |  (PD_AES_2)
-      470 |   0.3057 |  1.749719e+06 |   +3.49% |  1.41e-07 |      
-      470 |   0.3102 |  1.749719e+06 |   +3.49% |  3.13e-08 |  (PD_AES_1)
-      470 |   0.3496 |  1.749719e+06 |   +3.49% |  2.54e-08 |  (PD_AES_2)
+      420 |   0.4983 |  1.547063e+06 |  -12.17% |  2.03e-08 |      
+      420 |   0.6126 |  1.547063e+06 |  -12.17% |  3.46e-09 |  (PD_AES_1)
+      420 |   0.6115 |  1.547063e+06 |  -12.17% |  3.53e-09 |  (PD_AES_2)
+      430 |   0.4491 |  1.539160e+06 |   -0.51% |  2.98e-08 |      
+      430 |   0.5810 |  1.539160e+06 |   -0.51% |  5.08e-09 |  (PD_AES_1)
+      430 |   0.5814 |  1.539160e+06 |   -0.51% |  5.19e-09 |  (PD_AES_2)
+      440 |   0.4057 |  1.551029e+06 |   +0.77% |  4.39e-08 |      
+      440 |   0.5442 |  1.551029e+06 |   +0.77% |  7.48e-09 |  (PD_AES_1)
+      440 |   0.5458 |  1.551029e+06 |   +0.77% |  7.63e-09 |  (PD_AES_2)
+      450 |   0.3676 |  1.602033e+06 |   +3.29% |  6.44e-08 |      
+      450 |   0.4946 |  1.602033e+06 |   +3.29% |  1.10e-08 |  (PD_AES_1)
+      450 |   0.4920 |  1.602033e+06 |   +3.29% |  1.12e-08 |  (PD_AES_2)
+      460 |   0.3333 |  1.666738e+06 |   +4.04% |  9.43e-08 |      
+      460 |   0.4322 |  1.666738e+06 |   +4.04% |  1.61e-08 |  (PD_AES_1)
+      460 |   0.4271 |  1.666738e+06 |   +4.04% |  1.64e-08 |  (PD_AES_2)
+      470 |   0.3062 |  1.730323e+06 |   +3.81% |  1.38e-07 |      
+      470 |   0.3604 |  1.730323e+06 |   +3.81% |  2.35e-08 |  (PD_AES_1)
+      470 |   0.3566 |  1.730323e+06 |   +3.81% |  2.40e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 3
-[INFO GPL-0041] Total routing overflow: 7.6394
-[INFO GPL-0042] Number of overflowed tiles: 188 (0.91%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0633
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0365
-[INFO GPL-0045] Average top 2.0% routing congestion: 1.0051
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9503
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0499
-[INFO GPL-0048] Routing congestion (1.0499) lower than previous minimum (1.06). Updating minimum.
-[INFO GPL-0086] Inflated area:                  32.585 um^2 (+0.02%)
+[INFO GPL-0041] Total routing overflow: 9.9187
+[INFO GPL-0042] Number of overflowed tiles: 224 (1.08%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0723
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0475
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0122
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9554
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0599
+[INFO GPL-0048] Routing congestion (1.0599) lower than previous minimum (1.075). Updating minimum.
+[INFO GPL-0086] Inflated area:                  51.680 um^2 (+0.04%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 345, After: 341 (-1.16%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2681.086, After: 2650.001 (-1.16%)
-[INFO GPL-0078] Removed fillers count: 4, area removed: 31.085 um^2. Remaining area to be compensated by modifying density: 1.500 um^2
-[INFO GPL-0086] Inflated area:                 211.660 um^2 (+0.17%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 252, After: 225 (-10.71%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1966.727, After: 1756.006 (-10.71%)
-[INFO GPL-0078] Removed fillers count: 27, area removed: 210.721 um^2. Remaining area to be compensated by modifying density: 0.939 um^2
-[INFO GPL-0086] Inflated area:                 366.465 um^2 (+0.29%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 159, After: 113 (-28.93%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1240.911, After: 881.905 (-28.93%)
-[INFO GPL-0078] Removed fillers count: 46, area removed: 359.006 um^2. Remaining area to be compensated by modifying density: 7.460 um^2
+[INFO GPL-0076] Removing fillers, count: Before: 342, After: 336 (-1.75%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2657.773, After: 2611.145 (-1.75%)
+[INFO GPL-0078] Removed fillers count: 6, area removed: 46.628 um^2. Remaining area to be compensated by modifying density: 5.052 um^2
+[INFO GPL-0086] Inflated area:                 400.496 um^2 (+0.32%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 184, After: 133 (-27.72%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 1436.023, After: 1037.995 (-27.72%)
+[INFO GPL-0078] Removed fillers count: 51, area removed: 398.028 um^2. Remaining area to be compensated by modifying density: 2.467 um^2
+[INFO GPL-0086] Inflated area:                 366.799 um^2 (+0.29%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 192, After: 146 (-23.96%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 1498.459, After: 1139.453 (-23.96%)
+[INFO GPL-0078] Removed fillers count: 46, area removed: 359.006 um^2. Remaining area to be compensated by modifying density: 7.793 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2650.001 um^2 (-1.16%)
-[INFO GPL-0061] Total non-inflated area:    139540.026 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139572.611 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2611.145 um^2 (-1.75%)
+[INFO GPL-0061] Total non-inflated area:    139556.507 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139608.187 um^2 (+0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1756.006 um^2 (-10.71%)
-[INFO GPL-0061] Total non-inflated area:    127245.270 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127456.930 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             881.905 um^2 (-28.93%)
-[INFO GPL-0061] Total non-inflated area:    127254.589 um^2 (+0.01%)
-[INFO GPL-0062] Total inflated area:        127621.054 um^2 (+0.01%)
-[INFO GPL-0063] New Target Density:             0.4938
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140820.251 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            1037.995 um^2 (-27.72%)
+[INFO GPL-0061] Total non-inflated area:    127232.507 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127633.002 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4969
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            1139.453 um^2 (-23.96%)
+[INFO GPL-0061] Total non-inflated area:    127237.901 um^2 (+0.01%)
+[INFO GPL-0062] Total inflated area:        127604.700 um^2 (+0.01%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      480 |   0.5387 |  1.581191e+06 |   -9.63% |  1.64e-08 |      
-      480 |   0.6048 |  1.581191e+06 |   -9.63% |  3.65e-09 |  (PD_AES_1)
-      480 |   0.6339 |  1.581191e+06 |   -9.63% |  2.97e-09 |  (PD_AES_2)
-      490 |   0.4847 |  1.525062e+06 |   -3.55% |  2.42e-08 |      
-      490 |   0.5713 |  1.525062e+06 |   -3.55% |  5.37e-09 |  (PD_AES_1)
-      490 |   0.6095 |  1.525062e+06 |   -3.55% |  4.36e-09 |  (PD_AES_2)
-      500 |   0.4380 |  1.540969e+06 |   +1.04% |  3.56e-08 |      
-      500 |   0.5286 |  1.540969e+06 |   +1.04% |  7.90e-09 |  (PD_AES_1)
-      500 |   0.5719 |  1.540969e+06 |   +1.04% |  6.42e-09 |  (PD_AES_2)
-      510 |   0.3949 |  1.586267e+06 |   +2.94% |  5.22e-08 |      
-      510 |   0.4736 |  1.586267e+06 |   +2.94% |  1.16e-08 |  (PD_AES_1)
-      510 |   0.5234 |  1.586267e+06 |   +2.94% |  9.42e-09 |  (PD_AES_2)
-      520 |   0.3553 |  1.651343e+06 |   +4.10% |  7.65e-08 |      
-      520 |   0.4136 |  1.651343e+06 |   +4.10% |  1.70e-08 |  (PD_AES_1)
-      520 |   0.4647 |  1.651343e+06 |   +4.10% |  1.38e-08 |  (PD_AES_2)
-      530 |   0.3218 |  1.718020e+06 |   +4.04% |  1.12e-07 |      
-      530 |   0.3476 |  1.718020e+06 |   +4.04% |  2.49e-08 |  (PD_AES_1)
-      530 |   0.3902 |  1.718020e+06 |   +4.04% |  2.02e-08 |  (PD_AES_2)
-      540 |   0.2958 |  1.769538e+06 |   +3.00% |  1.64e-07 |      
-      540 |   0.2895 |  1.769538e+06 |   +3.00% |  3.65e-08 |  (PD_AES_1)
-      540 |   0.3258 |  1.769538e+06 |   +3.00% |  2.96e-08 |  (PD_AES_2)
+      480 |   0.5092 |  1.559859e+06 |   -9.85% |  1.55e-08 |      
+      480 |   0.6390 |  1.559859e+06 |   -9.85% |  2.64e-09 |  (PD_AES_1)
+      480 |   0.6340 |  1.559859e+06 |   -9.85% |  2.69e-09 |  (PD_AES_2)
+      490 |   0.4838 |  1.536695e+06 |   -1.49% |  2.27e-08 |      
+      490 |   0.6100 |  1.536695e+06 |   -1.49% |  3.86e-09 |  (PD_AES_1)
+      490 |   0.6043 |  1.536695e+06 |   -1.49% |  3.94e-09 |  (PD_AES_2)
+      500 |   0.4410 |  1.535444e+06 |   -0.08% |  3.34e-08 |      
+      500 |   0.5739 |  1.535444e+06 |   -0.08% |  5.69e-09 |  (PD_AES_1)
+      500 |   0.5748 |  1.535444e+06 |   -0.08% |  5.80e-09 |  (PD_AES_2)
+      510 |   0.3967 |  1.566115e+06 |   +2.00% |  4.90e-08 |      
+      510 |   0.5307 |  1.566115e+06 |   +2.00% |  8.36e-09 |  (PD_AES_1)
+      510 |   0.5297 |  1.566115e+06 |   +2.00% |  8.52e-09 |  (PD_AES_2)
+      520 |   0.3581 |  1.626252e+06 |   +3.84% |  7.19e-08 |      
+      520 |   0.4768 |  1.626252e+06 |   +3.84% |  1.22e-08 |  (PD_AES_1)
+      520 |   0.4739 |  1.626252e+06 |   +3.84% |  1.25e-08 |  (PD_AES_2)
+      530 |   0.3249 |  1.689039e+06 |   +3.86% |  1.05e-07 |      
+      530 |   0.4121 |  1.689039e+06 |   +3.86% |  1.79e-08 |  (PD_AES_1)
+      530 |   0.4059 |  1.689039e+06 |   +3.86% |  1.83e-08 |  (PD_AES_2)
+      540 |   0.2990 |  1.749143e+06 |   +3.56% |  1.54e-07 |      
+      540 |   0.3425 |  1.749143e+06 |   +3.56% |  2.63e-08 |  (PD_AES_1)
+      540 |   0.3370 |  1.749143e+06 |   +3.56% |  2.68e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 4
-[INFO GPL-0041] Total routing overflow: 7.2186
-[INFO GPL-0042] Number of overflowed tiles: 185 (0.89%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0599
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0342
-[INFO GPL-0045] Average top 2.0% routing congestion: 1.0014
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9460
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0471
-[INFO GPL-0048] Routing congestion (1.0471) lower than previous minimum (1.05). Updating minimum.
-[INFO GPL-0086] Inflated area:                  19.814 um^2 (+0.01%)
+[INFO GPL-0041] Total routing overflow: 9.1221
+[INFO GPL-0042] Number of overflowed tiles: 193 (0.93%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0733
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0438
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0099
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9549
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0585
+[INFO GPL-0048] Routing congestion (1.0585) lower than previous minimum (1.06). Updating minimum.
+[INFO GPL-0086] Inflated area:                  60.825 um^2 (+0.04%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 341, After: 339 (-0.59%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2650.001, After: 2634.459 (-0.59%)
-[INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 4.272 um^2
-[INFO GPL-0086] Inflated area:                 198.706 um^2 (+0.16%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 225, After: 200 (-11.11%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1756.006, After: 1560.894 (-11.11%)
-[INFO GPL-0078] Removed fillers count: 25, area removed: 195.112 um^2. Remaining area to be compensated by modifying density: 3.594 um^2
-[INFO GPL-0086] Inflated area:                 326.544 um^2 (+0.26%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 113, After: 72 (-36.28%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 881.905, After: 561.922 (-36.28%)
-[INFO GPL-0078] Removed fillers count: 41, area removed: 319.983 um^2. Remaining area to be compensated by modifying density: 6.561 um^2
+[INFO GPL-0076] Removing fillers, count: Before: 336, After: 329 (-2.08%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2611.145, After: 2556.746 (-2.08%)
+[INFO GPL-0078] Removed fillers count: 7, area removed: 54.399 um^2. Remaining area to be compensated by modifying density: 6.427 um^2
+[INFO GPL-0086] Inflated area:                 314.945 um^2 (+0.25%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 133, After: 93 (-30.08%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 1037.995, After: 725.816 (-30.08%)
+[INFO GPL-0078] Removed fillers count: 40, area removed: 312.179 um^2. Remaining area to be compensated by modifying density: 2.766 um^2
+[INFO GPL-0086] Inflated area:                 365.247 um^2 (+0.29%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 146, After: 100 (-31.51%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 1139.453, After: 780.447 (-31.51%)
+[INFO GPL-0078] Removed fillers count: 46, area removed: 359.006 um^2. Remaining area to be compensated by modifying density: 6.241 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2634.459 um^2 (-0.59%)
-[INFO GPL-0061] Total non-inflated area:    139544.297 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139564.111 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2556.746 um^2 (-2.08%)
+[INFO GPL-0061] Total non-inflated area:    139562.934 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139623.759 um^2 (+0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1560.894 um^2 (-11.11%)
-[INFO GPL-0061] Total non-inflated area:    127248.864 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127447.570 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             561.922 um^2 (-36.28%)
-[INFO GPL-0061] Total non-inflated area:    127261.150 um^2 (+0.01%)
-[INFO GPL-0062] Total inflated area:        127587.694 um^2 (+0.01%)
-[INFO GPL-0063] New Target Density:             0.4938
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140820.251 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:             725.816 um^2 (-30.08%)
+[INFO GPL-0061] Total non-inflated area:    127235.272 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127550.217 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4969
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:             780.447 um^2 (-31.51%)
+[INFO GPL-0061] Total non-inflated area:    127244.142 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127609.389 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      550 |   0.5210 |  1.567160e+06 |  -11.44% |  1.85e-08 |      
-      550 |   0.5902 |  1.567160e+06 |  -11.44% |  4.10e-09 |  (PD_AES_1)
-      550 |   0.6211 |  1.567160e+06 |  -11.44% |  3.33e-09 |  (PD_AES_2)
-      560 |   0.4666 |  1.545172e+06 |   -1.40% |  2.71e-08 |      
-      560 |   0.5532 |  1.545172e+06 |   -1.40% |  6.03e-09 |  (PD_AES_1)
-      560 |   0.5938 |  1.545172e+06 |   -1.40% |  4.90e-09 |  (PD_AES_2)
-      570 |   0.4221 |  1.558798e+06 |   +0.88% |  3.99e-08 |      
-      570 |   0.5107 |  1.558798e+06 |   +0.88% |  8.86e-09 |  (PD_AES_1)
-      570 |   0.5592 |  1.558798e+06 |   +0.88% |  7.20e-09 |  (PD_AES_2)
-      580 |   0.3822 |  1.608694e+06 |   +3.20% |  5.86e-08 |      
-      580 |   0.4561 |  1.608694e+06 |   +3.20% |  1.30e-08 |  (PD_AES_1)
-      580 |   0.5060 |  1.608694e+06 |   +3.20% |  1.06e-08 |  (PD_AES_2)
-      590 |   0.3442 |  1.676147e+06 |   +4.19% |  8.58e-08 |      
-      590 |   0.3920 |  1.676147e+06 |   +4.19% |  1.90e-08 |  (PD_AES_1)
-      590 |   0.4402 |  1.676147e+06 |   +4.19% |  1.55e-08 |  (PD_AES_2)
-      600 |   0.3135 |  1.736211e+06 |   +3.58% |  1.26e-07 |      
-      600 |   0.3284 |  1.736211e+06 |   +3.58% |  2.79e-08 |  (PD_AES_1)
-      600 |   0.3677 |  1.736211e+06 |   +3.58% |  2.27e-08 |  (PD_AES_2)
+      550 |   0.5311 |  1.572177e+06 |  -10.12% |  1.73e-08 |      
+      550 |   0.6322 |  1.572177e+06 |  -10.12% |  2.95e-09 |  (PD_AES_1)
+      550 |   0.6300 |  1.572177e+06 |  -10.12% |  3.01e-09 |  (PD_AES_2)
+      560 |   0.4712 |  1.530978e+06 |   -2.62% |  2.55e-08 |      
+      560 |   0.6049 |  1.530978e+06 |   -2.62% |  4.34e-09 |  (PD_AES_1)
+      560 |   0.6012 |  1.530978e+06 |   -2.62% |  4.43e-09 |  (PD_AES_2)
+      570 |   0.4248 |  1.541077e+06 |   +0.66% |  3.75e-08 |      
+      570 |   0.5653 |  1.541077e+06 |   +0.66% |  6.39e-09 |  (PD_AES_1)
+      570 |   0.5647 |  1.541077e+06 |   +0.66% |  6.51e-09 |  (PD_AES_2)
+      580 |   0.3838 |  1.584008e+06 |   +2.79% |  5.50e-08 |      
+      580 |   0.5169 |  1.584008e+06 |   +2.79% |  9.37e-09 |  (PD_AES_1)
+      580 |   0.5139 |  1.584008e+06 |   +2.79% |  9.56e-09 |  (PD_AES_2)
+      590 |   0.3471 |  1.647044e+06 |   +3.98% |  8.06e-08 |      
+      590 |   0.4584 |  1.647044e+06 |   +3.98% |  1.37e-08 |  (PD_AES_1)
+      590 |   0.4535 |  1.647044e+06 |   +3.98% |  1.40e-08 |  (PD_AES_2)
+      600 |   0.3167 |  1.709761e+06 |   +3.81% |  1.18e-07 |      
+      600 |   0.3907 |  1.709761e+06 |   +3.81% |  2.01e-08 |  (PD_AES_1)
+      600 |   0.3829 |  1.709761e+06 |   +3.81% |  2.05e-08 |  (PD_AES_2)
+      610 |   0.2914 |  1.762923e+06 |   +3.11% |  1.73e-07 |      
+      610 |   0.3251 |  1.762923e+06 |   +3.11% |  2.95e-08 |  (PD_AES_1)
+      610 |   0.3170 |  1.762923e+06 |   +3.11% |  3.01e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 5
-[INFO GPL-0041] Total routing overflow: 7.3735
-[INFO GPL-0042] Number of overflowed tiles: 170 (0.82%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0631
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0344
-[INFO GPL-0045] Average top 2.0% routing congestion: 1.0000
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9452
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0487
-[INFO GPL-0049] Routing congestion (1.0487) higher than minimum (1.0471). Consecutive non-improvement count: 1.
-[INFO GPL-0086] Inflated area:                  21.698 um^2 (+0.02%)
+[INFO GPL-0041] Total routing overflow: 8.0242
+[INFO GPL-0042] Number of overflowed tiles: 201 (0.97%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0642
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0385
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0062
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9497
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0514
+[INFO GPL-0048] Routing congestion (1.0514) lower than previous minimum (1.059). Updating minimum.
+[INFO GPL-0086] Inflated area:                  46.228 um^2 (+0.03%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 339, After: 337 (-0.59%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2634.459, After: 2618.916 (-0.59%)
-[INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 6.156 um^2
-[INFO GPL-0086] Inflated area:                 203.667 um^2 (+0.16%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 200, After: 174 (-13.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1560.894, After: 1357.978 (-13.00%)
-[INFO GPL-0078] Removed fillers count: 26, area removed: 202.916 um^2. Remaining area to be compensated by modifying density: 0.751 um^2
-[INFO GPL-0086] Inflated area:                 357.144 um^2 (+0.28%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 72, After: 27 (-62.50%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 561.922, After: 210.721 (-62.50%)
-[INFO GPL-0078] Removed fillers count: 45, area removed: 351.201 um^2. Remaining area to be compensated by modifying density: 5.942 um^2
+[INFO GPL-0076] Removing fillers, count: Before: 329, After: 324 (-1.52%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2556.746, After: 2517.890 (-1.52%)
+[INFO GPL-0078] Removed fillers count: 5, area removed: 38.856 um^2. Remaining area to be compensated by modifying density: 7.371 um^2
+[INFO GPL-0086] Inflated area:                 341.453 um^2 (+0.27%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 93, After: 50 (-46.24%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 725.816, After: 390.224 (-46.24%)
+[INFO GPL-0078] Removed fillers count: 43, area removed: 335.592 um^2. Remaining area to be compensated by modifying density: 5.861 um^2
+[INFO GPL-0086] Inflated area:                 286.625 um^2 (+0.23%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 100, After: 64 (-36.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 780.447, After: 499.486 (-36.00%)
+[INFO GPL-0078] Removed fillers count: 36, area removed: 280.961 um^2. Remaining area to be compensated by modifying density: 5.664 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2618.916 um^2 (-0.59%)
-[INFO GPL-0061] Total non-inflated area:    139550.453 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139572.151 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2517.890 um^2 (-1.52%)
+[INFO GPL-0061] Total non-inflated area:    139570.305 um^2 (+0.01%)
+[INFO GPL-0062] Total inflated area:        139616.532 um^2 (+0.01%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1357.978 um^2 (-13.00%)
-[INFO GPL-0061] Total non-inflated area:    127249.615 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127453.283 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             210.721 um^2 (-62.50%)
-[INFO GPL-0061] Total non-inflated area:    127267.092 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127624.236 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140820.251 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:             390.224 um^2 (-46.24%)
+[INFO GPL-0061] Total non-inflated area:    127241.133 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127582.586 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4969
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:             499.486 um^2 (-36.00%)
+[INFO GPL-0061] Total non-inflated area:    127249.806 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127536.430 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      610 |   0.5124 |  1.566332e+06 |   -9.78% |  1.41e-08 |      
-      610 |   0.6107 |  1.566332e+06 |   -9.78% |  3.13e-09 |  (PD_AES_1)
-      610 |   0.6497 |  1.566332e+06 |   -9.78% |  2.54e-09 |  (PD_AES_2)
-      620 |   0.4952 |  1.545478e+06 |   -1.33% |  2.07e-08 |      
-      620 |   0.5763 |  1.545478e+06 |   -1.33% |  4.60e-09 |  (PD_AES_1)
-      620 |   0.6117 |  1.545478e+06 |   -1.33% |  3.74e-09 |  (PD_AES_2)
-      630 |   0.4542 |  1.542693e+06 |   -0.18% |  3.05e-08 |      
-      630 |   0.5413 |  1.542693e+06 |   -0.18% |  6.77e-09 |  (PD_AES_1)
-      630 |   0.5810 |  1.542693e+06 |   -0.18% |  5.50e-09 |  (PD_AES_2)
-      640 |   0.4104 |  1.571172e+06 |   +1.85% |  4.48e-08 |      
-      640 |   0.4944 |  1.571172e+06 |   +1.85% |  9.94e-09 |  (PD_AES_1)
-      640 |   0.5422 |  1.571172e+06 |   +1.85% |  8.08e-09 |  (PD_AES_2)
-      650 |   0.3692 |  1.631076e+06 |   +3.81% |  6.56e-08 |      
-      650 |   0.4360 |  1.631076e+06 |   +3.81% |  1.46e-08 |  (PD_AES_1)
-      650 |   0.4881 |  1.631076e+06 |   +3.81% |  1.18e-08 |  (PD_AES_2)
-      660 |   0.3345 |  1.695826e+06 |   +3.97% |  9.62e-08 |      
-      660 |   0.3729 |  1.695826e+06 |   +3.97% |  2.14e-08 |  (PD_AES_1)
-      660 |   0.4199 |  1.695826e+06 |   +3.97% |  1.73e-08 |  (PD_AES_2)
-      670 |   0.3053 |  1.751986e+06 |   +3.31% |  1.41e-07 |      
-      670 |   0.3107 |  1.751986e+06 |   +3.31% |  3.13e-08 |  (PD_AES_1)
-      670 |   0.3509 |  1.751986e+06 |   +3.31% |  2.54e-08 |  (PD_AES_2)
+      620 |   0.5056 |  1.583850e+06 |  -10.16% |  1.94e-08 |      
+      620 |   0.6166 |  1.583850e+06 |  -10.16% |  3.31e-09 |  (PD_AES_1)
+      620 |   0.6133 |  1.583850e+06 |  -10.16% |  3.38e-09 |  (PD_AES_2)
+      630 |   0.4537 |  1.550951e+06 |   -2.08% |  2.86e-08 |      
+      630 |   0.5865 |  1.550951e+06 |   -2.08% |  4.87e-09 |  (PD_AES_1)
+      630 |   0.5847 |  1.550951e+06 |   -2.08% |  4.97e-09 |  (PD_AES_2)
+      640 |   0.4108 |  1.557047e+06 |   +0.39% |  4.21e-08 |      
+      640 |   0.5505 |  1.557047e+06 |   +0.39% |  7.17e-09 |  (PD_AES_1)
+      640 |   0.5489 |  1.557047e+06 |   +0.39% |  7.31e-09 |  (PD_AES_2)
+      650 |   0.3722 |  1.606562e+06 |   +3.18% |  6.17e-08 |      
+      650 |   0.5016 |  1.606562e+06 |   +3.18% |  1.05e-08 |  (PD_AES_1)
+      650 |   0.4983 |  1.606562e+06 |   +3.18% |  1.07e-08 |  (PD_AES_2)
+      660 |   0.3368 |  1.669035e+06 |   +3.89% |  9.04e-08 |      
+      660 |   0.4376 |  1.669035e+06 |   +3.89% |  1.54e-08 |  (PD_AES_1)
+      660 |   0.4335 |  1.669035e+06 |   +3.89% |  1.57e-08 |  (PD_AES_2)
+      670 |   0.3087 |  1.730258e+06 |   +3.67% |  1.32e-07 |      
+      670 |   0.3683 |  1.730258e+06 |   +3.67% |  2.26e-08 |  (PD_AES_1)
+      670 |   0.3620 |  1.730258e+06 |   +3.67% |  2.30e-08 |  (PD_AES_2)
+      680 |   0.2852 |  1.777244e+06 |   +2.72% |  1.94e-07 |      
+      680 |   0.3086 |  1.777244e+06 |   +2.72% |  3.31e-08 |  (PD_AES_1)
+      680 |   0.3039 |  1.777244e+06 |   +2.72% |  3.38e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 6
-[INFO GPL-0041] Total routing overflow: 6.1179
-[INFO GPL-0042] Number of overflowed tiles: 161 (0.78%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0541
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0278
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9977
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9443
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0410
-[INFO GPL-0048] Routing congestion (1.0410) lower than previous minimum (1.047). Updating minimum.
-[INFO GPL-0086] Inflated area:                  25.043 um^2 (+0.02%)
+[INFO GPL-0041] Total routing overflow: 6.3781
+[INFO GPL-0042] Number of overflowed tiles: 177 (0.85%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0542
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0300
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0004
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9471
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0421
+[INFO GPL-0048] Routing congestion (1.0421) lower than previous minimum (1.051). Updating minimum.
+[INFO GPL-0086] Inflated area:                  37.794 um^2 (+0.03%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 337, After: 334 (-0.89%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2618.916, After: 2595.603 (-0.89%)
-[INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 1.729 um^2
-[INFO GPL-0086] Inflated area:                 167.514 um^2 (+0.13%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 174, After: 153 (-12.07%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1357.978, After: 1194.084 (-12.07%)
-[INFO GPL-0078] Removed fillers count: 21, area removed: 163.894 um^2. Remaining area to be compensated by modifying density: 3.620 um^2
-[INFO GPL-0086] Inflated area:                 279.987 um^2 (+0.22%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 27, After: 0 (-100.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 210.721, After: 0.000 (-100.00%)
-[INFO GPL-0078] Removed fillers count: 27, area removed: 210.721 um^2. Remaining area to be compensated by modifying density: 69.267 um^2
-[INFO GPL-0079] New target density: 0.44648093
+[INFO GPL-0076] Removing fillers, count: Before: 324, After: 320 (-1.23%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2517.890, After: 2486.805 (-1.23%)
+[INFO GPL-0078] Removed fillers count: 4, area removed: 31.085 um^2. Remaining area to be compensated by modifying density: 6.709 um^2
+[INFO GPL-0086] Inflated area:                 265.045 um^2 (+0.21%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 50, After: 17 (-66.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 390.224, After: 132.676 (-66.00%)
+[INFO GPL-0078] Removed fillers count: 33, area removed: 257.548 um^2. Remaining area to be compensated by modifying density: 7.497 um^2
+[INFO GPL-0086] Inflated area:                 225.605 um^2 (+0.18%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 64, After: 36 (-43.75%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 499.486, After: 280.961 (-43.75%)
+[INFO GPL-0078] Removed fillers count: 28, area removed: 218.525 um^2. Remaining area to be compensated by modifying density: 7.079 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2595.603 um^2 (-0.89%)
-[INFO GPL-0061] Total non-inflated area:    139552.182 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139577.225 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2486.805 um^2 (-1.23%)
+[INFO GPL-0061] Total non-inflated area:    139577.014 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139614.807 um^2 (+0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1194.084 um^2 (-12.07%)
-[INFO GPL-0061] Total non-inflated area:    127253.236 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127420.750 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     127336.358 um^2 (-9.59%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (-100.00%)
-[INFO GPL-0061] Total non-inflated area:    127336.359 um^2 (+0.05%)
-[INFO GPL-0062] Total inflated area:        127616.346 um^2 (+0.05%)
-[INFO GPL-0063] New Target Density:             0.4465
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140820.251 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:             132.676 um^2 (-66.00%)
+[INFO GPL-0061] Total non-inflated area:    127248.630 um^2 (+0.01%)
+[INFO GPL-0062] Total inflated area:        127513.675 um^2 (+0.01%)
+[INFO GPL-0063] New Target Density:             0.4969
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:             280.961 um^2 (-43.75%)
+[INFO GPL-0061] Total non-inflated area:    127256.885 um^2 (+0.01%)
+[INFO GPL-0062] Total inflated area:        127482.489 um^2 (+0.01%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      680 |   0.5339 |  1.598840e+06 |   -8.74% |  1.64e-08 |      
-      680 |   0.5984 |  1.598840e+06 |   -8.74% |  3.65e-09 |  (PD_AES_1)
-      680 |   0.6364 |  1.598840e+06 |   -8.74% |  2.97e-09 |  (PD_AES_2)
-      690 |   0.4808 |  1.547839e+06 |   -3.19% |  2.42e-08 |      
-      690 |   0.5661 |  1.547839e+06 |   -3.19% |  5.37e-09 |  (PD_AES_1)
-      690 |   0.6182 |  1.547839e+06 |   -3.19% |  4.36e-09 |  (PD_AES_2)
-      700 |   0.4367 |  1.558682e+06 |   +0.70% |  3.56e-08 |      
-      700 |   0.5252 |  1.558682e+06 |   +0.70% |  7.90e-09 |  (PD_AES_1)
-      700 |   0.5815 |  1.558682e+06 |   +0.70% |  6.42e-09 |  (PD_AES_2)
-      710 |   0.3941 |  1.605318e+06 |   +2.99% |  5.22e-08 |      
-      710 |   0.4708 |  1.605318e+06 |   +2.99% |  1.16e-08 |  (PD_AES_1)
-      710 |   0.5350 |  1.605318e+06 |   +2.99% |  9.42e-09 |  (PD_AES_2)
-      720 |   0.3538 |  1.669005e+06 |   +3.97% |  7.65e-08 |      
-      720 |   0.4112 |  1.669005e+06 |   +3.97% |  1.70e-08 |  (PD_AES_1)
-      720 |   0.4758 |  1.669005e+06 |   +3.97% |  1.38e-08 |  (PD_AES_2)
-      730 |   0.3210 |  1.730909e+06 |   +3.71% |  1.12e-07 |      
-      730 |   0.3443 |  1.730909e+06 |   +3.71% |  2.49e-08 |  (PD_AES_1)
-      730 |   0.4135 |  1.730909e+06 |   +3.71% |  2.02e-08 |  (PD_AES_2)
-      740 |   0.2943 |  1.780604e+06 |   +2.87% |  1.64e-07 |      
-      740 |   0.2873 |  1.780604e+06 |   +2.87% |  3.65e-08 |  (PD_AES_1)
-      740 |   0.3534 |  1.780604e+06 |   +2.87% |  2.97e-08 |  (PD_AES_2)
+      690 |   0.4862 |  1.547815e+06 |  -12.91% |  2.18e-08 |      
+      690 |   0.6105 |  1.547815e+06 |  -12.91% |  3.72e-09 |  (PD_AES_1)
+      690 |   0.6070 |  1.547815e+06 |  -12.91% |  3.79e-09 |  (PD_AES_2)
+      700 |   0.4447 |  1.545447e+06 |   -0.15% |  3.21e-08 |      
+      700 |   0.5773 |  1.545447e+06 |   -0.15% |  5.47e-09 |  (PD_AES_1)
+      700 |   0.5758 |  1.545447e+06 |   -0.15% |  5.58e-09 |  (PD_AES_2)
+      710 |   0.4004 |  1.569005e+06 |   +1.52% |  4.72e-08 |      
+      710 |   0.5353 |  1.569005e+06 |   +1.52% |  8.04e-09 |  (PD_AES_1)
+      710 |   0.5357 |  1.569005e+06 |   +1.52% |  8.20e-09 |  (PD_AES_2)
+      720 |   0.3620 |  1.628203e+06 |   +3.77% |  6.92e-08 |      
+      720 |   0.4833 |  1.628203e+06 |   +3.77% |  1.18e-08 |  (PD_AES_1)
+      720 |   0.4805 |  1.628203e+06 |   +3.77% |  1.20e-08 |  (PD_AES_2)
+      730 |   0.3274 |  1.689266e+06 |   +3.75% |  1.01e-07 |      
+      730 |   0.4195 |  1.689266e+06 |   +3.75% |  1.73e-08 |  (PD_AES_1)
+      730 |   0.4132 |  1.689266e+06 |   +3.75% |  1.76e-08 |  (PD_AES_2)
+      740 |   0.3015 |  1.746612e+06 |   +3.39% |  1.49e-07 |      
+      740 |   0.3500 |  1.746612e+06 |   +3.39% |  2.53e-08 |  (PD_AES_1)
+      740 |   0.3417 |  1.746612e+06 |   +3.39% |  2.58e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 7
-[INFO GPL-0041] Total routing overflow: 4.2252
-[INFO GPL-0042] Number of overflowed tiles: 115 (0.55%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0405
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0150
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9860
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9350
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0277
-[INFO GPL-0048] Routing congestion (1.0277) lower than previous minimum (1.041). Updating minimum.
-[INFO GPL-0086] Inflated area:                  25.706 um^2 (+0.02%)
+[INFO GPL-0041] Total routing overflow: 6.4513
+[INFO GPL-0042] Number of overflowed tiles: 182 (0.88%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0555
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0305
+[INFO GPL-0045] Average top 2.0% routing congestion: 1.0013
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9473
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0430
+[INFO GPL-0049] Routing congestion (1.0430) higher than minimum (1.0421). Consecutive non-improvement count: 1.
+[INFO GPL-0086] Inflated area:                  61.322 um^2 (+0.04%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 334, After: 331 (-0.90%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2595.603, After: 2572.289 (-0.90%)
-[INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 2.392 um^2
-[INFO GPL-0086] Inflated area:                 132.188 um^2 (+0.10%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 153, After: 137 (-10.46%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1194.084, After: 1069.213 (-10.46%)
-[INFO GPL-0078] Removed fillers count: 16, area removed: 124.872 um^2. Remaining area to be compensated by modifying density: 7.316 um^2
-[INFO GPL-0086] Inflated area:                 159.339 um^2 (+0.13%)
-[INFO GPL-0052] Placement target density:       0.4465
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 159.339 um^2
-[INFO GPL-0079] New target density: 0.44703963
+[INFO GPL-0076] Removing fillers, count: Before: 320, After: 313 (-2.19%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2486.805, After: 2432.406 (-2.19%)
+[INFO GPL-0078] Removed fillers count: 7, area removed: 54.399 um^2. Remaining area to be compensated by modifying density: 6.923 um^2
+[INFO GPL-0086] Inflated area:                 265.892 um^2 (+0.21%)
+[INFO GPL-0052] Placement target density:       0.4969
+[INFO GPL-0076] Removing fillers, count: Before: 17, After: 0 (-100.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 132.676, After: 0.000 (-100.00%)
+[INFO GPL-0078] Removed fillers count: 17, area removed: 132.676 um^2. Remaining area to be compensated by modifying density: 133.216 um^2
+[INFO GPL-0079] New target density: 0.44947955
+[INFO GPL-0086] Inflated area:                 216.662 um^2 (+0.17%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 36, After: 9 (-75.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 280.961, After: 70.240 (-75.00%)
+[INFO GPL-0078] Removed fillers count: 27, area removed: 210.721 um^2. Remaining area to be compensated by modifying density: 5.941 um^2
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2572.289 um^2 (-0.90%)
-[INFO GPL-0061] Total non-inflated area:    139554.574 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139580.280 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2432.406 um^2 (-2.19%)
+[INFO GPL-0061] Total non-inflated area:    139583.936 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139645.258 um^2 (+0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            1069.213 um^2 (-10.46%)
-[INFO GPL-0061] Total non-inflated area:    127260.552 um^2 (+0.01%)
-[INFO GPL-0062] Total inflated area:        127392.740 um^2 (+0.01%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     127495.700 um^2 (+0.13%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    127495.697 um^2 (+0.13%)
-[INFO GPL-0062] Total inflated area:        127655.036 um^2 (+0.12%)
-[INFO GPL-0063] New Target Density:             0.4470
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     127381.848 um^2 (-9.54%)
+[INFO GPL-0060] Total filler area:               0.000 um^2 (-100.00%)
+[INFO GPL-0061] Total non-inflated area:    127381.846 um^2 (+0.10%)
+[INFO GPL-0062] Total inflated area:        127647.739 um^2 (+0.10%)
+[INFO GPL-0063] New Target Density:             0.4495
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     140826.198 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:              70.240 um^2 (-75.00%)
+[INFO GPL-0061] Total non-inflated area:    127262.826 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        127479.487 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.4959
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      750 |   0.5347 |  1.602494e+06 |  -10.00% |  1.71e-08 |      
-      750 |   0.5965 |  1.602494e+06 |  -10.00% |  3.79e-09 |  (PD_AES_1)
-      750 |   0.6325 |  1.602494e+06 |  -10.00% |  3.08e-09 |  (PD_AES_2)
-      760 |   0.4767 |  1.552813e+06 |   -3.10% |  2.51e-08 |      
-      760 |   0.5621 |  1.552813e+06 |   -3.10% |  5.58e-09 |  (PD_AES_1)
-      760 |   0.6159 |  1.552813e+06 |   -3.10% |  4.53e-09 |  (PD_AES_2)
-      770 |   0.4303 |  1.566124e+06 |   +0.86% |  3.70e-08 |      
-      770 |   0.5195 |  1.566124e+06 |   +0.86% |  8.21e-09 |  (PD_AES_1)
-      770 |   0.5791 |  1.566124e+06 |   +0.86% |  6.67e-09 |  (PD_AES_2)
-      780 |   0.3902 |  1.613805e+06 |   +3.04% |  5.43e-08 |      
-      780 |   0.4662 |  1.613805e+06 |   +3.04% |  1.20e-08 |  (PD_AES_1)
-      780 |   0.5306 |  1.613805e+06 |   +3.04% |  9.79e-09 |  (PD_AES_2)
-      790 |   0.3497 |  1.677668e+06 |   +3.96% |  7.95e-08 |      
-      790 |   0.4038 |  1.677668e+06 |   +3.96% |  1.76e-08 |  (PD_AES_1)
-      790 |   0.4701 |  1.677668e+06 |   +3.96% |  1.43e-08 |  (PD_AES_2)
-      800 |   0.3172 |  1.738017e+06 |   +3.60% |  1.16e-07 |      
-      800 |   0.3376 |  1.738017e+06 |   +3.60% |  2.59e-08 |  (PD_AES_1)
-      800 |   0.4069 |  1.738017e+06 |   +3.60% |  2.10e-08 |  (PD_AES_2)
-      810 |   0.2927 |  1.785700e+06 |   +2.74% |  1.71e-07 |      
-      810 |   0.2834 |  1.785700e+06 |   +2.74% |  3.79e-08 |  (PD_AES_1)
-      810 |   0.3476 |  1.785700e+06 |   +2.74% |  3.08e-08 |  (PD_AES_2)
+      750 |   0.5257 |  1.605636e+06 |   -8.07% |  1.67e-08 |      
+      750 |   0.6463 |  1.605636e+06 |   -8.07% |  2.84e-09 |  (PD_AES_1)
+      750 |   0.6270 |  1.605636e+06 |   -8.07% |  2.90e-09 |  (PD_AES_2)
+      760 |   0.4718 |  1.555085e+06 |   -3.15% |  2.45e-08 |      
+      760 |   0.6181 |  1.555085e+06 |   -3.15% |  4.18e-09 |  (PD_AES_1)
+      760 |   0.6015 |  1.555085e+06 |   -3.15% |  4.26e-09 |  (PD_AES_2)
+      770 |   0.4287 |  1.559615e+06 |   +0.29% |  3.61e-08 |      
+      770 |   0.5802 |  1.559615e+06 |   +0.29% |  6.15e-09 |  (PD_AES_1)
+      770 |   0.5651 |  1.559615e+06 |   +0.29% |  6.28e-09 |  (PD_AES_2)
+      780 |   0.3870 |  1.599436e+06 |   +2.55% |  5.30e-08 |      
+      780 |   0.5343 |  1.599436e+06 |   +2.55% |  9.04e-09 |  (PD_AES_1)
+      780 |   0.5152 |  1.599436e+06 |   +2.55% |  9.22e-09 |  (PD_AES_2)
+      790 |   0.3495 |  1.661225e+06 |   +3.86% |  7.77e-08 |      
+      790 |   0.4785 |  1.661225e+06 |   +3.86% |  1.32e-08 |  (PD_AES_1)
+      790 |   0.4580 |  1.661225e+06 |   +3.86% |  1.35e-08 |  (PD_AES_2)
+      800 |   0.3181 |  1.719791e+06 |   +3.53% |  1.14e-07 |      
+      800 |   0.4177 |  1.719791e+06 |   +3.53% |  1.94e-08 |  (PD_AES_1)
+      800 |   0.3887 |  1.719791e+06 |   +3.53% |  1.98e-08 |  (PD_AES_2)
+      810 |   0.2929 |  1.770770e+06 |   +2.96% |  1.67e-07 |      
+      810 |   0.3568 |  1.770770e+06 |   +2.96% |  2.85e-08 |  (PD_AES_1)
+      810 |   0.3222 |  1.770770e+06 |   +2.96% |  2.90e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 8
-[INFO GPL-0041] Total routing overflow: 4.1713
-[INFO GPL-0042] Number of overflowed tiles: 115 (0.55%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0400
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0142
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9847
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9342
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0271
-[INFO GPL-0049] Routing congestion (1.0271) higher than minimum (1.0277). Consecutive non-improvement count: 1.
-[INFO GPL-0086] Inflated area:                  23.808 um^2 (+0.02%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 331, After: 328 (-0.91%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2572.289, After: 2548.975 (-0.91%)
-[INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 0.494 um^2
-[INFO GPL-0086] Inflated area:                 139.003 um^2 (+0.11%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 137, After: 120 (-12.41%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 1069.213, After: 936.537 (-12.41%)
-[INFO GPL-0078] Removed fillers count: 17, area removed: 132.676 um^2. Remaining area to be compensated by modifying density: 6.327 um^2
-[INFO GPL-0086] Inflated area:                 143.255 um^2 (+0.11%)
-[INFO GPL-0052] Placement target density:       0.4470
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 143.255 um^2
-[INFO GPL-0079] New target density: 0.44754192
-[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2548.975 um^2 (-0.91%)
-[INFO GPL-0061] Total non-inflated area:    139555.068 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139578.876 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             936.537 um^2 (-12.41%)
-[INFO GPL-0061] Total non-inflated area:    127266.879 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127405.881 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     127638.954 um^2 (+0.11%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    127638.952 um^2 (+0.11%)
-[INFO GPL-0062] Total inflated area:        127782.207 um^2 (+0.11%)
-[INFO GPL-0063] New Target Density:             0.4475
-[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
-Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
----------------------------------------------------------------
-      820 |   0.5301 |  1.591614e+06 |  -10.87% |  1.77e-08 |      
-      820 |   0.5940 |  1.591614e+06 |  -10.87% |  3.94e-09 |  (PD_AES_1)
-      820 |   0.6314 |  1.591614e+06 |  -10.87% |  3.20e-09 |  (PD_AES_2)
-      830 |   0.4718 |  1.556850e+06 |   -2.18% |  2.61e-08 |      
-      830 |   0.5567 |  1.556850e+06 |   -2.18% |  5.80e-09 |  (PD_AES_1)
-      830 |   0.6099 |  1.556850e+06 |   -2.18% |  4.71e-09 |  (PD_AES_2)
-      840 |   0.4261 |  1.570083e+06 |   +0.85% |  3.84e-08 |      
-      840 |   0.5141 |  1.570083e+06 |   +0.85% |  8.53e-09 |  (PD_AES_1)
-      840 |   0.5738 |  1.570083e+06 |   +0.85% |  6.93e-09 |  (PD_AES_2)
-      850 |   0.3865 |  1.619802e+06 |   +3.17% |  5.64e-08 |      
-      850 |   0.4606 |  1.619802e+06 |   +3.17% |  1.25e-08 |  (PD_AES_1)
-      850 |   0.5254 |  1.619802e+06 |   +3.17% |  1.02e-08 |  (PD_AES_2)
-      860 |   0.3465 |  1.683636e+06 |   +3.94% |  8.26e-08 |      
-      860 |   0.3973 |  1.683636e+06 |   +3.94% |  1.83e-08 |  (PD_AES_1)
-      860 |   0.4642 |  1.683636e+06 |   +3.94% |  1.49e-08 |  (PD_AES_2)
-      870 |   0.3148 |  1.743606e+06 |   +3.56% |  1.21e-07 |      
-      870 |   0.3314 |  1.743606e+06 |   +3.56% |  2.69e-08 |  (PD_AES_1)
-      870 |   0.4010 |  1.743606e+06 |   +3.56% |  2.18e-08 |  (PD_AES_2)
-      880 |   0.2907 |  1.789751e+06 |   +2.65% |  1.77e-07 |      
-      880 |   0.2779 |  1.789751e+06 |   +2.65% |  3.94e-08 |  (PD_AES_1)
-      880 |   0.3440 |  1.789751e+06 |   +2.65% |  3.20e-08 |  (PD_AES_2)
-[INFO GPL-0040] Routability iteration: 9
-[INFO GPL-0041] Total routing overflow: 4.4594
-[INFO GPL-0042] Number of overflowed tiles: 119 (0.57%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0425
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0159
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9860
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9340
+[INFO GPL-0041] Total routing overflow: 4.4119
+[INFO GPL-0042] Number of overflowed tiles: 127 (0.61%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0414
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0169
+[INFO GPL-0045] Average top 2.0% routing congestion: 0.9887
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9375
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0292
-[INFO GPL-0049] Routing congestion (1.0292) higher than minimum (1.0277). Consecutive non-improvement count: 2.
-[INFO GPL-0086] Inflated area:                  22.731 um^2 (+0.02%)
+[INFO GPL-0048] Routing congestion (1.0292) lower than previous minimum (1.042). Updating minimum.
+[INFO GPL-0086] Inflated area:                  28.083 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 328, After: 326 (-0.61%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2548.975, After: 2533.432 (-0.61%)
-[INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 7.188 um^2
-[INFO GPL-0086] Inflated area:                 144.597 um^2 (+0.11%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 120, After: 102 (-15.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 936.537, After: 796.056 (-15.00%)
-[INFO GPL-0078] Removed fillers count: 18, area removed: 140.480 um^2. Remaining area to be compensated by modifying density: 4.116 um^2
-[INFO GPL-0086] Inflated area:                 147.575 um^2 (+0.12%)
-[INFO GPL-0052] Placement target density:       0.4475
+[INFO GPL-0076] Removing fillers, count: Before: 313, After: 310 (-0.96%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2432.406, After: 2409.092 (-0.96%)
+[INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 4.769 um^2
+[INFO GPL-0086] Inflated area:                 151.417 um^2 (+0.12%)
+[INFO GPL-0052] Placement target density:       0.4495
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 147.575 um^2
-[INFO GPL-0079] New target density: 0.44805935
+[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 151.417 um^2
+[INFO GPL-0079] New target density: 0.45001382
+[INFO GPL-0086] Inflated area:                 161.843 um^2 (+0.13%)
+[INFO GPL-0052] Placement target density:       0.4959
+[INFO GPL-0076] Removing fillers, count: Before: 9, After: 0 (-100.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 70.240, After: 0.000 (-100.00%)
+[INFO GPL-0078] Removed fillers count: 9, area removed: 70.240 um^2. Remaining area to be compensated by modifying density: 91.602 um^2
+[INFO GPL-0079] New target density: 0.4484415
 [INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2533.432 um^2 (-0.61%)
-[INFO GPL-0061] Total non-inflated area:    139562.256 um^2 (+0.01%)
-[INFO GPL-0062] Total inflated area:        139584.987 um^2 (+0.01%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2409.092 um^2 (-0.96%)
+[INFO GPL-0061] Total non-inflated area:    139588.705 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139616.788 um^2 (+0.00%)
 [INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             796.056 um^2 (-15.00%)
-[INFO GPL-0061] Total non-inflated area:    127270.995 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127415.592 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     127786.525 um^2 (+0.12%)
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     127533.261 um^2 (+0.12%)
 [INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    127786.527 um^2 (+0.12%)
-[INFO GPL-0062] Total inflated area:        127934.102 um^2 (+0.12%)
-[INFO GPL-0063] New Target Density:             0.4481
+[INFO GPL-0061] Total non-inflated area:    127533.264 um^2 (+0.12%)
+[INFO GPL-0062] Total inflated area:        127684.681 um^2 (+0.12%)
+[INFO GPL-0063] New Target Density:             0.4500
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     127354.429 um^2 (-9.57%)
+[INFO GPL-0060] Total filler area:               0.000 um^2 (-100.00%)
+[INFO GPL-0061] Total non-inflated area:    127354.428 um^2 (+0.07%)
+[INFO GPL-0062] Total inflated area:        127516.271 um^2 (+0.07%)
+[INFO GPL-0063] New Target Density:             0.4484
 [INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      890 |   0.5248 |  1.580833e+06 |  -11.67% |  1.84e-08 |      
-      890 |   0.5908 |  1.580833e+06 |  -11.67% |  4.09e-09 |  (PD_AES_1)
-      890 |   0.6285 |  1.580833e+06 |  -11.67% |  3.33e-09 |  (PD_AES_2)
-      900 |   0.4669 |  1.560987e+06 |   -1.26% |  2.71e-08 |      
-      900 |   0.5524 |  1.560987e+06 |   -1.26% |  6.03e-09 |  (PD_AES_1)
-      900 |   0.6047 |  1.560987e+06 |   -1.26% |  4.90e-09 |  (PD_AES_2)
-      910 |   0.4209 |  1.576378e+06 |   +0.99% |  3.99e-08 |      
-      910 |   0.5084 |  1.576378e+06 |   +0.99% |  8.86e-09 |  (PD_AES_1)
-      910 |   0.5689 |  1.576378e+06 |   +0.99% |  7.20e-09 |  (PD_AES_2)
-      920 |   0.3812 |  1.629046e+06 |   +3.34% |  5.85e-08 |      
-      920 |   0.4539 |  1.629046e+06 |   +3.34% |  1.30e-08 |  (PD_AES_1)
-      920 |   0.5184 |  1.629046e+06 |   +3.34% |  1.06e-08 |  (PD_AES_2)
-      930 |   0.3429 |  1.691485e+06 |   +3.83% |  8.58e-08 |      
-      930 |   0.3914 |  1.691485e+06 |   +3.83% |  1.90e-08 |  (PD_AES_1)
-      930 |   0.4569 |  1.691485e+06 |   +3.83% |  1.55e-08 |  (PD_AES_2)
-      940 |   0.3117 |  1.750229e+06 |   +3.47% |  1.26e-07 |      
-      940 |   0.3253 |  1.750229e+06 |   +3.47% |  2.79e-08 |  (PD_AES_1)
-      940 |   0.3954 |  1.750229e+06 |   +3.47% |  2.27e-08 |  (PD_AES_2)
-      950 |   0.2883 |  1.794618e+06 |   +2.54% |  1.84e-07 |      
-      950 |   0.2745 |  1.794618e+06 |   +2.54% |  4.10e-08 |  (PD_AES_1)
-      950 |   0.3403 |  1.794618e+06 |   +2.54% |  3.33e-08 |  (PD_AES_2)
+      820 |   0.5222 |  1.608721e+06 |   -9.15% |  1.73e-08 |      
+      820 |   0.6337 |  1.608721e+06 |   -9.15% |  2.95e-09 |  (PD_AES_1)
+      820 |   0.6305 |  1.608721e+06 |   -9.15% |  3.01e-09 |  (PD_AES_2)
+      830 |   0.4630 |  1.572318e+06 |   -2.26% |  2.55e-08 |      
+      830 |   0.6099 |  1.572318e+06 |   -2.26% |  4.34e-09 |  (PD_AES_1)
+      830 |   0.6074 |  1.572318e+06 |   -2.26% |  4.43e-09 |  (PD_AES_2)
+      840 |   0.4218 |  1.572619e+06 |   +0.02% |  3.75e-08 |      
+      840 |   0.5741 |  1.572619e+06 |   +0.02% |  6.39e-09 |  (PD_AES_1)
+      840 |   0.5709 |  1.572619e+06 |   +0.02% |  6.51e-09 |  (PD_AES_2)
+      850 |   0.3817 |  1.618307e+06 |   +2.91% |  5.50e-08 |      
+      850 |   0.5274 |  1.618307e+06 |   +2.91% |  9.38e-09 |  (PD_AES_1)
+      850 |   0.5236 |  1.618307e+06 |   +2.91% |  9.56e-09 |  (PD_AES_2)
+      860 |   0.3454 |  1.678590e+06 |   +3.73% |  8.06e-08 |      
+      860 |   0.4718 |  1.678590e+06 |   +3.73% |  1.37e-08 |  (PD_AES_1)
+      860 |   0.4678 |  1.678590e+06 |   +3.73% |  1.40e-08 |  (PD_AES_2)
+      870 |   0.3143 |  1.735398e+06 |   +3.38% |  1.18e-07 |      
+      870 |   0.4090 |  1.735398e+06 |   +3.38% |  2.01e-08 |  (PD_AES_1)
+      870 |   0.4046 |  1.735398e+06 |   +3.38% |  2.05e-08 |  (PD_AES_2)
+      880 |   0.2890 |  1.782776e+06 |   +2.73% |  1.73e-07 |      
+      880 |   0.3489 |  1.782776e+06 |   +2.73% |  2.95e-08 |  (PD_AES_1)
+      880 |   0.3433 |  1.782776e+06 |   +2.73% |  3.01e-08 |  (PD_AES_2)
+[INFO GPL-0040] Routability iteration: 9
+[INFO GPL-0041] Total routing overflow: 2.3707
+[INFO GPL-0042] Number of overflowed tiles: 88 (0.42%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0224
+[INFO GPL-0044] Average top 1.0% routing congestion: 1.0012
+[INFO GPL-0045] Average top 2.0% routing congestion: 0.9752
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9274
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0118
+[INFO GPL-0048] Routing congestion (1.0118) lower than previous minimum (1.029). Updating minimum.
+[INFO GPL-0086] Inflated area:                   5.828 um^2 (+0.00%)
+[INFO GPL-0052] Placement target density:       0.3961
+[INFO GPL-0076] Removing fillers, count: Before: 310, After: 310 (+0.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 2409.092, After: 2409.092 (+0.00%)
+[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 5.828 um^2
+[INFO GPL-0086] Inflated area:                  74.214 um^2 (+0.06%)
+[INFO GPL-0052] Placement target density:       0.4500
+[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
+[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 74.214 um^2
+[INFO GPL-0079] New target density: 0.45027572
+[INFO GPL-0086] Inflated area:                  85.009 um^2 (+0.07%)
+[INFO GPL-0052] Placement target density:       0.4484
+[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
+[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
+[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 85.009 um^2
+[INFO GPL-0079] New target density: 0.44874084
+[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     112349.315 um^2 (+0.00%)
+[INFO GPL-0060] Total filler area:            2409.092 um^2 (+0.00%)
+[INFO GPL-0061] Total non-inflated area:    139594.534 um^2 (+0.00%)
+[INFO GPL-0062] Total inflated area:        139600.362 um^2 (+0.00%)
+[INFO GPL-0063] New Target Density:             0.3961
+[INFO GPL-0058] White space area:           283398.550 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     127607.480 um^2 (+0.06%)
+[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
+[INFO GPL-0061] Total non-inflated area:    127607.478 um^2 (+0.06%)
+[INFO GPL-0062] Total inflated area:        127681.692 um^2 (+0.06%)
+[INFO GPL-0063] New Target Density:             0.4503
+[INFO GPL-0058] White space area:           283993.405 um^2 (+0.00%)
+[INFO GPL-0059] Movable instances area:     127439.438 um^2 (+0.07%)
+[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
+[INFO GPL-0061] Total non-inflated area:    127439.437 um^2 (+0.07%)
+[INFO GPL-0062] Total inflated area:        127524.446 um^2 (+0.07%)
+[INFO GPL-0063] New Target Density:             0.4487
+[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
+Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
+---------------------------------------------------------------
+      890 |   0.5130 |  1.618562e+06 |   -9.21% |  1.61e-08 |      
+      890 |   0.6573 |  1.618562e+06 |   -9.21% |  2.75e-09 |  (PD_AES_1)
+      890 |   0.6543 |  1.618562e+06 |   -9.21% |  2.80e-09 |  (PD_AES_2)
+      900 |   0.4746 |  1.566887e+06 |   -3.19% |  2.36e-08 |      
+      900 |   0.6196 |  1.566887e+06 |   -3.19% |  4.02e-09 |  (PD_AES_1)
+      900 |   0.6158 |  1.566887e+06 |   -3.19% |  4.10e-09 |  (PD_AES_2)
+      910 |   0.4325 |  1.569551e+06 |   +0.17% |  3.47e-08 |      
+      910 |   0.5821 |  1.569551e+06 |   +0.17% |  5.91e-09 |  (PD_AES_1)
+      910 |   0.5813 |  1.569551e+06 |   +0.17% |  6.03e-09 |  (PD_AES_2)
+      920 |   0.3910 |  1.605366e+06 |   +2.28% |  5.10e-08 |      
+      920 |   0.5380 |  1.605366e+06 |   +2.28% |  8.69e-09 |  (PD_AES_1)
+      920 |   0.5343 |  1.605366e+06 |   +2.28% |  8.86e-09 |  (PD_AES_2)
+      930 |   0.3531 |  1.667508e+06 |   +3.87% |  7.47e-08 |      
+      930 |   0.4821 |  1.667508e+06 |   +3.87% |  1.27e-08 |  (PD_AES_1)
+      930 |   0.4793 |  1.667508e+06 |   +3.87% |  1.30e-08 |  (PD_AES_2)
+      940 |   0.3204 |  1.724199e+06 |   +3.40% |  1.09e-07 |      
+      940 |   0.4222 |  1.724199e+06 |   +3.40% |  1.87e-08 |  (PD_AES_1)
+      940 |   0.4174 |  1.724199e+06 |   +3.40% |  1.90e-08 |  (PD_AES_2)
+      950 |   0.2938 |  1.778004e+06 |   +3.12% |  1.60e-07 |      
+      950 |   0.3608 |  1.778004e+06 |   +3.12% |  2.74e-08 |  (PD_AES_1)
+      950 |   0.3539 |  1.778004e+06 |   +3.12% |  2.79e-08 |  (PD_AES_2)
+      960 |   0.2717 |  1.811848e+06 |   +1.90% |  2.36e-07 |      
+      960 |   0.3113 |  1.811848e+06 |   +1.90% |  4.02e-08 |  (PD_AES_1)
+      960 |   0.3089 |  1.811848e+06 |   +1.90% |  4.10e-08 |  (PD_AES_2)
 [INFO GPL-0040] Routability iteration: 10
-[INFO GPL-0041] Total routing overflow: 3.3735
-[INFO GPL-0042] Number of overflowed tiles: 116 (0.56%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0322
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0101
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9813
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9314
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0211
-[INFO GPL-0048] Routing congestion (1.0211) lower than previous minimum (1.028). Updating minimum.
-[INFO GPL-0086] Inflated area:                  18.608 um^2 (+0.01%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 326, After: 324 (-0.61%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2533.432, After: 2517.890 (-0.61%)
-[INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 3.066 um^2
-[INFO GPL-0086] Inflated area:                 106.662 um^2 (+0.08%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 102, After: 89 (-12.75%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 796.056, After: 694.598 (-12.75%)
-[INFO GPL-0078] Removed fillers count: 13, area removed: 101.458 um^2. Remaining area to be compensated by modifying density: 5.204 um^2
-[INFO GPL-0086] Inflated area:                 135.441 um^2 (+0.11%)
-[INFO GPL-0052] Placement target density:       0.4481
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 135.441 um^2
-[INFO GPL-0079] New target density: 0.44853428
-[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2517.890 um^2 (-0.61%)
-[INFO GPL-0061] Total non-inflated area:    139565.322 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139583.931 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             694.598 um^2 (-12.75%)
-[INFO GPL-0061] Total non-inflated area:    127276.199 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127382.862 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     127921.971 um^2 (+0.11%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    127921.968 um^2 (+0.11%)
-[INFO GPL-0062] Total inflated area:        128057.410 um^2 (+0.11%)
-[INFO GPL-0063] New Target Density:             0.4485
-[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
+[INFO GPL-0041] Total routing overflow: 1.8438
+[INFO GPL-0042] Number of overflowed tiles: 78 (0.38%)
+[INFO GPL-0043] Average top 0.5% routing congestion: 1.0167
+[INFO GPL-0044] Average top 1.0% routing congestion: 0.9969
+[INFO GPL-0045] Average top 2.0% routing congestion: 0.9731
+[INFO GPL-0046] Average top 5.0% routing congestion: 0.9266
+[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0068
+[INFO GPL-0050] Weighted routing congestion is lower than target routing congestion(1.0100), end routability optimization.
+[INFO GPL-0090] Routability finished. Target routing congestion achieved succesfully.
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-      960 |   0.5152 |  1.575981e+06 |  -12.18% |  1.92e-08 |      
-      960 |   0.5871 |  1.575981e+06 |  -12.18% |  4.25e-09 |  (PD_AES_1)
-      960 |   0.6281 |  1.575981e+06 |  -12.18% |  3.46e-09 |  (PD_AES_2)
-      970 |   0.4611 |  1.560716e+06 |   -0.97% |  2.82e-08 |      
-      970 |   0.5468 |  1.560716e+06 |   -0.97% |  6.26e-09 |  (PD_AES_1)
-      970 |   0.5984 |  1.560716e+06 |   -0.97% |  5.09e-09 |  (PD_AES_2)
-      980 |   0.4170 |  1.578937e+06 |   +1.17% |  4.15e-08 |      
-      980 |   0.5037 |  1.578937e+06 |   +1.17% |  9.21e-09 |  (PD_AES_1)
-      980 |   0.5649 |  1.578937e+06 |   +1.17% |  7.48e-09 |  (PD_AES_2)
-      990 |   0.3768 |  1.636097e+06 |   +3.62% |  6.08e-08 |      
-      990 |   0.4481 |  1.636097e+06 |   +3.62% |  1.35e-08 |  (PD_AES_1)
-      990 |   0.5120 |  1.636097e+06 |   +3.62% |  1.10e-08 |  (PD_AES_2)
-     1000 |   0.3394 |  1.697459e+06 |   +3.75% |  8.91e-08 |      
-     1000 |   0.3846 |  1.697459e+06 |   +3.75% |  1.98e-08 |  (PD_AES_1)
-     1000 |   0.4510 |  1.697459e+06 |   +3.75% |  1.61e-08 |  (PD_AES_2)
-     1010 |   0.3094 |  1.755659e+06 |   +3.43% |  1.31e-07 |      
-     1010 |   0.3203 |  1.755659e+06 |   +3.43% |  2.90e-08 |  (PD_AES_1)
-     1010 |   0.3886 |  1.755659e+06 |   +3.43% |  2.36e-08 |  (PD_AES_2)
-     1020 |   0.2871 |  1.797905e+06 |   +2.41% |  1.92e-07 |      
-     1020 |   0.2691 |  1.797905e+06 |   +2.41% |  4.26e-08 |  (PD_AES_1)
-     1020 |   0.3346 |  1.797905e+06 |   +2.41% |  3.46e-08 |  (PD_AES_2)
-[INFO GPL-0040] Routability iteration: 11
-[INFO GPL-0041] Total routing overflow: 3.0697
-[INFO GPL-0042] Number of overflowed tiles: 102 (0.49%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0295
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0071
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9799
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9310
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0183
-[INFO GPL-0048] Routing congestion (1.0183) lower than previous minimum (1.021). Updating minimum.
-[INFO GPL-0086] Inflated area:                  16.683 um^2 (+0.01%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 324, After: 322 (-0.62%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2517.890, After: 2502.347 (-0.62%)
-[INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 1.140 um^2
-[INFO GPL-0086] Inflated area:                 121.666 um^2 (+0.10%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 89, After: 74 (-16.85%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 694.598, After: 577.531 (-16.85%)
-[INFO GPL-0078] Removed fillers count: 15, area removed: 117.067 um^2. Remaining area to be compensated by modifying density: 4.599 um^2
-[INFO GPL-0086] Inflated area:                 124.133 um^2 (+0.10%)
-[INFO GPL-0052] Placement target density:       0.4485
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 124.133 um^2
-[INFO GPL-0079] New target density: 0.4489695
-[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2502.347 um^2 (-0.62%)
-[INFO GPL-0061] Total non-inflated area:    139566.463 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139583.146 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             577.531 um^2 (-16.85%)
-[INFO GPL-0061] Total non-inflated area:    127280.798 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127402.464 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     128046.105 um^2 (+0.10%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    128046.101 um^2 (+0.10%)
-[INFO GPL-0062] Total inflated area:        128170.233 um^2 (+0.10%)
-[INFO GPL-0063] New Target Density:             0.4490
-[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
-Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
----------------------------------------------------------------
-     1030 |   0.5044 |  1.575285e+06 |  -12.38% |  1.99e-08 |      
-     1030 |   0.5828 |  1.575285e+06 |  -12.38% |  4.42e-09 |  (PD_AES_1)
-     1030 |   0.6259 |  1.575285e+06 |  -12.38% |  3.59e-09 |  (PD_AES_2)
-     1040 |   0.4573 |  1.562809e+06 |   -0.79% |  2.93e-08 |      
-     1040 |   0.5435 |  1.562809e+06 |   -0.79% |  6.51e-09 |  (PD_AES_1)
-     1040 |   0.5946 |  1.562809e+06 |   -0.79% |  5.29e-09 |  (PD_AES_2)
-     1050 |   0.4127 |  1.586087e+06 |   +1.49% |  4.31e-08 |      
-     1050 |   0.4989 |  1.586087e+06 |   +1.49% |  9.57e-09 |  (PD_AES_1)
-     1050 |   0.5604 |  1.586087e+06 |   +1.49% |  7.77e-09 |  (PD_AES_2)
-     1060 |   0.3717 |  1.644792e+06 |   +3.70% |  6.32e-08 |      
-     1060 |   0.4410 |  1.644792e+06 |   +3.70% |  1.40e-08 |  (PD_AES_1)
-     1060 |   0.5068 |  1.644792e+06 |   +3.70% |  1.14e-08 |  (PD_AES_2)
-     1070 |   0.3363 |  1.705292e+06 |   +3.68% |  9.26e-08 |      
-     1070 |   0.3778 |  1.705292e+06 |   +3.68% |  2.06e-08 |  (PD_AES_1)
-     1070 |   0.4453 |  1.705292e+06 |   +3.68% |  1.67e-08 |  (PD_AES_2)
-     1080 |   0.3066 |  1.761834e+06 |   +3.32% |  1.36e-07 |      
-     1080 |   0.3141 |  1.761834e+06 |   +3.32% |  3.01e-08 |  (PD_AES_1)
-     1080 |   0.3822 |  1.761834e+06 |   +3.32% |  2.45e-08 |  (PD_AES_2)
-[INFO GPL-0040] Routability iteration: 12
-[INFO GPL-0041] Total routing overflow: 2.4383
-[INFO GPL-0042] Number of overflowed tiles: 90 (0.43%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0230
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0024
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9775
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9308
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0127
-[INFO GPL-0048] Routing congestion (1.0127) lower than previous minimum (1.018). Updating minimum.
-[INFO GPL-0086] Inflated area:                   5.757 um^2 (+0.00%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 322, After: 322 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2502.347, After: 2502.347 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 5.757 um^2
-[INFO GPL-0086] Inflated area:                  67.117 um^2 (+0.05%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 74, After: 66 (-10.81%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 577.531, After: 515.095 (-10.81%)
-[INFO GPL-0078] Removed fillers count: 8, area removed: 62.436 um^2. Remaining area to be compensated by modifying density: 4.681 um^2
-[INFO GPL-0086] Inflated area:                  82.906 um^2 (+0.06%)
-[INFO GPL-0052] Placement target density:       0.4490
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 82.906 um^2
-[INFO GPL-0079] New target density: 0.4492602
-[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2502.347 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    139572.220 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139577.977 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             515.095 um^2 (-10.81%)
-[INFO GPL-0061] Total non-inflated area:    127285.479 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127352.597 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     128129.008 um^2 (+0.06%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    128129.007 um^2 (+0.06%)
-[INFO GPL-0062] Total inflated area:        128211.912 um^2 (+0.06%)
-[INFO GPL-0063] New Target Density:             0.4493
-[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
-Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
----------------------------------------------------------------
-     1090 |   0.5129 |  1.566096e+06 |  -11.11% |  1.41e-08 |      
-     1090 |   0.6133 |  1.566096e+06 |  -11.11% |  3.13e-09 |  (PD_AES_1)
-     1090 |   0.6767 |  1.566096e+06 |  -11.11% |  2.54e-09 |  (PD_AES_2)
-     1100 |   0.4945 |  1.570180e+06 |   +0.26% |  2.07e-08 |      
-     1100 |   0.5774 |  1.570180e+06 |   +0.26% |  4.60e-09 |  (PD_AES_1)
-     1100 |   0.6240 |  1.570180e+06 |   +0.26% |  3.73e-09 |  (PD_AES_2)
-     1110 |   0.4537 |  1.560781e+06 |   -0.60% |  3.05e-08 |      
-     1110 |   0.5405 |  1.560781e+06 |   -0.60% |  6.76e-09 |  (PD_AES_1)
-     1110 |   0.5918 |  1.560781e+06 |   -0.60% |  5.50e-09 |  (PD_AES_2)
-     1120 |   0.4097 |  1.588742e+06 |   +1.79% |  4.48e-08 |      
-     1120 |   0.4929 |  1.588742e+06 |   +1.79% |  9.94e-09 |  (PD_AES_1)
-     1120 |   0.5555 |  1.588742e+06 |   +1.79% |  8.08e-09 |  (PD_AES_2)
-     1130 |   0.3685 |  1.650206e+06 |   +3.87% |  6.56e-08 |      
-     1130 |   0.4347 |  1.650206e+06 |   +3.87% |  1.46e-08 |  (PD_AES_1)
-     1130 |   0.5014 |  1.650206e+06 |   +3.87% |  1.18e-08 |  (PD_AES_2)
-     1140 |   0.3334 |  1.710821e+06 |   +3.67% |  9.62e-08 |      
-     1140 |   0.3712 |  1.710821e+06 |   +3.67% |  2.14e-08 |  (PD_AES_1)
-     1140 |   0.4394 |  1.710821e+06 |   +3.67% |  1.73e-08 |  (PD_AES_2)
-     1150 |   0.3039 |  1.766783e+06 |   +3.27% |  1.41e-07 |      
-     1150 |   0.3094 |  1.766783e+06 |   +3.27% |  3.13e-08 |  (PD_AES_1)
-     1150 |   0.3750 |  1.766783e+06 |   +3.27% |  2.54e-08 |  (PD_AES_2)
-[INFO GPL-0040] Routability iteration: 13
-[INFO GPL-0041] Total routing overflow: 2.7514
-[INFO GPL-0042] Number of overflowed tiles: 92 (0.44%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0262
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0040
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9770
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9301
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0151
-[INFO GPL-0049] Routing congestion (1.0151) higher than minimum (1.0127). Consecutive non-improvement count: 1.
-[INFO GPL-0086] Inflated area:                  10.571 um^2 (+0.01%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 322, After: 321 (-0.31%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2502.347, After: 2494.576 (-0.31%)
-[INFO GPL-0078] Removed fillers count: 1, area removed: 7.771 um^2. Remaining area to be compensated by modifying density: 2.800 um^2
-[INFO GPL-0086] Inflated area:                  49.584 um^2 (+0.04%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 66, After: 60 (-9.09%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 515.095, After: 468.268 (-9.09%)
-[INFO GPL-0078] Removed fillers count: 6, area removed: 46.827 um^2. Remaining area to be compensated by modifying density: 2.757 um^2
-[INFO GPL-0086] Inflated area:                 142.678 um^2 (+0.11%)
-[INFO GPL-0052] Placement target density:       0.4493
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 142.678 um^2
-[INFO GPL-0079] New target density: 0.4497605
-[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2494.576 um^2 (-0.31%)
-[INFO GPL-0061] Total non-inflated area:    139575.020 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        139585.592 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             468.268 um^2 (-9.09%)
-[INFO GPL-0061] Total non-inflated area:    127288.236 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127337.820 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     128271.688 um^2 (+0.11%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    128271.685 um^2 (+0.11%)
-[INFO GPL-0062] Total inflated area:        128414.363 um^2 (+0.11%)
-[INFO GPL-0063] New Target Density:             0.4498
-[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
-Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
----------------------------------------------------------------
-     1160 |   0.5208 |  1.584393e+06 |  -10.32% |  1.47e-08 |      
-     1160 |   0.6072 |  1.584393e+06 |  -10.32% |  3.26e-09 |  (PD_AES_1)
-     1160 |   0.6634 |  1.584393e+06 |  -10.32% |  2.65e-09 |  (PD_AES_2)
-     1170 |   0.4893 |  1.566190e+06 |   -1.15% |  2.15e-08 |      
-     1170 |   0.5743 |  1.566190e+06 |   -1.15% |  4.78e-09 |  (PD_AES_1)
-     1170 |   0.6229 |  1.566190e+06 |   -1.15% |  3.88e-09 |  (PD_AES_2)
-     1180 |   0.4502 |  1.561852e+06 |   -0.28% |  3.17e-08 |      
-     1180 |   0.5376 |  1.561852e+06 |   -0.28% |  7.03e-09 |  (PD_AES_1)
-     1180 |   0.5912 |  1.561852e+06 |   -0.28% |  5.71e-09 |  (PD_AES_2)
-     1190 |   0.4056 |  1.594895e+06 |   +2.12% |  4.65e-08 |      
-     1190 |   0.4880 |  1.594895e+06 |   +2.12% |  1.03e-08 |  (PD_AES_1)
-     1190 |   0.5493 |  1.594895e+06 |   +2.12% |  8.39e-09 |  (PD_AES_2)
-     1200 |   0.3652 |  1.656950e+06 |   +3.89% |  6.82e-08 |      
-     1200 |   0.4295 |  1.656950e+06 |   +3.89% |  1.51e-08 |  (PD_AES_1)
-     1200 |   0.4950 |  1.656950e+06 |   +3.89% |  1.23e-08 |  (PD_AES_2)
-     1210 |   0.3303 |  1.717717e+06 |   +3.67% |  9.99e-08 |      
-     1210 |   0.3657 |  1.717717e+06 |   +3.67% |  2.22e-08 |  (PD_AES_1)
-     1210 |   0.4331 |  1.717717e+06 |   +3.67% |  1.80e-08 |  (PD_AES_2)
-     1220 |   0.3019 |  1.771938e+06 |   +3.16% |  1.46e-07 |      
-     1220 |   0.3042 |  1.771938e+06 |   +3.16% |  3.25e-08 |  (PD_AES_1)
-     1220 |   0.3700 |  1.771938e+06 |   +3.16% |  2.64e-08 |  (PD_AES_2)
-[INFO GPL-0040] Routability iteration: 14
-[INFO GPL-0041] Total routing overflow: 3.0769
-[INFO GPL-0042] Number of overflowed tiles: 99 (0.48%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0295
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0057
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9783
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9302
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0176
-[INFO GPL-0049] Routing congestion (1.0176) higher than minimum (1.0127). Consecutive non-improvement count: 2.
-[INFO GPL-0086] Inflated area:                   7.577 um^2 (+0.01%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 321, After: 321 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2494.576, After: 2494.576 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 7.577 um^2
-[INFO GPL-0086] Inflated area:                  80.813 um^2 (+0.06%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 60, After: 50 (-16.67%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 468.268, After: 390.224 (-16.67%)
-[INFO GPL-0078] Removed fillers count: 10, area removed: 78.045 um^2. Remaining area to be compensated by modifying density: 2.768 um^2
-[INFO GPL-0086] Inflated area:                 123.230 um^2 (+0.10%)
-[INFO GPL-0052] Placement target density:       0.4498
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 123.230 um^2
-[INFO GPL-0079] New target density: 0.45019254
-[INFO GPL-0058] White space area:           283642.035 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     112336.806 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:            2494.576 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    139582.597 um^2 (+0.01%)
-[INFO GPL-0062] Total inflated area:        139590.175 um^2 (+0.01%)
-[INFO GPL-0063] New Target Density:             0.3961
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     140838.273 um^2 (+0.00%)
-[INFO GPL-0060] Total filler area:             390.224 um^2 (-16.67%)
-[INFO GPL-0061] Total non-inflated area:    127291.004 um^2 (+0.00%)
-[INFO GPL-0062] Total inflated area:        127371.817 um^2 (+0.00%)
-[INFO GPL-0063] New Target Density:             0.4938
-[INFO GPL-0058] White space area:           285200.000 um^2 (+0.00%)
-[INFO GPL-0059] Movable instances area:     128394.912 um^2 (+0.10%)
-[INFO GPL-0060] Total filler area:               0.000 um^2 (+0.00%)
-[INFO GPL-0061] Total non-inflated area:    128394.915 um^2 (+0.10%)
-[INFO GPL-0062] Total inflated area:        128518.145 um^2 (+0.10%)
-[INFO GPL-0063] New Target Density:             0.4502
-[INFO GPL-0087] Routability end iteration: increase inflation and revert back to snapshot.
-Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
----------------------------------------------------------------
-     1230 |   0.5266 |  1.589253e+06 |  -10.31% |  1.52e-08 |      
-     1230 |   0.5982 |  1.589253e+06 |  -10.31% |  3.38e-09 |  (PD_AES_1)
-     1230 |   0.6500 |  1.589253e+06 |  -10.31% |  2.75e-09 |  (PD_AES_2)
-     1240 |   0.4855 |  1.560066e+06 |   -1.84% |  2.24e-08 |      
-     1240 |   0.5718 |  1.560066e+06 |   -1.84% |  4.97e-09 |  (PD_AES_1)
-     1240 |   0.6224 |  1.560066e+06 |   -1.84% |  4.03e-09 |  (PD_AES_2)
-     1250 |   0.4471 |  1.560246e+06 |   +0.01% |  3.29e-08 |      
-     1250 |   0.5336 |  1.560246e+06 |   +0.01% |  7.31e-09 |  (PD_AES_1)
-     1250 |   0.5887 |  1.560246e+06 |   +0.01% |  5.94e-09 |  (PD_AES_2)
-     1260 |   0.4017 |  1.599192e+06 |   +2.50% |  4.83e-08 |      
-     1260 |   0.4811 |  1.599192e+06 |   +2.50% |  1.07e-08 |  (PD_AES_1)
-     1260 |   0.5441 |  1.599192e+06 |   +2.50% |  8.72e-09 |  (PD_AES_2)
-     1270 |   0.3620 |  1.662298e+06 |   +3.95% |  7.08e-08 |      
-     1270 |   0.4236 |  1.662298e+06 |   +3.95% |  1.57e-08 |  (PD_AES_1)
-     1270 |   0.4885 |  1.662298e+06 |   +3.95% |  1.28e-08 |  (PD_AES_2)
-     1280 |   0.3272 |  1.723261e+06 |   +3.67% |  1.04e-07 |      
-     1280 |   0.3582 |  1.723261e+06 |   +3.67% |  2.30e-08 |  (PD_AES_1)
-     1280 |   0.4276 |  1.723261e+06 |   +3.67% |  1.87e-08 |  (PD_AES_2)
-     1290 |   0.2994 |  1.776616e+06 |   +3.10% |  1.52e-07 |      
-     1290 |   0.2997 |  1.776616e+06 |   +3.10% |  3.38e-08 |  (PD_AES_1)
-     1290 |   0.3628 |  1.776616e+06 |   +3.10% |  2.75e-08 |  (PD_AES_2)
-[INFO GPL-0040] Routability iteration: 15
-[INFO GPL-0041] Total routing overflow: 2.5686
-[INFO GPL-0042] Number of overflowed tiles: 95 (0.46%)
-[INFO GPL-0043] Average top 0.5% routing congestion: 1.0246
-[INFO GPL-0044] Average top 1.0% routing congestion: 1.0040
-[INFO GPL-0045] Average top 2.0% routing congestion: 0.9771
-[INFO GPL-0046] Average top 5.0% routing congestion: 0.9290
-[INFO GPL-0047] Routability iteration weighted routing congestion: 1.0143
-[INFO GPL-0049] Routing congestion (1.0143) higher than minimum (1.0127). Consecutive non-improvement count: 3.
-[INFO GPL-0086] Inflated area:                   4.631 um^2 (+0.00%)
-[INFO GPL-0052] Placement target density:       0.3961
-[INFO GPL-0076] Removing fillers, count: Before: 321, After: 321 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 2494.576, After: 2494.576 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 4.631 um^2
-[INFO GPL-0086] Inflated area:                  63.817 um^2 (+0.05%)
-[INFO GPL-0052] Placement target density:       0.4938
-[INFO GPL-0076] Removing fillers, count: Before: 50, After: 42 (-16.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 390.224, After: 327.788 (-16.00%)
-[INFO GPL-0078] Removed fillers count: 8, area removed: 62.436 um^2. Remaining area to be compensated by modifying density: 1.382 um^2
-[INFO GPL-0086] Inflated area:                 104.785 um^2 (+0.08%)
-[INFO GPL-0052] Placement target density:       0.4502
-[INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
-[INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
-[INFO GPL-0078] Removed fillers count: 0, area removed: 0.000 um^2. Remaining area to be compensated by modifying density: 104.785 um^2
-[INFO GPL-0079] New target density: 0.45055997
-[INFO GPL-0054] No improvement in routing congestion for 3 consecutive iterations (limit is 3).
-[INFO GPL-0055] Reverting inflation values and target density from the iteration with minimum observed routing congestion.
-[INFO GPL-0056] Minimum observed routing congestion: 1.0127
-[INFO GPL-0057] Target density at minimum routing congestion: 0.3961
-[INFO GPL-0080] Restoring 1 previously removed fillers.
-[INFO GPL-0081] Number of fillers before restoration 321 and after 322 . Relative change: +0.31%%
-[INFO GPL-0082] Total filler area before restoration 2494.58 and after 2502.35 (um^2). Relative change: +0.31%%
-[INFO GPL-0057] Target density at minimum routing congestion: 0.4938 (PD_AES_1)
-[INFO GPL-0080] Restoring 32 previously removed fillers.
-[INFO GPL-0081] Number of fillers before restoration 42 and after 74 . Relative change: +76.19%%
-[INFO GPL-0082] Total filler area before restoration 327.79 and after 577.53 (um^2). Relative change: +76.19%%
-[INFO GPL-0057] Target density at minimum routing congestion: 0.4490 (PD_AES_2)
-[INFO GPL-0080] Restoring 0 previously removed fillers.
-[INFO GPL-0089] Routability finished. Reverting to minimal observed routing congestion, could not reach target.
-Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
----------------------------------------------------------------
-     1300 |   0.5345 |  1.584777e+06 |  -10.80% |  1.58e-08 |      
-     1300 |   0.5972 |  1.584777e+06 |  -10.80% |  3.51e-09 |  (PD_AES_1)
-     1300 |   0.6399 |  1.584777e+06 |  -10.80% |  2.85e-09 |  (PD_AES_2)
-     1310 |   0.4832 |  1.554094e+06 |   -1.94% |  2.33e-08 |      
-     1310 |   0.5694 |  1.554094e+06 |   -1.94% |  5.16e-09 |  (PD_AES_1)
-     1310 |   0.6198 |  1.554094e+06 |   -1.94% |  4.20e-09 |  (PD_AES_2)
-     1320 |   0.4418 |  1.561413e+06 |   +0.47% |  3.42e-08 |      
-     1320 |   0.5296 |  1.561413e+06 |   +0.47% |  7.60e-09 |  (PD_AES_1)
-     1320 |   0.5844 |  1.561413e+06 |   +0.47% |  6.17e-09 |  (PD_AES_2)
-     1330 |   0.3977 |  1.604918e+06 |   +2.79% |  5.02e-08 |      
-     1330 |   0.4755 |  1.604918e+06 |   +2.79% |  1.12e-08 |  (PD_AES_1)
-     1330 |   0.5380 |  1.604918e+06 |   +2.79% |  9.06e-09 |  (PD_AES_2)
-     1340 |   0.3576 |  1.667667e+06 |   +3.91% |  7.36e-08 |      
-     1340 |   0.4163 |  1.667667e+06 |   +3.91% |  1.63e-08 |  (PD_AES_1)
-     1340 |   0.4811 |  1.667667e+06 |   +3.91% |  1.33e-08 |  (PD_AES_2)
-     1350 |   0.3244 |  1.729167e+06 |   +3.69% |  1.08e-07 |      
-     1350 |   0.3499 |  1.729167e+06 |   +3.69% |  2.40e-08 |  (PD_AES_1)
-     1350 |   0.4204 |  1.729167e+06 |   +3.69% |  1.95e-08 |  (PD_AES_2)
-     1360 |   0.2970 |  1.780048e+06 |   +2.94% |  1.58e-07 |      
-     1360 |   0.2933 |  1.780048e+06 |   +2.94% |  3.51e-08 |  (PD_AES_1)
-     1360 |   0.3584 |  1.780048e+06 |   +2.94% |  2.85e-08 |  (PD_AES_2)
-     1370 |   0.2757 |  1.815529e+06 |   +1.99% |  2.32e-07 |      
-     1370 |   0.2468 |  1.815529e+06 |   +1.99% |  5.16e-08 |  (PD_AES_1)
-     1370 |   0.3107 |  1.815529e+06 |   +1.99% |  4.19e-08 |  (PD_AES_2)
-     1380 |   0.2579 |  1.847101e+06 |   +1.74% |  3.41e-07 |      
-     1380 |   0.2094 |  1.847101e+06 |   +1.74% |  7.58e-08 |  (PD_AES_1)
-     1380 |   0.2691 |  1.847101e+06 |   +1.74% |  6.15e-08 |  (PD_AES_2)
-     1390 |   0.2424 |  1.868183e+06 |   +1.14% |  5.02e-07 |      
-     1390 |   0.1777 |  1.868183e+06 |   +1.14% |  1.11e-07 |  (PD_AES_1)
-     1390 |   0.2372 |  1.868183e+06 |   +1.14% |  9.05e-08 |  (PD_AES_2)
-     1400 |   0.2300 |  1.884773e+06 |   +0.89% |  7.38e-07 |      
-     1400 |   0.1510 |  1.884773e+06 |   +0.89% |  1.64e-07 |  (PD_AES_1)
-     1400 |   0.2085 |  1.884773e+06 |   +0.89% |  1.33e-07 |  (PD_AES_2)
+      970 |   0.2551 |  1.843353e+06 |   +1.74% |  3.46e-07 |      
+      970 |   0.2700 |  1.843353e+06 |   +1.74% |  5.90e-08 |  (PD_AES_1)
+      970 |   0.2694 |  1.843353e+06 |   +1.74% |  6.02e-08 |  (PD_AES_2)
+      980 |   0.2420 |  1.865876e+06 |   +1.22% |  5.09e-07 |      
+      980 |   0.2354 |  1.865876e+06 |   +1.22% |  8.68e-08 |  (PD_AES_1)
+      980 |   0.2338 |  1.865876e+06 |   +1.22% |  8.85e-08 |  (PD_AES_2)
+      990 |   0.2297 |  1.881546e+06 |   +0.84% |  7.49e-07 |      
+      990 |   0.2065 |  1.881546e+06 |   +0.84% |  1.28e-07 |  (PD_AES_1)
+      990 |   0.2058 |  1.881546e+06 |   +0.84% |  1.30e-07 |  (PD_AES_2)
+     1000 |   0.2210 |  1.892098e+06 |   +0.56% |  1.10e-06 |      
+     1000 |   0.1812 |  1.892098e+06 |   +0.56% |  1.88e-07 |  (PD_AES_1)
+     1000 |   0.1810 |  1.892098e+06 |   +0.56% |  1.92e-07 |  (PD_AES_2)
 [INFO GPL-0100] Timing-driven iteration 2/2, virtual: false.
-[INFO GPL-0101]    Iter: 1402, overflow: 0.194, keep resizer changes at: 1, HPWL: 1886252493
+[INFO GPL-0101]    Iter: 1001, overflow: 0.194, keep resizer changes at: 1, HPWL: 1892097995
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
-        0 |     +0.0% |       0 |       0 |             0 |     45090
-    final |     +0.1% |      38 |       9 |            15 |         0
+        0 |     +0.0% |       0 |       0 |             0 |     45096
+    final |     +0.2% |      42 |      19 |            25 |         0
 ---------------------------------------------------------------------
-[INFO RSZ-0034] Found 39 slew violations.
+[INFO RSZ-0034] Found 44 slew violations.
 [INFO RSZ-0036] Found 3 capacitance violations.
-[INFO RSZ-0039] Resized 38 instances.
-[INFO RSZ-0038] Inserted 9 buffers in 15 nets.
+[INFO RSZ-0039] Resized 42 instances.
+[INFO RSZ-0038] Inserted 19 buffers in 25 nets.
    Iter   |    Area   | Removed | Inserted |   Pins
           |           | Buffers | Buffers  | Remaining
 -------------------------------------------------------
-        0 |     +0.0% |       0 |        0 |     43797
-     4300 |     +0.1% |      46 |       89 |     39497
-     8600 |     +0.1% |      46 |       90 |     35197
-    12900 |     +0.1% |      46 |       90 |     30897
-    17200 |     +0.1% |      49 |       95 |     26597
-    21500 |     +0.1% |      49 |       95 |     22297
-    25800 |     +0.1% |      52 |      103 |     17997
-    30100 |     +0.1% |      52 |      109 |     13697
-    34400 |     +0.2% |      52 |      151 |      9397
-    38700 |     +0.7% |     236 |      571 |      5097
-    43000 |     +1.6% |     674 |     1404 |       797
-    final |     +2.0% |     850 |     1750 |         0
+        0 |     +0.0% |       0 |        0 |     43796
+     4300 |     +0.0% |      51 |       79 |     39496
+     8600 |     +0.1% |      51 |       80 |     35196
+    12900 |     +0.1% |      51 |       80 |     30896
+    17200 |     +0.0% |      56 |       86 |     26596
+    21500 |     +0.0% |      56 |       86 |     22296
+    25800 |     +0.1% |      59 |       95 |     17996
+    30100 |     +0.1% |      59 |      103 |     13696
+    34400 |     +0.2% |      59 |      145 |      9396
+    38700 |     +0.7% |     243 |      567 |      5096
+    43000 |     +1.6% |     689 |     1418 |       796
+    final |     +2.0% |     864 |     1753 |         0
 -------------------------------------------------------
 [INFO GPL-0106] Timing-driven: worst slack 0
-[INFO GPL-0107] Timing-driven: repair_design delta area: 7059.483 um^2 (+5.15%)
-[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: 909 (+2.03%)
-[INFO GPL-0109] Timing-driven: repair_design, gcells created: 1759, deleted: 850
-[INFO GPL-0110] Timing-driven: new target density: 0.5170244
+[INFO GPL-0107] Timing-driven: repair_design delta area: 7167.361 um^2 (+5.22%)
+[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: 908 (+2.03%)
+[INFO GPL-0109] Timing-driven: repair_design, gcells created: 1772, deleted: 864
+[INFO GPL-0110] Timing-driven: new target density: 0.5174194
 [INFO GPL-0107] Timing-driven: repair_design delta area: 0.000 um^2 (+0.00%)
-[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: 909 (+2.03%)
+[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: 908 (+2.03%)
 [INFO GPL-0109] Timing-driven: repair_design, gcells created: 0, deleted: 0
-[INFO GPL-0110] Timing-driven: new target density: 0.44697866
+[INFO GPL-0110] Timing-driven: new target density: 0.45027572
 [INFO GPL-0107] Timing-driven: repair_design delta area: 0.000 um^2 (+0.00%)
-[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: 909 (+2.03%)
+[INFO GPL-0108] Timing-driven: repair_design, gpl delta gcells: 908 (+2.03%)
 [INFO GPL-0109] Timing-driven: repair_design, gcells created: 0, deleted: 0
-[INFO GPL-0110] Timing-driven: new target density: 0.45019254
-[WARNING GPL-0323] Divergence detected between consecutive iterations
-[WARNING GPL-0323] Divergence detected between consecutive iterations
-Divergence occured in 2 regions.
-[WARNING GPL-0998] Divergence detected, reverting to snapshot with min hpwl.
-[WARNING GPL-0999] Revert to iter: 1402 overflow: 0.194 HPWL: 1927859647
+[INFO GPL-0110] Timing-driven: new target density: 0.44874084
+Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
+---------------------------------------------------------------
+     1010 |   0.1804 |  3.013877e+06 |  +59.29% |  1.47e-06 |      
+     1010 |   0.1701 |  3.013877e+06 |  +59.29% |  2.51e-07 |  (PD_AES_1)
+     1010 |   0.1693 |  3.013877e+06 |  +59.29% |  2.56e-07 |  (PD_AES_2)
+     1020 |   0.1062 |  3.113391e+06 |   +3.30% |  2.14e-06 |      
+     1020 |   0.1684 |  3.113391e+06 |   +3.30% |  3.65e-07 |  (PD_AES_1)
+     1020 |   0.1661 |  3.113391e+06 |   +3.30% |  3.72e-07 |  (PD_AES_2)
+     1023 |   0.0996 |  3.054761e+06 |          |  2.50e-06 |      
+---------------------------------------------------------------
+[INFO GPL-1001] Global placement finished at iteration 1023
+[INFO GPL-1017] Routability mode iteration count: 661
+[INFO GPL-1005] Routability final weighted congestion: 1.3341
+[INFO GPL-1002] Placed Cell Area            144352.8031
+[INFO GPL-1003] Available Free Area         283642.0352
+[INFO GPL-1004] Minimum Feasible Density        0.5100 (cell_area / free_area)
+[INFO GPL-1006]   Suggested Target Densities:
+[INFO GPL-1007]     - For 90% usage of free space: 0.5655
+[INFO GPL-1008]     - For 80% usage of free space: 0.6362
+     1030 |   0.1482 |  3.028714e+06 |   -2.72% |  5.38e-07 |  (PD_AES_1)
+     1030 |   0.1481 |  3.028714e+06 |   -2.72% |  5.48e-07 |  (PD_AES_2)
+     1040 |   0.1272 |  3.013960e+06 |   -0.49% |  7.92e-07 |  (PD_AES_1)
+     1040 |   0.1253 |  3.013960e+06 |   -0.49% |  8.08e-07 |  (PD_AES_2)
+     1050 |   0.1095 |  3.007597e+06 |   -0.21% |  1.17e-06 |  (PD_AES_1)
+     1050 |   0.1099 |  3.007597e+06 |   -0.21% |  1.19e-06 |  (PD_AES_2)
+     1057 |   0.0988 |  3.006721e+06 |          |  1.62e-06 | PD_AES_2
+---------------------------------------------------------------
+[INFO GPL-1016] Region 'PD_AES_2' placement finished at iteration 1057
+[INFO GPL-1005] Routability final weighted congestion: 1.3338
+[INFO GPL-1002] Placed Cell Area            127439.4372
+[INFO GPL-1003] Available Free Area         283993.4048
+[INFO GPL-1004] Minimum Feasible Density        0.4900 (cell_area / free_area)
+[INFO GPL-1006]   Suggested Target Densities:
+[INFO GPL-1007]     - For 90% usage of free space: 0.4986
+[INFO GPL-1008]     - For 80% usage of free space: 0.5609
+[INFO GPL-1009]     - For 50% usage of free space: 0.8975
+     1058 |   0.0990 |  3.006559e+06 |          |  1.65e-06 | PD_AES_1
+---------------------------------------------------------------
+[INFO GPL-1016] Region 'PD_AES_1' placement finished at iteration 1058
+[INFO GPL-1005] Routability final weighted congestion: 1.3339
+[INFO GPL-1002] Placed Cell Area            127607.4780
+[INFO GPL-1003] Available Free Area         283398.5504
+[INFO GPL-1004] Minimum Feasible Density        0.4900 (cell_area / free_area)
+[INFO GPL-1006]   Suggested Target Densities:
+[INFO GPL-1007]     - For 90% usage of free space: 0.5003
+[INFO GPL-1008]     - For 80% usage of free space: 0.5628
+[INFO GPL-1009]     - For 50% usage of free space: 0.9006
 [INFO GPL-1011] Original area (um^2): 419910.99
-[INFO GPL-1012] Total routability artificial inflation: 6340.52 (+1.51%)
-[INFO GPL-1013] Total timing-driven delta area: -27378.55 (-6.52%)
-[INFO GPL-1014] Final placement area: 398872.97 (-5.01%)
-[INFO DPL-0006] Core area: 878902.94 um^2
-[INFO DPL-0007] Movable instances area: 341436.21 um^2
-[INFO DPL-0008] Fixed instances area within core: 0.00 um^2
-[INFO DPL-0009] Utilization: 38.8%
+[INFO GPL-1012] Total routability artificial inflation: 6746.89 (+1.61%)
+[INFO GPL-1013] Total timing-driven delta area: -27258.16 (-6.49%)
+[INFO GPL-1014] Final placement area: 399399.72 (-4.88%)
+[INFO DPL-0006] Core area: 878902.94 um^2, Instances area: 341550.07 um^2, Utilization: 38.9%
 [INFO DPL-0005] Diamond search max displacement: +/- 1413 sites horizontally, +/- 238 rows vertically.
-[INFO DPL-1102] Legalizing using negotiation legalizer.
-[INFO DPL-1103] Negotiation base search window: +/-20 sites horizontally, +/-5 rows vertically 
-	Automatic search window extension enabled.
-	Search window extendable up to the max displacement cap of +/-1413 sites, +/-238 rows near walls.
-[INFO DPL-1104] NegotiationLegalizer DRC penalty: 5.
-[INFO DPL-0392] Negotiation cell height distribution (1 unique row-count(s)):
-[INFO DPL-0393]   height 1 row(s): 45710 cells
-          |      Total |  Illegal |  Illegal
-Iteration | Violations |    Cells |    Sites
----------------------------------------------
-        0 |       5280 |      2584 |      2488
-        1 |       4983 |      2519 |      2256
-        2 |       4974 |      2516 |      2250
-        3 |       4974 |      2516 |      2250
-        4 |       4974 |      2516 |      2250
-        5 |       4974 |      2516 |      2250
-[WARNING DPL-0700] Negotiation phase 1: violations stuck at 4974 for 3 consecutive iterations.
-Using old diamond search for 2516 remaining illegal cells.
-diamond recovery: recovered 2516/2516 stuck cells.
-Negotiation phase 2: isolation point active, 1000 iterations.
-      400 |          0 |         0 |         0
-Negotiation phase 2 converged at iteration 0.
+[INFO DPL-1101] Legalizing using diamond search.
+Movements Summary
+---------------------------------------
+Total cells:                   16929
+Diamond Move Success:          16929 (100.00%)
+Diamond Move Failure:              0
+Rip-up and replace Success:        0 (  0.00% of diamond failures)
+Rip-up and replace Failure:        0
+Total Placement Failures:          0
+---------------------------------------
 Placement Analysis
 ---------------------------------
-total displacement     951699.7 u
-average displacement       20.8 u
-max displacement          863.1 u
-original HPWL         1921358.8 u
-legalized HPWL        2634085.0 u
-delta HPWL                   37 %
+total displacement     105480.2 u
+average displacement        2.3 u
+max displacement          636.0 u
+original HPWL         3007148.2 u
+legalized HPWL        3117557.6 u
+delta HPWL                    4 %
 
 Detailed placement improvement.
 [INFO DPL-0401] Setting random seed to 1.
 [INFO DPL-0402] Setting maximum displacement 0 0 to 1878640 1878640 units.
 [INFO DPL-0320] Collected 739 fixed cells.
-[INFO DPL-0318] Collected 45710 single height cells.
+[INFO DPL-0318] Collected 45715 single height cells.
 [INFO DPL-0321] Collected 0 wide cells.
 [INFO DPL-0322] Image (30360, 32640) - (969680, 968320)
-[INFO DPL-0310] Assigned 45710 cells into segments.  Movement in X-direction is 0.000000, movement in Y-direction is 0.000000.
+[INFO DPL-0310] Assigned 45715 cells into segments.  Movement in X-direction is 0.000000, movement in Y-direction is 0.000000.
 [INFO DPL-0313] Found 0 cells in wrong regions.
 [INFO DPL-0315] Found 0 row alignment problems.
 [INFO DPL-0314] Found 0 site alignment problems.
@@ -1355,44 +1001,56 @@ Detailed placement improvement.
 [INFO DPL-0312] Found 0 edge spacing violations and 0 padding violations.
 [INFO DPL-0303] Running algorithm for independent set matching.
 [INFO DPL-0300] Set matching objective is wirelength.
-[INFO DPL-0301] Pass   1 of matching; objective is 2.634154e+09.
-[INFO DPL-0302] End of matching; objective is 2.621945e+09, improvement is 0.46 percent.
+[INFO DPL-0301] Pass   1 of matching; objective is 3.117910e+09.
+[INFO DPL-0301] Pass   2 of matching; objective is 3.058705e+09.
+[INFO DPL-0302] End of matching; objective is 3.045506e+09, improvement is 2.32 percent.
 [INFO DPL-0303] Running algorithm for global swaps.
-[INFO DPL-0306] Pass   1 of global swaps; hpwl is 2.553515e+09.
-[INFO DPL-0306] Pass   2 of global swaps; hpwl is 2.523981e+09.
-[INFO DPL-0306] Pass   3 of global swaps; hpwl is 2.507577e+09.
-[INFO DPL-0307] End of global swaps; objective is 2.507577e+09, improvement is 4.36 percent.
+[INFO DPL-0306] Pass   1 of global swaps; hpwl is 2.939838e+09.
+[INFO DPL-0306] Pass   2 of global swaps; hpwl is 2.889527e+09.
+[INFO DPL-0306] Pass   3 of global swaps; hpwl is 2.860291e+09.
+[INFO DPL-0306] Pass   4 of global swaps; hpwl is 2.841017e+09.
+[INFO DPL-0307] End of global swaps; objective is 2.841017e+09, improvement is 6.71 percent.
 [INFO DPL-0303] Running algorithm for vertical swaps.
-[INFO DPL-0308] Pass   1 of vertical swaps; hpwl is 2.485749e+09.
-[INFO DPL-0309] End of vertical swaps; objective is 2.485749e+09, improvement is 0.87 percent.
+[INFO DPL-0308] Pass   1 of vertical swaps; hpwl is 2.813716e+09.
+[INFO DPL-0309] End of vertical swaps; objective is 2.813716e+09, improvement is 0.96 percent.
 [INFO DPL-0303] Running algorithm for reordering.
-[INFO DPL-0304] Pass   1 of reordering; objective is 2.459613e+09.
-[INFO DPL-0304] Pass   2 of reordering; objective is 2.445549e+09.
-[INFO DPL-0305] End of reordering; objective is 2.445549e+09, improvement is 1.62 percent.
+[INFO DPL-0304] Pass   1 of reordering; objective is 2.785118e+09.
+[INFO DPL-0304] Pass   2 of reordering; objective is 2.768384e+09.
+[INFO DPL-0305] End of reordering; objective is 2.768384e+09, improvement is 1.61 percent.
 [INFO DPL-0303] Running algorithm for random improvement.
 [INFO DPL-0324] Random improver is using random generator.
 [INFO DPL-0325] Random improver is using hpwl objective.
 [INFO DPL-0326] Random improver cost string is (a).
-[INFO DPL-0332] End of pass, Generator random called 914200 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 914200, swaps 303961, moves 602257 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.436481e+09, Scratch cost 2.392045e+09, Incremental cost 2.392045e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.392045e+09.
-[INFO DPL-0327] Pass   1 of random improver; improvement in cost is 1.82 percent.
-[INFO DPL-0332] End of pass, Generator random called 914200 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 1828400, swaps 614684, moves 1198378 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.392045e+09, Scratch cost 2.363545e+09, Incremental cost 2.363545e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.363545e+09.
-[INFO DPL-0327] Pass   2 of random improver; improvement in cost is 1.19 percent.
-[INFO DPL-0332] End of pass, Generator random called 914200 times.
-[INFO DPL-0335] Generator random, Cumulative attempts 2742600, swaps 933824, moves 1786219 since last reset.
-[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.363545e+09, Scratch cost 2.340636e+09, Incremental cost 2.340636e+09, Mismatch? N
-[INFO DPL-0338] End of pass, Total cost is 2.340636e+09.
-[INFO DPL-0327] Pass   3 of random improver; improvement in cost is 0.97 percent.
-[INFO DPL-0328] End of random improver; improvement is 3.933733 percent.
+[INFO DPL-0332] End of pass, Generator random called 914300 times.
+[INFO DPL-0335] Generator random, Cumulative attempts 914300, swaps 272252, moves 641425 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.759646e+09, Scratch cost 2.685537e+09, Incremental cost 2.685537e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.685537e+09.
+[INFO DPL-0327] Pass   1 of random improver; improvement in cost is 2.69 percent.
+[INFO DPL-0332] End of pass, Generator random called 914300 times.
+[INFO DPL-0335] Generator random, Cumulative attempts 1828600, swaps 553849, moves 1273248 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.685537e+09, Scratch cost 2.637342e+09, Incremental cost 2.637342e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.637342e+09.
+[INFO DPL-0327] Pass   2 of random improver; improvement in cost is 1.79 percent.
+[INFO DPL-0332] End of pass, Generator random called 914300 times.
+[INFO DPL-0335] Generator random, Cumulative attempts 2742900, swaps 845943, moves 1894392 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.637342e+09, Scratch cost 2.597091e+09, Incremental cost 2.597091e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.597091e+09.
+[INFO DPL-0327] Pass   3 of random improver; improvement in cost is 1.53 percent.
+[INFO DPL-0332] End of pass, Generator random called 914300 times.
+[INFO DPL-0335] Generator random, Cumulative attempts 3657200, swaps 1148298, moves 2505102 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.597091e+09, Scratch cost 2.563627e+09, Incremental cost 2.563627e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.563627e+09.
+[INFO DPL-0327] Pass   4 of random improver; improvement in cost is 1.29 percent.
+[INFO DPL-0332] End of pass, Generator random called 914300 times.
+[INFO DPL-0335] Generator random, Cumulative attempts 4571500, swaps 1458823, moves 3107387 since last reset.
+[INFO DPL-0333] End of pass, Objective hpwl, Initial cost 2.563627e+09, Scratch cost 2.533726e+09, Incremental cost 2.533726e+09, Mismatch? N
+[INFO DPL-0338] End of pass, Total cost is 2.533726e+09.
+[INFO DPL-0327] Pass   5 of random improver; improvement in cost is 1.17 percent.
+[INFO DPL-0328] End of random improver; improvement is 8.186575 percent.
 [INFO DPL-0380] Cell flipping.
 [INFO DPL-0382] Changed 0 cell orientations for row compatibility.
-[INFO DPL-0383] Performed 12607 cell flips.
-[INFO DPL-0384] End of flipping; objective is 2.331832e+09, improvement is 0.76 percent.
+[INFO DPL-0383] Performed 12818 cell flips.
+[INFO DPL-0384] End of flipping; objective is 2.523988e+09, improvement is 0.73 percent.
 [INFO DPL-0313] Found 0 cells in wrong regions.
 [INFO DPL-0315] Found 0 row alignment problems.
 [INFO DPL-0314] Found 0 site alignment problems.
@@ -1400,8 +1058,8 @@ Detailed placement improvement.
 [INFO DPL-0312] Found 0 edge spacing violations and 0 padding violations.
 Detailed Improvement Results
 ------------------------------------------
-Original HPWL          2634085.0 u ( 1616917.1,  1017167.8)
-Final HPWL             2331893.8 u ( 1428040.9,   903852.9)
-Delta HPWL                 -11.5 % (     -11.7,      -11.1)
+Original HPWL          3117557.6 u ( 2036579.9,  1080977.6)
+Final HPWL             2524139.9 u ( 1630894.0,   893245.8)
+Delta HPWL                 -19.0 % (     -19.9,      -17.4)
 
 No differences found.

--- a/test/upf_test.ok
+++ b/test/upf_test.ok
@@ -22,6 +22,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0002] DBU: 1000
 [INFO GPL-0003] SiteSize: (  0.460  2.720 ) um
 [INFO GPL-0004] CoreBBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
+[INFO GPL-0016] Core area:                   11467.248 um^2
 [INFO GPL-0036] Movable instances area:        158.902 um^2
 [INFO GPL-0037] Total instances area:          158.902 um^2
 [INFO GPL-0035] Pin density area adjust:        16.145 um^2

--- a/test/upf_test.ok
+++ b/test/upf_test.ok
@@ -32,9 +32,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                    24
 [INFO GPL-0010] Number of nets:                     26
 [INFO GPL-0011] Number of pins:                     65
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 112.450 112.450 ) um
-[INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
-[INFO GPL-0016] Core area:                   11467.248 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 112.450 112.450 ) um
+[INFO GPL-0013] Placement BBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                 11467.248 um^2
 [INFO GPL-0017] Fixed instances area:         4684.493 um^2
@@ -49,9 +48,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     26
 [INFO GPL-0011] Number of pins:                     65
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 112.450 112.450 ) um
-[INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
-[INFO GPL-0016] Core area:                   11467.248 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 112.450 112.450 ) um
+[INFO GPL-0013] Placement BBox: (  2.300  2.720 ) ( 57.500 19.040 ) um
 [INFO GPL-0014] Region name: PD_D1.
 [INFO GPL-0015] Region area:                   900.864 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2
@@ -66,9 +64,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                     26
 [INFO GPL-0011] Number of pins:                     65
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 112.450 112.450 ) um
-[INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
-[INFO GPL-0016] Core area:                   11467.248 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 112.450 112.450 ) um
+[INFO GPL-0013] Placement BBox: (  2.300 92.480 ) ( 57.500 108.800 ) um
 [INFO GPL-0014] Region name: PD_D2.
 [INFO GPL-0015] Region area:                   900.864 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2


### PR DESCRIPTION
## Summary
Closes #4875

Changes:
- Adds support for non-rectangular regions
  - The placement region is the bounding box of the region
  - If the region is non-rectangular, the areas that do not belong to the region are filled with dummies
- Check the overlap with all fixed cells, even if it isn't part of the group
  - new method: dbRegion::getOverlapArea
- Change PlacerBase::initInstsForUnusableSites to look only at the placement region
- region_bbox_ is now bounded by the core area
- PlacerBase log info was changed
  - Core BBox changed to Region BBox
  - The core area log was moved to the PlacerBaseCommon report

## Type of Change
- Bug fix
- New feature

## Impact
Now PlacerBase uses the region boundaries to initialize the placement regions.

region_bbox_ is now bounded by the core area (This changes the upf_aes test results).

The PlacerBase log info was changed (those infos are already printed in the PlaceBaseCommon log):
- Message "[INFO GPL-0013]" changed from showing the "Core BBox" to the "Placement BBox".
- Message "[INFO GPL-0016] Core area" moved to the PlacerBaseCommon

## Verification
- [ X ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ X ] I have run the relevant tests and they pass.
- [ X ] My code follows the repository's formatting guidelines.
- [ X ] **I have signed my commits (DCO).**

## Related Issues
Issue [#4875](https://github.com/The-OpenROAD-Project/OpenROAD/issues/4875#issuecomment-4845133098)