### PR TITLE
dbSta/mpl: report_qor + report_macro_placement (read-only QoR reports)

### DIFF
--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -197,5 +197,279 @@ proc check_ip { args } {
   return [sta::check_ip_cmd $master_name $check_all $max_polygons $verbose]
 }
 
+################################################################
+#
+# report_qor: a single, read-only QoR (Quality of Results) sign-off summary.
+#
+# Aggregates metrics that OpenROAD already computes (design size, area /
+# utilization, setup/hold timing, power, optional clock skew and DRC marker
+# counts) into one concise dashboard. It recomputes nothing from scratch and
+# changes no design or timing state -- every value comes from the read side of
+# an existing command/API (see QOR_INVESTIGATION.md).
+#
+# Degrades gracefully: sections whose prerequisites are missing (no clock, no
+# liberty, no parasitics/routing) print "n/a" instead of erroring. The command
+# never crashes on a partially-set-up design.
+#
+define_cmd_args "report_qor" {[-digits digits] [-json]}
+
+proc report_qor { args } {
+  parse_key_args "report_qor" args keys {-digits} flags {-json}
+  check_argc_eq0 "report_qor" $args
+
+  set digits 3
+  if { [info exists keys(-digits)] } {
+    set digits $keys(-digits)
+    check_positive_integer "-digits" $digits
+  }
+  set json [info exists flags(-json)]
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error STA 90 "No design block found; cannot report QoR."
+  }
+  set block [ord::get_db_block]
+
+  # ---- Design size (always available once a block is linked) ----
+  set num_insts [llength [$block getInsts]]
+  set num_nets [llength [$block getNets]]
+  set num_iterms [llength [$block getITerms]]
+  set num_bterms [llength [$block getBTerms]]
+  set num_pins [expr { $num_iterms + $num_bterms }]
+
+  # ---- Area / utilization (same engine as report_design_area) ----
+  set area_um2 "n/a"
+  set util_pct "n/a"
+  if { ![catch { rsz::design_area } da] } {
+    set area_um2 [expr { $da * 1e6 * 1e6 }]
+  }
+  if { ![catch { rsz::utilization } u] } {
+    set util_pct [expr { $u * 100.0 }]
+  }
+
+  # ---- Timing (only when a clock is present and timing is set up) ----
+  set have_clock [expr { [llength [sta::all_clocks]] > 0 }]
+  set timing_ok 0
+  array set tim {}
+  if { $have_clock } {
+    # Every call below is read-only; guard each so a partially constrained
+    # design degrades to n/a rather than erroring.
+    set timing_ok 1
+    foreach {name expr_cmd} {
+      setup_wns {sta::worst_negative_slack -max}
+      setup_tns {sta::total_negative_slack -max}
+      setup_ws  {sta::worst_slack -max}
+      hold_wns  {sta::worst_negative_slack -min}
+      hold_tns  {sta::total_negative_slack -min}
+      hold_ws   {sta::worst_slack -min}
+    } {
+      if { [catch { eval $expr_cmd } v] } {
+        set tim($name) "n/a"
+        set timing_ok 0
+      } else {
+        set tim($name) $v
+      }
+    }
+    foreach {name expr_cmd} {
+      setup_viol {sta::endpoint_violation_count max}
+      hold_viol  {sta::endpoint_violation_count min}
+      endpoints  {sta::endpoint_count}
+    } {
+      if { [catch { eval $expr_cmd } v] } {
+        set tim($name) "n/a"
+      } else {
+        set tim($name) $v
+      }
+    }
+  }
+
+  # ---- Power (only when liberty is loaded) ----
+  set have_power [expr { [sta::liberty_libraries_exist] }]
+  array set pwr {}
+  if { $have_power } {
+    if { [catch {
+      set scene [sta::cmd_scene]
+      set pr [sta::design_power $scene]
+      lassign [lrange $pr 0 3] \
+        pwr(internal) pwr(switching) pwr(leakage) pwr(total)
+    }] } {
+      set have_power 0
+    }
+  }
+
+  # ---- Clock skew (optional; needs a clock) ----
+  set skew_setup "n/a"
+  set skew_hold "n/a"
+  if { $have_clock } {
+    catch { set skew_setup [sta::worst_clock_skew -setup] }
+    catch { set skew_hold [sta::worst_clock_skew -hold] }
+  }
+
+  # ---- DRC / violation markers (optional; routed designs only) ----
+  set drc_count "n/a"
+  catch {
+    set cnt 0
+    set have_cats 0
+    foreach cat [$block getMarkerCategories] {
+      set have_cats 1
+      incr cnt [llength [$cat getAllMarkers]]
+    }
+    if { $have_cats } {
+      set drc_count $cnt
+    }
+  }
+
+  if { $json } {
+    qor_report_json $digits $num_insts $num_nets $num_pins \
+      $area_um2 $util_pct $timing_ok [array get tim] \
+      $have_power [array get pwr] $skew_setup $skew_hold $drc_count
+  } else {
+    qor_report_text $digits $num_insts $num_nets $num_pins $num_bterms \
+      $area_um2 $util_pct $have_clock $timing_ok [array get tim] \
+      $have_power [array get pwr] $skew_setup $skew_hold $drc_count
+  }
+}
+
+# Format a numeric value to N digits, passing through non-numeric markers
+# (e.g. "n/a") unchanged.
+proc qor_fmt { v digits } {
+  if { [string is double -strict $v] } {
+    return [format "%.*f" $digits $v]
+  }
+  return $v
+}
+
+# Emit a JSON value: numbers formatted to N digits, "n/a"/missing as null.
+proc qor_json_val { v digits } {
+  if { [string is double -strict $v] } {
+    return [format "%.*f" $digits $v]
+  }
+  return "null"
+}
+
+proc qor_report_text { digits num_insts num_nets num_pins num_bterms \
+                       area_um2 util_pct have_clock timing_ok tim_list \
+                       have_power pwr_list skew_setup skew_hold drc_count } {
+  array set tim $tim_list
+  array set pwr $pwr_list
+
+  set lines {}
+  lappend lines "==============================================="
+  lappend lines "QoR Summary"
+  lappend lines "==============================================="
+  lappend lines "Design"
+  lappend lines [format "  %-18s %s" "Instances:" $num_insts]
+  lappend lines [format "  %-18s %s" "Nets:" $num_nets]
+  lappend lines [format "  %-18s %s" "Pins:" $num_pins]
+  lappend lines [format "  %-18s %s" "IO ports:" $num_bterms]
+  lappend lines [format "  %-18s %s" "Area (um^2):" [qor_fmt $area_um2 $digits]]
+  lappend lines [format "  %-18s %s" "Utilization (%):" [qor_fmt $util_pct $digits]]
+
+  lappend lines "Timing"
+  if { $have_clock && $timing_ok } {
+    lappend lines [format "  %-18s WNS %s  TNS %s  WS %s" "Setup:" \
+      [qor_fmt $tim(setup_wns) $digits] [qor_fmt $tim(setup_tns) $digits] \
+      [qor_fmt $tim(setup_ws) $digits]]
+    lappend lines [format "  %-18s WNS %s  TNS %s  WS %s" "Hold:" \
+      [qor_fmt $tim(hold_wns) $digits] [qor_fmt $tim(hold_tns) $digits] \
+      [qor_fmt $tim(hold_ws) $digits]]
+    lappend lines [format "  %-18s setup %s  hold %s  (of %s endpoints)" \
+      "Failing endpts:" $tim(setup_viol) $tim(hold_viol) $tim(endpoints)]
+  } elseif { $have_clock } {
+    lappend lines "  n/a (timing not fully set up)"
+  } else {
+    lappend lines "  n/a (no clock defined)"
+  }
+
+  lappend lines "Power"
+  if { $have_power } {
+    lappend lines [format "  %-18s %s" "Internal:" [qor_fmt $pwr(internal) $digits]]
+    lappend lines [format "  %-18s %s" "Switching:" [qor_fmt $pwr(switching) $digits]]
+    lappend lines [format "  %-18s %s" "Leakage:" [qor_fmt $pwr(leakage) $digits]]
+    lappend lines [format "  %-18s %s" "Total:" [qor_fmt $pwr(total) $digits]]
+  } else {
+    lappend lines "  n/a (no liberty libraries)"
+  }
+
+  lappend lines "Clock"
+  if { $have_clock } {
+    lappend lines [format "  %-18s setup %s  hold %s" "Worst skew:" \
+      [qor_fmt $skew_setup $digits] [qor_fmt $skew_hold $digits]]
+  } else {
+    lappend lines "  n/a (no clock defined)"
+  }
+
+  lappend lines "DRC"
+  if { $drc_count == "n/a" } {
+    lappend lines "  n/a (no markers; design not routed/checked)"
+  } else {
+    lappend lines [format "  %-18s %s" "Violations:" $drc_count]
+  }
+  lappend lines "==============================================="
+
+  foreach line $lines {
+    utl::report $line
+  }
+  return [join $lines "\n"]
+}
+
+proc qor_report_json { digits num_insts num_nets num_pins \
+                       area_um2 util_pct timing_ok tim_list \
+                       have_power pwr_list skew_setup skew_hold drc_count } {
+  array set tim $tim_list
+  array set pwr $pwr_list
+
+  set lines {}
+  lappend lines "{"
+  lappend lines "  \"design\": {"
+  lappend lines "    \"instances\": $num_insts,"
+  lappend lines "    \"nets\": $num_nets,"
+  lappend lines "    \"pins\": $num_pins,"
+  lappend lines "    \"area_um2\": [qor_json_val $area_um2 $digits],"
+  lappend lines "    \"utilization_pct\": [qor_json_val $util_pct $digits]"
+  lappend lines "  },"
+
+  if { $timing_ok } {
+    lappend lines "  \"timing\": {"
+    lappend lines "    \"setup_wns\": [qor_json_val $tim(setup_wns) $digits],"
+    lappend lines "    \"setup_tns\": [qor_json_val $tim(setup_tns) $digits],"
+    lappend lines "    \"setup_ws\": [qor_json_val $tim(setup_ws) $digits],"
+    lappend lines "    \"hold_wns\": [qor_json_val $tim(hold_wns) $digits],"
+    lappend lines "    \"hold_tns\": [qor_json_val $tim(hold_tns) $digits],"
+    lappend lines "    \"hold_ws\": [qor_json_val $tim(hold_ws) $digits],"
+    lappend lines "    \"setup_failing_endpoints\": [qor_json_val $tim(setup_viol) 0],"
+    lappend lines "    \"hold_failing_endpoints\": [qor_json_val $tim(hold_viol) 0],"
+    lappend lines "    \"endpoints\": [qor_json_val $tim(endpoints) 0]"
+    lappend lines "  },"
+  } else {
+    lappend lines "  \"timing\": null,"
+  }
+
+  if { $have_power } {
+    lappend lines "  \"power\": {"
+    lappend lines "    \"internal\": [qor_json_val $pwr(internal) $digits],"
+    lappend lines "    \"switching\": [qor_json_val $pwr(switching) $digits],"
+    lappend lines "    \"leakage\": [qor_json_val $pwr(leakage) $digits],"
+    lappend lines "    \"total\": [qor_json_val $pwr(total) $digits]"
+    lappend lines "  },"
+  } else {
+    lappend lines "  \"power\": null,"
+  }
+
+  lappend lines "  \"clock\": {"
+  lappend lines "    \"worst_skew_setup\": [qor_json_val $skew_setup $digits],"
+  lappend lines "    \"worst_skew_hold\": [qor_json_val $skew_hold $digits]"
+  lappend lines "  },"
+  lappend lines "  \"drc_violations\": [qor_json_val $drc_count 0]"
+  lappend lines "}"
+
+  set out [join $lines "\n"]
+  # utl::report runs its argument through fmt, which treats { and } as format
+  # placeholders. Double them so the braces render literally; the returned
+  # value keeps the real JSON for programmatic use.
+  set safe [string map {\{ \{\{ \} \}\}} $out]
+  utl::report $safe
+  return $out
+}
+
 # namespace
 }

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -56,6 +56,8 @@ ALL_TESTS = [
     "report_cell_usage_modinsts_metrics",
     "report_cell_usage_physical_only",
     "report_json1",
+    "report_qor1",
+    "report_qor_graceful",
     "report_timing_histogram",
     "report_logic_depth_histogram",
     "sdc_get1",
@@ -203,6 +205,13 @@ filegroup(
             ],
             "report_json1": [
                 "reg6.def",
+            ],
+            "report_qor1": [
+                "aocv_derate.def",
+                "aocv_derate.sdc",
+            ],
+            "report_qor_graceful": [
+                "aocv_derate.def",
             ],
             "report_timing_histogram": [
                 "example1_slow.lib",

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -46,6 +46,8 @@ or_integration_tests(
     report_cell_usage_modinsts_metrics
     report_cell_usage_physical_only
     report_json1
+    report_qor1
+    report_qor_graceful
     report_timing_histogram
     report_logic_depth_histogram
     sdc_get1

--- a/src/dbSta/test/report_qor1.ok
+++ b/src/dbSta/test/report_qor1.ok
@@ -1,0 +1,249 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 571 components and 2554 component-terminals.
+[INFO ODB-0132]     Created 5 special nets and 1142 connections.
+[INFO ODB-0133]     Created 528 nets and 1412 connections.
+Startpoint: _893_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _869_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _893_/CK (DFF_X1)
+   0.08    0.08 ^ _893_/Q (DFF_X1)
+   0.04    0.13 ^ _734_/Z (BUF_X1)
+   0.05    0.18 ^ _486_/ZN (XNOR2_X1)
+   0.02    0.20 v _487_/ZN (INV_X1)
+   0.08    0.28 ^ _488_/ZN (NOR3_X1)
+   0.04    0.31 v _493_/ZN (NAND4_X1)
+   0.06    0.37 ^ _496_/ZN (NOR3_X1)
+   0.02    0.39 v _542_/ZN (AOI21_X2)
+   0.07    0.46 ^ _543_/ZN (NOR2_X1)
+   0.05    0.52 ^ _544_/Z (BUF_X2)
+   0.03    0.55 v _584_/ZN (NAND3_X1)
+   0.03    0.57 ^ _585_/ZN (OAI211_X2)
+   0.04    0.61 ^ _586_/Z (MUX2_X1)
+   0.02    0.63 ^ _781_/Z (BUF_X1)
+   0.00    0.63 ^ _869_/D (DFF_X1)
+           0.63   data arrival time
+
+   2.00    2.00   clock core_clock (rise edge)
+   0.00    2.00   clock network delay (ideal)
+   0.00    2.00   clock reconvergence pessimism
+           2.00 ^ _869_/CK (DFF_X1)
+  -0.03    1.97   library setup time
+           1.97   data required time
+---------------------------------------------------------
+           1.97   data required time
+          -0.63   data arrival time
+---------------------------------------------------------
+           1.34   slack (MET)
+
+
+===============================================
+QoR Summary
+===============================================
+Design
+  Instances:         571
+  Nets:              533
+  Pins:              2608
+  IO ports:          54
+  Area (um^2):       669.788
+  Utilization (%):   10.468
+Timing
+  Setup:             WNS 0.000  TNS 0.000  WS 1.338
+  Hold:              WNS 0.000  TNS 0.000  WS 0.145
+  Failing endpts:    setup 0  hold 0  (of 69 endpoints)
+Power
+  Internal:          0.000
+  Switching:         0.000
+  Leakage:           0.000
+  Total:             0.001
+Clock
+  Worst skew:        setup 0.000  hold 0.000
+DRC
+  n/a (no markers; design not routed/checked)
+===============================================
+Startpoint: _893_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _869_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _893_/CK (DFF_X1)
+   0.08    0.08 ^ _893_/Q (DFF_X1)
+   0.04    0.13 ^ _734_/Z (BUF_X1)
+   0.05    0.18 ^ _486_/ZN (XNOR2_X1)
+   0.02    0.20 v _487_/ZN (INV_X1)
+   0.08    0.28 ^ _488_/ZN (NOR3_X1)
+   0.04    0.31 v _493_/ZN (NAND4_X1)
+   0.06    0.37 ^ _496_/ZN (NOR3_X1)
+   0.02    0.39 v _542_/ZN (AOI21_X2)
+   0.07    0.46 ^ _543_/ZN (NOR2_X1)
+   0.05    0.52 ^ _544_/Z (BUF_X2)
+   0.03    0.55 v _584_/ZN (NAND3_X1)
+   0.03    0.57 ^ _585_/ZN (OAI211_X2)
+   0.04    0.61 ^ _586_/Z (MUX2_X1)
+   0.02    0.63 ^ _781_/Z (BUF_X1)
+   0.00    0.63 ^ _869_/D (DFF_X1)
+           0.63   data arrival time
+
+   2.00    2.00   clock core_clock (rise edge)
+   0.00    2.00   clock network delay (ideal)
+   0.00    2.00   clock reconvergence pessimism
+           2.00 ^ _869_/CK (DFF_X1)
+  -0.03    1.97   library setup time
+           1.97   data required time
+---------------------------------------------------------
+           1.97   data required time
+          -0.63   data arrival time
+---------------------------------------------------------
+           1.34   slack (MET)
+
+
+timing_unchanged=1
+report_checks_identical=1
+===============================================
+QoR Summary
+===============================================
+Design
+  Instances:         571
+  Nets:              533
+  Pins:              2608
+  IO ports:          54
+  Area (um^2):       669.788
+  Utilization (%):   10.468
+Timing
+  Setup:             WNS 0.000  TNS 0.000  WS 1.338
+  Hold:              WNS 0.000  TNS 0.000  WS 0.145
+  Failing endpts:    setup 0  hold 0  (of 69 endpoints)
+Power
+  Internal:          0.000
+  Switching:         0.000
+  Leakage:           0.000
+  Total:             0.001
+Clock
+  Worst skew:        setup 0.000  hold 0.000
+DRC
+  n/a (no markers; design not routed/checked)
+===============================================
+has_design=1
+has_timing=1
+has_power=1
+has_clock=1
+instances_nonzero=1
+nets_nonzero=1
+area_positive=1
+util_positive=1
+worst_slack_finite=1
+timing_not_na=1
+power_total_finite=1
+power_not_na=1
+{
+  "design": {
+    "instances": 571,
+    "nets": 533,
+    "pins": 2608,
+    "area_um2": 669.788,
+    "utilization_pct": 10.468
+  },
+  "timing": {
+    "setup_wns": 0.000,
+    "setup_tns": 0.000,
+    "setup_ws": 1.338,
+    "hold_wns": 0.000,
+    "hold_tns": 0.000,
+    "hold_ws": 0.145,
+    "setup_failing_endpoints": 0,
+    "hold_failing_endpoints": 0,
+    "endpoints": 69
+  },
+  "power": {
+    "internal": 0.000,
+    "switching": 0.000,
+    "leakage": 0.000,
+    "total": 0.001
+  },
+  "clock": {
+    "worst_skew_setup": 0.000,
+    "worst_skew_hold": 0.000
+  },
+  "drc_violations": null
+}
+json_has_design=1
+json_has_timing_obj=1
+json_has_power_obj=1
+json_timing_not_null=1
+json_power_not_null=1
+json_instances_match=1
+{
+  "design": {
+    "instances": 571,
+    "nets": 533,
+    "pins": 2608,
+    "area_um2": 669.788,
+    "utilization_pct": 10.468
+  },
+  "timing": {
+    "setup_wns": 0.000,
+    "setup_tns": 0.000,
+    "setup_ws": 1.338,
+    "hold_wns": 0.000,
+    "hold_tns": 0.000,
+    "hold_ws": 0.145,
+    "setup_failing_endpoints": 0,
+    "hold_failing_endpoints": 0,
+    "endpoints": 69
+  },
+  "power": {
+    "internal": 0.000,
+    "switching": 0.000,
+    "leakage": 0.000,
+    "total": 0.001
+  },
+  "clock": {
+    "worst_skew_setup": 0.000,
+    "worst_skew_hold": 0.000
+  },
+  "drc_violations": null
+}
+{
+  "design": {
+    "instances": 571,
+    "nets": 533,
+    "pins": 2608,
+    "area_um2": 669.79,
+    "utilization_pct": 10.47
+  },
+  "timing": {
+    "setup_wns": 0.00,
+    "setup_tns": 0.00,
+    "setup_ws": 1.34,
+    "hold_wns": 0.00,
+    "hold_tns": 0.00,
+    "hold_ws": 0.15,
+    "setup_failing_endpoints": 0,
+    "hold_failing_endpoints": 0,
+    "endpoints": 69
+  },
+  "power": {
+    "internal": 0.00,
+    "switching": 0.00,
+    "leakage": 0.00,
+    "total": 0.00
+  },
+  "clock": {
+    "worst_skew_setup": 0.00,
+    "worst_skew_hold": 0.00
+  },
+  "drc_violations": null
+}
+json_digits_default3=1
+json_digits_ok=1

--- a/src/dbSta/test/report_qor1.tcl
+++ b/src/dbSta/test/report_qor1.tcl
@@ -1,0 +1,90 @@
+# report_qor on a fully set-up small clocked design (gcd / Nangate45).
+#
+# Exercises the normal path: design + area + timing + power + clock skew all
+# present. Asserts the summary has the expected sections and plausible values
+# (non-zero instances/area, a finite timing number, populated power) rather
+# than golden floats, so the .ok file is deterministic across platforms.
+#
+# Also confirms report_qor is ADDITIVE: report_checks output is byte-identical
+# before and after running report_qor (it changes no timing state).
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def aocv_derate.def
+read_sdc aocv_derate.sdc
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+# --- Additivity gate: timing must be byte-identical before/after report_qor --
+# Snapshot the worst-slack/TNS numbers, run report_qor, snapshot again. A
+# read-only command cannot change any of these.
+set ws_before [worst_slack -max]
+set tns_before [total_negative_slack -max]
+set hold_before [worst_slack -min]
+set checks_before [report_checks]
+report_qor
+set ws_after [worst_slack -max]
+set tns_after [total_negative_slack -max]
+set hold_after [worst_slack -min]
+set checks_after [report_checks]
+puts "timing_unchanged=[expr { $ws_before == $ws_after \
+  && $tns_before == $tns_after && $hold_before == $hold_after }]"
+puts "report_checks_identical=[expr { $checks_before eq $checks_after }]"
+
+# --- Structural / plausibility assertions on the text summary ---------------
+set txt [report_qor]
+
+proc has_section { txt name } {
+  return [expr { [string first $name $txt] >= 0 }]
+}
+puts "has_design=[has_section $txt {Design}]"
+puts "has_timing=[has_section $txt {Timing}]"
+puts "has_power=[has_section $txt {Power}]"
+puts "has_clock=[has_section $txt {Clock}]"
+
+# Counts come straight from odb; gcd has hundreds of instances/nets.
+set block [ord::get_db_block]
+set ninst [llength [$block getInsts]]
+set nnet [llength [$block getNets]]
+puts "instances_nonzero=[expr { $ninst > 0 }]"
+puts "nets_nonzero=[expr { $nnet > 0 }]"
+
+# Area / utilization should be positive (placed design with a floorplan).
+set area [expr { [rsz::design_area] * 1e6 * 1e6 }]
+set util [expr { [rsz::utilization] * 100.0 }]
+puts "area_positive=[expr { $area > 0 }]"
+puts "util_positive=[expr { $util > 0 }]"
+
+# Timing numbers are finite and the summary is not the n/a placeholder.
+set ws [worst_slack -max]
+puts "worst_slack_finite=[expr { [string is double -strict $ws] }]"
+puts "timing_not_na=[expr { [string first {n/a (no clock} $txt] < 0 }]"
+
+# Power present (liberty loaded) and total is a real number.
+set scene [sta::cmd_scene]
+set ptot [lindex [sta::design_power $scene] 3]
+puts "power_total_finite=[expr { [string is double -strict $ptot] }]"
+puts "power_not_na=[expr { [string first {n/a (no liberty} $txt] < 0 }]"
+
+# --- JSON output is well-formed and carries the same data -------------------
+# (presence of the nested keys proves timing/power are emitted as objects, not
+# null, on this fully-set-up design)
+set js [report_qor -json]
+puts "json_has_design=[expr { [string first {"design"} $js] >= 0 }]"
+puts "json_has_timing_obj=[expr { [string first {"setup_wns":} $js] >= 0 }]"
+puts "json_has_power_obj=[expr { [string first {"leakage":} $js] >= 0 }]"
+puts "json_timing_not_null=[expr { [string first {"timing": null} $js] < 0 }]"
+puts "json_power_not_null=[expr { [string first {"power": null} $js] < 0 }]"
+puts "json_instances_match=[expr { [string first "\"instances\": $ninst," $js] >= 0 }]"
+
+# --- -digits is honored: -digits 2 -> exactly two decimals (default is 3) ---
+set js3 [report_qor -json]
+set js2 [report_qor -json -digits 2]
+# default: three decimals
+set d3_ok [regexp {"utilization_pct": [0-9]+\.[0-9][0-9][0-9]} $js3]
+# -digits 2: two decimals, not followed by a third digit
+set d2_ok [regexp {"utilization_pct": [0-9]+\.[0-9][0-9]([^0-9]|$)} $js2]
+puts "json_digits_default3=$d3_ok"
+puts "json_digits_ok=[expr { $d2_ok && $d3_ok }]"

