### PR TITLE
odb: Coverity - Avoid unnecessary copy in makeUniqueHierName

### DIFF
--- a/src/odb/src/db/dbInsertBuffer.cpp
+++ b/src/odb/src/db/dbInsertBuffer.cpp
@@ -539,9 +539,10 @@ std::string dbInsertBuffer::makeUniqueHierName(const dbModule* module,
                                                const char* suffix) const
 {
   // insertBuffer only punches scalar hierarchy ports, never bus ports.
-  std::string scalar_base_name = replaceBracketsWithUnderscores(base_name);
-  std::string name
-      = (suffix == nullptr) ? scalar_base_name : scalar_base_name + suffix;
+  std::string name = replaceBracketsWithUnderscores(base_name);
+  if (suffix != nullptr) {
+    name += suffix;
+  }
   std::string full = block_->makeNewNetName(
       module, name.c_str(), dbNameUniquifyType::IF_NEEDED_WITH_UNDERSCORE);
   return std::string(block_->getBaseName(full.c_str()));


### PR DESCRIPTION
## Summary
- Fixes Coverity CID 1663680 by building the unique hierarchy name in place and appending the suffix only when needed.
- Removes the copy/move path instead of adding an explicit move.

## Problem
```
** CID 1663680:       Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/src/odb/src/db/dbInsertBuffer.cpp: 544           in odb::dbInsertBuffer::makeUniqueHierName(const odb::dbModule *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const char *) const()


_____________________________________________________________________________________________
*** CID 1663680:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/src/odb/src/db/dbInsertBuffer.cpp: 544             in odb::dbInsertBuffer::makeUniqueHierName(const odb::dbModule *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const char *) const()
538                                                    const std::string& base_name,
539                                                    const char* suffix) const
540     {
541       // insertBuffer only punches scalar hierarchy ports, never bus ports.
542       std::string scalar_base_name = replaceBracketsWithUnderscores(base_name);
543       std::string name
>>>     CID 1663680:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
>>>     "scalar_base_name" is copied in call to copy constructor for class "std::string", when it could be moved instead.
544           = (suffix == nullptr) ? scalar_base_name : scalar_base_name + suffix;
545       std::string full = block_->makeNewNetName(
546           module, name.c_str(), dbNameUniquifyType::IF_NEEDED_WITH_UNDERSCORE);
547       return std::string(block_->getBaseName(full.c_str()));
548     }
549     
```
