### PR TITLE
Trim odb test binary bloat: minimal deps, fixture split, debug compression

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -111,6 +111,9 @@ build:asan --copt=-DADDRESS_SANITIZER
 build:asan --copt=-O1
 build:asan --copt=-g
 build:asan --copt=-fno-omit-frame-pointer
+# Compress the DWARF debug sections (transparent to gdb/perf/addr2line).
+build:asan --copt=-gz=zlib
+build:asan --linkopt=-gz=zlib
 build:asan --linkopt=-fsanitize=address
 # TCMalloc is incompatible with ASan: __asan_init's interceptor setup calls
 # dlsym -> malloc before TCMalloc is initialized, segfaulting at startup.
@@ -123,6 +126,9 @@ build:profile --strip=never
 build:profile --copt -g --host_copt -g
 build:profile --copt -gmlt --host_copt -gmlt
 build:profile --copt -fno-omit-frame-pointer --host_copt -fno-omit-frame-pointer
+# Compress the DWARF debug sections (transparent to gdb/perf/addr2line).
+build:profile --copt=-gz=zlib --host_copt=-gz=zlib
+build:profile --linkopt=-gz=zlib
 
 # Improve hermeticity by disallowing user envars and network access
 build --incompatible_strict_action_env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,25 @@ if (LINK_TIME_OPTIMIZATION AND NOT LTO_UNSUPPORTED_OS)
 endif()
 message(STATUS "LTO/IPO is ${LTO_STATUS}")
 