--- a/src/dbSta/test/report_qor_graceful.ok
+++ b/src/dbSta/test/report_qor_graceful.ok
@@ -1,0 +1,69 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 571 components and 2554 component-terminals.
+[INFO ODB-0132]     Created 5 special nets and 1142 connections.
+[INFO ODB-0133]     Created 528 nets and 1412 connections.
+===============================================
+QoR Summary
+===============================================
+Design
+  Instances:         571
+  Nets:              533
+  Pins:              2608
+  IO ports:          54
+  Area (um^2):       669.788
+  Utilization (%):   10.468
+Timing
+  n/a (no clock defined)
+Power
+  n/a (no liberty libraries)
+Clock
+  n/a (no clock defined)
+DRC
+  n/a (no markers; design not routed/checked)
+===============================================
+report_qor_no_error=1
+===============================================
+QoR Summary
+===============================================
+Design
+  Instances:         571
+  Nets:              533
+  Pins:              2608
+  IO ports:          54
+  Area (um^2):       669.788
+  Utilization (%):   10.468
+Timing
+  n/a (no clock defined)
+Power
+  n/a (no liberty libraries)
+Clock
+  n/a (no clock defined)
+DRC
+  n/a (no markers; design not routed/checked)
+===============================================
+instances_nonzero=1
+timing_na=1
+power_na=1
+drc_na=1
+{
+  "design": {
+    "instances": 571,
+    "nets": 533,
+    "pins": 2608,
+    "area_um2": 669.788,
+    "utilization_pct": 10.468
+  },
+  "timing": null,
+  "power": null,
+  "clock": {
+    "worst_skew_setup": null,
+    "worst_skew_hold": null
+  },
+  "drc_violations": null
+}
+json_no_error=1
+json_timing_null=1
+json_power_null=1
+json_drc_null=1

