### PR TITLE
ci: fix first-interaction input names for v3 (snake_case)

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Greet First-Time Contributor
         uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Welcome to OpenROAD! Thanks for opening your first issue.
             To get started:
             - Build Instructions: https://openroad.readthedocs.io/en/latest/contrib/BuildWithCMake.html
@@ -25,7 +25,7 @@ jobs:
 
             Please search existing issues before submitting to avoid duplicates.
             A maintainer will get back to you soon!
-          pr-message: |
+          pr_message: |
             Welcome to OpenROAD! Thanks for opening your first PR.
             Before we review:
             - Contribution Guide: https://openroad.readthedocs.io/en/latest/contrib/contributing.html


### PR DESCRIPTION
## Problem

The `greet` job (First-Time Contributor Bot) fails on every issue/PR open with:

```
Error: Input required and not supplied: issue_message
```

## Cause

`actions/first-interaction` was bumped to v3.1.0, which renamed its inputs from kebab-case to snake_case. The workflow still used the old `repo-token` / `issue-message` / `pr-message` keys, so they were silently ignored and the required `issue_message` input was never supplied. GitHub logs a warning confirming the valid inputs are `issue_message`, `pr_message`, `repo_token`.

## Fix

Rename the three input keys to snake_case to match the v3 action.