### PR TITLE
odb: make 3DBlox connection region check direction-aware

### DIFF
--- a/src/odb/src/3dblox/checker.cpp
+++ b/src/odb/src/3dblox/checker.cpp
@@ -183,53 +183,55 @@ const char* sideToString(dbUnfoldedChipRegionInst::EffectiveSide side)
   return "UNKNOWN";
 }
 
-MatingSurfaces getMatingSurfaces(dbUnfoldedChipConn* conn)
+enum class ConnectionStatus
 {
-  dbUnfoldedChipRegionInst* r1 = conn->getTopRegion();
-  dbUnfoldedChipRegionInst* r2 = conn->getBottomRegion();
-  if (!r1 || !r2) {
-    return {.valid = false, .top_z = 0, .bot_z = 0};
+  kValid,
+  // The declared top/bot regions contradict the physical stackup: the top
+  // region must face down and the bottom region must face up.
+  kInvalidDirection,
+  // The regions do not overlap in the XY plane.
+  kInvalidXYOverlap,
+  // The internal_ext regions do not overlap in Z.
+  kInvalidZOverlap,
+  // The gap between the mating surfaces does not match the connection
+  // thickness.
+  kInvalidThickness,
+};
+
+ConnectionStatus getConnectionStatus(dbUnfoldedChipConn* conn)
+{
+  dbUnfoldedChipRegionInst* top = conn->getTopRegion();
+  dbUnfoldedChipRegionInst* bot = conn->getBottomRegion();
+  if (!top || !bot) {
+    return ConnectionStatus::kValid;
+  }
+  if (!top->getCuboid().xyIntersects(bot->getCuboid())) {
+    return ConnectionStatus::kInvalidXYOverlap;
+  }
+  if (top->isInternalExt() || bot->isInternalExt()) {
+    return std::max(top->getCuboid().zMin(), bot->getCuboid().zMin())
+                   <= std::min(top->getCuboid().zMax(), bot->getCuboid().zMax())
+               ? ConnectionStatus::kValid
+               : ConnectionStatus::kInvalidZOverlap;
   }
 
-  // r1 faces down (Bottom side) and r2 faces up (Top side) -> r1 is above r2
-  bool r1_down_r2_up = r1->isBottom() && r2->isTop();
-  // r1 faces up (Top side) and r2 faces down (Bottom side) -> r2 is above r1
-  bool r1_up_r2_down = r1->isTop() && r2->isBottom();
-
-  if (r1_down_r2_up == r1_up_r2_down) {
-    return {.valid = false, .top_z = 0, .bot_z = 0};
+  // The top region mates from the die above the connection, so its surface
+  // must face down; the bottom region mates from below and must face up.
+  if (!top->isBottom() || !bot->isTop()) {
+    return ConnectionStatus::kInvalidDirection;
   }
 
-  auto* top = r1_down_r2_up ? r1 : r2;
-  auto* bot = r1_down_r2_up ? r2 : r1;
-  return {
-      .valid = true, .top_z = top->getSurfaceZ(), .bot_z = bot->getSurfaceZ()};
+  // A negative gap means the declared top surface lies below the bottom one.
+  const int gap = top->getSurfaceZ() - bot->getSurfaceZ();
+  if (gap != conn->getChipConn()->getThickness()) {
+    return ConnectionStatus::kInvalidThickness;
+  }
+  return ConnectionStatus::kValid;
 }
 
 bool isValid(dbUnfoldedChipConn* conn)
 {
-  auto* r1 = conn->getTopRegion();
-  auto* r2 = conn->getBottomRegion();
-  if (!r1 || !r2) {
-    return true;
-  }
-  if (!r1->getCuboid().xyIntersects(r2->getCuboid())) {
-    return false;
-  }
-  if (r1->isInternalExt() || r2->isInternalExt()) {
-    return std::max(r1->getCuboid().zMin(), r2->getCuboid().zMin())
-           <= std::min(r1->getCuboid().zMax(), r2->getCuboid().zMax());
-  }
-
-  auto surfaces = getMatingSurfaces(conn);
-  if (!surfaces.valid) {
-    return false;
-  }
-  if (surfaces.top_z < surfaces.bot_z) {
-    return false;
-  }
-  return (surfaces.top_z - surfaces.bot_z)
-         == conn->getChipConn()->getThickness();
+  return getConnectionStatus(conn) == ConnectionStatus::kValid;
 }
 
 }  // namespace
@@ -428,17 +430,56 @@ void Checker::checkConnectionRegions(dbMarkerCategory* top_cat)
   int count = 0;
   dbMarkerCategory* cat = nullptr;
   for (dbUnfoldedChipConn* conn : db_->getUnfoldedChipConns()) {
-    if (!isValid(conn)) {
+    const ConnectionStatus status = getConnectionStatus(conn);
+    if (status != ConnectionStatus::kValid) {
       if (!cat) {
         cat = dbMarkerCategory::createOrReplace(top_cat, "Connection regions");
       }
       if (auto* marker = dbMarker::create(cat)) {
         marker->addSource(conn->getChipConn());
-        std::string msg
-            = fmt::format("Invalid connection {}: {} to {}",
-                          conn->getChipConn()->getName(),
-                          describe(conn->getTopRegion(), marker),
-                          describe(conn->getBottomRegion(), marker));
+        const std::string conn_name = conn->getChipConn()->getName();
+        const std::string top_desc = describe(conn->getTopRegion(), marker);
+        const std::string bot_desc = describe(conn->getBottomRegion(), marker);
+        std::string msg;
+        switch (status) {
+          case ConnectionStatus::kInvalidDirection:
+            msg = fmt::format(
+                "Ill-defined stacking direction for connection {}: top region "
+                "{} must face BOTTOM and bottom region {} must face TOP",
+                conn_name,
+                top_desc,
+                bot_desc);
+            break;
+          case ConnectionStatus::kInvalidXYOverlap:
+            msg = fmt::format(
+                "Invalid connection {}: {} and {} do not overlap in the XY "
+                "plane",
+                conn_name,
+                top_desc,
+                bot_desc);
+            break;
+          case ConnectionStatus::kInvalidZOverlap:
+            msg = fmt::format(
+                "Invalid connection {}: internal_ext regions {} and {} do not "
+                "overlap in Z",
+                conn_name,
+                top_desc,
+                bot_desc);
+            break;
+          case ConnectionStatus::kInvalidThickness:
+            msg = fmt::format(
+                "Invalid connection {}: gap {} between {} and {} does not "
+                "match connection thickness {}",
+                conn_name,
+                conn->getTopRegion()->getSurfaceZ()
+                    - conn->getBottomRegion()->getSurfaceZ(),
+                top_desc,
+                bot_desc,
+                conn->getChipConn()->getThickness());
+            break;
+          case ConnectionStatus::kValid:
+            break;
+        }
         marker->setComment(msg);
         logger_->warn(utl::ODB, 207, msg);
       }

--- a/src/odb/src/3dblox/checker.h
+++ b/src/odb/src/3dblox/checker.h
@@ -15,13 +15,6 @@ namespace odb {
 class dbDatabase;
 class dbMarkerCategory;
 
-struct MatingSurfaces
-{
-  bool valid;
-  int top_z;
-  int bot_z;
-};
-
 class Checker
 {
  public:

--- a/src/odb/src/db/dbUnfoldedBuilder.cpp
+++ b/src/odb/src/db/dbUnfoldedBuilder.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "dbChip.h"
@@ -89,7 +90,7 @@ void dbUnfoldedBuilder::build()
   for (dbChipInst* inst : chip->getChipInsts()) {
     buildUnfoldedChip(inst, path, dbTransform());
   }
-  unfoldConnections(chip, {});
+  unfoldConnections(chip, {}, dbTransform());
   unfoldNets(chip, {});
 }
 
@@ -109,7 +110,7 @@ _dbUnfoldedChipInst* dbUnfoldedBuilder::buildUnfoldedChip(
     for (auto* sub : master->getChipInsts()) {
       buildUnfoldedChip(sub, path, total);
     }
-    unfoldConnections(master, path);
+    unfoldConnections(master, path, total);
     unfoldNets(master, path);
     path.pop_back();
     return nullptr;
@@ -207,7 +208,8 @@ _dbUnfoldedChipInst* dbUnfoldedBuilder::findUnfoldedChip(
 
 void dbUnfoldedBuilder::unfoldConnections(
     dbChip* chip,
-    const std::vector<dbChipInst*>& parent_path)
+    const std::vector<dbChipInst*>& parent_path,
+    const dbTransform& parent_xform)
 {
   for (auto* conn : chip->getChipConns()) {
     dbId<_dbUnfoldedChipRegionInst> top_region = 0;
@@ -231,6 +233,9 @@ void dbUnfoldedBuilder::unfoldConnections(
     if (top_region.isValid() || bot_region.isValid()) {
       _dbUnfoldedChipConn* uf_conn = db_->unfolded_chip_conn_tbl_->create();
       uf_conn->chip_conn_ = conn->getImpl()->getOID();
+      if (parent_xform.isMirrorZ()) {
+        std::swap(top_region, bot_region);
+      }
       uf_conn->top_region_ = top_region;
       uf_conn->bottom_region_ = bot_region;
     }

--- a/src/odb/src/db/dbUnfoldedBuilder.h
+++ b/src/odb/src/db/dbUnfoldedBuilder.h
@@ -36,7 +36,8 @@ class dbUnfoldedBuilder
   void unfoldBumps(_dbUnfoldedChipRegionInst* uf_region,
                    dbChipRegionInst* region_inst);
   void unfoldConnections(dbChip* chip,
-                         const std::vector<dbChipInst*>& parent_path);
+                         const std::vector<dbChipInst*>& parent_path,
+                         const dbTransform& parent_xform);
   void unfoldNets(dbChip* chip, const std::vector<dbChipInst*>& parent_path);
 
   _dbUnfoldedChipInst* findUnfoldedChip(const std::vector<dbChipInst*>& path);

--- a/src/odb/test/check_3dblox.ok
+++ b/src/odb/test/check_3dblox.ok
@@ -6,14 +6,14 @@
 [INFO ODB-0131]     Created 10 components and 32 component-terminals.
 [INFO ODB-0133]     Created 12 nets and 24 connections.
 [WARNING ODB-0151] Found 1 floating chip sets
-[WARNING ODB-0207] Invalid connection soc_to_soc: soc_inst_duplicate/front_reg (faces BOTTOM) to soc_inst/front_reg (faces TOP)
+[WARNING ODB-0207] Invalid connection soc_to_soc: gap 10000 between soc_inst_duplicate/front_reg (faces BOTTOM) and soc_inst/front_reg (faces TOP) does not match connection thickness 0
 [WARNING ODB-0273] Found 1 invalid connections
 [WARNING ODB-0151] Found 2 floating chip sets
-[WARNING ODB-0207] Invalid connection soc_to_soc: soc_inst_duplicate/front_reg (faces BOTTOM) to soc_inst/front_reg (faces TOP)
+[WARNING ODB-0207] Invalid connection soc_to_soc: gap 10000 between soc_inst_duplicate/front_reg (faces BOTTOM) and soc_inst/front_reg (faces TOP) does not match connection thickness 0
 [WARNING ODB-0273] Found 1 invalid connections
 [WARNING ODB-0151] Found 2 floating chip sets
 [WARNING ODB-0156] Found 1 overlapping chips
-[WARNING ODB-0207] Invalid connection soc_to_soc: soc_inst_duplicate/front_reg (faces BOTTOM) to soc_inst/front_reg (faces TOP)
+[WARNING ODB-0207] Invalid connection soc_to_soc: gap -300000 between soc_inst_duplicate/front_reg (faces BOTTOM) and soc_inst/front_reg (faces TOP) does not match connection thickness 0
 [WARNING ODB-0273] Found 1 invalid connections
 Summary 6 / 6 (100% pass)
 pass

--- a/src/odb/test/cpp/Test3DBloxChecker.cpp
+++ b/src/odb/test/cpp/Test3DBloxChecker.cpp
@@ -24,7 +24,7 @@ TEST_F(CheckerFixture, test_no_violations)
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
 
-  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn1->setThickness(0);
 
   check();
@@ -70,7 +70,7 @@ TEST_F(CheckerFixture, test_single_floating_chip)
 
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
-  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn1->setThickness(0);
 
   check();
@@ -107,7 +107,7 @@ TEST_F(CheckerFixture, test_multiple_floating_groups)
 
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
-  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn1->setThickness(0);
 
   check();
@@ -124,7 +124,7 @@ TEST_F(CheckerFixture, test_connectivity_gap)
   auto inst2 = dbChipInst::create(top_chip_, chip2_, "inst2");
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
-  auto* conn = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn->setThickness(100);  // Expect gap of 100
 
   // Case 1: Valid connection
@@ -359,12 +359,14 @@ TEST_F(CheckerFixture, test_connection_invalid_xy)
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
 
-  auto* conn = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn->setThickness(0);
 
   check();
   auto markers = getMarkers(connected_regions_category);
-  EXPECT_EQ(markers.size(), 1);
+  ASSERT_EQ(markers.size(), 1);
+  EXPECT_NE(markers[0]->getComment().find("do not overlap in the XY plane"),
+            std::string::npos);
 }
 
 TEST_F(CheckerFixture, test_connection_invalid_sides)
@@ -387,7 +389,78 @@ TEST_F(CheckerFixture, test_connection_invalid_sides)
 
   check();
   auto markers = getMarkers(connected_regions_category);
-  EXPECT_EQ(markers.size(), 1);
+  ASSERT_EQ(markers.size(), 1);
+  EXPECT_NE(markers[0]->getComment().find("Ill-defined stacking direction"),
+            std::string::npos);
+}
+
+TEST_F(CheckerFixture, test_connection_swapped_top_bottom)
+{
+  auto inst1 = dbChipInst::create(top_chip_, chip1_, "inst1");
+  inst1->setLoc(Point3D(0, 0, 0));
+  inst1->setOrient(dbOrientType3D(dbOrientType::R0, false));
+
+  auto inst2 = dbChipInst::create(top_chip_, chip2_, "inst2");
+  inst2->setLoc(Point3D(0, 0, 500));  // Stacked on top
+  inst2->setOrient(dbOrientType3D(dbOrientType::R0, false));
+
+  auto* ri1 = inst1->findChipRegionInst("r1_fr");
+  auto* ri2 = inst2->findChipRegionInst("r2_bk");
+
+  // The regions mate physically, but the connection declares the lower die's
+  // region as top and the upper die's region as bottom.
+  auto* conn = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  conn->setThickness(0);
+
+  check();
+  auto markers = getMarkers(connected_regions_category);
+  ASSERT_EQ(markers.size(), 1);
+  EXPECT_NE(markers[0]->getComment().find("Ill-defined stacking direction"),
+            std::string::npos);
+}
+
+TEST_F(CheckerFixture, test_connection_in_z_mirrored_assembly)
+{
+  // Assembly with chip2 stacked on chip1 and a properly declared connection:
+  // top is the upper die's down-facing region.
+  auto* assembly
+      = dbChip::create(db_.get(), nullptr, "Assembly", dbChip::ChipType::HIER);
+
+  auto inst1 = dbChipInst::create(assembly, chip1_, "inst1");
+  inst1->setLoc(Point3D(0, 0, 0));
+  inst1->setOrient(dbOrientType3D(dbOrientType::R0, false));
+
+  auto inst2 = dbChipInst::create(assembly, chip2_, "inst2");
+  inst2->setLoc(Point3D(0, 0, 500));  // Stacked on top
+  inst2->setOrient(dbOrientType3D(dbOrientType::R0, false));
+
+  auto* ri1 = inst1->findChipRegionInst("r1_fr");
+  auto* ri2 = inst2->findChipRegionInst("r2_bk");
+  auto* conn = dbChipConn::create("c1", assembly, {inst2}, ri2, {inst1}, ri1);
+  conn->setThickness(0);
+
+  // Mirror the whole assembly in Z at the top level. In world coordinates
+  // r1_fr now faces down from above and r2_bk faces up from below.
+  auto asm_inst = dbChipInst::create(top_chip_, assembly, "asm_inst");
+  asm_inst->setOrient(dbOrientType3D(dbOrientType::R0, true));
+  asm_inst->setLoc(Point3D(0, 0, 0));
+
+  check();
+  EXPECT_TRUE(getMarkers(connected_regions_category).empty());
+
+  // The unfolded connection reflects world orientation: the declared roles
+  // swap under the mirror.
+  auto conns = db_->getUnfoldedChipConns();
+  ASSERT_EQ(conns.size(), 1);
+  dbUnfoldedChipConn* uf_conn = *conns.begin();
+  EXPECT_EQ(
+      uf_conn->getTopRegion()->getChipRegionInst()->getChipRegion()->getName(),
+      "r1_fr");
+  EXPECT_EQ(uf_conn->getBottomRegion()
+                ->getChipRegionInst()
+                ->getChipRegion()
+                ->getName(),
+            "r2_bk");
 }
 
 TEST_F(CheckerFixture, test_connection_thickness_mismatch)
@@ -403,12 +476,15 @@ TEST_F(CheckerFixture, test_connection_thickness_mismatch)
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
 
-  auto* conn = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn->setThickness(50);  // Mismatch (100 != 50)
 
   check();
   auto markers = getMarkers(connected_regions_category);
-  EXPECT_EQ(markers.size(), 1);
+  ASSERT_EQ(markers.size(), 1);
+  EXPECT_NE(
+      markers[0]->getComment().find("does not match connection thickness"),
+      std::string::npos);
 }
 
 TEST_F(CheckerFixture, test_connection_internal_ext)
@@ -442,7 +518,10 @@ TEST_F(CheckerFixture, test_connection_internal_ext)
   // Test failure: move inst2 outside Z-range of inst1
   inst2->setLoc(Point3D(0, 0, 600));
   check();
-  EXPECT_EQ(getMarkers(connected_regions_category).size(), 1);
+  auto markers = getMarkers(connected_regions_category);
+  ASSERT_EQ(markers.size(), 1);
+  EXPECT_NE(markers[0]->getComment().find("do not overlap in Z"),
+            std::string::npos);
 }
 
 }  // namespace

--- a/src/odb/test/cpp/Test3DBloxCheckerAlignmentMarkers.cpp
+++ b/src/odb/test/cpp/Test3DBloxCheckerAlignmentMarkers.cpp
@@ -93,7 +93,7 @@ class AlignmentMarkersFixture : public CheckerFixture
     auto* ri1 = inst1->findChipRegionInst("r1_fr");
     auto* ri2 = inst2->findChipRegionInst("r2_bk");
     auto* conn
-        = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+        = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
     conn->setThickness(0);
   }
 

--- a/src/odb/test/cpp/Test3DBloxCheckerLogicalConn.cpp
+++ b/src/odb/test/cpp/Test3DBloxCheckerLogicalConn.cpp
@@ -104,7 +104,7 @@ TEST_F(CheckerLogicalConnFixture, test_logical_connectivity_matching_nets)
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
 
-  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn1->setThickness(0);
 
   auto inst1_bump1 = *ri1->getChipBumpInsts().begin();
@@ -139,7 +139,7 @@ TEST_F(CheckerLogicalConnFixture, test_logical_connectivity_mismatching_nets)
   auto* ri1 = inst1->findChipRegionInst("r1_fr");
   auto* ri2 = inst2->findChipRegionInst("r2_bk");
 
-  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);
+  auto* conn1 = dbChipConn::create("c1", top_chip_, {inst2}, ri2, {inst1}, ri1);
   conn1->setThickness(0);
 
   auto inst1_bump1 = *ri1->getChipBumpInsts().begin();


### PR DESCRIPTION
## Summary
- Make the 3DBlox connection region check direction-aware: the declared `top` region must face down and the declared `bot` region must face up
- Split geometric failures into specific messages: no XY overlap, no Z overlap (internal_ext), and surface gap vs connection thickness (with values)
- Swap top/bottom regions of unfolded connections when the holding chip is Z-mirrored so the unfolded model reflects world orientation
- Fix checker unit-test fixtures that declared connections backwards; add tests for the swapped-declaration and Z-mirrored assembly cases

## Type of Change
- New feature

## Impact
- `check_3dblox` now flags connections whose `top`/`bot` declaration contradicts the physical stackup; invalid-connection messages state the exact failure reason

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Closes #10836