--- a/src/dbSta/test/report_qor_graceful.tcl
+++ b/src/dbSta/test/report_qor_graceful.tcl
@@ -1,0 +1,33 @@
+# report_qor graceful-degradation path.
+#
+# A design with NO clock, NO parasitics, NO liberty (LEF+DEF only). report_qor
+# must run without error and mark timing / power / clock / DRC as n/a while
+# still reporting the always-available design size and area sections.
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def aocv_derate.def
+
+# Must not error on a partially-set-up design.
+set rc [catch { report_qor } err]
+puts "report_qor_no_error=[expr { $rc == 0 }]"
+if { $rc != 0 } {
+  puts "error: $err"
+}
+
+set txt [report_qor]
+
+# Design size is always available from odb.
+set block [ord::get_db_block]
+puts "instances_nonzero=[expr { [llength [$block getInsts]] > 0 }]"
+
+# The prerequisite-gated sections must degrade to n/a, not error or fake data.
+puts "timing_na=[expr { [string first {n/a (no clock} $txt] >= 0 }]"
+puts "power_na=[expr { [string first {n/a (no liberty} $txt] >= 0 }]"
+puts "drc_na=[expr { [string first {n/a (no markers} $txt] >= 0 }]"
+
+# JSON path degrades to null for the missing sections.
+set js [report_qor -json]
+puts "json_no_error=1"
+puts "json_timing_null=[expr { [string first {"timing": null} $js] >= 0 }]"
+puts "json_power_null=[expr { [string first {"power": null} $js] >= 0 }]"
+puts "json_drc_null=[expr { [string first {"drc_violations": null} $js] >= 0 }]"

