### PR TITLE
drt: preserve top-layer wrong-way tracks

### DIFF
--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -466,22 +466,20 @@ void FlexGridGraph::initTracks(
     frLayerDirMap& layerNum2PreRouteDir,
     const odb::Rect& bbox)
 {
+  bool collectedAboveTopTracks = false;
   for (auto& layer : getTech()->getLayers()) {
     if (layer->getType() != dbTechLayerType::ROUTING) {
       continue;
     }
     frLayerNum currLayerNum = layer->getLayerNum();
-    // Layers above TOP_ROUTING_LAYER carry no routing edges or access vias
-    // (initEdges and the special-access via loop already cap work at
-    // TOP_ROUTING_LAYER), yet they were still added to the grid here, sizing
-    // nodes_, the per-node arrays, and the maze search bounds across the full
-    // layer stack. Skip them so the grid graph spans only the routing range,
-    // cutting detailed-route memory and runtime when the design's top routing
-    // layer is below the technology top. Default TOP_ROUTING_LAYER is INT_MAX,
-    // so this is a no-op unless the top routing layer is explicitly lowered.
-    if (currLayerNum > router_cfg_->TOP_ROUTING_LAYER) {
+    // Do not add z planes above TOP_ROUTING_LAYER. Keep tracks from the first
+    // routing layer above it because initEdges uses those coordinates for
+    // wrong-way edges on the top routing layer.
+    const bool aboveTop = currLayerNum > router_cfg_->TOP_ROUTING_LAYER;
+    if (aboveTop && collectedAboveTopTracks) {
       continue;
     }
+    collectedAboveTopTracks = aboveTop;
     dbTechLayerDir currPrefRouteDir = layer->getDir();
     for (auto& tp : design->getTopBlock()->getTrackPatterns(currLayerNum)) {
       // allow wrongway if global variable and design rule allow
@@ -515,7 +513,9 @@ void FlexGridGraph::initTracks(
         }
       }
     }
-    layerNum2PreRouteDir[currLayerNum] = currPrefRouteDir;
+    if (!aboveTop) {
+      layerNum2PreRouteDir[currLayerNum] = currPrefRouteDir;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #10873.

The regression came from dropping all track data above TOP_ROUTING_LAYER. The top routing layer uses coordinates from the next routing layer to create wrong-way edges and to build the maze x/y coordinate union. Removing those coordinates left valid routes without a path.

Keep the reduced z dimension, but collect tracks from the first routing layer above TOP_ROUTING_LAYER. That preserves the memory optimization while restoring the missing top-layer topology.

Tested on the GCP Linux VM:

* The supplied tiny_rocket/IHP130 replay passed the original 50% and 70% failure points without DRT-0255.
* Replay completed optimization iterations 0 and 1, then entered iteration 2 before the 20-minute cap.
* Peak reported memory was 1650 MB. The full-grid rollback reached about 1900 MB.
* All 26 //src/drt/test:all targets passed after rebasing onto current master.
* Bazel --config=lint build for //src/drt:drt passed.
* Stamped //:openroad build passed.
* clang-format and git diff --check passed.
