### PR TITLE
bazel: build xcb-util-cursor from source in qt-bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -181,6 +181,15 @@ bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
     commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
+    # Build xcb-util-cursor 0.1.5 from source (fetched hermetically via an
+    # http_archive in qt-bazel's MODULE.bazel) so the Qt xcb platform plugin
+    # doesn't dlopen libxcb-cursor.so.0 from the host, dropping the apt
+    # libxcb-cursor0 dependency. Carries the closed
+    # The-OpenROAD-Project/qt_bazel_prebuilts#11 (0328997a).
+    patch_strip = 1,
+    patches = [
+        "//bazel/qt-bazel-patches:0001-xcb-build-xcb-util-cursor-from-source.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -46,7 +46,6 @@ RUN apt-get -y update \
       libsm6 \
       libice6 \
       libxcb1 \
-      libxcb-cursor0 \
       libxcb-icccm4 \
       libxcb-image0 \
       libxcb-keysyms1 \

--- a/bazel/qt-bazel-patches/0001-xcb-build-xcb-util-cursor-from-source.patch
+++ b/bazel/qt-bazel-patches/0001-xcb-build-xcb-util-cursor-from-source.patch
@@ -1,0 +1,97 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index e31e108..68682db 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -11,3 +11,21 @@ bazel_dep(name = "libxcb", version = "1.17.0.bcr.2")
+ bazel_dep(name = "platforms", version = "1.0.0")
+ bazel_dep(name = "rules_cc", version = "0.1.2")
+ bazel_dep(name = "zlib", version = "1.3.1.bcr.6")
++
++# xcb-util-cursor 0.1.5 source — used by interface_libs/xcb to provide
++# a static replacement for the system libxcb-cursor.so.0 so the Qt xcb
++# platform plugin doesn't dlopen it from the host. Fetched from
++# xcb.freedesktop.org with the xorg.freedesktop.org mirror as fallback
++# (identical tarball), verified by sha256.
++http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++
++http_archive(
++    name = "xcb_util_cursor",
++    build_file = "//interface_libs/xcb:xcb_util_cursor.BUILD",
++    sha256 = "0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57",
++    strip_prefix = "xcb-util-cursor-0.1.5",
++    urls = [
++        "https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.5.tar.xz",
++        "https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz",
++    ],
++)
+diff --git a/interface_libs/xcb/BUILD.bazel b/interface_libs/xcb/BUILD.bazel
+index c1c5b6b..5dea923 100644
+--- a/interface_libs/xcb/BUILD.bazel
++++ b/interface_libs/xcb/BUILD.bazel
+@@ -67,10 +67,17 @@ cc_import(
+     system_provided = True,
+ )
+ 
+-cc_import(
+-    name = "xcb_cursor_ifso",
+-    interface_library = "libxcb-cursor.ifso",
+-    system_provided = True,
++# Headers consumed by @xcb_util_cursor//:cursor (declared in this module's
++# MODULE.bazel): the xcb-util-image / xcb-util-renderutil headers plus the
++# xcb-proto headers (xcb/render.h, xcb/xproto.h, ...) that xcb-util-cursor
++# #includes. These ship in interface_libs/xcb and aren't on BCR; @libxcb
++# supplies the libxcb link symbols.
++cc_library(
++    name = "xcb_hdrs",
++    hdrs = glob(["xcb/*.h"]),
++    includes = ["."],
++    strip_include_prefix = ".",
++    visibility = ["//visibility:public"],
+ )
+ 
+ cc_import(
+@@ -94,7 +101,7 @@ cc_library(
+     deps = select({
+         "@platforms//cpu:aarch64": [],
+         "//conditions:default": [
+-            ":xcb_cursor_ifso",
++            "@xcb_util_cursor//:cursor",
+             ":xcb_icccm_ifso",
+             ":xcb_ifso",
+             ":xcb_image_ifso",
+diff --git a/interface_libs/xcb/xcb_util_cursor.BUILD b/interface_libs/xcb/xcb_util_cursor.BUILD
+new file mode 100644
+index 0000000..4adf18c
+--- /dev/null
++++ b/interface_libs/xcb/xcb_util_cursor.BUILD
+@@ -0,0 +1,30 @@
++# BUILD overlay for the @xcb_util_cursor http_archive declared in
++# qt-bazel's MODULE.bazel. Builds xcb-util-cursor 0.1.5 as a static
++# cc_library so the Qt xcb platform plugin doesn't dlopen
++# libxcb-cursor.so.0 from the host.
++
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
++
++cc_library(
++    name = "cursor",
++    srcs = [
++        "cursor/cursor.c",
++        "cursor/cursor.h",
++        "cursor/load_cursor.c",
++        "cursor/parse_cursor_file.c",
++        "cursor/shape_to_id.c",
++    ],
++    hdrs = ["cursor/xcb_cursor.h"],
++    copts = [
++        # asprintf() is a GNU extension; glibc gates it behind _GNU_SOURCE.
++        "-D_GNU_SOURCE",
++        "-DXCURSORPATH='\"~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons\"'",
++    ],
++    include_prefix = "xcb",
++    strip_include_prefix = "cursor",
++    visibility = ["@qt-bazel//interface_libs/xcb:__pkg__"],
++    deps = [
++        "@libxcb",
++        "@qt-bazel//interface_libs/xcb:xcb_hdrs",
++    ],
++)

--- a/bazel/qt-bazel-patches/BUILD
+++ b/bazel/qt-bazel-patches/BUILD
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -926,7 +926,7 @@ _install_bazel() {
                     libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev \
                     libxcb-xinerama0-dev libxcb-xkb-dev \
                     libx11-xcb1 libx11-6 libsm6 libice6 \
-                    libxcb-cursor0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 \
+                    libxcb-shape0 libxcb-sync1 libxcb-xfixes0 \
                     libdbus-1-3 libfontconfig1 libxkbcommon0 libxkbcommon-x11-0
             elif _command_exists "yum"; then
                 _execute "Installing xcb libraries for GUI support..." \
@@ -934,7 +934,7 @@ _install_bazel() {
                     libxcb-devel xcb-util-devel xcb-util-image-devel \
                     xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel \
                     libX11-xcb libX11 libSM libICE \
-                    xcb-util-cursor libxcb \
+                    libxcb \
                     dbus-libs fontconfig \
                     libxkbcommon libxkbcommon-x11
             fi


### PR DESCRIPTION
## Summary

The Qt xcb platform plugin `dlopen`s `libxcb-cursor.so.0` from the host, so any
consumer of `qt-bazel`'s Qt GUI must `apt install libxcb-cursor0` separately.
This builds `xcb-util-cursor 0.1.5` from source instead:

- Adds an `http_archive` for `xcb-util-cursor` in `qt-bazel`'s `MODULE.bazel`
  (sha256-verified, with `xcb.freedesktop.org` + `xorg.freedesktop.org` mirrors)
  and a small overlay BUILD that compiles it as a static `cc_library`, applied to
  `qt-bazel` via `git_override` `patches` (`bazel/qt-bazel-patches/`).
- Replaces the `system_provided` `xcb_cursor_ifso` `cc_import` with the
  from-source `@xcb_util_cursor//:cursor`.
- Drops `libxcb-cursor0` / `xcb-util-cursor` from `bazel/Dockerfile` and the GUI
  lists in `etc/DependencyInstaller.sh`.

Scope is intentionally just the cursor lib — the one host leak with a ready fix.
`openroad-qt` is inspection-only; CI and downstream builds use the hermetic
headless/CLI + web OpenROAD, which needs no X11/xcb host libs, so the remaining
xcb/X11 interface-lib stubs are left as-is.

This carries the closed `The-OpenROAD-Project/qt_bazel_prebuilts#11`
(`0328997a`) as a patch (with the header-target fix so `xcb/render.h` resolves,
and a mirror added).

## Verification

- `bazelisk build --//:platform=gui //:openroad-qt` — links successfully.
- `ldd bazel-bin/openroad-qt | grep cursor` — **no** `libxcb-cursor` dependency
  (statically compiled from source); other xcb libs remain host deps (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
