### PR TITLE
cts: add -num_max_leaf_sinks knob and report_clock_tree QoR command

### DIFF
--- a/src/cts/README.md
+++ b/src/cts/README.md
@@ -131,6 +131,29 @@ report_cts
 | ----- | ----- |
 | `-out_file` | The file to save `cts` reports. If this parameter is omitted, the report is streamed to `stdout` and not saved. |
 
+### Report Clock Tree
+
+This command reports clock-tree quality-of-results (QoR) metrics after a
+successful `clock_tree_synthesis` run. It is read-only and does not modify the
+design. For each synthesized clock (and a combined total when there is more
+than one), it reports:
+- Number of sinks, clock buffers, clock nets and tree levels
+- Total clock-net wire length (microns)
+- Achieved insertion delay / clock latency (min, max, average) from STA
+- Achieved clock skew (max latency - min latency)
+- An estimate of clock switching power (with `-power`)
+
+```tcl
+report_clock_tree
+    [-power]
+```
+
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-power` | Also report an estimate of the clock-tree dynamic switching power. The estimate uses `P = C_load * Vdd^2 * f_clk`, where the load capacitance combines input-pin capacitance and an HPWL-based wire-cap proxy, `Vdd` is taken from the operating conditions, and `f_clk` is derived from the SDC clock period. |
+
 ### Set CTS configuration
 
 This command is used to set the configuration of CTS.

--- a/src/cts/README.md
+++ b/src/cts/README.md
@@ -59,6 +59,7 @@ clock_tree_synthesis
     [-balance_levels]
     [-sink_clustering_levels levels]
     [-num_static_layers]
+    [-num_max_leaf_sinks sinks]
     [-sink_clustering_buffer]
     [-obstruction_aware]
     [-apply_ndr strategy]
@@ -90,6 +91,7 @@ clock_tree_synthesis
 | `-balance_levels` | Attempt to keep a similar number of levels in the clock tree across non-register cells (e.g., clock-gate or inverter). The default value is `False`, and the allowed values are bool. |
 | `-clk_nets` | String containing the names of the clock roots. If this parameter is omitted, `cts` looks for the clock roots automatically. |
 | `-num_static_layers` | Set the number of static layers. The default value is `0`, and the allowed values are integers `[0, MAX_INT]`. |
+| `-num_max_leaf_sinks` | Maximum number of sinks per leaf sub-region used as the H-tree stop criterion. The H-tree keeps adding levels until the number of sinks per sub-region drops below this value. The default value is `15`, and the allowed values are positive integers `[1, MAX_INT]`. Lowering it produces a deeper H-tree with more buffers but tighter skew/latency balance; raising it produces a shallower tree with fewer buffers but looser balance. (A value larger than the root buffer's fanout limit is clamped to that limit.) |
 | `-sink_clustering_buffer` | Set the sink clustering buffer(s) to be used. |
 | `-obstruction_aware` | Enables obstruction-aware buffering such that clock buffers are not placed on top of blockages or hard macros. This option may reduce legalizer displacement, leading to better latency, skew or timing QoR.  The default value is `False`, and the allowed values are bool. |
 | `-apply_ndr` | Applies 2X spacing non-default rule to clock nets except leaf-level nets following some strategy. There are four strategy options: `none, root_only, half, full`. If this is not specified, the default value is `none`. |

--- a/src/cts/include/cts/TritonCTS.h
+++ b/src/cts/include/cts/TritonCTS.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
@@ -66,6 +67,11 @@ class TritonCTS
 
   void runTritonCts();
   void reportCtsMetrics();
+  // Additive, read-only post-CTS QoR analysis.  Walks the synthesized clock
+  // tree in the OpenDB and reports per-clock and total skew, insertion delay
+  // (latency), buffer/level counts, clock-net wire length and an estimate of
+  // clock switching power.  Does not modify the database.
+  void reportClockTree(bool report_power);
   CtsOptions* getParms() { return options_; }
   TechChar* getCharacterization() { return techChar_.get(); }
   odb::dbBlock* getBlock() { return db_->getChip()->getBlock(); }
@@ -213,6 +219,36 @@ class TritonCTS
                         ClockInst& dummyClock);
   void printClockNetwork(const Clock& clockNet) const;
   void setAllClocksPropagated();
+
+  // report_clock_tree helpers (read-only DB/STA analysis)
+  struct ClockTreeReport
+  {
+    std::string clock_name;
+    odb::dbNet* root_net = nullptr;
+    unsigned num_sinks = 0;
+    unsigned num_buffers = 0;
+    unsigned num_clock_nets = 0;
+    int max_level = 0;
+    double wire_length_um = 0.0;  // total clock-net wire length (um)
+    double total_load_cap = 0.0;  // sum of pin + estimated wire cap (F)
+    float min_latency = std::numeric_limits<float>::max();
+    float max_latency = std::numeric_limits<float>::lowest();
+    double sum_latency = 0.0;
+    unsigned latency_samples = 0;
+    bool has_latency = false;
+    float clock_period = 0.0;  // seconds, from SDC (0 if unknown)
+    // >=0 means the switching power was precomputed (per-clock sum, used for
+    // the multi-clock totals); <0 means compute it from cap * vdd^2 * f.
+    double switching_power = -1.0;
+  };
+  void collectClockTreeReport(odb::dbNet* root_net,
+                              const std::string& clock_name,
+                              float clock_period,
+                              ClockTreeReport& report);
+  float getSinkClkArrival(odb::dbITerm* sink_iterm, odb::dbNet* root_net);
+  double clockOperatingVoltage();
+  double clockSwitchingPower(const ClockTreeReport& report, double vdd);
+  void emitClockTreeReport(const ClockTreeReport& report, bool report_power);
   void repairClockNets();
   void balanceMacroRegisterLatencies();
 

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -22,6 +22,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -47,12 +48,16 @@
 #include "sta/Graph.hh"
 #include "sta/GraphDelayCalc.hh"
 #include "sta/Liberty.hh"
+#include "sta/MinMax.hh"
 #include "sta/Mode.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/PathEnd.hh"
+#include "sta/Path.hh"
+#include "sta/PathExpanded.hh"
 #include "sta/PatternMatch.hh"
 #include "sta/Sdc.hh"
+#include "sta/Units.hh"
 #include "stt/SteinerTreeBuilder.h"
 #include "utl/Logger.h"
 #include "utl/timer.h"
@@ -623,6 +628,375 @@ void TritonCTS::reportCtsMetrics()
         logger_->report("  {}: {}", master->getName(), count);
       }
     }
+  }
+}
+
+//----------------------------------------------------------------------------
+// report_clock_tree: additive, read-only post-CTS QoR analysis.
+//
+// Operates entirely on the OpenDB clock network and OpenSTA timing graph.  It
+// does NOT use the in-memory builders_ (which are cleared after
+// runTritonCts()), nor does it modify the database, so it can be invoked any
+// time after clock_tree_synthesis (or on a restored .odb).
+//----------------------------------------------------------------------------
+
+// Find the rising/max clock arrival at a sink input pin, restricted to paths
+// whose clock network originates at root_net.  Same technique as
+// LatencyBalancer::getVertexClkArrival, but tolerant of missing paths.
+float TritonCTS::getSinkClkArrival(odb::dbITerm* sink_iterm,
+                                   odb::dbNet* root_net)
+{
+  sta::Pin* pin = network_->dbToSta(sink_iterm);
+  if (pin == nullptr) {
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+  sta::Graph* graph = openSta_->ensureGraph();
+  sta::Vertex* vertex = graph->pinDrvrVertex(pin);
+  if (vertex == nullptr) {
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+
+  sta::VertexPathIterator path_iter(vertex, openSta_);
+  while (path_iter.hasNext()) {
+    sta::Path* path = path_iter.next();
+    const sta::ClockEdge* clock_edge = path->clkEdge(openSta_);
+    if (clock_edge == nullptr) {
+      continue;
+    }
+    if (clock_edge->transition() != sta::RiseFall::rise()) {
+      continue;
+    }
+    if (path->minMax(openSta_) != sta::MinMax::max()) {
+      continue;
+    }
+    if (path->clock(openSta_) == nullptr) {
+      continue;
+    }
+    sta::PathExpanded expand(path, openSta_);
+    const sta::Path* start = expand.startPath();
+    if (start == nullptr) {
+      continue;
+    }
+    odb::dbITerm* term = nullptr;
+    odb::dbBTerm* port = nullptr;
+    odb::dbModITerm* modIterm = nullptr;
+    network_->staToDb(start->pin(openSta_), term, port, modIterm);
+    odb::dbNet* start_net = nullptr;
+    if (term) {
+      start_net = term->getNet();
+    } else if (port) {
+      start_net = port->getNet();
+    }
+    if (start_net == root_net) {
+      return path->arrival();
+    }
+  }
+  return std::numeric_limits<float>::quiet_NaN();
+}
+
+// Walk the clock network rooted at root_net, accumulating structural and
+// timing metrics.  Buffers are clock instances with an output that drives
+// another clock net; sinks are clock instances whose input is a leaf (no clock
+// output) -- the same notion used by countSinksPostDbWrite.
+void TritonCTS::collectClockTreeReport(odb::dbNet* root_net,
+                                       const std::string& clock_name,
+                                       float clock_period,
+                                       ClockTreeReport& report)
+{
+  report.clock_name = clock_name;
+  report.root_net = root_net;
+  report.clock_period = clock_period;
+
+  const double dbu = block_ ? block_->getDbUnitsPerMicron()
+                            : db_->getChip()->getBlock()->getDbUnitsPerMicron();
+
+  // Capacitance per dbu of clock wire (farads/dbu) for wire-cap estimate.
+  double cap_per_dbu = 0.0;
+  sta::Scene* corner = openSta_->cmdScene();
+  if (corner != nullptr && estimate_parasitics_ != nullptr) {
+    cap_per_dbu = estimate_parasitics_->wireClkCapacitance(corner) * 1e-6 / dbu;
+  }
+
+  std::unordered_set<odb::dbNet*> visited;
+  std::vector<odb::dbNet*> stack;
+  stack.push_back(root_net);
+  std::unordered_set<odb::dbInst*> counted_buffers;
+
+  // BFS/DFS over the clock-signal nets.  level is tracked per net.
+  std::unordered_map<odb::dbNet*, int> net_level;
+  net_level[root_net] = 0;
+
+  while (!stack.empty()) {
+    odb::dbNet* net = stack.back();
+    stack.pop_back();
+    if (net == nullptr || !visited.insert(net).second) {
+      continue;
+    }
+    if (net->getSigType() != odb::dbSigType::CLOCK) {
+      continue;
+    }
+    report.num_clock_nets++;
+    const int level = net_level[net];
+    report.max_level = std::max(report.max_level, level);
+
+    // Wire length of this clock net (HPWL of its pins, in um) as a wire-length
+    // and wire-cap proxy.  (CTS does not route, so HPWL is the standard proxy.)
+    int min_x = std::numeric_limits<int>::max();
+    int min_y = std::numeric_limits<int>::max();
+    int max_x = std::numeric_limits<int>::lowest();
+    int max_y = std::numeric_limits<int>::lowest();
+    bool has_pin = false;
+    for (odb::dbITerm* iterm : net->getITerms()) {
+      int x, y;
+      iterm->getAvgXY(&x, &y);
+      min_x = std::min(min_x, x);
+      min_y = std::min(min_y, y);
+      max_x = std::max(max_x, x);
+      max_y = std::max(max_y, y);
+      has_pin = true;
+    }
+    double net_wl_dbu = 0.0;
+    if (has_pin) {
+      net_wl_dbu = (max_x - min_x) + (max_y - min_y);
+      report.wire_length_um += net_wl_dbu / dbu;
+    }
+    report.total_load_cap += net_wl_dbu * cap_per_dbu;
+
+    // Classify each input pin on this net.
+    for (odb::dbITerm* iterm : net->getITerms()) {
+      if (iterm->getIoType() != odb::dbIoType::INPUT) {
+        continue;
+      }
+      odb::dbInst* inst = iterm->getInst();
+      odb::dbITerm* out = inst->getFirstOutput();
+      odb::dbNet* out_net = out ? out->getNet() : nullptr;
+      const bool drives_clock
+          = out_net != nullptr && out_net != net
+            && out_net->getSigType() == odb::dbSigType::CLOCK;
+
+      // Accumulate input-pin capacitance into the driving net's load.
+      report.total_load_cap += getInputPinCap(iterm);
+
+      if (drives_clock) {
+        // This is a clock-tree buffer/inverter: descend.
+        if (counted_buffers.insert(inst).second) {
+          report.num_buffers++;
+        }
+        if (visited.find(out_net) == visited.end()) {
+          net_level[out_net] = level + 1;
+          stack.push_back(out_net);
+        }
+      } else {
+        // Leaf sink pin.
+        report.num_sinks++;
+        const float arrival = getSinkClkArrival(iterm, root_net);
+        if (!std::isnan(arrival)) {
+          report.has_latency = true;
+          report.min_latency = std::min(report.min_latency, arrival);
+          report.max_latency = std::max(report.max_latency, arrival);
+          report.sum_latency += arrival;
+          report.latency_samples++;
+        }
+      }
+    }
+  }
+}
+
+// Operating Vdd for the clock switching-power estimate: SDC operating
+// conditions if set, else the liberty default / nominal voltage. 0 if unknown.
+double TritonCTS::clockOperatingVoltage()
+{
+  const sta::Pvt* pvt
+      = openSta_->cmdMode()->sdc()->operatingConditions(sta::MinMax::max());
+  double vdd = (pvt != nullptr) ? pvt->voltage() : 0.0;
+  if (vdd <= 0.0) {
+    sta::LibertyLibrary* lib = network_->defaultLibertyLibrary();
+    if (lib != nullptr) {
+      sta::OperatingConditions* op = lib->defaultOperatingConditions();
+      if (op != nullptr && op->voltage() > 0.0) {
+        vdd = op->voltage();
+      } else if (lib->nominalVoltage() > 0.0) {
+        vdd = lib->nominalVoltage();
+      }
+    }
+  }
+  return vdd;
+}
+
+// Dynamic clock switching power P = C_load * Vdd^2 * f_clk for one clock tree.
+// A clock node toggles every cycle, so per-cycle energy is C*Vdd^2. This is an
+// ESTIMATE (C_load combines pin cap and an HPWL wire-cap proxy). <0 if inputs
+// are unavailable.
+double TritonCTS::clockSwitchingPower(const ClockTreeReport& report, double vdd)
+{
+  if (vdd > 0.0 && report.clock_period > 0.0 && report.total_load_cap > 0.0) {
+    return report.total_load_cap * vdd * vdd / report.clock_period;
+  }
+  return -1.0;
+}
+
+void TritonCTS::emitClockTreeReport(const ClockTreeReport& report,
+                                    bool report_power)
+{
+  const sta::Unit* time_unit = openSta_->units()->timeUnit();
+  // scaleSuffix() yields e.g. "1ns"; drop the leading scale digit so we print
+  // a conventional "0.056 ns" rather than "0.056 1ns".
+  auto unit_suffix = [](const sta::Unit* unit) {
+    std::string s = unit->scaleSuffix();
+    if (!s.empty() && s[0] == '1') {
+      s.erase(0, 1);
+    }
+    return s;
+  };
+  const std::string time_suffix = unit_suffix(time_unit);
+  auto fmt_time = [&](double t) {
+    return time_unit->asString(static_cast<float>(t), 3) + " " + time_suffix;
+  };
+
+  if (report.root_net != nullptr) {
+    logger_->report("Clock tree report for \"{}\" (net {})",
+                    report.clock_name,
+                    report.root_net->getName());
+  } else {
+    logger_->report("Clock tree report for \"{}\"", report.clock_name);
+  }
+  logger_->report("  Sinks:              {}", report.num_sinks);
+  logger_->report("  Clock buffers:      {}", report.num_buffers);
+  logger_->report("  Clock nets:         {}", report.num_clock_nets);
+  logger_->report("  Tree levels:        {}", report.max_level);
+  logger_->report("  Clock wire length:  {:.2f} um", report.wire_length_um);
+
+  if (report.has_latency && report.latency_samples > 0) {
+    const double avg = report.sum_latency / report.latency_samples;
+    const double skew = report.max_latency - report.min_latency;
+    logger_->report("  Insertion delay (latency):");
+    logger_->report("    min: {}", fmt_time(report.min_latency));
+    logger_->report("    max: {}", fmt_time(report.max_latency));
+    logger_->report("    avg: {}", fmt_time(avg));
+    logger_->report("  Clock skew (max-min): {}", fmt_time(skew));
+  } else {
+    logger_->report(
+        "  Insertion delay / skew: not available (run a timing-aware flow"
+        " with clock defined; STA found no clock paths to the sinks).");
+  }
+
+  if (report_power) {
+    const sta::Unit* power_unit = openSta_->units()->powerUnit();
+    if (report.switching_power >= 0.0) {
+      // Multi-clock totals: sum of each clock's own P = C_i * Vdd^2 * f_i,
+      // so clocks at different frequencies are accounted for correctly (a
+      // single aggregate frequency would misestimate the total).
+      logger_->report(
+          "  Estimated clock switching power: {} {} (sum over clocks, "
+          "Cload={:.4g} pF)",
+          power_unit->asString(static_cast<float>(report.switching_power), 3),
+          unit_suffix(power_unit),
+          report.total_load_cap * 1e12);
+    } else {
+      const double vdd = clockOperatingVoltage();
+      const double power = clockSwitchingPower(report, vdd);
+      if (power >= 0.0) {
+        const double freq = 1.0 / report.clock_period;  // Hz
+        logger_->report(
+            "  Estimated clock switching power: {} {} (Vdd={:.3f} V, "
+            "f={:.3f} GHz, Cload={:.4g} pF)",
+            power_unit->asString(static_cast<float>(power), 3),
+            unit_suffix(power_unit),
+            vdd,
+            freq / 1e9,
+            report.total_load_cap * 1e12);
+      } else {
+        logger_->report(
+            "  Estimated clock switching power: not available (need clock"
+            " period from SDC, Vdd from operating conditions, and load cap).");
+      }
+    }
+  }
+}
+
+void TritonCTS::reportClockTree(bool report_power)
+{
+  odb::dbChip* chip = db_->getChip();
+  if (chip == nullptr) {
+    logger_->error(CTS, 253, "No design loaded for report_clock_tree.");
+  }
+  block_ = chip->getBlock();
+  if (block_ == nullptr) {
+    logger_->error(CTS, 250, "No design loaded for report_clock_tree.");
+  }
+
+  // Ensure the timing graph and clock network are built and arrivals are
+  // current, so the clock-arrival queries below have data to read.  This is
+  // read-only with respect to the design (it only updates STA's internal
+  // timing state), mirroring LatencyBalancer::initSta().
+  openSta_->ensureGraph();
+  for (auto mode : openSta_->modes()) {
+    openSta_->ensureClkNetwork(mode);
+  }
+  openSta_->updateTiming(false);
+
+  // Build a map of clock root net -> (sdc clock name, period) from the SDC.
+  sta::Sdc* sdc = openSta_->cmdMode()->sdc();
+  std::vector<odb::dbNet*> skip_nets = options_->getSkipNets();
+
+  unsigned reported = 0;
+  ClockTreeReport totals;
+  totals.clock_name = "ALL CLOCKS";
+
+  for (sta::Clock* clk : sdc->clocks()) {
+    odb::PtrSet<odb::dbNet> clock_nets;
+    findClockRoots(clk, clock_nets);
+    for (odb::dbNet* root_net : clock_nets) {
+      if (root_net == nullptr) {
+        continue;
+      }
+      if (std::ranges::find(skip_nets, root_net) != skip_nets.end()) {
+        continue;
+      }
+      ClockTreeReport report;
+      collectClockTreeReport(root_net, clk->name(), clk->period(), report);
+      if (report.num_sinks == 0 && report.num_buffers == 0) {
+        continue;
+      }
+      emitClockTreeReport(report, report_power);
+      reported++;
+
+      // Accumulate into totals.
+      totals.num_sinks += report.num_sinks;
+      totals.num_buffers += report.num_buffers;
+      totals.num_clock_nets += report.num_clock_nets;
+      totals.max_level = std::max(totals.max_level, report.max_level);
+      totals.wire_length_um += report.wire_length_um;
+      totals.total_load_cap += report.total_load_cap;
+      if (report.has_latency) {
+        totals.has_latency = true;
+        totals.min_latency = std::min(totals.min_latency, report.min_latency);
+        totals.max_latency = std::max(totals.max_latency, report.max_latency);
+        totals.sum_latency += report.sum_latency;
+        totals.latency_samples += report.latency_samples;
+      }
+      totals.clock_period = std::max(totals.clock_period, report.clock_period);
+      // Sum each clock's own switching power (correct across mixed frequencies).
+      const double clk_power
+          = clockSwitchingPower(report, clockOperatingVoltage());
+      if (clk_power >= 0.0) {
+        totals.switching_power
+            = (totals.switching_power < 0.0 ? 0.0 : totals.switching_power)
+              + clk_power;
+      }
+    }
+  }
+
+  if (reported == 0) {
+    logger_->warn(CTS,
+                  251,
+                  "report_clock_tree found no synthesized clock tree. Run "
+                  "clock_tree_synthesis first.");
+    return;
+  }
+
+  if (reported > 1) {
+    emitClockTreeReport(totals, report_power);
   }
 }
 

--- a/src/cts/src/TritonCTS.i
+++ b/src/cts/src/TritonCTS.i
@@ -131,6 +131,12 @@ report_cts_metrics()
 }
 
 void
+report_clock_tree(bool report_power)
+{
+  getTritonCts()->reportClockTree(report_power);
+}
+
+void
 set_tree_buf(const char* buffer)
 {
   getTritonCts()->getParms()->setTreeBuffer(buffer);

--- a/src/cts/src/TritonCTS.i
+++ b/src/cts/src/TritonCTS.i
@@ -193,6 +193,12 @@ set_num_static_layers(unsigned num)
 }
 
 void
+set_num_max_leaf_sinks(unsigned num)
+{
+  getTritonCts()->getParms()->setNumMaxLeafSinks(num);
+}
+
+void
 set_sink_buffer(const char* buffer)
 {
   getTritonCts()->setSinkBuffer(buffer);
@@ -344,6 +350,12 @@ unsigned
 get_num_static_layers()
 {
   return getTritonCts()->getParms()->getNumStaticLayers();
+}
+
+unsigned
+get_num_max_leaf_sinks()
+{
+  return getTritonCts()->getParms()->getNumMaxLeafSinks();
 }
 
 std::string

--- a/src/cts/src/TritonCTS.tcl
+++ b/src/cts/src/TritonCTS.tcl
@@ -614,6 +614,18 @@ proc report_cts { args } {
   cts::report_cts_metrics
 }
 
+sta::define_cmd_args "report_clock_tree" {[-power]}
+
+proc report_clock_tree { args } {
+  sta::parse_key_args "report_clock_tree" args \
+    keys {} flags {-power}
+
+  sta::check_argc_eq0 "report_clock_tree" $args
+
+  set report_power [info exists flags(-power)]
+  cts::report_clock_tree $report_power
+}
+
 namespace eval cts {
 proc clock_tree_synthesis_debug { args } {
   sta::parse_key_args "clock_tree_synthesis_debug" args \

--- a/src/cts/src/TritonCTS.tcl
+++ b/src/cts/src/TritonCTS.tcl
@@ -397,6 +397,7 @@ sta::define_cmd_args "clock_tree_synthesis" {[-wire_unit unit]
                                              [-balance_levels] \
                                              [-sink_clustering_levels levels] \
                                              [-num_static_layers] \
+                                             [-num_max_leaf_sinks sinks] \
                                              [-sink_clustering_buffer] \
                                              [-obstruction_aware] \
                                              [-no_obstruction_aware] \
@@ -413,6 +414,7 @@ proc clock_tree_synthesis { args } {
   sta::parse_key_args "clock_tree_synthesis" args \
     keys {-root_buf -buf_list -wire_unit -clk_nets -sink_clustering_size \
           -num_static_layers -sink_clustering_buffer \
+          -num_max_leaf_sinks \
           -distance_between_buffers -branching_point_buffers_distance \
           -clustering_exponent \
           -clustering_unbalance_ratio -sink_clustering_max_diameter \
@@ -469,6 +471,14 @@ proc clock_tree_synthesis { args } {
   if { [info exists keys(-num_static_layers)] } {
     set num $keys(-num_static_layers)
     cts::set_num_static_layers $num
+  }
+
+  if { [info exists keys(-num_max_leaf_sinks)] } {
+    set num_max_leaf_sinks $keys(-num_max_leaf_sinks)
+    if { ![string is integer -strict $num_max_leaf_sinks] || $num_max_leaf_sinks < 1 } {
+      utl::error CTS 252 "-num_max_leaf_sinks must be a positive integer."
+    }
+    cts::set_num_max_leaf_sinks $num_max_leaf_sinks
   }
 
   if { [info exists keys(-distance_between_buffers)] } {

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -43,6 +43,8 @@ COMPULSORY_TESTS = [
     "max_cap",
     "no_clocks",
     "no_sinks",
+    "num_max_leaf_sinks",
+    "num_max_leaf_sinks_default",
     "post_cts_opt",
     "simple_test",
     "simple_test_clustered",
@@ -195,6 +197,12 @@ filegroup(
             ],
             "no_clocks": [
                 "no_clock.def",
+            ],
+            "num_max_leaf_sinks": [
+                "16sinks.def",
+            ],
+            "num_max_leaf_sinks_default": [
+                "16sinks.def",
             ],
             "post_cts_opt": [
                 "cts-helpers.tcl",

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -43,6 +43,7 @@ COMPULSORY_TESTS = [
     "max_cap",
     "no_clocks",
     "no_sinks",
+    "report_clock_tree",
     "num_max_leaf_sinks",
     "num_max_leaf_sinks_default",
     "post_cts_opt",
@@ -206,6 +207,9 @@ filegroup(
             ],
             "post_cts_opt": [
                 "cts-helpers.tcl",
+            ],
+            "report_clock_tree": [
+                "16sinks.def",
             ],
             "simple_test": [
                 "16sinks.def",

--- a/src/cts/test/CMakeLists.txt
+++ b/src/cts/test/CMakeLists.txt
@@ -38,6 +38,8 @@ or_integration_tests(
     max_cap
     no_clocks
     no_sinks
+    num_max_leaf_sinks
+    num_max_leaf_sinks_default
     post_cts_opt
     simple_test
     simple_test_clustered

--- a/src/cts/test/CMakeLists.txt
+++ b/src/cts/test/CMakeLists.txt
@@ -38,6 +38,7 @@ or_integration_tests(
     max_cap
     no_clocks
     no_sinks
+    report_clock_tree
     num_max_leaf_sinks
     num_max_leaf_sinks_default
     post_cts_opt

--- a/src/cts/test/cts_readme_msgs_check.ok
+++ b/src/cts/test/cts_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 6,        Desc: 6,        Syn: 6,        Options: 6,        Args: 6
+Names: 7,        Desc: 7,        Syn: 7,        Options: 7,        Args: 7
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.

--- a/src/cts/test/num_max_leaf_sinks.ok
+++ b/src/cts/test/num_max_leaf_sinks.ok
@@ -1,0 +1,64 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: test_16_sinks
+[INFO ODB-0130]     Created 1 pins.
+[INFO ODB-0131]     Created 16 components and 96 component-terminals.
+[INFO ODB-0133]     Created 1 nets and 16 connections.
+[INFO CTS-0050] Root buffer is CLKBUF_X3.
+[INFO CTS-0051] Sink buffer is CLKBUF_X3.
+[INFO CTS-0052] The following clock buffers will be used for CTS:
+                    CLKBUF_X3
+[INFO CTS-0049] Characterization buffer is CLKBUF_X3.
+[INFO CTS-0007] Net "clk" found for clock "clk".
+[INFO CTS-0010]  Clock net "clk" has 16 sinks.
+[INFO CTS-0008] TritonCTS found 1 clock nets.
+[INFO CTS-0097] Characterization used 1 buffer(s) types.
+[INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
+[INFO CTS-0027] Generating H-Tree topology for net clk.
+[INFO CTS-0028]  Total number of sinks: 16.
+[INFO CTS-0030]  Number of static layers: 0.
+[INFO CTS-0020]  Wire segment unit: 14000  dbu (7 um).
+[INFO CTS-0023]  Original sink region: [(3730, 1730), (22730, 20730)].
+[INFO CTS-0024]  Normalized sink region: [(0.266429, 0.123571), (1.62357, 1.48071)].
+[INFO CTS-0025]     Width:  1.3571.
+[INFO CTS-0026]     Height: 1.3571.
+ Level 1
+    Direction: Vertical
+    Sinks per sub-region: 8
+    Sub-region size: 1.3571 X 0.6786
+[INFO CTS-0034]     Segment length (rounded): 1.
+ Level 2
+    Direction: Horizontal
+    Sinks per sub-region: 4
+    Sub-region size: 0.6786 X 0.6786
+[INFO CTS-0034]     Segment length (rounded): 1.
+ Level 3
+    Direction: Vertical
+    Sinks per sub-region: 2
+    Sub-region size: 0.6786 X 0.3393
+[INFO CTS-0034]     Segment length (rounded): 1.
+[INFO CTS-0032]  Stop criterion found. Max number of sinks is 4.
+[INFO CTS-0035]  Number of sinks covered: 16.
+[INFO CTS-0018]     Created 9 clock buffers.
+[INFO CTS-0012]     Minimum number of buffers in the clock path: 2.
+[INFO CTS-0013]     Maximum number of buffers in the clock path: 2.
+[INFO CTS-0015]     Created 9 clock nets.
+[INFO CTS-0016]     Fanout distribution for the current clock = 2:8..
+[INFO CTS-0017]     Max level of the clock tree: 3.
+[INFO CTS-0098] Clock net "clk"
+[INFO CTS-0099]  Sinks 16
+[INFO CTS-0100]  Leaf buffers 0
+[INFO CTS-0101]  Average sink wire length 19.38 um
+[INFO CTS-0102]  Path depth 2 - 2
+[INFO CTS-0207]  Dummy loads inserted 0
+Effective num_max_leaf_sinks = 4
+Clock tree report for "clk" (net clk)
+  Sinks:              16
+  Clock buffers:      9
+  Clock nets:         10
+  Tree levels:        2
+  Clock wire length:  71.92 um
+  Insertion delay (latency):
+    min: 0.061 ns
+    max: 0.061 ns
+    avg: 0.061 ns
+  Clock skew (max-min): 0.000 ns

--- a/src/cts/test/num_max_leaf_sinks.tcl
+++ b/src/cts/test/num_max_leaf_sinks.tcl
@@ -1,0 +1,27 @@
+# Opt-in path for the -num_max_leaf_sinks knob.
+#
+# The H-tree stop criterion keeps adding levels until the number of sinks
+# per sub-region drops below num_max_leaf_sinks.  Lowering it below the
+# default (15) forces a deeper H-tree with more branch buffers and a
+# tighter (more uniform) latency balance.  On 16sinks.def the default
+# stops at level 1 (3 buffers); -num_max_leaf_sinks 4 grows the tree to
+# level 3 (9 buffers).  See num_max_leaf_sinks_default.tcl for the proof
+# that the default (knob unset) reproduces the baseline tree exactly.
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_def "16sinks.def"
+
+create_clock -period 5 clk
+
+set_wire_rc -clock -layer metal3
+
+set_cts_config -wire_unit 20 \
+  -root_buf CLKBUF_X3 \
+  -buf_list CLKBUF_X3
+
+clock_tree_synthesis -num_max_leaf_sinks 4
+
+puts "Effective num_max_leaf_sinks = [cts::get_num_max_leaf_sinks]"
+
+report_clock_tree

--- a/src/cts/test/num_max_leaf_sinks_default.ok
+++ b/src/cts/test/num_max_leaf_sinks_default.ok
@@ -1,0 +1,54 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: test_16_sinks
+[INFO ODB-0130]     Created 1 pins.
+[INFO ODB-0131]     Created 16 components and 96 component-terminals.
+[INFO ODB-0133]     Created 1 nets and 16 connections.
+[INFO CTS-0050] Root buffer is CLKBUF_X3.
+[INFO CTS-0051] Sink buffer is CLKBUF_X3.
+[INFO CTS-0052] The following clock buffers will be used for CTS:
+                    CLKBUF_X3
+[INFO CTS-0049] Characterization buffer is CLKBUF_X3.
+[INFO CTS-0007] Net "clk" found for clock "clk".
+[INFO CTS-0010]  Clock net "clk" has 16 sinks.
+[INFO CTS-0008] TritonCTS found 1 clock nets.
+[INFO CTS-0097] Characterization used 1 buffer(s) types.
+[INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
+[INFO CTS-0027] Generating H-Tree topology for net clk.
+[INFO CTS-0028]  Total number of sinks: 16.
+[INFO CTS-0030]  Number of static layers: 0.
+[INFO CTS-0020]  Wire segment unit: 14000  dbu (7 um).
+[INFO CTS-0023]  Original sink region: [(3730, 1730), (22730, 20730)].
+[INFO CTS-0024]  Normalized sink region: [(0.266429, 0.123571), (1.62357, 1.48071)].
+[INFO CTS-0025]     Width:  1.3571.
+[INFO CTS-0026]     Height: 1.3571.
+ Level 1
+    Direction: Vertical
+    Sinks per sub-region: 8
+    Sub-region size: 1.3571 X 0.6786
+[INFO CTS-0034]     Segment length (rounded): 1.
+[INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
+[INFO CTS-0035]  Number of sinks covered: 16.
+[INFO CTS-0018]     Created 3 clock buffers.
+[INFO CTS-0012]     Minimum number of buffers in the clock path: 2.
+[INFO CTS-0013]     Maximum number of buffers in the clock path: 2.
+[INFO CTS-0015]     Created 3 clock nets.
+[INFO CTS-0016]     Fanout distribution for the current clock = 8:2..
+[INFO CTS-0017]     Max level of the clock tree: 1.
+[INFO CTS-0098] Clock net "clk"
+[INFO CTS-0099]  Sinks 16
+[INFO CTS-0100]  Leaf buffers 0
+[INFO CTS-0101]  Average sink wire length 18.87 um
+[INFO CTS-0102]  Path depth 2 - 2
+[INFO CTS-0207]  Dummy loads inserted 0
+Effective num_max_leaf_sinks = 15
+Clock tree report for "clk" (net clk)
+  Sinks:              16
+  Clock buffers:      3
+  Clock nets:         4
+  Tree levels:        2
+  Clock wire length:  46.52 um
+  Insertion delay (latency):
+    min: 0.056 ns
+    max: 0.056 ns
+    avg: 0.056 ns
+  Clock skew (max-min): 0.000 ns

--- a/src/cts/test/num_max_leaf_sinks_default.tcl
+++ b/src/cts/test/num_max_leaf_sinks_default.tcl
@@ -1,0 +1,24 @@
+# Default-safety check for the -num_max_leaf_sinks knob.
+#
+# When the option is NOT passed, the effective threshold stays at the
+# existing default (15) and CTS must produce the identical baseline tree
+# (3 buffers, H-tree level 1 on 16sinks.def) -- i.e. the new knob is
+# additive and changes nothing unless explicitly opted into.
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_def "16sinks.def"
+
+create_clock -period 5 clk
+
+set_wire_rc -clock -layer metal3
+
+set_cts_config -wire_unit 20 \
+  -root_buf CLKBUF_X3 \
+  -buf_list CLKBUF_X3
+
+clock_tree_synthesis
+
+puts "Effective num_max_leaf_sinks = [cts::get_num_max_leaf_sinks]"
+
+report_clock_tree

--- a/src/cts/test/report_clock_tree.ok
+++ b/src/cts/test/report_clock_tree.ok
@@ -1,0 +1,54 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: test_16_sinks
+[INFO ODB-0130]     Created 1 pins.
+[INFO ODB-0131]     Created 16 components and 96 component-terminals.
+[INFO ODB-0133]     Created 1 nets and 16 connections.
+[INFO CTS-0050] Root buffer is CLKBUF_X3.
+[INFO CTS-0051] Sink buffer is CLKBUF_X3.
+[INFO CTS-0052] The following clock buffers will be used for CTS:
+                    CLKBUF_X3
+[INFO CTS-0049] Characterization buffer is CLKBUF_X3.
+[INFO CTS-0007] Net "clk" found for clock "clk".
+[INFO CTS-0010]  Clock net "clk" has 16 sinks.
+[INFO CTS-0008] TritonCTS found 1 clock nets.
+[INFO CTS-0097] Characterization used 1 buffer(s) types.
+[INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
+[INFO CTS-0027] Generating H-Tree topology for net clk.
+[INFO CTS-0028]  Total number of sinks: 16.
+[INFO CTS-0030]  Number of static layers: 0.
+[INFO CTS-0020]  Wire segment unit: 14000  dbu (7 um).
+[INFO CTS-0023]  Original sink region: [(3730, 1730), (22730, 20730)].
+[INFO CTS-0024]  Normalized sink region: [(0.266429, 0.123571), (1.62357, 1.48071)].
+[INFO CTS-0025]     Width:  1.3571.
+[INFO CTS-0026]     Height: 1.3571.
+ Level 1
+    Direction: Vertical
+    Sinks per sub-region: 8
+    Sub-region size: 1.3571 X 0.6786
+[INFO CTS-0034]     Segment length (rounded): 1.
+[INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
+[INFO CTS-0035]  Number of sinks covered: 16.
+[INFO CTS-0018]     Created 3 clock buffers.
+[INFO CTS-0012]     Minimum number of buffers in the clock path: 2.
+[INFO CTS-0013]     Maximum number of buffers in the clock path: 2.
+[INFO CTS-0015]     Created 3 clock nets.
+[INFO CTS-0016]     Fanout distribution for the current clock = 8:2..
+[INFO CTS-0017]     Max level of the clock tree: 1.
+[INFO CTS-0098] Clock net "clk"
+[INFO CTS-0099]  Sinks 16
+[INFO CTS-0100]  Leaf buffers 0
+[INFO CTS-0101]  Average sink wire length 18.87 um
+[INFO CTS-0102]  Path depth 2 - 2
+[INFO CTS-0207]  Dummy loads inserted 0
+Clock tree report for "clk" (net clk)
+  Sinks:              16
+  Clock buffers:      3
+  Clock nets:         4
+  Tree levels:        2
+  Clock wire length:  46.52 um
+  Insertion delay (latency):
+    min: 0.056 ns
+    max: 0.056 ns
+    avg: 0.056 ns
+  Clock skew (max-min): 0.000 ns
+  Estimated clock switching power: 5297.105 nW (Vdd=1.100 V, f=0.200 GHz, Cload=0.02189 pF)

--- a/src/cts/test/report_clock_tree.tcl
+++ b/src/cts/test/report_clock_tree.tcl
@@ -1,0 +1,19 @@
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_def "16sinks.def"
+
+create_clock -period 5 clk
+
+set_wire_rc -clock -layer metal3
+
+set_cts_config -wire_unit 20 \
+  -root_buf CLKBUF_X3 \
+  -buf_list CLKBUF_X3
+
+clock_tree_synthesis
+
+# New additive, read-only QoR report.  Reports sinks, buffers, levels,
+# clock-net wire length, achieved insertion delay (latency) min/max/avg,
+# clock skew, and an estimate of clock switching power.
+report_clock_tree -power


### PR DESCRIPTION
## Summary

Split out of #10850 per review feedback (@arthurjolo) — that PR now contains only the CTS speedups. This PR carries the two additive command/knob changes:

1. **`-num_max_leaf_sinks`** knob on `clock_tree_synthesis`.
2. **`report_clock_tree`** — read-only post-CTS QoR report (sinks, buffers, levels, wirelength, latency, skew, and an estimated clock switching power).

## Review fixes
- Multi-clock switching-power estimate now **sums each clock's own `C*Vdd^2*f`** instead of aggregating capacitance and applying a single (min) frequency, so mixed-frequency clocks are accounted for correctly (addresses gemini's comment on the totals power basis).

## Testing

Built `openroad`; full **cts regression suite passes (57/57)**, including `report_clock_tree`.

## Notes
- Both additive / read-only / opt-in; no default behavior change. No `src/sta` change.