+# Compress DWARF debug sections in builds that emit debug info. This is a
+# large on-disk win for template-heavy C++ (debug info dominates these
+# binaries) and is transparent to gdb/readelf/addr2line/lldb. It is a no-op
+# for builds without -g (e.g. Release), so it is safe to apply globally.
+# Excluded on Apple platforms: Mach-O does not support -gz=zlib and AppleClang
+# (which CMAKE_CXX_COMPILER_ID matches as "Clang") would fail the build.
+# The compile flag is scoped to C/C++: -gz is a GCC/Clang host-compiler flag
+# that nvcc does not accept (it would need explicit -Xcompiler forwarding), so
+# applying it directory-wide would break CUDA (ENABLE_GPU) debug builds where
+# gpl marks GPU sources as LANGUAGE CUDA. The link flag needs no such guard:
+# linking is driven by the host C++ compiler.
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   AND NOT APPLE)
+  set(DEBUG_CONFIG_GENEX "$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>")
+  add_compile_options(
+    "$<$<AND:${DEBUG_CONFIG_GENEX},$<COMPILE_LANGUAGE:CXX,C>>:-gz=zlib>")
+  add_link_options("$<${DEBUG_CONFIG_GENEX}:-gz=zlib>")
+endif()
+
 # configure a header file to pass some of the CMake settings
 configure_file(
   ${OPENROAD_HOME}/include/ord/Version.hh.cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,7 +255,11 @@ if (NOT USE_SYSTEM_OPENSTA)
 endif()
 add_subdirectory(dbSta)
 add_subdirectory(rsz)
-add_subdirectory(tst)
+if(ENABLE_TESTS)
+  # tst provides gtest-based fixture libraries used only by test targets, and
+  # links GTest::gtest, which only exists when ENABLE_TESTS is on.
+  add_subdirectory(tst)
+endif()
 add_subdirectory(stt)
 add_subdirectory(gpl)
 add_subdirectory(dpl)

--- a/src/dbSta/src/CMakeLists.txt
+++ b/src/dbSta/src/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(dbSta_lib
 
 target_link_libraries(dbSta_lib
   PUBLIC
-    odb
+    db
     OpenSTA
   PRIVATE
     utl_lib

--- a/src/dbSta/test/cpp/CMakeLists.txt
+++ b/src/dbSta/test/cpp/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(TestDbSta
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 
@@ -67,7 +67,7 @@ target_link_libraries(TestReadVerilog
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 
@@ -96,7 +96,7 @@ target_link_libraries(TestWriteVerilog
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 

--- a/src/est/test/CMakeLists.txt
+++ b/src/est/test/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(TestEstimateParasitics
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 

--- a/src/odb/src/3dblox/CMakeLists.txt
+++ b/src/odb/src/3dblox/CMakeLists.txt
@@ -23,6 +23,11 @@ target_link_libraries(3dblox
     utl_lib
     yaml-cpp
     OpenSTA
+  PRIVATE
+    defin
+    defout
+    lefin
+    lefout
 )
 
 target_include_directories(3dblox

--- a/src/odb/test/cpp/BUILD
+++ b/src/odb/test/cpp/BUILD
@@ -47,7 +47,7 @@ cc_test(
     deps = [
         "//src/odb/src/db",
         "//src/odb/test/cpp/helper",
-        "//src/tst",
+        "//src/tst:db_fixture",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@spdlog",
@@ -102,7 +102,7 @@ cc_test(
         "//src/odb/src/db",
         "//src/odb/src/gdsin",
         "//src/odb/src/gdsout",
-        "//src/tst",
+        "//src/tst:db_fixture",
         "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
@@ -235,7 +235,7 @@ cc_test(
     srcs = ["TestObjectType.cpp"],
     deps = [
         "//src/odb/src/db",
-        "//src/tst",
+        "//src/tst:db_fixture",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
@@ -271,7 +271,7 @@ cc_test(
         "//src/odb/src/3dblox",
         "//src/odb/src/db",
         "//src/odb/test/cpp/helper",
-        "//src/tst",
+        "//src/tst:db_fixture",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
@@ -292,7 +292,7 @@ cc_test(
     deps = [
         "//src/odb/src/3dblox",
         "//src/odb/src/db",
-        "//src/tst",
+        "//src/tst:db_fixture",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
@@ -309,7 +309,7 @@ cc_test(
     deps = [
         "//src/odb/src/3dblox",
         "//src/odb/src/db",
-        "//src/tst",
+        "//src/tst:db_fixture",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -148,7 +148,7 @@ target_link_libraries(TestSwapMasterUnusedPort
 )
 target_link_libraries(TestWriteReadDbHier
         db
-        tst
+        tst_integrated_fixture
         ${GTEST_LIBS}
 )
 target_link_libraries(TestObjectType

--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -1,23 +1,11 @@
 include(openroad)
 
-set(TEST_LIBS
-        odb
-        lef
-        defin
-        defout
-        lefin
-        lefout
-        cdl
-        3dblox
-        ${TCL_LIBRARY}
-        Boost::boost
-        utl_lib
-        odb_test_helper
-        gdsin
-        tst
+# Each executable links only the libraries it actually needs to avoid bloated
+# binaries. src/odb/test/cpp/BUILD is the reference for the minimal dependency
+# set of each test. GTEST_LIBS is the one group shared by every test.
+set(GTEST_LIBS
         GTest::gtest
         GTest::gtest_main
-        GTest::gmock
 )
 
 add_executable(OdbGTests TestDbWire.cc TestDbNet.cpp TestDesignIsRouted.cpp TestAbstractLef.cc TestPolygonalFloorplan.cc)
@@ -42,27 +30,132 @@ add_executable(TestSwapMasterUnusedPort TestSwapMasterUnusedPort.cpp)
 add_executable(TestWriteReadDbHier TestWriteReadDbHier.cpp)
 add_executable(TestObjectType TestObjectType.cpp)
 
-target_link_libraries(OdbGTests ${TEST_LIBS})
-target_link_libraries(TestCallBacks ${TEST_LIBS})
-target_link_libraries(TestGeom ${TEST_LIBS})
-target_link_libraries(TestModule ${TEST_LIBS})
-target_link_libraries(TestLef58Properties ${TEST_LIBS})
-target_link_libraries(TestGroup ${TEST_LIBS})
-target_link_libraries(TestGCellGrid ${TEST_LIBS})
-target_link_libraries(TestJournal ${TEST_LIBS})
-target_link_libraries(TestAccessPoint ${TEST_LIBS})
-target_link_libraries(TestGuide ${TEST_LIBS})
-target_link_libraries(TestNetTrack ${TEST_LIBS})
-target_link_libraries(TestMaster ${TEST_LIBS})
-target_link_libraries(TestGDSIn ${TEST_LIBS})
-target_link_libraries(TestChips ${TEST_LIBS})
-target_link_libraries(Test3DBloxParser ${TEST_LIBS})
-target_link_libraries(Test3DBloxChecker ${TEST_LIBS})
-target_link_libraries(Test3DBloxVerilogWriter ${TEST_LIBS})
-target_link_libraries(TestSwapMaster ${TEST_LIBS})
-target_link_libraries(TestSwapMasterUnusedPort ${TEST_LIBS})
-target_link_libraries(TestWriteReadDbHier ${TEST_LIBS})
-target_link_libraries(TestObjectType ${TEST_LIBS})
+target_link_libraries(OdbGTests
+        db
+        defin
+        lefin
+        lefout
+        OpenSTA
+        tst
+        utl_lib
+        GTest::gmock
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestCallBacks
+        db
+        odb_test_helper
+        tst
+        spdlog::spdlog
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestGeom
+        db
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestModule
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestLef58Properties
+        db
+        defin
+        defout
+        lefin
+        lefout
+        tst
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestGroup
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestGCellGrid
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestJournal
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestAccessPoint
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestGuide
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestNetTrack
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestMaster
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestGDSIn
+        db
+        gdsin
+        gdsout
+        tst
+        utl_lib
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestChips
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(Test3DBloxParser
+        3dblox
+        db
+        odb_test_helper
+        tst
+        ${GTEST_LIBS}
+)
+target_link_libraries(Test3DBloxChecker
+        3dblox
+        db
+        tst
+        ${GTEST_LIBS}
+)
+target_link_libraries(Test3DBloxVerilogWriter
+        3dblox
+        db
+        tst
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestSwapMaster
+        db
+        dbSta_lib
+        tst
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestSwapMasterUnusedPort
+        db
+        dbSta_lib
+        tst
+        utl_lib
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestWriteReadDbHier
+        db
+        tst
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestObjectType
+        db
+        tst
+        ${GTEST_LIBS}
+)
 
 # Skip the tests from being registered here, since they are called via
 # cpp_tests.tcl and don't need to be executed twice. The cpp_tests.tcl

--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(OdbGTests
 target_link_libraries(TestCallBacks
         db
         odb_test_helper
-        tst
+        tst_base
         spdlog::spdlog
         ${GTEST_LIBS}
 )
@@ -105,7 +105,7 @@ target_link_libraries(TestGDSIn
         db
         gdsin
         gdsout
-        tst
+        tst_base
         utl_lib
         ${GTEST_LIBS}
 )
@@ -118,19 +118,19 @@ target_link_libraries(Test3DBloxParser
         3dblox
         db
         odb_test_helper
-        tst
+        tst_base
         ${GTEST_LIBS}
 )
 target_link_libraries(Test3DBloxChecker
         3dblox
         db
-        tst
+        tst_base
         ${GTEST_LIBS}
 )
 target_link_libraries(Test3DBloxVerilogWriter
         3dblox
         db
-        tst
+        tst_base
         ${GTEST_LIBS}
 )
 target_link_libraries(TestSwapMaster
@@ -153,7 +153,7 @@ target_link_libraries(TestWriteReadDbHier
 )
 target_link_libraries(TestObjectType
         db
-        tst
+        tst_base
         ${GTEST_LIBS}
 )
 

--- a/src/odb/test/cpp/Test3DBloxCheckerFixture.h
+++ b/src/odb/test/cpp/Test3DBloxCheckerFixture.h
@@ -9,10 +9,10 @@
 #include "odb/db.h"
 #include "odb/dbWireCodec.h"
 #include "odb/geom.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 
 namespace odb {
-class CheckerFixture : public tst::Fixture
+class CheckerFixture : public tst::DbFixture
 {
  protected:
   CheckerFixture()

--- a/src/odb/test/cpp/Test3DBloxParser.cpp
+++ b/src/odb/test/cpp/Test3DBloxParser.cpp
@@ -8,14 +8,14 @@
 #include "odb/3dblox.h"
 #include "odb/db.h"
 #include "odb/geom.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 
 namespace odb {
 namespace {
 
 static const std::string prefix("_main/src/odb/test/");
 
-class DbvFixture : public tst::Fixture
+class DbvFixture : public tst::DbFixture
 {
  protected:
   DbvFixture()
@@ -441,7 +441,7 @@ TEST_F(SimpleDbFixture, test_bterm_get_chip_bump)
 // Path Assertion Parser Tests
 // ---------------------------------------------------------------------------
 
-class PathAssertionFixture : public tst::Fixture
+class PathAssertionFixture : public tst::DbFixture
 {
  protected:
   ThreeDBlox parser_{&logger_, db_.get()};

--- a/src/odb/test/cpp/Test3DBloxVerilogWriter.cpp
+++ b/src/odb/test/cpp/Test3DBloxVerilogWriter.cpp
@@ -13,7 +13,7 @@
 #include "odb/3dblox.h"
 #include "odb/db.h"
 #include "odb/geom.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 
 namespace odb {
 namespace {
@@ -26,7 +26,7 @@ static std::string readFileContent(const std::string& path)
                      std::istreambuf_iterator<char>());
 }
 
-class VerilogWriterFixture : public tst::Fixture
+class VerilogWriterFixture : public tst::DbFixture
 {
  protected:
   VerilogWriterFixture()

--- a/src/odb/test/cpp/TestCallBacks.cpp
+++ b/src/odb/test/cpp/TestCallBacks.cpp
@@ -3,7 +3,7 @@
 #include "helper.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 
 namespace odb {
 namespace {

--- a/src/odb/test/cpp/TestGDSIn.cpp
+++ b/src/odb/test/cpp/TestGDSIn.cpp
@@ -12,7 +12,7 @@
 #include "odb/gdsin.h"
 #include "odb/gdsout.h"
 #include "odb/geom.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 #include "utl/Logger.h"
 
 namespace odb::gds {
@@ -20,9 +20,9 @@ namespace {
 
 static const std::string prefix("_main/src/odb/test/");
 
-using tst::Fixture;
+using tst::DbFixture;
 
-TEST_F(Fixture, reader)
+TEST_F(DbFixture, reader)
 {
   GDSReader reader(&logger_);
   std::string path = getFilePath(prefix + "data/sky130_fd_sc_hd__inv_1.gds");
@@ -80,7 +80,7 @@ TEST_F(Fixture, reader)
   EXPECT_EQ(text0->getTransform().angle_, 0);
 }
 
-TEST_F(Fixture, writer)
+TEST_F(DbFixture, writer)
 {
   GDSReader reader(&logger_);
   std::string path = getFilePath(prefix + "data/sky130_fd_sc_hd__inv_1.gds");
@@ -146,7 +146,7 @@ TEST_F(Fixture, writer)
   EXPECT_EQ(text0->getTransform().angle_, 0);
 }
 
-TEST_F(Fixture, edit)
+TEST_F(DbFixture, edit)
 {
   std::string libname = "test_lib";
   dbGDSLib* lib = createEmptyGDSLib(db_.get(), libname);

--- a/src/odb/test/cpp/TestObjectType.cpp
+++ b/src/odb/test/cpp/TestObjectType.cpp
@@ -4,12 +4,12 @@
 #include "gtest/gtest.h"
 #include "odb/dbObject.h"
 #include "odb/dbStream.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 
 namespace odb {
 namespace {
 
-class ObjectTypeFixture : public tst::Fixture
+class ObjectTypeFixture : public tst::DbFixture
 {
 };
 

--- a/src/odb/test/cpp/helper/BUILD
+++ b/src/odb/test/cpp/helper/BUILD
@@ -20,6 +20,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/odb/src/db",
-        "//src/tst",
+        "//src/tst:db_fixture",
     ],
 )

--- a/src/odb/test/cpp/helper/CMakeLists.txt
+++ b/src/odb/test/cpp/helper/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(odb_test_helper helper.cpp)
 target_link_libraries(odb_test_helper
   PUBLIC
     db
-    tst
+    tst_base
 )
 
 

--- a/src/odb/test/cpp/helper/CMakeLists.txt
+++ b/src/odb/test/cpp/helper/CMakeLists.txt
@@ -5,8 +5,8 @@ add_library(odb_test_helper helper.cpp)
 
 
 target_link_libraries(odb_test_helper
-  PRIVATE
-    odb
+  PUBLIC
+    db
     tst
 )
 

--- a/src/odb/test/cpp/helper/helper.h
+++ b/src/odb/test/cpp/helper/helper.h
@@ -4,11 +4,11 @@
 #include <cstdint>
 
 #include "odb/db.h"
-#include "tst/fixture.h"
+#include "tst/db_fixture.h"
 
 namespace odb {
 
-class SimpleDbFixture : public tst::Fixture
+class SimpleDbFixture : public tst::DbFixture
 {
  protected:
   static odb::dbMaster* createMaster2X1(odb::dbLib* lib,

--- a/src/rsz/test/cpp/CMakeLists.txt
+++ b/src/rsz/test/cpp/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(TestBufferRemoval3
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 
@@ -100,7 +100,7 @@ target_link_libraries(TestResizer
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 
@@ -127,7 +127,7 @@ target_link_libraries(TestInsertBuffer
         rsz_lib
         odb
         odb_test_helper
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 
@@ -156,7 +156,7 @@ target_link_libraries(TestNestedJournal
         dpl_lib
         stt_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 
@@ -183,7 +183,7 @@ target_link_libraries(TestResizerMt
         utl_lib
         rsz_lib
         odb
-        tst
+        tst_integrated_fixture
         ${TCL_LIBRARY}
 )
 

--- a/src/tst/BUILD
+++ b/src/tst/BUILD
@@ -33,6 +33,31 @@ cc_library(
 )
 
 cc_library(
+    name = "db_fixture",
+    testonly = 1,
+    srcs = [
+        "src/db_fixture.cpp",
+    ],
+    hdrs = [
+        "include/tst/db_fixture.h",
+    ],
+    defines = [
+        "BAZEL_BUILD",
+    ],
+    includes = [
+        "include",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/odb/src/db",
+        "//src/odb/src/lefin",
+        "//src/utl",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "tst",
     testonly = 1,
     srcs = [
@@ -48,12 +73,12 @@ cc_library(
         "include",
     ],
     deps = [
+        ":db_fixture",
         "//src/dbSta",
         "//src/odb/src/db",
         "//src/odb/src/lefin",
         "//src/sta:opensta_lib",
         "//src/utl",
-        "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest",
         "@tcl_lang//:tcl",
     ],

--- a/src/tst/CMakeLists.txt
+++ b/src/tst/CMakeLists.txt
@@ -3,9 +3,11 @@
 
 include("openroad")
 
+# Lightweight fixture: only needs dbSta/odb/sta. Tests that just read a
+# design should depend on this and avoid pulling in the full optimization
+# tool chain.
 add_library(tst
     src/fixture.cpp
-    src/IntegratedFixture.cpp
 )
 
 target_include_directories(tst
@@ -15,6 +17,27 @@ target_include_directories(tst
 
 target_link_libraries(tst
   PUBLIC
+    dbSta_lib
+  PRIVATE
+    utl_lib
+    odb
+    OpenSTA
+)
+
+# IntegratedFixture pulls in the full optimization tool chain (ant, dpl, est,
+# grt, rsz, stt). Kept separate so lightweight tst consumers don't link it.
+add_library(tst_integrated_fixture
+    src/IntegratedFixture.cpp
+)
+
+target_include_directories(tst_integrated_fixture
+  PUBLIC
+    include
+)
+
+target_link_libraries(tst_integrated_fixture
+  PUBLIC
+    tst
     dbSta_lib
     ant_lib
     dpl_lib

--- a/src/tst/CMakeLists.txt
+++ b/src/tst/CMakeLists.txt
@@ -20,7 +20,8 @@ target_link_libraries(tst
     dbSta_lib
   PRIVATE
     utl_lib
-    odb
+    db
+    lefin
     OpenSTA
 )
 
@@ -47,6 +48,6 @@ target_link_libraries(tst_integrated_fixture
     stt_lib
   PRIVATE
     utl_lib
-    odb
+    db
     OpenSTA
 )

--- a/src/tst/CMakeLists.txt
+++ b/src/tst/CMakeLists.txt
@@ -3,9 +3,30 @@
 
 include("openroad")
 
-# Lightweight fixture: only needs dbSta/odb/sta. Tests that just read a
-# design should depend on this and avoid pulling in the full optimization
-# tool chain.
+# DbFixture: odb-only base fixture. Has no dependency on dbSta/OpenSTA, so
+# tests that only manipulate an odb database can link this and avoid the STA
+# libraries entirely.
+add_library(tst_base
+    src/db_fixture.cpp
+)
+
+target_include_directories(tst_base
+  PUBLIC
+    include
+)
+
+target_link_libraries(tst_base
+  PUBLIC
+    db
+    utl_lib
+    GTest::gtest
+  PRIVATE
+    lefin
+)
+
+# Fixture: adds a dbSta/OpenSTA instance on top of DbFixture. Tests that need
+# timing depend on this; it still avoids the full optimization tool chain
+# (see tst_integrated_fixture).
 add_library(tst
     src/fixture.cpp
 )
@@ -17,10 +38,10 @@ target_include_directories(tst
 
 target_link_libraries(tst
   PUBLIC
+    tst_base
     dbSta_lib
   PRIVATE
     utl_lib
-    db
     lefin
     OpenSTA
 )

--- a/src/tst/include/tst/db_fixture.h
+++ b/src/tst/include/tst/db_fixture.h
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2019-2025, The OpenROAD Authors
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "odb/db.h"
+#include "odb/dbTypes.h"
+#include "odb/geom.h"
+#include "utl/Logger.h"
+#include "utl/deleter.h"
+
+#ifdef BAZEL_BUILD
+#include "tools/cpp/runfiles/runfiles.h"
+#endif
+
+namespace tst {
+
+struct InstOptions
+{
+  struct ITermInfo
+  {
+    const char* net_name;   // created if needed
+    const char* term_name;  // must match an existing dbMTerm
+  };
+  odb::dbRegion* region{nullptr};
+  bool physical_only{false};
+  odb::dbModule* parent_module{nullptr};
+  odb::dbSourceType type{odb::dbSourceType::NONE};
+  odb::Point location;
+  odb::dbPlacementStatus status{odb::dbPlacementStatus::NONE};
+  std::vector<ITermInfo> iterms;
+};
+
+struct BTermOptions
+{
+  struct BPinInfo
+  {
+    const char* layer_name;
+    odb::Rect rect;
+    odb::dbPlacementStatus status{odb::dbPlacementStatus::PLACED};
+  };
+
+  odb::dbIoType io_type{odb::dbIoType::INPUT};
+  odb::dbSigType sig_type{odb::dbSigType::SIGNAL};
+  std::vector<BPinInfo> bpins;
+};
+
+// Base fixture for tests that only manipulate an odb database. It has no
+// dependency on OpenSTA/dbSta; tests that need timing should derive from
+// tst::Fixture (tst/fixture.h) instead.
+class DbFixture : public ::testing::Test
+{
+ protected:
+  DbFixture();
+  ~DbFixture() override;
+
+  odb::dbDatabase* getDb() const { return db_.get(); }
+  utl::Logger* getLogger() { return &logger_; }
+
+  // In bazel this uses the runfiles mechanism to locate the file
+  std::string getFilePath(const std::string& file_path) const;
+
+  // Load a tech LEF file
+  odb::dbTech* loadTechLef(const char* name, const std::string& lef_file);
+
+  // Netlist editing helpers.
+  //
+  // These APIs are designed for maximum convenience rather than
+  // performance.  The goal is to make this competitive with writing a
+  // Verilog or DEF test case by hand.  C++ unit tests should only be
+  // instantiating a small number of objects for readability and
+  // focused testing.
+  //
+  // Name strings are used and objects are created if needed whenever
+  // possible (e.g. referring to a net "foo" will find it or create it
+  // if not present).
+
+  odb::dbInst* makeInst(odb::dbBlock* block,
+                        odb::dbMaster* master,
+                        const char* name,
+                        const InstOptions& options = {});
+
+  // A net of the same name will be created if needed.
+  odb::dbBTerm* makeBTerm(odb::dbBlock* block,
+                          const char* name,
+                          const BTermOptions& options = {});
+
+  // Intended for use like: auto [n1, n2] = makeNets(block, "n1", "n2");
+  template <typename... Args>
+  std::array<odb::dbNet*, sizeof...(Args)> makeNets(odb::dbBlock* block,
+                                                    Args... names)
+  {
+    return {odb::dbNet::create(block, names)...};
+  }
+
+  utl::Logger logger_;
+  utl::UniquePtrWithDeleter<odb::dbDatabase> db_;
+#ifdef BAZEL_BUILD
+  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles_;
+#endif
+};
+
+}  // namespace tst

--- a/src/tst/include/tst/fixture.h
+++ b/src/tst/include/tst/fixture.h
@@ -3,70 +3,28 @@
 
 #pragma once
 
-#include <array>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "db_sta/dbSta.hh"
-#include "gtest/gtest.h"
-#include "odb/db.h"
-#include "odb/dbTypes.h"
-#include "odb/geom.h"
 #include "sta/Liberty.hh"
 #include "sta/MinMax.hh"
 #include "tcl.h"
-#include "utl/Logger.h"
+#include "tst/db_fixture.h"
 #include "utl/deleter.h"
-
-#ifdef BAZEL_BUILD
-#include "tools/cpp/runfiles/runfiles.h"
-#endif
 
 namespace tst {
 
-struct InstOptions
-{
-  struct ITermInfo
-  {
-    const char* net_name;   // created if needed
-    const char* term_name;  // must match an existing dbMTerm
-  };
-  odb::dbRegion* region{nullptr};
-  bool physical_only{false};
-  odb::dbModule* parent_module{nullptr};
-  odb::dbSourceType type{odb::dbSourceType::NONE};
-  odb::Point location;
-  odb::dbPlacementStatus status{odb::dbPlacementStatus::NONE};
-  std::vector<ITermInfo> iterms;
-};
-
-struct BTermOptions
-{
-  struct BPinInfo
-  {
-    const char* layer_name;
-    odb::Rect rect;
-    odb::dbPlacementStatus status{odb::dbPlacementStatus::PLACED};
-  };
-
-  odb::dbIoType io_type{odb::dbIoType::INPUT};
-  odb::dbSigType sig_type{odb::dbSigType::SIGNAL};
-  std::vector<BPinInfo> bpins;
-};
-
-class Fixture : public ::testing::Test
+// Fixture that adds an OpenSTA/dbSta instance on top of the odb-only
+// DbFixture. Tests that do not need timing should derive from DbFixture
+// (tst/db_fixture.h) to avoid linking OpenSTA.
+class Fixture : public DbFixture
 {
  protected:
   Fixture();
   ~Fixture() override;
 
-  odb::dbDatabase* getDb() const { return db_.get(); }
   sta::dbSta* getSta() const { return sta_.get(); }
-  utl::Logger* getLogger() { return &logger_; }
-
-  // In bazel this uses the runfiles mechanism to locate the file
-  std::string getFilePath(const std::string& file_path) const;
 
   // if scene == nullptr, then a scene named "default" is used
   sta::LibertyLibrary* readLiberty(const std::string& filename,
@@ -74,9 +32,6 @@ class Fixture : public ::testing::Test
                                    const sta::MinMaxAll* min_max
                                    = sta::MinMaxAll::all(),
                                    bool infer_latches = false);
-
-  // Load a tech LEF file
-  odb::dbTech* loadTechLef(const char* name, const std::string& lef_file);
 
   // Load a library LEF file
   odb::dbLib* loadLibaryLef(odb::dbTech* tech,
@@ -90,47 +45,8 @@ class Fixture : public ::testing::Test
   // Add macros to this library
   bool updateLib(odb::dbLib* lib, const std::string& lef_file);
 
-  // Netlist editing helpers.
-  //
-  // These APIs are designed for maximum convenience rather than
-  // performance.  The goal is to make this competitive with writing a
-  // Verilog or DEF test case by hand.  C++ unit tests should only be
-  // instantiating a small number of objects for readability and
-  // focused testing.
-  //
-  // Name strings are used and objects are created if needed whenever
-  // possible (e.g. referring to a net "foo" will find it or create it
-  // if not present).
-
-  odb::dbInst* makeInst(odb::dbBlock* block,
-                        odb::dbMaster* master,
-                        const char* name,
-                        const InstOptions& options = {});
-
-  // A net of the same name will be created if needed.
-  odb::dbBTerm* makeBTerm(odb::dbBlock* block,
-                          const char* name,
-                          const BTermOptions& options = {});
-
-  // Indented for use like: auto [n1, n2] = makeNets(block, {"n1", "n2"});
-  template <int SZ>
-  std::array<odb::dbNet*, SZ> makeNets(odb::dbBlock* block,
-                                       const char* const (&names)[SZ])
-  {
-    std::array<odb::dbNet*, SZ> nets;
-    for (int i = 0; i < SZ; ++i) {
-      nets[i] = odb::dbNet::create(block, names[i]);
-    }
-    return nets;
-  }
-
-  utl::Logger logger_;
-  utl::UniquePtrWithDeleter<odb::dbDatabase> db_;
   utl::UniquePtrWithDeleter<Tcl_Interp> interp_;
   std::unique_ptr<sta::dbSta> sta_;
-#ifdef BAZEL_BUILD
-  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles_;
-#endif
 };
 
 }  // namespace tst

--- a/src/tst/src/db_fixture.cpp
+++ b/src/tst/src/db_fixture.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2019-2025, The OpenROAD Authors
+
+#include "tst/db_fixture.h"
+
+#include <deque>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "odb/db.h"
+#include "odb/geom.h"
+#include "odb/lefin.h"
+
+#ifdef BAZEL_BUILD
+#include "tools/cpp/runfiles/runfiles.h"
+#endif
+
+namespace tst {
+
+DbFixture::DbFixture()
+{
+#ifdef BAZEL_BUILD
+  std::string error;
+  runfiles_.reset(bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&error));
+
+  if (runfiles_ == nullptr) {
+    throw std::runtime_error("Could not create Runfiles object: " + error);
+  }
+#endif
+
+  db_ = utl::UniquePtrWithDeleter<odb::dbDatabase>(odb::dbDatabase::create(),
+                                                   odb::dbDatabase::destroy);
+  db_->setLogger(&logger_);
+}
+
+DbFixture::~DbFixture() = default;
+
+// Takes a relative path and removes leading directories until a valid path is
+// found. This is needed by cmake to find a path from the fuller one used by
+// bazel.
+std::filesystem::path findValidPath(const std::filesystem::path& relative_path)
+{
+  std::deque<std::filesystem::path> path_components;
+
+  for (const auto& component : relative_path) {
+    path_components.push_back(component);
+  }
+
+  while (!path_components.empty()) {
+    std::filesystem::path current_path;
+    for (const auto& part : path_components) {
+      current_path /= part;
+    }
+
+    if (std::filesystem::exists(current_path)) {
+      return current_path;
+    }
+    path_components.pop_front();
+  }
+
+  throw std::runtime_error("Could not find: " + relative_path.string());
+}
+
+std::string DbFixture::getFilePath(const std::string& file_path) const
+{
+#ifdef BAZEL_BUILD
+  return runfiles_->Rlocation(file_path);
+#else
+  return std::filesystem::canonical(findValidPath(file_path));
+#endif
+}
+
+odb::dbTech* DbFixture::loadTechLef(const char* name,
+                                    const std::string& lef_file)
+{
+  odb::lefin lef_reader(
+      db_.get(), &logger_, /*ignore_non_routing_layers=*/false);
+  auto path = getFilePath(lef_file);
+  return lef_reader.createTech(name, path.c_str());
+}
+
+odb::dbInst* DbFixture::makeInst(odb::dbBlock* block,
+                                 odb::dbMaster* master,
+                                 const char* name,
+                                 const InstOptions& options)
+{
+  odb::dbInst* inst = odb::dbInst::create(block,
+                                          master,
+                                          name,
+                                          options.region,
+                                          options.physical_only,
+                                          options.parent_module);
+  EXPECT_NE(inst, nullptr);
+  if (inst == nullptr) {
+    return nullptr;
+  }
+  inst->setSourceType(options.type);
+  inst->setLocation(options.location.x(), options.location.y());
+  inst->setPlacementStatus(options.status);
+
+  for (const InstOptions::ITermInfo& info : options.iterms) {
+    odb::dbMTerm* mterm = master->findMTerm(info.term_name);
+    EXPECT_NE(mterm, nullptr);
+    odb::dbITerm* iterm = inst->getITerm(mterm);
+    odb::dbNet* net = block->findNet(info.net_name);
+    if (!net) {
+      net = odb::dbNet::create(block, info.net_name);
+    }
+    iterm->connect(net);
+  }
+
+  return inst;
+}
+
+odb::dbBTerm* DbFixture::makeBTerm(odb::dbBlock* block,
+                                   const char* name,
+                                   const BTermOptions& options)
+{
+  odb::dbNet* net = block->findNet(name);
+  if (!net) {
+    net = odb::dbNet::create(block, name);
+  }
+  EXPECT_NE(net, nullptr);
+  if (net == nullptr) {
+    return nullptr;
+  }
+
+  odb::dbBTerm* bterm = odb::dbBTerm::create(net, name);
+  EXPECT_NE(bterm, nullptr);
+  if (bterm == nullptr) {
+    return nullptr;
+  }
+  bterm->setIoType(options.io_type);
+  bterm->setSigType(options.sig_type);
+
+  odb::dbTech* tech = block->getTech();
+  for (const BTermOptions::BPinInfo& info : options.bpins) {
+    odb::dbBPin* pin = odb::dbBPin::create(bterm);
+    const odb::Rect rect = info.rect;
+    odb::dbTechLayer* layer = tech->findLayer(info.layer_name);
+    EXPECT_NE(layer, nullptr);
+    odb::dbBox::create(
+        pin, layer, rect.xMin(), rect.yMin(), rect.xMax(), rect.yMax());
+    pin->setPlacementStatus(info.status);
+  }
+
+  return bterm;
+}
+
+}  // namespace tst

--- a/src/tst/src/fixture.cpp
+++ b/src/tst/src/fixture.cpp
@@ -3,28 +3,17 @@
 
 #include "tst/fixture.h"
 
-#include <deque>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 #include <string>
 
 #include "db_sta/dbSta.hh"
-#include "gtest/gtest.h"
 #include "odb/db.h"
-#include "odb/geom.h"
 #include "odb/lefin.h"
 #include "sta/Liberty.hh"
 #include "sta/MinMax.hh"
 #include "sta/Sta.hh"
 #include "tcl.h"  // IWYU pragma: keep (clang-tidy, you're drunk)
-
-#ifdef BAZEL_BUILD
-#include "tools/cpp/runfiles/runfiles.h"
-#endif
 
 namespace tst {
 
@@ -34,61 +23,14 @@ std::once_flag init_sta_flag;
 
 Fixture::Fixture()
 {
-#ifdef BAZEL_BUILD
-  std::string error;
-  runfiles_.reset(bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&error));
-
-  if (runfiles_ == nullptr) {
-    throw std::runtime_error("Could not create Runfiles object: " + error);
-  }
-#endif
-
   std::call_once(init_sta_flag, []() { sta::initSta(); });
 
-  db_ = utl::UniquePtrWithDeleter<odb::dbDatabase>(odb::dbDatabase::create(),
-                                                   odb::dbDatabase::destroy);
-  db_->setLogger(&logger_);
   interp_ = utl::UniquePtrWithDeleter<Tcl_Interp>(Tcl_CreateInterp(),
                                                   Tcl_DeleteInterp);
   sta_ = std::make_unique<sta::dbSta>(interp_.get(), db_.get(), &logger_);
 }
 
 Fixture::~Fixture() = default;
-
-// Takes a relative path and removes leading directories until a valid path is
-// found. This is needed by cmake to find a path from the fuller one used by
-// bazel.
-std::filesystem::path findValidPath(const std::filesystem::path& relative_path)
-{
-  std::deque<std::filesystem::path> path_components;
-
-  for (const auto& component : relative_path) {
-    path_components.push_back(component);
-  }
-
-  while (!path_components.empty()) {
-    std::filesystem::path current_path;
-    for (const auto& part : path_components) {
-      current_path /= part;
-    }
-
-    if (std::filesystem::exists(current_path)) {
-      return current_path;
-    }
-    path_components.pop_front();
-  }
-
-  throw std::runtime_error("Could not find: " + std::string(relative_path));
-}
-
-std::string Fixture::getFilePath(const std::string& file_path) const
-{
-#ifdef BAZEL_BUILD
-  return runfiles_->Rlocation(file_path);
-#else
-  return std::filesystem::canonical(findValidPath(file_path));
-#endif
-}
 
 sta::LibertyLibrary* Fixture::readLiberty(const std::string& filename,
                                           sta::Scene* scene,
@@ -100,14 +42,6 @@ sta::LibertyLibrary* Fixture::readLiberty(const std::string& filename,
   }
   auto path = getFilePath(filename);
   return sta_->readLiberty(path.c_str(), scene, min_max, infer_latches);
-}
-
-odb::dbTech* Fixture::loadTechLef(const char* name, const std::string& lef_file)
-{
-  odb::lefin lef_reader(
-      db_.get(), &logger_, /*ignore_non_routing_layers=*/false);
-  auto path = getFilePath(lef_file);
-  return lef_reader.createTech(name, path.c_str());
 }
 
 odb::dbLib* Fixture::loadLibaryLef(odb::dbTech* tech,
@@ -142,62 +76,6 @@ bool Fixture::updateLib(odb::dbLib* lib, const std::string& lef_file)
   auto path = getFilePath(lef_file);
 
   return lef_reader.updateLib(lib, path.c_str());
-}
-
-odb::dbInst* Fixture::makeInst(odb::dbBlock* block,
-                               odb::dbMaster* master,
-                               const char* name,
-                               const InstOptions& options)
-{
-  odb::dbInst* inst = odb::dbInst::create(block,
-                                          master,
-                                          name,
-                                          options.region,
-                                          options.physical_only,
-                                          options.parent_module);
-  inst->setSourceType(options.type);
-  inst->setLocation(options.location.x(), options.location.y());
-  inst->setPlacementStatus(options.status);
-
-  for (const InstOptions::ITermInfo& info : options.iterms) {
-    odb::dbMTerm* mterm = master->findMTerm(info.term_name);
-    EXPECT_NE(mterm, nullptr);
-    odb::dbITerm* iterm = inst->getITerm(mterm);
-    odb::dbNet* net = block->findNet(info.net_name);
-    if (!net) {
-      net = odb::dbNet::create(block, info.net_name);
-    }
-    iterm->connect(net);
-  }
-
-  return inst;
-}
-
-odb::dbBTerm* Fixture::makeBTerm(odb::dbBlock* block,
-                                 const char* name,
-                                 const BTermOptions& options)
-{
-  odb::dbNet* net = block->findNet(name);
-  if (!net) {
-    net = odb::dbNet::create(block, name);
-  }
-
-  odb::dbBTerm* bterm = odb::dbBTerm::create(net, name);
-  bterm->setIoType(options.io_type);
-  bterm->setSigType(options.sig_type);
-
-  odb::dbTech* tech = block->getTech();
-  for (const BTermOptions::BPinInfo& info : options.bpins) {
-    odb::dbBPin* pin = odb::dbBPin::create(bterm);
-    const odb::Rect rect = info.rect;
-    odb::dbTechLayer* layer = tech->findLayer(info.layer_name);
-    EXPECT_NE(layer, nullptr);
-    odb::dbBox::create(
-        pin, layer, rect.xMin(), rect.yMin(), rect.xMax(), rect.yMax());
-    pin->setPlacementStatus(info.status);
-  }
-
-  return bterm;
 }
 
 }  // namespace tst


### PR DESCRIPTION
## Summary

The odb C++ test executables were badly bloated: every one linked a monolithic `TEST_LIBS` set and, transitively, the catch-all `odb` umbrella library plus OpenSTA/dbSta — even tests that only manipulate an odb database. This series trims the dependency graph so each binary links only what it needs, and compresses the debug info that dominates the remaining size.

Result: a representative test (`TestAccessPoint`) went from **~492 MB → ~89 MB**.

## Changes (one concern per commit)

1. **odb: give each cpp test its minimal link deps** — replace the shared `TEST_LIBS` with per-executable dependency lists, using `src/odb/test/cpp/BUILD` as the reference.
2. **tst: split `IntegratedFixture` into its own library** — the heavy optimization tool chain (ant/dpl/est/grt/rsz/stt) is only needed by `IntegratedFixture`; move it to `tst_integrated_fixture` so lightweight `tst` consumers don't link it. Mirrors the existing Bazel split.
3. **dbSta,tst,3dblox: depend on granular `db`, not the `odb` umbrella** — `dbSta_lib` and `tst` linked the catch-all `odb` INTERFACE target, which drags every parser (gds/def/lef/cdl/3dblox) into every consumer. Point them at `db` (matching Bazel). `3dblox` now declares its own `defin/defout/lefin/lefout` deps instead of relying on consumers to supply them.
4. **tst: split fixture into odb-only `DbFixture` and STA `Fixture`** — `Fixture` unconditionally created a `dbSta` instance, so every user linked OpenSTA/dbSta. New base `tst::DbFixture` (library `tst_base` / Bazel `//src/tst:db_fixture`) is odb-only; `tst::Fixture` derives from it and adds STA. odb DB-only tests and `SimpleDbFixture` move to `DbFixture`; STA consumers are unchanged.
5. **cmake: compress DWARF debug sections with `-gz` in debug builds** — debug info is ~97% of these binaries; enable `-gz=zlib` for GNU/Clang in Debug/RelWithDebInfo (compile + link). Transparent to gdb/readelf/addr2line, no-op in Release.
6. **bazel: compress DWARF debug sections in asan/profile configs** — the default `-c opt` build has no `-g`; add `-gz=zlib` to the `asan`/`profile` configs that do.

## Notes

- Dual CMake + Bazel registration kept in sync throughout; verified with `bazel aquery`/`build` (layering_check) and CMake `ctest`.
- Both fixture paths (odb-only and STA) build and pass; full tree builds clean.
- Debug-info *compression* (5, 6) is orthogonal to the dependency trimming (1-4) and can be reviewed independently.