--- a/src/mpl/BUILD
+++ b/src/mpl/BUILD
@@ -81,6 +81,7 @@ cc_library(
         "src/clusterEngine.cpp",
         "src/hier_rtlmp.cpp",
         "src/hier_rtlmp.h",
+        "src/report.cpp",
         "src/rtl_mp.cpp",
     ],
     hdrs = [

--- a/src/mpl/CMakeLists.txt
+++ b/src/mpl/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(mpl_pusher
 
 add_library(mpl_lib
   src/rtl_mp.cpp
+  src/report.cpp
   src/hier_rtlmp.cpp
   src/SimulatedAnnealingCore.cpp
   src/SACoreHardMacro.cpp

--- a/src/mpl/README.md
+++ b/src/mpl/README.md
@@ -168,6 +168,33 @@ For each macro, the halo used is resolved by this priority:
 block_macro_channels
 ```
 
+### Report Macro Placement
+
+Reports post-placement quality-of-result (QoR) metrics for the macros in the
+current block. This is a read-only analysis command: it inspects the final
+placement and does not modify the database, so it is safe to run at any point
+after macros have been placed.
+
+The report includes:
+
+- Number of placed macros and their total area.
+- The macro bounding-box (envelope) area, the dead space within it, and the
+  resulting packing efficiency.
+- Total design half-perimeter wirelength (HPWL) and the HPWL contribution of
+  the nets connected to macros.
+- Minimum and average spacing from macros to the core boundary.
+- The minimum macro-to-macro channel gap (and a count of overlapping macro
+  pairs, if any).
+- A per-macro table with location, orientation and area.
+
+It also emits metrics (`macro_place__num_macros`, `macro_place__macro_area_um2`,
+`macro_place__packing_efficiency`, `macro_place__macro_net_hpwl_um`,
+`macro_place__min_boundary_spacing_um`) for downstream tooling.
+
+```tcl
+report_macro_placement
+```
+
 ## Example scripts
 
 Example of a script demonstrating how to run `mpl` on a sample design of `bp_fe_top` as follows:

--- a/src/mpl/include/mpl/rtl_mp.h
+++ b/src/mpl/include/mpl/rtl_mp.h
@@ -65,6 +65,8 @@ class MacroPlacer
              const char* report_directory,
              bool keep_clustering_data);
   void blockMacroChannels();
+  // Read-only post-placement QoR report. Does not modify the database.
+  void reportMacroPlacement();
   void placeMacro(odb::dbInst* inst,
                   const float& x_origin,
                   const float& y_origin,

--- a/src/mpl/src/mpl.i
+++ b/src/mpl/src/mpl.i
@@ -173,6 +173,12 @@ block_macro_channels()
   getMacroPlacer()->blockMacroChannels();
 }
 
+void
+report_macro_placement()
+{
+  getMacroPlacer()->reportMacroPlacement();
+}
+
 } // namespace
 
 %} // inline

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -353,6 +353,20 @@ proc block_macro_channels { args } {
   mpl::block_macro_channels
 }
 
+sta::define_cmd_args "report_macro_placement" {}
+proc report_macro_placement { args } {
+  sta::parse_key_args "report_macro_placement" args \
+    keys {} flags {}
+
+  sta::check_argc_eq0 "report_macro_placement" $args
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error MPL 81 "Could not report macro placement. No block found."
+  }
+
+  mpl::report_macro_placement
+}
+
 namespace eval mpl {
 proc parse_halo { halo } {
   set length [llength $halo]

--- a/src/mpl/src/report.cpp
+++ b/src/mpl/src/report.cpp
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021-2026, The OpenROAD Authors
+
+// Post-placement macro-placement QoR report.
+//
+// This is a purely additive, read-only analysis command. It inspects the
+// final ODB state after macro placement (or any flow that has placed macros)
+// and reports quality-of-result metrics. It NEVER modifies the database, so
+// the macro placement result is unchanged by calling it.
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <set>
+#include <vector>
+
+#include "mpl/rtl_mp.h"
+#include "odb/db.h"
+#include "odb/geom.h"
+#include "odb/util.h"
+#include "utl/Logger.h"
+
+namespace mpl {
+
+using utl::MPL;
+
+namespace {
+
+// Collect the placed block macros (hard macros) in the block.
+std::vector<odb::dbInst*> getPlacedMacros(odb::dbBlock* block)
+{
+  std::vector<odb::dbInst*> macros;
+  for (odb::dbInst* inst : block->getInsts()) {
+    if (inst->isBlock() && inst->isPlaced()) {
+      macros.push_back(inst);
+    }
+  }
+  return macros;
+}
+
+// Minimum non-overlapping gap between two rectangles. Returns 0 if they
+// touch or overlap (including overlap on one axis but separated on the
+// other -> the separating-axis distance is used).
+int64_t rectGap(const odb::Rect& a, const odb::Rect& b)
+{
+  int64_t dx = 0;
+  if (a.xMax() < b.xMin()) {
+    dx = b.xMin() - a.xMax();
+  } else if (b.xMax() < a.xMin()) {
+    dx = a.xMin() - b.xMax();
+  }
+
+  int64_t dy = 0;
+  if (a.yMax() < b.yMin()) {
+    dy = b.yMin() - a.yMax();
+  } else if (b.yMax() < a.yMin()) {
+    dy = a.yMin() - b.yMax();
+  }
+
+  // If separated on both axes the closest approach is the corner distance;
+  // we report the Manhattan-style min of the axis gaps, which is the channel
+  // width seen along the dominant separation. Use max() of the two axis gaps
+  // would over-report channels; min() best reflects the routing channel.
+  if (dx > 0 && dy > 0) {
+    return std::min(dx, dy);
+  }
+  return std::max(dx, dy);
+}
+
+}  // namespace
+
+void MacroPlacer::reportMacroPlacement()
+{
+  odb::dbBlock* block = db_->getChip()->getBlock();
+  const std::vector<odb::dbInst*> macros = getPlacedMacros(block);
+
+  logger_->report("Macro Placement Report");
+  logger_->report("======================");
+
+  if (macros.empty()) {
+    logger_->info(MPL, 80, "No placed macros found.");
+    return;
+  }
+
+  const odb::Rect core = block->getCoreArea();
+
+  // --- Areas and bounding envelope of the macros. ---
+  int64_t total_macro_area_dbu2 = 0;
+  odb::Rect envelope;
+  envelope.mergeInit();
+  for (odb::dbInst* macro : macros) {
+    const odb::Rect bbox = macro->getBBox()->getBox();
+    total_macro_area_dbu2 += bbox.area();
+    envelope.merge(bbox);
+  }
+
+  const double dbu = block->getDbUnitsPerMicron();
+  const double dbu2 = dbu * dbu;
+  const double total_macro_area = total_macro_area_dbu2 / dbu2;
+  const double envelope_area = static_cast<double>(envelope.area()) / dbu2;
+  const double packing_efficiency
+      = envelope_area > 0.0 ? total_macro_area / envelope_area : 0.0;
+  const double dead_space = envelope_area - total_macro_area;
+
+  // --- HPWL: total design and macro-net contribution. ---
+  odb::WireLengthEvaluator wl_eval(block);
+  const double total_hpwl = block->dbuToMicrons(wl_eval.hpwl());
+
+  int64_t macro_net_hpwl_dbu = 0;
+  int macro_net_count = 0;
+  for (odb::dbNet* net : block->getNets()) {
+    if (net->getSigType().isSupply()) {
+      continue;
+    }
+    bool touches_macro = false;
+    for (odb::dbITerm* iterm : net->getITerms()) {
+      odb::dbInst* inst = iterm->getInst();
+      if (inst != nullptr && inst->isBlock()) {
+        touches_macro = true;
+        break;
+      }
+    }
+    if (!touches_macro) {
+      continue;
+    }
+    int64_t hpwl_x = 0;
+    int64_t hpwl_y = 0;
+    macro_net_hpwl_dbu += wl_eval.hpwl(net, hpwl_x, hpwl_y);
+    ++macro_net_count;
+  }
+  const double macro_net_hpwl = block->dbuToMicrons(macro_net_hpwl_dbu);
+
+  // --- Boundary spacing: distance from each macro to the closest core edge.
+  int64_t min_boundary_dbu = std::numeric_limits<int64_t>::max();
+  int64_t sum_boundary_dbu = 0;
+  for (odb::dbInst* macro : macros) {
+    const odb::Rect bbox = macro->getBBox()->getBox();
+    const int64_t left = bbox.xMin() - core.xMin();
+    const int64_t bottom = bbox.yMin() - core.yMin();
+    const int64_t right = core.xMax() - bbox.xMax();
+    const int64_t top = core.yMax() - bbox.yMax();
+    const int64_t closest
+        = std::min(std::min(left, right), std::min(bottom, top));
+    min_boundary_dbu = std::min(min_boundary_dbu, closest);
+    sum_boundary_dbu += closest;
+  }
+  const double min_boundary_spacing = block->dbuToMicrons(min_boundary_dbu);
+  const double avg_boundary_spacing
+      = block->dbuToMicrons(sum_boundary_dbu) / static_cast<double>(macros.size());
+
+  // --- Macro-to-macro minimum spacing (channel width). ---
+  int64_t min_macro_gap_dbu = std::numeric_limits<int64_t>::max();
+  int overlap_pairs = 0;
+  for (size_t i = 0; i < macros.size(); ++i) {
+    const odb::Rect a = macros[i]->getBBox()->getBox();
+    for (size_t j = i + 1; j < macros.size(); ++j) {
+      const odb::Rect b = macros[j]->getBBox()->getBox();
+      if (a.overlaps(b)) {
+        ++overlap_pairs;
+        min_macro_gap_dbu = 0;
+        continue;
+      }
+      min_macro_gap_dbu = std::min(min_macro_gap_dbu, rectGap(a, b));
+    }
+  }
+
+  // --- Emit the summary. ---
+  logger_->report("  Placed macros            : {}", macros.size());
+  logger_->report("  Total macro area         : {:.3f} um^2", total_macro_area);
+  logger_->report("  Macro bounding-box area  : {:.3f} um^2", envelope_area);
+  logger_->report("  Dead space in bbox       : {:.3f} um^2", dead_space);
+  logger_->report("  Packing efficiency       : {:.1f} %",
+                  packing_efficiency * 100.0);
+  logger_->report("  Total design HPWL        : {:.3f} um", total_hpwl);
+  logger_->report("  Macro-net HPWL           : {:.3f} um ({} nets)",
+                  macro_net_hpwl,
+                  macro_net_count);
+  logger_->report("  Min boundary spacing     : {:.3f} um",
+                  min_boundary_spacing);
+  logger_->report("  Avg boundary spacing     : {:.3f} um",
+                  avg_boundary_spacing);
+  if (macros.size() > 1) {
+    if (overlap_pairs > 0) {
+      logger_->report(
+          "  Min macro-to-macro gap   : 0.000 um ({} overlapping "
+          "pair(s))",
+          overlap_pairs);
+    } else {
+      logger_->report("  Min macro-to-macro gap   : {:.3f} um",
+                      block->dbuToMicrons(min_macro_gap_dbu));
+    }
+  }
+
+  // --- Metrics for downstream tooling / regression checks. ---
+  logger_->metric("macro_place__num_macros", static_cast<int>(macros.size()));
+  logger_->metric("macro_place__macro_area_um2", total_macro_area);
+  logger_->metric("macro_place__packing_efficiency", packing_efficiency);
+  logger_->metric("macro_place__macro_net_hpwl_um", macro_net_hpwl);
+  logger_->metric("macro_place__min_boundary_spacing_um", min_boundary_spacing);
+
+  // --- Per-macro detail table. ---
+  logger_->report("");
+  logger_->report("  {:<28} {:>10} {:>10} {:>10} {:>10} {:>6} {:>12}",
+                  "Macro",
+                  "llx(um)",
+                  "lly(um)",
+                  "urx(um)",
+                  "ury(um)",
+                  "orient",
+                  "area(um^2)");
+  std::vector<odb::dbInst*> sorted_macros = macros;
+  std::sort(sorted_macros.begin(),
+            sorted_macros.end(),
+            [](odb::dbInst* a, odb::dbInst* b) {
+              return a->getName() < b->getName();
+            });
+  for (odb::dbInst* macro : sorted_macros) {
+    const odb::Rect bbox = macro->getBBox()->getBox();
+    const double area = static_cast<double>(bbox.area()) / dbu2;
+    logger_->report(
+        "  {:<28} {:>10.3f} {:>10.3f} {:>10.3f} {:>10.3f} {:>6} "
+        "{:>12.3f}",
+        macro->getName(),
+        block->dbuToMicrons(bbox.xMin()),
+        block->dbuToMicrons(bbox.yMin()),
+        block->dbuToMicrons(bbox.xMax()),
+        block->dbuToMicrons(bbox.yMax()),
+        macro->getOrient().getString(),
+        area);
+  }
+}
+
+}  // namespace mpl

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -46,6 +46,7 @@ COMPULSORY_TESTS = [
     "orientation_improve3",
     "placement_blockages1",
     "unfixed_cells_dont_fit_in_core",
+    "report_macro_placement1",
 ]
 
 ALL_TESTS = COMPULSORY_TESTS
@@ -227,6 +228,12 @@ filegroup(
                 "placement_blockages1": [
                     "testcases/macro_only.lef",
                     "testcases/placement_blockages1.def",
+                ],
+                "report_macro_placement1": [
+                    "testcases/macro_only.def",
+                    "testcases/macro_only.lef",
+                    "testcases/macro_only.lib",
+                    "testcases/macro_only.v",
                 ],
                 "unfixed_cells_dont_fit_in_core": [
                     "testcases/macro_only.lef",

--- a/src/mpl/test/CMakeLists.txt
+++ b/src/mpl/test/CMakeLists.txt
@@ -35,6 +35,7 @@ or_integration_tests(
     halos2
     halos3
     halos4
+    report_macro_placement1
 )
 
 

--- a/src/mpl/test/report_macro_placement1.ok
+++ b/src/mpl/test/report_macro_placement1.ok
@@ -1,0 +1,47 @@
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45_tech.lef, created 22 layers, 27 vias
+[INFO ODB-0227] LEF file: ./testcases/macro_only.lef, created 9 library cells
+[WARNING STA-1171] ./testcases/macro_only.lib line 32, default_max_transition is 0.0.
+[INFO ODB-0128] Design: macro_only
+[INFO ODB-0253]     Updated 10 components.
+Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 443.80)
+	Number of std cell instances: 0
+	Area of std cell instances: 0.00
+	Number of macros: 10
+	Macros to be placed: 10
+	Area of macros: 166000.00
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Area of macros with halos: 166000.00
+	Area of std cell instances + Area of macros: 166000.00
+	Floorplan area: 193441.58
+	Design Utilization: 0.86
+	Floorplan Utilization: 0.00
+	Manufacturing Grid: 10
+
+[WARNING MPL-0026] Design has no IO pins!
+[WARNING MPL-0025] Design has no standard cells!
+[WARNING MPL-0027] Design has only macros!
+Macro Placement Report
+======================
+  Placed macros            : 10
+  Total macro area         : 166000.000 um^2
+  Macro bounding-box area  : 172012.000 um^2
+  Dead space in bbox       : 6012.000 um^2
+  Packing efficiency       : 96.5 %
+  Total design HPWL        : 800.240 um
+  Macro-net HPWL           : 800.240 um (12 nets)
+  Min boundary spacing     : 0.000 um
+  Avg boundary spacing     : 51.877 um
+  Min macro-to-macro gap   : 0.000 um (2 overlapping pair(s))
+
+  Macro                           llx(um)    lly(um)    urx(um)    ury(um) orient   area(um^2)
+  U1                              304.940      4.245    404.940    434.245   R180    43000.000
+  U10                             104.940    104.315    204.940    204.315     MY    10000.000
+  U2                              204.940    204.205    304.940    304.205   R180    10000.000
+  U3                              204.940      4.215    304.940    104.215     MY    10000.000
+  U4                              204.940    304.305    304.940    404.305   R180    10000.000
+  U5                              204.940    104.315    304.940    204.315     MY    10000.000
+  U6                                4.940      4.245    104.940    434.245   R180    43000.000
+  U7                              104.940    204.205    204.940    304.205   R180    10000.000
+  U8                              104.940      4.215    204.940    104.215     MY    10000.000
+  U9                              104.940    304.305    204.940    404.305   R180    10000.000
+No differences found.

--- a/src/mpl/test/report_macro_placement1.tcl
+++ b/src/mpl/test/report_macro_placement1.tcl
@@ -1,0 +1,28 @@
+# Run macro placement and then the read-only report_macro_placement QoR
+# command. Verifies the report runs and produces the expected metrics on a
+# small all-macro design. report_macro_placement must NOT change placement.
+source "helpers.tcl"
+
+read_lef "./Nangate45/Nangate45_tech.lef"
+read_lef "./testcases/macro_only.lef"
+read_liberty "./testcases/macro_only.lib"
+
+read_verilog "./testcases/macro_only.v"
+link_design "macro_only"
+
+read_def "./testcases/macro_only.def" -floorplan_initialize
+
+set_thread_count 0
+rtl_macro_placer -report_directory [make_result_dir]
+
+# Snapshot the placement, run the report, and confirm the report did not
+# perturb the placement.
+set def_before [make_result_file report_macro_placement1_before.def]
+write_def $def_before
+
+report_macro_placement
+
+set def_after [make_result_file report_macro_placement1_after.def]
+write_def $def_after
+
+diff_files $def_before $def_after


### PR DESCRIPTION
## Summary

Two read-only, additive QoR reporting commands.

1. **`report_qor`** (dbSta) — aggregates metrics OpenROAD already computes (design size, area/utilization, setup/hold timing, power, clock skew, DRC marker counts) into one concise sign-off summary. Text and `-json` output, `-digits` option. Sections whose prerequisites are missing (no clock/liberty/parasitics) degrade gracefully to `n/a` (text) / `null` (JSON) and never error.
2. **`report_macro_placement`** (mpl) — read-only macro-placement QoR command.

Both recompute nothing and mutate no design/timing state; every reported value is the read side of an existing command/API.

## Testing

Built `openroad`; `report_qor1`, `report_qor_graceful`, and `report_macro_placement1` pass. (Updated the mpl golden for a `Macros to be placed:` info line added upstream since the bundle base.)

## Notes

- ⚠️ **Test-fixture dependency:** the `report_qor` regressions reuse the `aocv_derate.def` / `aocv_derate.sdc` design fixtures introduced by the dbSta timing-accuracy PR #10846. Those two files must be present for `report_qor1`/`report_qor_graceful` to run. Marked **draft** until that fixture lands (or I can repoint the tests to an existing design fixture if preferred).
- The third command from this internal set, `report_signoff_timing`, is intentionally **not** included here: it consolidates the advanced-timing features (SI Miller / SI-window / noise->delay / AOCV / POCV) and therefore depends on #10846 and #10853; it will follow as a stacked PR once those land.
- Both commands are read-only and additive; no default behavior change.