### PR TITLE
build: defer gtest discovery to ctest time to fix flaky CI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set_property(DIRECTORY PROPERTY TEST_DISCOVERY_TIMEOUT 60)
+# Defer GoogleTest case discovery from build time (POST_BUILD default, which
+# execs each test binary during the build) to ctest time. On a loaded CI host
+# the build-time discovery run can exceed the timeout and fail the whole build.
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
 
 # Get version string in OPENROAD_VERSION
 if(NOT OPENROAD_VERSION)


### PR DESCRIPTION
## Problem

Intermittent single-distro failures in the `Build binary <distro>` CI stages (e.g. rockylinux9) that are unrelated to the code under test. Example: PR-10859 (a no-op Dependabot `setup-java` bump) failed only the rockylinux9 binary build while all other distros passed.

Root cause is GoogleTest **test discovery**, not compilation or linking. `gtest_discover_tests()` defaults to `POST_BUILD` mode, which executes each freshly-built test binary *during the build* (`--gtest_list_tests`) to enumerate cases. On a CI host saturated by parallel compiles, that launch can exceed the discovery timeout, so CMake aborts the whole build:

```
CMake Error at GoogleTestAddTests.cmake:132 (message):
  Error running test executable.
    Path: '/OpenROAD/build/src/syn/test/liveness_test'
    Result: Process terminated due to timeout
```

(seen for `liveness_test`, `TestSnapper`, `TestInsertBuffer`, `OdbGTests`).

## Fix

Set `CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST` so discovery is deferred to `ctest` time, where the host is not competing with parallel compilation. This removes test-binary execution from the build entirely, so the build stage can no longer fail on discovery.

Verified: with this change the generated discovery files are ctest-time includes and no `--gtest_list_tests` recipe remains in the build graph.

## Notes

- Replaces the prior `set_property(DIRECTORY PROPERTY TEST_DISCOVERY_TIMEOUT 60)`, which had no effect — `TEST_DISCOVERY_TIMEOUT` is not a real CMake property and `gtest_discover_tests` only honors an explicit `DISCOVERY_TIMEOUT` argument (there is no global timeout variable).
- A per-project wrapper to inject `DISCOVERY_TIMEOUT` was ruled out: `find_package(GTest)` re-includes `GoogleTest.cmake` throughout the tree, reinstating the stock command and defeating any single-point override.
- Known trade-off of `PRE_TEST`: if a test binary fails to *load* at ctest time, discovery registers zero cases and ctest reports a green "0 tests run". Low risk for in-container CPU binaries; the `*_load_sentinel` pattern in `src/gpl/test/CMakeLists.txt` can be generalized later if we want to close it.