### PR TITLE
odb: ignore supply pins when validating buffers

### DIFF
--- a/src/odb/src/db/dbInsertBuffer.cpp
+++ b/src/odb/src/db/dbInsertBuffer.cpp
@@ -277,6 +277,9 @@ dbInst* dbInsertBuffer::checkAndCreateBuffer()
   dbMTerm* input_mterm = nullptr;
   dbMTerm* output_mterm = nullptr;
   for (dbMTerm* mterm : const_cast<dbMaster*>(buffer_master_)->getMTerms()) {
+    if (mterm->getSigType().isSupply()) {
+      continue;
+    }
     if (mterm->getIoType() == dbIoType::INPUT) {
       if (input_mterm != nullptr) {
         logger_->warn(utl::ODB,

--- a/src/odb/test/cpp/TestDbNet.cpp
+++ b/src/odb/test/cpp/TestDbNet.cpp
@@ -216,6 +216,48 @@ TEST_F(TestDbNet, FindRelatedModNetsClearsSet)
   EXPECT_TRUE(related_modnets.empty());
 }
 
+TEST_F(TestDbNet, InsertBufferIgnoresSupplyInputs)
+{
+  dbMaster* inv_master = db_->findMaster("INV_X1");
+  ASSERT_NE(inv_master, nullptr);
+
+  dbMaster* buffer_master
+      = dbMaster::create(inv_master->getLib(), "BUF_WITH_INPUT_SUPPLIES");
+  buffer_master->setWidth(inv_master->getWidth());
+  buffer_master->setHeight(inv_master->getHeight());
+  buffer_master->setType(dbMasterType::CORE);
+  dbMTerm* buffer_input
+      = dbMTerm::create(buffer_master, "A", dbIoType::INPUT, dbSigType::SIGNAL);
+  dbMTerm* buffer_output = dbMTerm::create(
+      buffer_master, "Z", dbIoType::OUTPUT, dbSigType::SIGNAL);
+  dbMTerm::create(buffer_master, "VDD", dbIoType::INPUT, dbSigType::POWER);
+  dbMTerm::create(buffer_master, "VSS", dbIoType::INPUT, dbSigType::GROUND);
+  buffer_master->setFrozen();
+
+  dbInst* driver = dbInst::create(block_, inv_master, "driver");
+  dbInst* load = dbInst::create(block_, inv_master, "load");
+  dbITerm* driver_output = driver->findITerm("ZN");
+  dbITerm* load_input = load->findITerm("A");
+  ASSERT_NE(driver_output, nullptr);
+  ASSERT_NE(load_input, nullptr);
+
+  dbNet* net = dbNet::create(block_, "signal");
+  driver_output->connect(net);
+  load_input->connect(net);
+
+  dbInst* buffer
+      = net->insertBufferBeforeLoad(load_input, buffer_master, nullptr, "buf");
+
+  ASSERT_NE(buffer, nullptr);
+  EXPECT_EQ(buffer->getITerm(buffer_input)->getNet(), net);
+  dbNet* buffered_net = buffer->getITerm(buffer_output)->getNet();
+  ASSERT_NE(buffered_net, nullptr);
+  EXPECT_NE(buffered_net, net);
+  EXPECT_EQ(load_input->getNet(), buffered_net);
+  EXPECT_EQ(buffer->findITerm("VDD")->getNet(), nullptr);
+  EXPECT_EQ(buffer->findITerm("VSS")->getNet(), nullptr);
+}
+
 // Test that the net is renamed to the name of the highest-level modnet
 TEST_F(TestDbNet, RenameWithModNetInHighestHier)
 {


### PR DESCRIPTION
Fixes #10870.

LEF power and ground pins are allowed to use INPUT direction, but dbInsertBuffer counted every INPUT MTerm when deciding whether a master was a simple buffer. A normal buffer with A, VDD, and VSS therefore looked like it had three signal inputs and was rejected with ODB-1207.

Skip supply MTerms before identifying the signal input and output. This uses dbSigType::isSupply(), so both POWER and GROUND are handled independently of their LEF direction.

The regression constructs that exact master, inserts it through dbNet::insertBufferBeforeLoad, and checks the input net, newly created output net, moved load, and disconnected supply ITerms.

Tested on the GCP Linux VM:
- red baseline reproduced ODB-1207 and a null buffer
- focused TestDbNet.InsertBufferIgnoresSupplyInputs passed after the fix
- complete //src/odb/test/cpp:OdbGTests passed
- Bazel --config=lint build for //src/odb/src/db:db and OdbGTests passed (189 actions)
- clang-format --dry-run --Werror
- git diff --check