### PR TITLE
gpl: hoist loop-invariant accessors in getDensityGradient (bit-identical)

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -2859,11 +2859,14 @@ FloatPoint NesterovBase::getDensityGradient(const GCell* gCell) const
 
   FloatPoint electroForce;
 
+  const int bin_cnt_x = getBinCntX();
+  const auto& bins = bg_.getBinsConst();
+  const float scale = gCell->getDensityScale();
+
   for (int i = pairX.first; i < pairX.second; i++) {
     for (int j = pairY.first; j < pairY.second; j++) {
-      const Bin& bin = bg_.getBinsConst()[j * getBinCntX() + i];
-      float overlapArea
-          = getOverlapDensityArea(bin, gCell) * gCell->getDensityScale();
+      const Bin& bin = bins[j * bin_cnt_x + i];
+      float overlapArea = getOverlapDensityArea(bin, gCell) * scale;
 
       electroForce.x += overlapArea * bin.electroFieldX();
       electroForce.y += overlapArea * bin.electroFieldY();


### PR DESCRIPTION
## Summary

Hoist loop-invariant accessors out of the `getDensityGradient` inner loop in global placement. **Placed DEF is bit-identical (MD5 unchanged).**

Split out of #10849 as its own PR per review feedback (@gudeh) — that PR now contains only the detailed-placement (`src/dpl`) changes.

## Testing

Built `openroad`; gpl regression suite passes, placed DEF bit-identical to baseline.

## Notes
- Pure constant-factor optimization; no placement behavior change. No `src/sta` change.