### PR TITLE
grt: O(1) coordinate dedup in setTreeNodesVariables (FastRoute)

### DIFF
--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -808,6 +808,11 @@ class FastRouteCore
   std::vector<int> xcor_;
   std::vector<int> ycor_;
   std::vector<int> dcor_;
+  // Scratch map for setTreeNodesVariables() coordinate deduplication.
+  // Maps a packed (x,y) grid position to the dcor index of the first node
+  // inserted at that position, replacing an O(numpoints^2) linear scan with
+  // O(1) average lookups. Reused across calls to avoid per-call allocation.
+  std::unordered_map<int32_t, int> tree_node_coord_dedup_;
 
   std::vector<FrNet*> nets_;
   std::unordered_map<odb::dbNet*, int> db_net_id_map_;  // db net -> net id

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -812,7 +812,7 @@ class FastRouteCore
   // Maps a packed (x,y) grid position to the dcor index of the first node
   // inserted at that position, replacing an O(numpoints^2) linear scan with
   // O(1) average lookups. Reused across calls to avoid per-call allocation.
-  std::unordered_map<int32_t, int> tree_node_coord_dedup_;
+  std::unordered_map<uint32_t, int> tree_node_coord_dedup_;
 
   std::vector<FrNet*> nets_;
   std::unordered_map<odb::dbNet*, int> db_net_id_map_;  // db net -> net id

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -3018,10 +3018,11 @@ void FastRouteCore::setTreeNodesVariables(const int netID)
     treenodes[d].lID = BIG_INT;
     treenodes[d].status = 0;
 
-    // Pack the int16_t grid coordinates into a single 32-bit key.
-    const int32_t key
-        = (static_cast<int32_t>(static_cast<uint16_t>(treenodes[d].x)) << 16)
-          | static_cast<int32_t>(static_cast<uint16_t>(treenodes[d].y));
+    // Pack the int16_t grid coordinates into a single unsigned 32-bit key.
+    // Unsigned avoids undefined behavior from shifting into the sign bit.
+    const uint32_t key
+        = (static_cast<uint32_t>(static_cast<uint16_t>(treenodes[d].x)) << 16)
+          | static_cast<uint32_t>(static_cast<uint16_t>(treenodes[d].y));
 
     if (d < num_terminals) {
       const int pin_idx = sttrees_[netID].node_to_pin_idx[d];

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -2996,6 +2996,18 @@ void FastRouteCore::setTreeNodesVariables(const int netID)
   auto& treenodes = sttrees_[netID].nodes;
 
   // Setting the values needed for each TreeNode
+  //
+  // Coordinate deduplication: non-terminal nodes that share a grid (x,y)
+  // position with an earlier node are aliased (stackAlias) to that earlier
+  // node. The original implementation found the earliest matching node with an
+  // O(numpoints) linear scan, making the whole loop O(numpoints^2). For large
+  // multi-pin nets this dominates global routing runtime. We replace the scan
+  // with a hash-map keyed by the packed (x,y) position, mapping to the dcor
+  // index of the FIRST node inserted at that position. This yields identical
+  // results (same first-match semantics, same xcor_/ycor_/dcor_ contents)
+  // with O(1) average lookups.
+  auto& coord_map = tree_node_coord_dedup_;
+  coord_map.clear();
   for (int d = 0; d < sttrees_[netID].num_nodes(); d++) {
     treenodes[d].topL = -1;
     treenodes[d].botL = num_layers_;
@@ -3006,6 +3018,11 @@ void FastRouteCore::setTreeNodesVariables(const int netID)
     treenodes[d].lID = BIG_INT;
     treenodes[d].status = 0;
 
+    // Pack the int16_t grid coordinates into a single 32-bit key.
+    const int32_t key
+        = (static_cast<int32_t>(static_cast<uint16_t>(treenodes[d].x)) << 16)
+          | static_cast<int32_t>(static_cast<uint16_t>(treenodes[d].y));
+
     if (d < num_terminals) {
       const int pin_idx = sttrees_[netID].node_to_pin_idx[d];
       treenodes[d].botL = nets_[netID]->getPinL()[pin_idx];
@@ -3013,20 +3030,21 @@ void FastRouteCore::setTreeNodesVariables(const int netID)
       treenodes[d].assigned = true;
       treenodes[d].status = 1;
 
+      // Terminals are always appended (they are never aliased away), matching
+      // the original behavior. Record only the first dcor per position so
+      // later lookups resolve to the earliest insertion, as the linear scan
+      // did.
+      coord_map.try_emplace(key, d);
       xcor_[numpoints] = treenodes[d].x;
       ycor_[numpoints] = treenodes[d].y;
       dcor_[numpoints] = d;
       numpoints++;
     } else {
-      bool redundant = false;
-      for (int k = 0; k < numpoints; k++) {
-        if ((treenodes[d].x == xcor_[k]) && (treenodes[d].y == ycor_[k])) {
-          treenodes[d].stackAlias = dcor_[k];
-          redundant = true;
-          break;
-        }
-      }
-      if (!redundant) {
+      const auto it = coord_map.find(key);
+      if (it != coord_map.end()) {
+        treenodes[d].stackAlias = it->second;
+      } else {
+        coord_map.emplace(key, d);
         xcor_[numpoints] = treenodes[d].x;
         ycor_[numpoints] = treenodes[d].y;
         dcor_[numpoints] = d;


### PR DESCRIPTION
## Summary
`setTreeNodesVariables()` was the largest measured global-route hotspot (~41% of
routing instructions). It deduplicated tree-node coordinates with an
O(numpoints^2) linear scan, dominated by a few very large multi-pin nets
(instrumentation on medium03 showed ~12.4B inner iterations, ~99.7% of the
function's work, across ~8.1K calls).

This replaces the linear scan with a reused hash-map keyed by the packed (x,y)
grid position, mapping to the `dcor` index of the first node inserted at that
position. It reproduces the original first-match aliasing **exactly** (identical
`stackAlias` values and identical `xcor_`/`ycor_`/`dcor_` contents), so routing
results are unchanged.

## Type of Change
- Performance (no functional / QoR change)

## Impact
Timed region = `global_route` only (interleaved base-vs-opt medians):
- medium03 (98.6K cells): 20529 ms -> 10314 ms (**1.99x**, -49.8%)
- medium04 (135K cells): 268179 ms -> 84948 ms (**3.16x**, -68.3%)

## Verification
- [x] Local build succeeds.
- [x] `ctest -L grt` **140/140 pass**.
- [x] Wirelength / via count / routed nets / congestion / overflow unchanged
  (byte-for-byte identical on the grt regression designs).
- [x] clang-format clean.
- [x] I have signed my commits (DCO).

## Scope
Two files, grt-only, no `src/sta` changes, no new dependencies:
- `src/grt/src/fastroute/include/FastRoute.h`
- `src/grt/src/fastroute/src/utility.cpp`
