### PR TITLE
Addresses a portion of #10619, 2.5 Display controls — overlays, grids & misc

### DIFF
--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -28,6 +28,7 @@ genrule(
     srcs = [
         "src/style.css",
         "src/theme.js",
+        "src/display-state.js",
         "src/3d-viewer-widget.js",
         "src/coordinates.js",
         "src/ui-utils.js",
@@ -58,6 +59,7 @@ genrule(
           " --output $@" +
           " --css $(location src/style.css)" +
           " --js $(location src/theme.js)" +
+          " $(location src/display-state.js)" +
           " $(location src/3d-viewer-widget.js)" +
           " $(location src/coordinates.js)" +
           " $(location src/ui-utils.js)" +
@@ -93,6 +95,7 @@ _WEB_ASSET_FILES = [
     "src/tile-request.js",
     "src/device-pixels.js",
     "src/merged-tile-layer.js",
+    "src/display-state.js",
     "src/3d-viewer-widget.js",
     "src/coordinates.js",
     "src/ui-utils.js",

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -20,6 +20,7 @@ set(WEB_ASSET_FILES
     src/tile-request.js
     src/device-pixels.js
     src/merged-tile-layer.js
+    src/display-state.js
     src/coordinates.js
     src/ui-utils.js
     src/checkbox-tree-model.js
@@ -56,6 +57,7 @@ add_custom_command(
     --output ${REPORT_ASSETS_CPP}
     --css ${CMAKE_CURRENT_SOURCE_DIR}/src/style.css
     --js ${CMAKE_CURRENT_SOURCE_DIR}/src/theme.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/display-state.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/coordinates.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ui-utils.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/checkbox-tree-model.js

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -15,20 +15,23 @@ designs without a native GUI.
 ### Web Server
 
 Start the web viewer server. This opens a WebSocket server and launches the
-viewer in the default browser.
+viewer in the default browser. The command blocks until the server stops, so
+the design can be explored interactively; Tcl commands typed in the browser
+console run on the server.
 
 ```tcl
 web_server
     [-port port]
-    -dir dir
+    [-stop]
 ```
 
 #### Options
 
 | Switch Name | Description |
 | ---------- | -------------------------------------------------- |
-| `-port` | TCP port to listen on. Default: `8080`. |
-| `-dir` | Path to the document root directory containing the web assets (`index.html`, `*.js`, `*.css`). |
+| `-port` | TCP port to listen on. Default: `0`, which picks a free port. |
+| `-stop` | Stop a running server and return from the blocked `web_server` call. |
+| `-dir` | Deprecated and ignored; the web assets are embedded in the binary. |
 
 ### Save Image
 
@@ -151,6 +154,66 @@ web_save_report timing.html
 web_save_report -setup_paths 200 -hold_paths 200 timing.html
 ```
 
+### Save Display Controls
+
+Write the display-controls state of the connected viewer to a JSON file, so a
+particular set of visibility, selectability, layer-pattern and theme choices
+can be reused later or shared.
+
+```tcl
+save_display_controls
+    filename
+```
+
+#### Options
+
+| Switch Name | Description |
+| ----------- | ------------------------------------------------- |
+| `filename` | Output JSON file path. |
+
+The viewer pushes a snapshot of its state to the server whenever a control
+changes, and this command writes the most recent snapshot. It therefore
+requires a running server (`web_server`) with a viewer open; otherwise it
+errors, or warns if no snapshot has arrived yet. The server caches a single
+snapshot, so with several viewers connected the state saved is that of
+whichever one synced last.
+
+Because Tcl commands typed into the browser console run on the server, this is
+normally invoked from the viewer's own console after arranging the panel.
+
+### Restore Display Controls
+
+Apply a previously saved display-controls file to every connected viewer.
+
+```tcl
+restore_display_controls
+    filename
+```
+
+#### Options
+
+| Switch Name | Description |
+| ----------- | ------------------------------------------------- |
+| `filename` | Input JSON file path, as written by `save_display_controls`. |
+
+The state is broadcast to all connected clients, each of which re-applies it
+and reloads, preserving the current camera position. A key absent from the file
+is reset to its default rather than left as-is. The file is validated before it
+is broadcast; a malformed or unexpectedly shaped file is rejected with an error
+and nothing is applied.
+
+Like `save_display_controls`, this requires a running server.
+
+#### Examples
+
+```tcl
+# In the viewer's Tcl console, after setting up the panel
+save_display_controls my_view.json
+
+# Later, in another session with the viewer open
+restore_display_controls my_view.json
+```
+
 ## Features
 
 - **Tile-based rendering** — The server renders 256x256 PNG tiles on demand,
@@ -168,7 +231,8 @@ web_save_report -setup_paths 200 -hold_paths 200 timing.html
   palette.
 - **Display controls** — Toggle visibility of cell types (stdcells, macros,
   pads), net types (signal, power, clock), and shapes (routing, pins, blockages,
-  rows, tracks).
+  rows, tracks). The panel state can be saved to and restored from a file with
+  `save_display_controls` / `restore_display_controls`.
 - **Focus nets** — Isolate specific nets for inspection, dimming all other
   routing.
 - **Tcl console** — Execute Tcl commands interactively from the browser.
@@ -196,8 +260,11 @@ response shapes, error contract) is documented in
 ## Example scripts
 
 ```tcl
-# Start the web viewer, pointing at the web assets directory
-web_server -dir /path/to/OpenROAD/src/web/src
+# Start the web viewer on an OS-assigned port
+web_server
+
+# Start on a fixed port
+web_server -port 8080
 ```
 
 ## Regression tests

--- a/src/web/include/web/web.h
+++ b/src/web/include/web/web.h
@@ -122,6 +122,22 @@ class WebServer
                  double dbu_per_pixel,
                  const std::string& vis_json);
 
+  // Persist the connected client's current display-controls state (as
+  // synced via the "set_display_state" request) to a JSON file.  The cache
+  // holds a single snapshot: with several clients connected, the state of
+  // whichever client synced last is the one saved.
+  void saveDisplayControls(const std::string& filename);
+
+  // Read a display-controls JSON file and broadcast it to every connected
+  // client so they re-apply the saved state.
+  void restoreDisplayControls(const std::string& filename);
+
+  // Cache a display-controls snapshot (forwarded to the viewer hook).
+  // No-op if the server was never initialized.  The live
+  // "set_display_state" request writes to the hook directly; this entry
+  // point exists for tests and embedders.
+  void setDisplayState(std::string json);
+
   // Tears down the I/O threads and cleans up hooks.  Safe to call multiple
   // times and from any thread; after it returns, isRunning() is false and
   // serve() may be called again to restart the server.

--- a/src/web/src/3d-viewer-widget.js
+++ b/src/web/src/3d-viewer-widget.js
@@ -289,6 +289,9 @@ export class ThreeDViewerWidget {
     trueZCb.addEventListener('change', () => {
       this._app.useTrueZ = trueZCb.checked;
       setCookie('or_use_true_z', trueZCb.checked ? '1' : '0');
+      // or_use_true_z is part of the saved display state and no redraw
+      // path pushes it (in static/saved-report mode the sync no-ops).
+      this._app.syncDisplayState();
       this.refreshSceneForOptions();
     });
     trueZLabel.appendChild(trueZCb);

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -5,7 +5,9 @@
 
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
 import { VisTree } from './vis-tree.js';
-import { getCookie, setCookie } from './theme.js';
+import { getCookie, setCookie, setBackgroundColor, resetBackgroundColor }
+    from './theme.js';
+import { isValidHexColor } from './ui-utils.js';
 
 // Compute a Set of layer indices around `center` within [0, count).
 // `lower` layers below and `upper` layers above are included.
@@ -919,6 +921,8 @@ export function populateDisplayControls(app, visibility, selectability,
         ]},
         { key: 'rulers', label: 'Rulers' },
         { key: 'scale_bar', label: 'Scale bar' },
+        { key: 'focused_nets_guides', label: 'Focused nets guides' },
+        { key: 'highlight_selected', label: 'Highlight selected' },
     ]});
     visTree.add({ key: 'module_view', label: 'Module view' });
     visTree.add({ key: 'debug', label: 'Debug tiles' });
@@ -930,6 +934,41 @@ export function populateDisplayControls(app, visibility, selectability,
         ],
     });
     visTree.render(app.displayControlsEl);
+
+    // Background color control (Qt GUI "Background" parity): a swatch that
+    // opens the native color picker + a reset-to-theme link.  The layout
+    // background is the CSS var --bg-map on the Leaflet container, so this
+    // is purely client-side (tiles are transparent).
+    // Mirrors the CSS default (--bg-map: #111) in the "#rrggbb" form an
+    // <input type="color"> requires.
+    const DEFAULT_BG_COLOR = '#111111';
+    const bgRow = document.createElement('div');
+    bgRow.className = 'bg-color-row';
+    const bgLabel = document.createElement('span');
+    bgLabel.textContent = 'Background';
+    const bgInput = document.createElement('input');
+    bgInput.type = 'color';
+    bgInput.className = 'bg-color-input';
+    bgInput.title = 'Layout background color';
+    const savedBg = getCookie('or_bg_color');
+    bgInput.value = isValidHexColor(savedBg) ? savedBg : DEFAULT_BG_COLOR;
+    bgInput.addEventListener('input', () => {
+        setBackgroundColor(bgInput.value, app);
+        app.syncDisplayState();
+    });
+    const bgReset = document.createElement('button');
+    bgReset.className = 'bg-color-reset';
+    bgReset.textContent = 'Reset';
+    bgReset.title = 'Reset background to the theme default';
+    bgReset.addEventListener('click', () => {
+        resetBackgroundColor(app);
+        bgInput.value = DEFAULT_BG_COLOR;
+        app.syncDisplayState();
+    });
+    bgRow.appendChild(bgLabel);
+    bgRow.appendChild(bgInput);
+    bgRow.appendChild(bgReset);
+    app.displayControlsEl.appendChild(bgRow);
 
     if (!app.heatMapLayer) {
         app.heatMapLayer = new HeatMapTileLayer(app.websocketManager, app, {

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -5,7 +5,8 @@
 
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
 import { VisTree } from './vis-tree.js';
-import { getCookie, setCookie, setBackgroundColor, resetBackgroundColor }
+import { getCookie, setCookie, setBackgroundColor, resetBackgroundColor,
+         getThemeDefaultBgColor }
     from './theme.js';
 import { isValidHexColor } from './ui-utils.js';
 
@@ -296,6 +297,10 @@ export function populateDisplayControls(app, visibility, selectability,
         const hiddenNodes = allLayerIds.filter(n => !app.visibleLayers.has(n));
         setCookie('or_hidden_layers',
                   encodeURIComponent(JSON.stringify(hiddenNodes)));
+        // or_hidden_layers is part of the saved display state; the chiplet
+        // mirror below only reaches the sync (via redrawAllLayers) when the
+        // visible-chiplet set changes, so push explicitly (rAF-coalesced).
+        app.syncDisplayState();
 
         // Mirror chiplet toggles into the Chiplets panel.  Toggling
         // wrapper_1 in the Layers tree must also remove its path from
@@ -350,6 +355,9 @@ export function populateDisplayControls(app, visibility, selectability,
             = techData.layers.filter(n => !app.selectableLayers.has(n));
         setCookie('or_nonselectable_layers',
                   encodeURIComponent(JSON.stringify(nonSel)));
+        // Selectability changes rendering of nothing, so no redraw runs;
+        // push the saved display state explicitly.
+        app.syncDisplayState();
     });
     layerSelModel.addFromSpec(layerSelSpec);
 
@@ -939,9 +947,6 @@ export function populateDisplayControls(app, visibility, selectability,
     // opens the native color picker + a reset-to-theme link.  The layout
     // background is the CSS var --bg-map on the Leaflet container, so this
     // is purely client-side (tiles are transparent).
-    // Mirrors the CSS default (--bg-map: #111) in the "#rrggbb" form an
-    // <input type="color"> requires.
-    const DEFAULT_BG_COLOR = '#111111';
     const bgRow = document.createElement('div');
     bgRow.className = 'bg-color-row';
     const bgLabel = document.createElement('span');
@@ -951,7 +956,7 @@ export function populateDisplayControls(app, visibility, selectability,
     bgInput.className = 'bg-color-input';
     bgInput.title = 'Layout background color';
     const savedBg = getCookie('or_bg_color');
-    bgInput.value = isValidHexColor(savedBg) ? savedBg : DEFAULT_BG_COLOR;
+    bgInput.value = isValidHexColor(savedBg) ? savedBg : getThemeDefaultBgColor();
     // 'input' fires on every tick while dragging inside the picker: keep it
     // to the cheap CSS-var preview.  Persistence (cookie), the 3D-viewer
     // re-render and the server sync run once, on 'change' (picker closed).
@@ -960,16 +965,16 @@ export function populateDisplayControls(app, visibility, selectability,
     });
     bgInput.addEventListener('change', () => {
         setBackgroundColor(bgInput.value, app);
-        app.syncDisplayState();
     });
     const bgReset = document.createElement('button');
     bgReset.className = 'bg-color-reset';
     bgReset.textContent = 'Reset';
     bgReset.title = 'Reset background to the theme default';
     bgReset.addEventListener('click', () => {
+        // resetBackgroundColor removes the inline --bg-map override, so
+        // the default read afterwards is the theme's own value.
         resetBackgroundColor(app);
-        bgInput.value = DEFAULT_BG_COLOR;
-        app.syncDisplayState();
+        bgInput.value = getThemeDefaultBgColor();
     });
     bgRow.appendChild(bgLabel);
     bgRow.appendChild(bgInput);

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -952,7 +952,13 @@ export function populateDisplayControls(app, visibility, selectability,
     bgInput.title = 'Layout background color';
     const savedBg = getCookie('or_bg_color');
     bgInput.value = isValidHexColor(savedBg) ? savedBg : DEFAULT_BG_COLOR;
+    // 'input' fires on every tick while dragging inside the picker: keep it
+    // to the cheap CSS-var preview.  Persistence (cookie), the 3D-viewer
+    // re-render and the server sync run once, on 'change' (picker closed).
     bgInput.addEventListener('input', () => {
+        document.documentElement.style.setProperty('--bg-map', bgInput.value);
+    });
+    bgInput.addEventListener('change', () => {
         setBackgroundColor(bgInput.value, app);
         app.syncDisplayState();
     });

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -6,9 +6,12 @@
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
 import { VisTree, makeColumnHeader, makeNameSpan, makeSelSpacer }
     from './vis-tree.js';
-import { getCookie, setCookie } from './theme.js';
+import { getCookie, setCookie, setBackgroundColor, resetBackgroundColor,
+         getThemeDefaultBgColor }
+    from './theme.js';
 import { isStaticMode, makeGroupHeader, attachGroupCollapse, beginSelection,
-         isCurrentSelection, onSelectionReset } from './ui-utils.js';
+         isCurrentSelection, onSelectionReset, isValidHexColor }
+    from './ui-utils.js';
 
 // Compute a Set of layer indices around `center` within [0, count).
 // `lower` layers below and `upper` layers above are included.
@@ -598,6 +601,10 @@ export function populateDisplayControls(app, visibility, selectability,
             window.sessionStorage.setItem(
                 'or_hidden_layers', JSON.stringify(hiddenNodes));
         } catch (_) { /* ignore */ }
+        // or_hidden_layers is part of the saved display state; the chiplet
+        // mirror below only reaches the sync (via redrawAllLayers) when the
+        // visible-chiplet set changes, so push explicitly (rAF-coalesced).
+        app.syncDisplayState();
 
         // Mirror chiplet toggles into the Chiplets panel.  Toggling
         // wrapper_1 in the Layers tree must also remove its path from
@@ -654,6 +661,9 @@ export function populateDisplayControls(app, visibility, selectability,
             window.sessionStorage.setItem(
                 'or_nonselectable_layers', JSON.stringify(nonSel));
         } catch (_) { /* ignore */ }
+        // Selectability changes the rendering of nothing, so no redraw runs;
+        // push the saved display state explicitly.
+        app.syncDisplayState();
     });
     layerSelModel.addFromSpec(layerSelSpec);
 
@@ -1345,6 +1355,8 @@ export function populateDisplayControls(app, visibility, selectability,
         { key: 'mfg_grid', label: 'Manufacturing grid' },
         { key: 'gcell_grid', label: 'GCell grid' },
         { key: 'flywires_only', label: 'Flywires only' },
+        { key: 'focused_nets_guides', label: 'Focused nets guides' },
+        { key: 'highlight_selected', label: 'Highlight selected' },
     ]});
     visTree.add({ key: 'module_view', label: 'Module view' });
     // Developer overlays.  All three are plain leaves under a visKey-less
@@ -1360,6 +1372,44 @@ export function populateDisplayControls(app, visibility, selectability,
         { key: 'debug', label: 'Tiles' },
     ]});
     visTree.render(app.displayControlsEl);
+
+    // Background color control (Qt GUI "Background" parity): a swatch that
+    // opens the native color picker + a reset-to-theme link.  The layout
+    // background is the CSS var --bg-map on the Leaflet container, so this
+    // is purely client-side (tiles are transparent).
+    const bgRow = document.createElement('div');
+    bgRow.className = 'bg-color-row';
+    const bgLabel = document.createElement('span');
+    bgLabel.textContent = 'Background';
+    const bgInput = document.createElement('input');
+    bgInput.type = 'color';
+    bgInput.className = 'bg-color-input';
+    bgInput.title = 'Layout background color';
+    const savedBg = getCookie('or_bg_color');
+    bgInput.value = isValidHexColor(savedBg) ? savedBg : getThemeDefaultBgColor();
+    // 'input' fires on every tick while dragging inside the picker: keep it
+    // to the cheap CSS-var preview.  Persistence (cookie), the 3D-viewer
+    // re-render and the server sync run once, on 'change' (picker closed).
+    bgInput.addEventListener('input', () => {
+        document.documentElement.style.setProperty('--bg-map', bgInput.value);
+    });
+    bgInput.addEventListener('change', () => {
+        setBackgroundColor(bgInput.value, app);
+    });
+    const bgReset = document.createElement('button');
+    bgReset.className = 'bg-color-reset';
+    bgReset.textContent = 'Reset';
+    bgReset.title = 'Reset background to the theme default';
+    bgReset.addEventListener('click', () => {
+        // resetBackgroundColor removes the inline --bg-map override, so
+        // the default read afterwards is the theme's own value.
+        resetBackgroundColor(app);
+        bgInput.value = getThemeDefaultBgColor();
+    });
+    bgRow.appendChild(bgLabel);
+    bgRow.appendChild(bgInput);
+    bgRow.appendChild(bgReset);
+    app.displayControlsEl.appendChild(bgRow);
 
     if (!app.heatMapLayer) {
         app.heatMapLayer = new HeatMapTileLayer(app.websocketManager, app, {

--- a/src/web/src/display-state.js
+++ b/src/web/src/display-state.js
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+// Serialization of the display-controls panel state, for the Tcl
+// save_display_controls / restore_display_controls round trip.
+//
+// Split out of main.js so it can be unit-tested: main.js keeps the parts that
+// need the live app (pushing the snapshot over the WebSocket, saving the
+// camera, reloading the page), and everything that only touches browser
+// storage lives here.
+
+import { getCookie, setCookie, deleteCookie, persistTheme,
+         clearPersistedTheme } from './theme.js';
+
+// Every key that together captures the full display-controls state, with the
+// browser store it lives in.  The individual controls already persist to these
+// keys, so serializing them lets save_display_controls /
+// restore_display_controls round-trip the entire panel through the normal
+// page-init path — no parallel apply logic to drift out of sync with the
+// controls.
+//
+// The split between the two stores is deliberate, not incidental: per-layer
+// visibility, selectability and fill patterns live in sessionStorage rather
+// than cookies, because they must survive the reload that opening a database
+// triggers but start fresh in a new session, as in Qt (review feedback on
+// #10795).  Both paths below dispatch on `store`, so neither silently skips
+// the sessionStorage-backed entries.
+//
+// `store: 'theme'` routes through theme.js, which owns that key's two-store
+// persistence (cookie plus a localStorage mirror for standalone reports).
+const DISPLAY_STATE_KEYS = [
+    { key: 'or_visibility', store: 'cookie' },
+    { key: 'or_selectability', store: 'cookie' },
+    { key: 'or_hidden_layers', store: 'session' },
+    { key: 'or_nonselectable_layers', store: 'session' },
+    { key: 'or_layer_patterns', store: 'session' },
+    { key: 'or_hidden_chiplets', store: 'cookie' },
+    { key: 'or_bg_color', store: 'cookie' },
+    { key: 'or_show_dbu', store: 'cookie' },
+    { key: 'or_theme', store: 'theme' },
+    { key: 'or_use_true_z', store: 'cookie' },
+];
+
+// Storage accessors, tolerant of a browser with Web Storage disabled (the
+// cookie helpers in theme.js already are).  The store is resolved by NAME
+// inside the try: with storage blocked, reading `window.sessionStorage` throws
+// on the property access itself, so passing the object in would throw at the
+// call site, outside this guard.
+function readStorage(name, key) {
+    try {
+        return window[name].getItem(key);
+    } catch (_) {
+        return null;
+    }
+}
+
+function writeStorage(name, key, value) {
+    try {
+        if (value === null) {
+            window[name].removeItem(key);
+        } else {
+            window[name].setItem(key, value);
+        }
+    } catch (_) { /* storage disabled */ }
+}
+
+// Values are moved verbatim: the cookie helpers are raw pass-through (their
+// callers URI-encode) and the Web Storage keys hold plain JSON, so reading and
+// writing through the same store round-trips without re-encoding.
+function readDisplayStateKey({ key, store }) {
+    if (store === 'session') {
+        return readStorage('sessionStorage', key);
+    }
+    // The theme's cookie is authoritative: its mirror only exists where there
+    // is no server to push a snapshot to.
+    return getCookie(key);
+}
+
+// `value === null` means "unset", so the reload falls back to the default.
+function writeDisplayStateKey({ key, store }, value) {
+    if (store === 'session') {
+        writeStorage('sessionStorage', key, value);
+    } else if (store === 'theme') {
+        if (value === null) {
+            clearPersistedTheme();
+        } else {
+            persistTheme(value);
+        }
+    } else if (value === null) {
+        deleteCookie(key);
+    } else {
+        setCookie(key, value);
+    }
+}
+
+// Snapshot the current display state as a plain object for the server to
+// persist.  Only non-empty entries are included so restore can tell "unset"
+// (use default) from "set".
+export function serializeDisplayState() {
+    const entries = {};
+    for (const spec of DISPLAY_STATE_KEYS) {
+        const value = readDisplayStateKey(spec);
+        if (value) entries[spec.key] = value;
+    }
+    return { version: 1, entries };
+}
+
+// Write a saved state's entries back into browser storage.  A key missing from
+// the state is cleared, so the page-init path that runs next falls back to the
+// default.
+//
+// Reject anything that is not a cookie-safe string rather than coercing it: a
+// number or boolean would silently change a key's meaning (a JSON `1` and the
+// string '1' are not interchangeable for readers comparing with ===), and a
+// ';' CR or LF would forge attributes on the cookie this is written into.
+// Belt and braces — WEB-0054 already rejects such a file server-side, where the
+// user gets an actionable error naming the offending entry.
+function isUsableDisplayStateValue(value) {
+    return typeof value === 'string' && value !== ''
+        && !/[;\r\n]/.test(value);
+}
+
+export function applyDisplayStateEntries(entries) {
+    for (const spec of DISPLAY_STATE_KEYS) {
+        const value = entries[spec.key];
+        writeDisplayStateKey(
+            spec, isUsableDisplayStateValue(value) ? value : null);
+    }
+}

--- a/src/web/src/embed_report_assets.py
+++ b/src/web/src/embed_report_assets.py
@@ -14,8 +14,12 @@ import re
 
 def process_js_file(content):
     """Process a single JS file for concatenation into a shared scope."""
-    # Remove import lines.
-    content = re.sub(r"^import\s+.*;\s*$", "", content, flags=re.MULTILINE)
+    # Remove import statements, including ones wrapped over several lines.
+    # `[^;]*` spans newlines but stops at the first ';', so a statement is
+    # consumed whole and no real code can be swallowed.  A single-line-only
+    # pattern left the tail of a wrapped import behind, which is a syntax error
+    # for the whole concatenated bundle.
+    content = re.sub(r"^import\s[^;]*;[ \t]*$", "", content, flags=re.MULTILINE)
 
     # Find exported names and strip the export keyword.
     # Two patterns:

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -370,11 +370,18 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
     function highlightBBox(x1, y1, x2, y2) {
         if (app.highlightRect) {
             app.map.removeLayer(app.highlightRect);
+            app.highlightRect = null;
         }
         const bounds = dbuRectToBounds(x1, y1, x2, y2, app.designScale, app.designMaxDXDY, app.designOriginX, app.designOriginY);
+        // Always build the outline; only attach it while the "Highlight
+        // selected" toggle (Misc) is on, so toggling it back on can
+        // re-attach the current selection's outline (redrawAllLayers).
         app.highlightRect = L.rectangle(bounds, {
             color: '#ff0', weight: 2, fill: false, dashArray: '6,4',
-        }).addTo(app.map);
+        });
+        if (!(app.visibility && app.visibility.highlight_selected === false)) {
+            app.highlightRect.addTo(app.map);
+        }
     }
 
     // Briefly pulse the object's bbox so the user can see which object
@@ -384,9 +391,15 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
     let pulseLayer = null;
     function pulseHighlight(bbox) {
         if (!bbox || !app.map || !app.designScale) return;
+        // Clear any pulse in flight before honoring the toggle, so a call
+        // while highlighting is off doesn't leave a stale pulse behind.
         if (pulseLayer) {
             app.map.removeLayer(pulseLayer);
             pulseLayer = null;
+        }
+        // Honor the "Highlight selected" toggle (Misc).
+        if (app.visibility && app.visibility.highlight_selected === false) {
+            return;
         }
         const [x1, y1, x2, y2] = bbox;
         const bounds = dbuRectToBounds(
@@ -414,6 +427,15 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             }
         }, 1100);
     }
+
+    // Let redrawAllLayers cancel an in-flight pulse when the "Highlight
+    // selected" toggle is turned off (pulseLayer is private to this closure).
+    app.clearSelectionPulse = function() {
+        if (pulseLayer) {
+            app.map.removeLayer(pulseLayer);
+            pulseLayer = null;
+        }
+    };
 
     function renderProperty(prop, data) {
         // Group with children (PropertyList or SelectionSet)

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -380,11 +380,18 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
     function highlightBBox(x1, y1, x2, y2) {
         if (app.highlightRect) {
             app.map.removeLayer(app.highlightRect);
+            app.highlightRect = null;
         }
         const bounds = dbuRectToBounds(x1, y1, x2, y2, app.designScale, app.designMaxDXDY, app.designOriginX, app.designOriginY);
+        // Always build the outline; only attach it while the "Highlight
+        // selected" toggle (Misc) is on, so toggling it back on can
+        // re-attach the current selection's outline (redrawAllLayers).
         app.highlightRect = L.rectangle(bounds, {
             color: '#ff0', weight: 2, fill: false, dashArray: '6,4',
-        }).addTo(app.map);
+        });
+        if (!(app.visibility && app.visibility.highlight_selected === false)) {
+            app.highlightRect.addTo(app.map);
+        }
     }
 
     // Briefly pulse the object's bbox so the user can see which object
@@ -394,9 +401,15 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
     let pulseLayer = null;
     function pulseHighlight(bbox) {
         if (!bbox || !app.map || !app.designScale) return;
+        // Clear any pulse in flight before honoring the toggle, so a call
+        // while highlighting is off doesn't leave a stale pulse behind.
         if (pulseLayer) {
             app.map.removeLayer(pulseLayer);
             pulseLayer = null;
+        }
+        // Honor the "Highlight selected" toggle (Misc).
+        if (app.visibility && app.visibility.highlight_selected === false) {
+            return;
         }
         const [x1, y1, x2, y2] = bbox;
         const bounds = dbuRectToBounds(
@@ -424,6 +437,15 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             }
         }, 1100);
     }
+
+    // Let redrawAllLayers cancel an in-flight pulse when the "Highlight
+    // selected" toggle is turned off (pulseLayer is private to this closure).
+    app.clearSelectionPulse = function() {
+        if (pulseLayer) {
+            app.map.removeLayer(pulseLayer);
+            pulseLayer = null;
+        }
+    };
 
     // Build the collapsible shell (header row + body) shared by the group and
     // table property renderers.  `count` is the parenthesised badge after the

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -10,14 +10,14 @@ import { ClockTreeWidget } from './clock-tree-widget.js';
 import { ChartsWidget } from './charts-widget.js';
 import { HierarchyBrowser } from './hierarchy-browser.js';
 import { createInspectorPanel } from './inspector.js';
-import { isStaticMode } from './ui-utils.js';
+import { isStaticMode, computeScaleBar, rafCoalesce } from './ui-utils.js';
 import { populateDisplayControls } from './display-controls.js';
 import { createMenuBar } from './menu-bar.js';
 import { RulerManager } from './ruler.js';
 import { SchematicWidget } from './schematic-widget.js';
 import { DrcWidget } from './drc-widget.js';
 import { TclCompleter } from './tcl-completer.js';
-import { getCookie, setCookie, applyGLTheme } from './theme.js';
+import { getCookie, setCookie, deleteCookie, applyGLTheme } from './theme.js';
 import { updateDocumentTitle } from './title.js';
 import { ThreeDViewerWidget } from './3d-viewer-widget.js';
 
@@ -201,6 +201,10 @@ const visibility = {
     // Misc
     rulers: true,
     scale_bar: true,
+    // Route guides of focused nets — off by default, matching GUI
+    focused_nets_guides: false,
+    // Highlight of the current selection — on by default, matching GUI
+    highlight_selected: true,
     // Debug
     debug: false,
 };
@@ -388,16 +392,8 @@ function refreshOverlay() {
         app.overlayLayer.refreshTiles();
     }
 }
+const scheduleRefreshOverlay = rafCoalesce(refreshOverlay);
 app.refreshOverlay = scheduleRefreshOverlay;
-
-let _overlayRAF = null;
-function scheduleRefreshOverlay() {
-    if (_overlayRAF !== null) return;
-    _overlayRAF = requestAnimationFrame(() => {
-        _overlayRAF = null;
-        refreshOverlay();
-    });
-}
 
 function redrawAllLayers() {
     // Persist visibility and selectability state to cookies so they survive
@@ -405,6 +401,8 @@ function redrawAllLayers() {
     setCookie('or_visibility', encodeURIComponent(JSON.stringify(visibility)));
     setCookie('or_selectability',
               encodeURIComponent(JSON.stringify(selectability)));
+    // Keep the server's saved-state snapshot current for save_display_controls.
+    scheduleSyncDisplayState();
 
     // Show/hide modules layer based on module_view visibility
     if (app.modulesLayer) {
@@ -428,6 +426,22 @@ function redrawAllLayers() {
     if (app.heatMapLayer) {
         app.heatMapLayer.refreshTiles();
     }
+    // Keep the client-side selection outline in sync with the "Highlight
+    // selected" toggle: detach it when off, re-attach it when back on (the
+    // rectangle object is preserved so the current selection survives an
+    // off→on round trip; the server-side highlight is gated by the overlay
+    // refresh below).  An in-flight selection pulse is cancelled on off.
+    if (app.highlightRect) {
+        const showHighlight = visibility.highlight_selected !== false;
+        if (!showHighlight && app.map.hasLayer(app.highlightRect)) {
+            app.map.removeLayer(app.highlightRect);
+        } else if (showHighlight && !app.map.hasLayer(app.highlightRect)) {
+            app.highlightRect.addTo(app.map);
+        }
+    }
+    if (!visibility.highlight_selected && app.clearSelectionPulse) {
+        app.clearSelectionPulse();
+    }
     // Overlay layer must also refresh on structural changes (e.g. design
     // reload changes the coordinate space).
     refreshOverlay();
@@ -442,13 +456,74 @@ function redrawAllLayers() {
 
 // Debounced wrapper: coalesces back-to-back server pushes (e.g.
 // debug_refresh + debug_paused) into a single redrawAllLayers() call.
-let _redrawRAF = null;
-function scheduleRedrawAllLayers() {
-    if (_redrawRAF !== null) return;
-    _redrawRAF = requestAnimationFrame(() => {
-        _redrawRAF = null;
-        redrawAllLayers();
-    });
+const scheduleRedrawAllLayers = rafCoalesce(redrawAllLayers);
+
+// Cookies that together capture the full display-controls state.  The
+// individual controls already persist to these keys, so serializing them
+// lets `save_display_controls`/`restore_display_controls` (Tcl) round-trip
+// the entire panel through the normal page-init path — no parallel apply
+// logic to drift out of sync with the controls.
+const DISPLAY_STATE_COOKIES = [
+    'or_visibility',
+    'or_selectability',
+    'or_hidden_layers',
+    'or_nonselectable_layers',
+    'or_hidden_chiplets',
+    'or_bg_color',
+    'or_show_dbu',
+    'or_theme',
+    'or_use_true_z',
+];
+
+// Snapshot the current display state as a plain object for the server to
+// persist.  Only non-empty cookies are included so restore can tell "unset"
+// (use default) from "set".
+function serializeDisplayState() {
+    const cookies = {};
+    for (const key of DISPLAY_STATE_COOKIES) {
+        const value = getCookie(key);
+        if (value) cookies[key] = value;
+    }
+    return { version: 1, cookies };
+}
+
+// Push the current display state to the server (coalesced via rAF) so the
+// Tcl save_display_controls command has an up-to-date snapshot to write.
+const scheduleSyncDisplayState = rafCoalesce(() => {
+    if (!app.websocketManager) return;
+    app.websocketManager.request({
+        type: 'set_display_state',
+        state: serializeDisplayState(),
+    }).catch(() => { /* server offline / not ready — ignore */ });
+});
+app.syncDisplayState = scheduleSyncDisplayState;
+
+// Apply a saved display state (from restore_display_controls) by writing
+// the cookies back and reloading, so the well-tested init path rebuilds the
+// panel consistently.  The current camera is preserved across the reload.
+function applyDisplayState(state) {
+    if (!state || typeof state !== 'object') return;
+    const cookies = state.cookies;
+    if (!cookies || typeof cookies !== 'object') return;
+    for (const key of DISPLAY_STATE_COOKIES) {
+        const value = cookies[key];
+        if (value === undefined || value === null || value === '') {
+            // Absent in the saved state → clear so the reload uses defaults.
+            deleteCookie(key);
+        } else {
+            setCookie(key, String(value));
+        }
+    }
+    // Preserve the current view so restoring controls doesn't move the map.
+    try {
+        if (app.map && typeof sessionStorage !== 'undefined') {
+            const c = app.map.getCenter();
+            sessionStorage.setItem('or_restore_view',
+                JSON.stringify({ lat: c.lat, lng: c.lng,
+                                 zoom: app.map.getZoom() }));
+        }
+    } catch (_) { /* ignore */ }
+    window.location.reload();
 }
 
 function createLayoutViewer(container) {
@@ -494,25 +569,44 @@ function createLayoutViewer(container) {
     });
     app.map.on('mouseout', () => { app.lastMouseLatLng = null; });
 
-    // Scale bar overlay (bottom-left, above coord bar).
+    // Scale bar overlay (bottom-left, above coord bar).  Content is an
+    // inline SVG rebuilt on each update (bracket + ticks + 0/total labels).
     const scaleBar = document.createElement('div');
     scaleBar.id = 'scale-bar';
     mapDiv.appendChild(scaleBar);
-    const scaleBarLine = document.createElement('div');
-    scaleBarLine.className = 'scale-bar-line';
-    scaleBar.appendChild(scaleBarLine);
-    const scaleBarLabel = document.createElement('span');
-    scaleBarLabel.className = 'scale-bar-label';
-    scaleBar.appendChild(scaleBarLabel);
 
-    // Round to the nearest 1/2/5 × 10^n value (e.g. 1, 2, 5, 10, 20, …).
-    function niceRound(value) {
-        const mag = Math.pow(10, Math.floor(Math.log10(value)));
-        const residual = value / mag;
-        if (residual < 1.5) return 1 * mag;
-        if (residual < 3.5) return 2 * mag;
-        if (residual < 7.5) return 5 * mag;
-        return 10 * mag;
+    const SB_H = 22;       // svg height
+    const SB_BAR_H = 8;    // bracket height
+    const SB_PAD = 22;     // horizontal room for end labels overflowing the bar
+
+    function renderScaleBar(barPx, label, segments) {
+        const top = 2;
+        const base = top + SB_BAR_H;
+        const x0 = SB_PAD;
+        const x1 = SB_PAD + barPx;
+        const labelY = SB_H - 2;
+        const wide = barPx >= 40;  // hide "0"/ticks on very short bars
+        const parts = [];
+        // Bracket: |_| (left/right verticals + baseline, open top).
+        parts.push(`<path d="M${x0} ${top} V${base} H${x1} V${top}" `
+            + `fill="none" stroke="currentColor" stroke-width="2"/>`);
+        // Interior ticks (half height), only when the bar is wide enough.
+        if (wide && segments > 1) {
+            for (let i = 1; i < segments; i++) {
+                const tx = x0 + (barPx * i) / segments;
+                parts.push(`<line x1="${tx}" y1="${base - SB_BAR_H / 2}" `
+                    + `x2="${tx}" y2="${base}" stroke="currentColor" stroke-width="1"/>`);
+            }
+        }
+        // Labels: "0" at the left end, the total at the right end.
+        if (wide) {
+            parts.push(`<text x="${x0}" y="${labelY}" text-anchor="middle" `
+                + `class="scale-bar-text">0</text>`);
+        }
+        parts.push(`<text x="${x1}" y="${labelY}" text-anchor="middle" `
+            + `class="scale-bar-text">${label}</text>`);
+        scaleBar.innerHTML =
+            `<svg width="${x1 + SB_PAD}" height="${SB_H}">${parts.join('')}</svg>`;
     }
 
     function updateScaleBar() {
@@ -520,39 +614,30 @@ function createLayoutViewer(container) {
             scaleBar.style.display = 'none';
             return;
         }
-        scaleBar.style.display = '';
-
         // Pixels per DBU at current zoom: designScale * 2^zoom.
-        const zoom = app.map.getZoom();
-        const pxPerDbu = app.designScale * Math.pow(2, zoom);
-
+        const pxPerDbu = app.designScale * Math.pow(2, app.map.getZoom());
         // Target bar width: ~15% of the map container width.
         const containerWidth = app.map.getContainer().clientWidth || 400;
-        const targetPx = containerWidth * 0.15;
-
-        let barPx, label;
-        if (app.showDbu) {
-            const niceDbu = Math.max(1, niceRound(targetPx / pxPerDbu));
-            barPx = Math.round(niceDbu * pxPerDbu);
-            label = String(Math.round(niceDbu));
-        } else {
-            const dbuPerUm = app.techData?.dbu_per_micron || 1000;
-            const pxPerUm = pxPerDbu * dbuPerUm;
-            const niceUm = niceRound(targetPx / pxPerUm);
-
-            barPx = Math.round(niceUm * pxPerUm);
-
-            // Format with appropriate units.
-            if (niceUm >= 1000) label = (niceUm / 1000) + ' mm';
-            else if (niceUm >= 1) label = niceUm + ' \u00b5m';
-            else if (niceUm >= 0.001) label = (niceUm * 1000) + ' nm';
-            else label = (niceUm * 1e6) + ' pm';
+        const sb = computeScaleBar({
+            targetPx: containerWidth * 0.15,
+            pxPerDbu,
+            dbuPerMicron: app.techData?.dbu_per_micron,
+            showDbu: app.showDbu,
+        });
+        if (!sb) {
+            scaleBar.style.display = 'none';
+            return;
         }
-
-        scaleBarLine.style.width = barPx + 'px';
-        scaleBarLabel.textContent = label;
+        scaleBar.style.display = '';
+        renderScaleBar(sb.barPx, sb.label, sb.segments);
     }
-    app.map.on('zoomend moveend resize', updateScaleBar);
+
+    // Coalesce updates during continuous zoom gestures so the bar tracks
+    // the animation instead of only snapping at gesture end.  Pan doesn't
+    // change the bar (geometry depends only on zoom and container width),
+    // so 'move'/'moveend' are deliberately not listened to.
+    const scheduleUpdateScaleBar = rafCoalesce(updateScaleBar);
+    app.map.on('zoom zoomend resize', scheduleUpdateScaleBar);
     app.updateScaleBar = updateScaleBar;
 
     app.rulerManager = new RulerManager(app, visibility, updateInspector, focusComponent);
@@ -672,6 +757,9 @@ function createTclConsole(container) {
 
 // ─── Inspector Panel ────────────────────────────────────────────────────────
 
+// Expose visibility so the inspector can honor the "Highlight selected"
+// toggle when drawing its client-side selection outline/pulse.
+app.visibility = visibility;
 const inspector = createInspectorPanel(app, redrawAllLayers, scheduleRefreshOverlay);
 const createInspector = inspector.createInspector;
 const updateInspector = inspector.updateInspector;
@@ -948,6 +1036,7 @@ app.toggleTheme = function() {
     // Re-render canvas-based widgets that read theme colors.
     if (app.chartsWidget) app.chartsWidget.render();
     if (app.clockTreeWidget) app.clockTreeWidget.render();
+    scheduleSyncDisplayState();
 };
 
 app.toggleShowDbu = function() {
@@ -961,6 +1050,7 @@ app.toggleShowDbu = function() {
     if (app.updateScaleBar) app.updateScaleBar();
     // Re-request inspector properties with new formatting.
     if (app.refreshInspector) app.refreshInspector();
+    scheduleSyncDisplayState();
 };
 
 // ─── Menu Bar ────────────────────────────────────────────────────────────────
@@ -1032,6 +1122,9 @@ app.websocketManager.onPush = (msg) => {
         let text = msg.text;
         if (text.endsWith('\n')) text = text.slice(0, -1);
         if (text) tclAppend(text + '\n', '');
+    } else if (msg.type === 'restore_display_state') {
+        // restore_display_controls (Tcl) broadcast a saved state — apply it.
+        applyDisplayState(msg.state);
     } else if (msg.type === 'shutdown') {
         // Server is stopping intentionally (web_server -stop).
         // Disable auto-reconnect and show a clear message. Note that
@@ -1108,6 +1201,20 @@ app.websocketManager.readyPromise.then(async () => {
                     }
                 };
             }
+
+            // Restore the pre-reload camera saved by applyDisplayState so
+            // restore_display_controls doesn't move the view.
+            try {
+                const raw = sessionStorage.getItem('or_restore_view');
+                if (raw) {
+                    sessionStorage.removeItem('or_restore_view');
+                    const v = JSON.parse(raw);
+                    if (v && isFinite(v.lat) && isFinite(v.lng)
+                        && isFinite(v.zoom)) {
+                        app.map.setView([v.lat, v.lng], v.zoom);
+                    }
+                }
+            } catch (_) { /* ignore */ }
         }
 
         // Click-to-select: convert click position to DBU and query server

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -490,7 +490,7 @@ function serializeDisplayState() {
 // Push the current display state to the server (coalesced via rAF) so the
 // Tcl save_display_controls command has an up-to-date snapshot to write.
 const scheduleSyncDisplayState = rafCoalesce(() => {
-    if (!app.websocketManager) return;
+    if (!app.websocketManager || isStaticMode(app)) return;
     app.websocketManager.request({
         type: 'set_display_state',
         state: serializeDisplayState(),
@@ -1379,6 +1379,11 @@ app.websocketManager.readyPromise.then(async () => {
         if (hasDesign && !boundsData.shapes_ready) {
             document.getElementById('loading-overlay').style.display = 'flex';
         }
+
+        // Seed the server's display-state cache with the cookie-restored
+        // state, so save_display_controls works before any interaction
+        // (otherwise it would warn or write a previous session's state).
+        scheduleSyncDisplayState();
     } catch (err) {
         console.error('Failed to load initial data from server:', err);
     }

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -22,7 +22,7 @@ import { ChartsWidget } from './charts-widget.js';
 import { HierarchyBrowser } from './hierarchy-browser.js';
 import { createInspectorPanel } from './inspector.js';
 import { isStaticMode, buildMapOptions, beginSelection, isCurrentSelection,
-         computeScaleBar, rafCoalesce }
+         computeScaleBar, rafCoalesce, maxUsefulZoom }
     from './ui-utils.js';
 import { populateDisplayControls } from './display-controls.js';
 import { createMenuBar } from './menu-bar.js';
@@ -1239,6 +1239,11 @@ app.websocketManager.readyPromise.then(async () => {
                 [-maxDXDY * scale, 0],
                 [(designHeight - maxDXDY) * scale, designWidth * scale]
             ];
+            // Bound the zoom before the first fit: the tile layers are
+            // L.GridLayer, which contributes no maxZoom, so the map would
+            // otherwise let the user zoom until the tile math degenerates.
+            // Set per design, since the cap depends on this design's scale.
+            app.map.setMaxZoom(maxUsefulZoom(scale));
             app.map.fitBounds(app.fitBounds);
 
             if (staticCache) {

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -21,7 +21,8 @@ import { ClockTreeWidget } from './clock-tree-widget.js';
 import { ChartsWidget } from './charts-widget.js';
 import { HierarchyBrowser } from './hierarchy-browser.js';
 import { createInspectorPanel } from './inspector.js';
-import { isStaticMode, buildMapOptions, beginSelection, isCurrentSelection }
+import { isStaticMode, buildMapOptions, beginSelection, isCurrentSelection,
+         computeScaleBar, rafCoalesce }
     from './ui-utils.js';
 import { populateDisplayControls } from './display-controls.js';
 import { createMenuBar } from './menu-bar.js';
@@ -29,7 +30,7 @@ import { RulerManager } from './ruler.js';
 import { SchematicWidget } from './schematic-widget.js';
 import { DrcWidget } from './drc-widget.js';
 import { TclCompleter } from './tcl-completer.js';
-import { getCookie, setCookie, applyGLTheme } from './theme.js';
+import { getCookie, setCookie, deleteCookie, applyGLTheme } from './theme.js';
 import { updateDocumentTitle } from './title.js';
 import { ThreeDViewerWidget } from './3d-viewer-widget.js';
 
@@ -238,6 +239,10 @@ const visibility = {
     detailed: false,
     rulers: true,
     scale_bar: true,
+    // Route guides of focused nets — off by default, matching GUI
+    focused_nets_guides: false,
+    // Highlight of the current selection — on by default, matching GUI
+    highlight_selected: true,
     // Debug
     debug: false,
 };
@@ -481,16 +486,8 @@ function refreshOverlay() {
         app.overlayLayer.refreshTiles();
     }
 }
+const scheduleRefreshOverlay = rafCoalesce(refreshOverlay);
 app.refreshOverlay = scheduleRefreshOverlay;
-
-let _overlayRAF = null;
-function scheduleRefreshOverlay() {
-    if (_overlayRAF !== null) return;
-    _overlayRAF = requestAnimationFrame(() => {
-        _overlayRAF = null;
-        refreshOverlay();
-    });
-}
 
 function redrawAllLayers() {
     // Persist visibility and selectability state to cookies so they survive
@@ -498,6 +495,8 @@ function redrawAllLayers() {
     setCookie('or_visibility', encodeURIComponent(JSON.stringify(visibility)));
     setCookie('or_selectability',
               encodeURIComponent(JSON.stringify(selectability)));
+    // Keep the server's saved-state snapshot current for save_display_controls.
+    scheduleSyncDisplayState();
 
     // Show/hide the toggleable pseudo-layer tile layers.
     const toggleableLayers = [
@@ -522,6 +521,22 @@ function redrawAllLayers() {
     if (app.heatMapLayer) {
         app.heatMapLayer.refreshTiles();
     }
+    // Keep the client-side selection outline in sync with the "Highlight
+    // selected" toggle: detach it when off, re-attach it when back on (the
+    // rectangle object is preserved so the current selection survives an
+    // off→on round trip; the server-side highlight is gated by the overlay
+    // refresh below).  An in-flight selection pulse is cancelled on off.
+    if (app.highlightRect) {
+        const showHighlight = visibility.highlight_selected !== false;
+        if (!showHighlight && app.map.hasLayer(app.highlightRect)) {
+            app.map.removeLayer(app.highlightRect);
+        } else if (showHighlight && !app.map.hasLayer(app.highlightRect)) {
+            app.highlightRect.addTo(app.map);
+        }
+    }
+    if (!visibility.highlight_selected && app.clearSelectionPulse) {
+        app.clearSelectionPulse();
+    }
     // Overlay layer must also refresh on structural changes (e.g. design
     // reload changes the coordinate space).
     refreshOverlay();
@@ -536,13 +551,114 @@ function redrawAllLayers() {
 
 // Debounced wrapper: coalesces back-to-back server pushes (e.g.
 // debug_refresh + debug_paused) into a single redrawAllLayers() call.
-let _redrawRAF = null;
-function scheduleRedrawAllLayers() {
-    if (_redrawRAF !== null) return;
-    _redrawRAF = requestAnimationFrame(() => {
-        _redrawRAF = null;
-        redrawAllLayers();
-    });
+const scheduleRedrawAllLayers = rafCoalesce(redrawAllLayers);
+
+// Every key that together captures the full display-controls state, with the
+// browser store it lives in.  The individual controls already persist to these
+// keys, so serializing them lets `save_display_controls` /
+// `restore_display_controls` (Tcl) round-trip the entire panel through the
+// normal page-init path — no parallel apply logic to drift out of sync with
+// the controls.
+//
+// The split between the two stores is deliberate, not incidental: per-layer
+// visibility, selectability and fill patterns live in sessionStorage rather
+// than cookies, because they must survive the reload that opening a database
+// triggers but start fresh in a new session, as in Qt (review feedback on
+// #10795).  Both paths below dispatch on `store`, so neither silently skips
+// the sessionStorage-backed entries.
+const DISPLAY_STATE_KEYS = [
+    { key: 'or_visibility', store: 'cookie' },
+    { key: 'or_selectability', store: 'cookie' },
+    { key: 'or_hidden_layers', store: 'session' },
+    { key: 'or_nonselectable_layers', store: 'session' },
+    { key: 'or_layer_patterns', store: 'session' },
+    { key: 'or_hidden_chiplets', store: 'cookie' },
+    { key: 'or_bg_color', store: 'cookie' },
+    { key: 'or_show_dbu', store: 'cookie' },
+    { key: 'or_theme', store: 'cookie' },
+    { key: 'or_use_true_z', store: 'cookie' },
+];
+
+// Values are moved verbatim: the cookie helpers are raw pass-through (their
+// callers URI-encode) and the sessionStorage keys hold plain JSON, so reading
+// and writing through the same store round-trips without re-encoding.
+function readDisplayStateKey({ key, store }) {
+    if (store !== 'session') {
+        return getCookie(key);
+    }
+    try {
+        return window.sessionStorage.getItem(key);
+    } catch (_) {
+        return null;  // storage disabled
+    }
+}
+
+// `value === null` means "unset", so the reload falls back to the default.
+function writeDisplayStateKey({ key, store }, value) {
+    if (store !== 'session') {
+        if (value === null) {
+            deleteCookie(key);
+        } else {
+            setCookie(key, value);
+        }
+        return;
+    }
+    try {
+        if (value === null) {
+            window.sessionStorage.removeItem(key);
+        } else {
+            window.sessionStorage.setItem(key, value);
+        }
+    } catch (_) { /* storage disabled */ }
+}
+
+// Snapshot the current display state as a plain object for the server to
+// persist.  Only non-empty entries are included so restore can tell "unset"
+// (use default) from "set".
+function serializeDisplayState() {
+    const entries = {};
+    for (const spec of DISPLAY_STATE_KEYS) {
+        const value = readDisplayStateKey(spec);
+        if (value) entries[spec.key] = value;
+    }
+    return { version: 1, entries };
+}
+
+// Push the current display state to the server (coalesced via rAF) so the
+// Tcl save_display_controls command has an up-to-date snapshot to write.
+const scheduleSyncDisplayState = rafCoalesce(() => {
+    if (!app.websocketManager || isStaticMode(app)) return;
+    app.websocketManager.request({
+        type: 'set_display_state',
+        state: serializeDisplayState(),
+    }).catch(() => { /* server offline / not ready — ignore */ });
+});
+app.syncDisplayState = scheduleSyncDisplayState;
+
+// Apply a saved display state (from restore_display_controls) by writing the
+// entries back and reloading, so the well-tested init path rebuilds the panel
+// consistently.  The current camera is preserved across the reload, and
+// sessionStorage survives it — which is why the split store works here.
+function applyDisplayState(state) {
+    if (!state || typeof state !== 'object') return;
+    const entries = state.entries;
+    if (!entries || typeof entries !== 'object') return;
+    for (const spec of DISPLAY_STATE_KEYS) {
+        const value = entries[spec.key];
+        const absent = value === undefined || value === null || value === '';
+        // Absent in the saved state → clear so the reload uses defaults.
+        writeDisplayStateKey(spec, absent ? null : String(value));
+    }
+    // Preserve the current view so restoring controls doesn't move the map.
+    try {
+        if (app.map && typeof sessionStorage !== 'undefined') {
+            const c = app.map.getCenter();
+            sessionStorage.setItem('or_restore_view',
+                JSON.stringify({ lat: c.lat, lng: c.lng,
+                                 zoom: app.map.getZoom() }));
+        }
+    } catch (_) { /* ignore */ }
+    window.location.reload();
 }
 
 function createLayoutViewer(container) {
@@ -591,25 +707,44 @@ function createLayoutViewer(container) {
     });
     app.map.on('mouseout', () => { app.lastMouseLatLng = null; });
 
-    // Scale bar overlay (bottom-left, above coord bar).
+    // Scale bar overlay (bottom-left, above coord bar).  Content is an
+    // inline SVG rebuilt on each update (bracket + ticks + 0/total labels).
     const scaleBar = document.createElement('div');
     scaleBar.id = 'scale-bar';
     mapDiv.appendChild(scaleBar);
-    const scaleBarLine = document.createElement('div');
-    scaleBarLine.className = 'scale-bar-line';
-    scaleBar.appendChild(scaleBarLine);
-    const scaleBarLabel = document.createElement('span');
-    scaleBarLabel.className = 'scale-bar-label';
-    scaleBar.appendChild(scaleBarLabel);
 
-    // Round to the nearest 1/2/5 × 10^n value (e.g. 1, 2, 5, 10, 20, …).
-    function niceRound(value) {
-        const mag = Math.pow(10, Math.floor(Math.log10(value)));
-        const residual = value / mag;
-        if (residual < 1.5) return 1 * mag;
-        if (residual < 3.5) return 2 * mag;
-        if (residual < 7.5) return 5 * mag;
-        return 10 * mag;
+    const SB_H = 22;       // svg height
+    const SB_BAR_H = 8;    // bracket height
+    const SB_PAD = 22;     // horizontal room for end labels overflowing the bar
+
+    function renderScaleBar(barPx, label, segments) {
+        const top = 2;
+        const base = top + SB_BAR_H;
+        const x0 = SB_PAD;
+        const x1 = SB_PAD + barPx;
+        const labelY = SB_H - 2;
+        const wide = barPx >= 40;  // hide "0"/ticks on very short bars
+        const parts = [];
+        // Bracket: |_| (left/right verticals + baseline, open top).
+        parts.push(`<path d="M${x0} ${top} V${base} H${x1} V${top}" `
+            + `fill="none" stroke="currentColor" stroke-width="2"/>`);
+        // Interior ticks (half height), only when the bar is wide enough.
+        if (wide && segments > 1) {
+            for (let i = 1; i < segments; i++) {
+                const tx = x0 + (barPx * i) / segments;
+                parts.push(`<line x1="${tx}" y1="${base - SB_BAR_H / 2}" `
+                    + `x2="${tx}" y2="${base}" stroke="currentColor" stroke-width="1"/>`);
+            }
+        }
+        // Labels: "0" at the left end, the total at the right end.
+        if (wide) {
+            parts.push(`<text x="${x0}" y="${labelY}" text-anchor="middle" `
+                + `class="scale-bar-text">0</text>`);
+        }
+        parts.push(`<text x="${x1}" y="${labelY}" text-anchor="middle" `
+            + `class="scale-bar-text">${label}</text>`);
+        scaleBar.innerHTML =
+            `<svg width="${x1 + SB_PAD}" height="${SB_H}">${parts.join('')}</svg>`;
     }
 
     function updateScaleBar() {
@@ -617,39 +752,30 @@ function createLayoutViewer(container) {
             scaleBar.style.display = 'none';
             return;
         }
-        scaleBar.style.display = '';
-
         // Pixels per DBU at current zoom: designScale * 2^zoom.
-        const zoom = app.map.getZoom();
-        const pxPerDbu = app.designScale * Math.pow(2, zoom);
-
+        const pxPerDbu = app.designScale * Math.pow(2, app.map.getZoom());
         // Target bar width: ~15% of the map container width.
         const containerWidth = app.map.getContainer().clientWidth || 400;
-        const targetPx = containerWidth * 0.15;
-
-        let barPx, label;
-        if (app.showDbu) {
-            const niceDbu = Math.max(1, niceRound(targetPx / pxPerDbu));
-            barPx = Math.round(niceDbu * pxPerDbu);
-            label = String(Math.round(niceDbu));
-        } else {
-            const dbuPerUm = app.techData?.dbu_per_micron || 1000;
-            const pxPerUm = pxPerDbu * dbuPerUm;
-            const niceUm = niceRound(targetPx / pxPerUm);
-
-            barPx = Math.round(niceUm * pxPerUm);
-
-            // Format with appropriate units.
-            if (niceUm >= 1000) label = (niceUm / 1000) + ' mm';
-            else if (niceUm >= 1) label = niceUm + ' \u00b5m';
-            else if (niceUm >= 0.001) label = (niceUm * 1000) + ' nm';
-            else label = (niceUm * 1e6) + ' pm';
+        const sb = computeScaleBar({
+            targetPx: containerWidth * 0.15,
+            pxPerDbu,
+            dbuPerMicron: app.techData?.dbu_per_micron,
+            showDbu: app.showDbu,
+        });
+        if (!sb) {
+            scaleBar.style.display = 'none';
+            return;
         }
-
-        scaleBarLine.style.width = barPx + 'px';
-        scaleBarLabel.textContent = label;
+        scaleBar.style.display = '';
+        renderScaleBar(sb.barPx, sb.label, sb.segments);
     }
-    app.map.on('zoomend moveend resize', updateScaleBar);
+
+    // Coalesce updates during continuous zoom gestures so the bar tracks
+    // the animation instead of only snapping at gesture end.  Pan doesn't
+    // change the bar (geometry depends only on zoom and container width),
+    // so 'move'/'moveend' are deliberately not listened to.
+    const scheduleUpdateScaleBar = rafCoalesce(updateScaleBar);
+    app.map.on('zoom zoomend resize', scheduleUpdateScaleBar);
     app.updateScaleBar = updateScaleBar;
 
     app.rulerManager = new RulerManager(app, visibility, updateInspector, focusComponent);
@@ -769,6 +895,9 @@ function createTclConsole(container) {
 
 // ─── Inspector Panel ────────────────────────────────────────────────────────
 
+// Expose visibility so the inspector can honor the "Highlight selected"
+// toggle when drawing its client-side selection outline/pulse.
+app.visibility = visibility;
 const inspector = createInspectorPanel(app, redrawAllLayers, scheduleRefreshOverlay);
 const createInspector = inspector.createInspector;
 const updateInspector = inspector.updateInspector;
@@ -1048,6 +1177,7 @@ app.toggleTheme = function() {
     // Re-render canvas-based widgets that read theme colors.
     if (app.chartsWidget) app.chartsWidget.render();
     if (app.clockTreeWidget) app.clockTreeWidget.render();
+    scheduleSyncDisplayState();
 };
 
 app.toggleShowDbu = function() {
@@ -1061,6 +1191,7 @@ app.toggleShowDbu = function() {
     if (app.updateScaleBar) app.updateScaleBar();
     // Re-request inspector properties with new formatting.
     if (app.refreshInspector) app.refreshInspector();
+    scheduleSyncDisplayState();
 };
 
 // ─── Menu Bar ────────────────────────────────────────────────────────────────
@@ -1132,6 +1263,9 @@ app.websocketManager.onPush = (msg) => {
         let text = msg.text;
         if (text.endsWith('\n')) text = text.slice(0, -1);
         if (text) tclAppend(text + '\n', '');
+    } else if (msg.type === 'restore_display_state') {
+        // restore_display_controls (Tcl) broadcast a saved state — apply it.
+        applyDisplayState(msg.state);
     } else if (msg.type === 'shutdown') {
         // Server is stopping intentionally (web_server -stop).
         // Disable auto-reconnect and show a clear message. Note that
@@ -1210,6 +1344,20 @@ app.websocketManager.readyPromise.then(async () => {
                     }
                 };
             }
+
+            // Restore the pre-reload camera saved by applyDisplayState so
+            // restore_display_controls doesn't move the view.
+            try {
+                const raw = sessionStorage.getItem('or_restore_view');
+                if (raw) {
+                    sessionStorage.removeItem('or_restore_view');
+                    const v = JSON.parse(raw);
+                    if (v && isFinite(v.lat) && isFinite(v.lng)
+                        && isFinite(v.zoom)) {
+                        app.map.setView([v.lat, v.lng], v.zoom);
+                    }
+                }
+            } catch (_) { /* ignore */ }
         }
 
         // Click-to-select: convert click position to DBU and query server
@@ -1391,6 +1539,11 @@ app.websocketManager.readyPromise.then(async () => {
         if (hasDesign && !boundsData.shapes_ready) {
             document.getElementById('loading-overlay').style.display = 'flex';
         }
+
+        // Seed the server's display-state cache with the cookie-restored
+        // state, so save_display_controls works before any interaction
+        // (otherwise it would warn or write a previous session's state).
+        scheduleSyncDisplayState();
     } catch (err) {
         console.error('Failed to load initial data from server:', err);
     }

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -30,7 +30,8 @@ import { RulerManager } from './ruler.js';
 import { SchematicWidget } from './schematic-widget.js';
 import { DrcWidget } from './drc-widget.js';
 import { TclCompleter } from './tcl-completer.js';
-import { getCookie, setCookie, deleteCookie, applyGLTheme } from './theme.js';
+import { getCookie, setCookie, applyGLTheme, persistTheme } from './theme.js';
+import { serializeDisplayState, applyDisplayStateEntries } from './display-state.js';
 import { updateDocumentTitle } from './title.js';
 import { ThreeDViewerWidget } from './3d-viewer-widget.js';
 
@@ -553,77 +554,6 @@ function redrawAllLayers() {
 // debug_refresh + debug_paused) into a single redrawAllLayers() call.
 const scheduleRedrawAllLayers = rafCoalesce(redrawAllLayers);
 
-// Every key that together captures the full display-controls state, with the
-// browser store it lives in.  The individual controls already persist to these
-// keys, so serializing them lets `save_display_controls` /
-// `restore_display_controls` (Tcl) round-trip the entire panel through the
-// normal page-init path — no parallel apply logic to drift out of sync with
-// the controls.
-//
-// The split between the two stores is deliberate, not incidental: per-layer
-// visibility, selectability and fill patterns live in sessionStorage rather
-// than cookies, because they must survive the reload that opening a database
-// triggers but start fresh in a new session, as in Qt (review feedback on
-// #10795).  Both paths below dispatch on `store`, so neither silently skips
-// the sessionStorage-backed entries.
-const DISPLAY_STATE_KEYS = [
-    { key: 'or_visibility', store: 'cookie' },
-    { key: 'or_selectability', store: 'cookie' },
-    { key: 'or_hidden_layers', store: 'session' },
-    { key: 'or_nonselectable_layers', store: 'session' },
-    { key: 'or_layer_patterns', store: 'session' },
-    { key: 'or_hidden_chiplets', store: 'cookie' },
-    { key: 'or_bg_color', store: 'cookie' },
-    { key: 'or_show_dbu', store: 'cookie' },
-    { key: 'or_theme', store: 'cookie' },
-    { key: 'or_use_true_z', store: 'cookie' },
-];
-
-// Values are moved verbatim: the cookie helpers are raw pass-through (their
-// callers URI-encode) and the sessionStorage keys hold plain JSON, so reading
-// and writing through the same store round-trips without re-encoding.
-function readDisplayStateKey({ key, store }) {
-    if (store !== 'session') {
-        return getCookie(key);
-    }
-    try {
-        return window.sessionStorage.getItem(key);
-    } catch (_) {
-        return null;  // storage disabled
-    }
-}
-
-// `value === null` means "unset", so the reload falls back to the default.
-function writeDisplayStateKey({ key, store }, value) {
-    if (store !== 'session') {
-        if (value === null) {
-            deleteCookie(key);
-        } else {
-            setCookie(key, value);
-        }
-        return;
-    }
-    try {
-        if (value === null) {
-            window.sessionStorage.removeItem(key);
-        } else {
-            window.sessionStorage.setItem(key, value);
-        }
-    } catch (_) { /* storage disabled */ }
-}
-
-// Snapshot the current display state as a plain object for the server to
-// persist.  Only non-empty entries are included so restore can tell "unset"
-// (use default) from "set".
-function serializeDisplayState() {
-    const entries = {};
-    for (const spec of DISPLAY_STATE_KEYS) {
-        const value = readDisplayStateKey(spec);
-        if (value) entries[spec.key] = value;
-    }
-    return { version: 1, entries };
-}
-
 // Push the current display state to the server (coalesced via rAF) so the
 // Tcl save_display_controls command has an up-to-date snapshot to write.
 const scheduleSyncDisplayState = rafCoalesce(() => {
@@ -643,12 +573,7 @@ function applyDisplayState(state) {
     if (!state || typeof state !== 'object') return;
     const entries = state.entries;
     if (!entries || typeof entries !== 'object') return;
-    for (const spec of DISPLAY_STATE_KEYS) {
-        const value = entries[spec.key];
-        const absent = value === undefined || value === null || value === '';
-        // Absent in the saved state → clear so the reload uses defaults.
-        writeDisplayStateKey(spec, absent ? null : String(value));
-    }
+    applyDisplayStateEntries(entries);
     // Preserve the current view so restoring controls doesn't move the map.
     try {
         if (app.map && typeof sessionStorage !== 'undefined') {
@@ -1169,11 +1094,7 @@ app.toggleTheme = function() {
     const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
     document.documentElement.dataset.theme = next;
     applyGLTheme(next);
-    setCookie('or_theme', next);
-    // Also write to localStorage for standalone file:// reports.
-    if (typeof localStorage !== 'undefined') {
-        localStorage.setItem('or_theme', next);
-    }
+    persistTheme(next);
     // Re-render canvas-based widgets that read theme colors.
     if (app.chartsWidget) app.chartsWidget.render();
     if (app.clockTreeWidget) app.clockTreeWidget.render();

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -2343,78 +2343,105 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
 WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
                                                  SessionState& state)
 {
-  // When debug renderers are active, instance positions change between
-  // frames.  Re-derive highlight shapes from the current inspected
-  // object so the selection tracks the moving instance.
-  const bool debug_renderers = jsonOr(req.json, "debug_renderers", false);
-  if (debug_renderers) {
-    std::lock_guard<std::mutex> lock(state.selection_mutex);
-    if (state.current_inspected) {
-      collectHighlightShapes(state.current_inspected,
-                             state.highlight_rects,
-                             state.highlight_polys);
-    }
-  }
-
-  // Snapshot current highlight state
-  std::vector<odb::Rect> rects;
-  std::vector<odb::Polygon> polys;
-  std::vector<ColoredRect> colored;
-  std::vector<FlightLine> lines;
-  {
-    std::lock_guard<std::mutex> lock(state.selection_mutex);
-    rects = state.highlight_rects;
-    rects.insert(
-        rects.end(), state.hover_rects.begin(), state.hover_rects.end());
-    polys = state.highlight_polys;
-    colored = state.timing_rects;
-    lines = state.timing_lines;
-  }
-
-  // Merge DRC overlay shapes
-  {
-    std::lock_guard<std::mutex> lock(state.drc_mutex);
-    colored.insert(
-        colored.end(), state.drc_rects.begin(), state.drc_rects.end());
-    lines.insert(lines.end(), state.drc_lines.begin(), state.drc_lines.end());
-  }
-
-  // Snapshot route guide nets
-  std::set<uint32_t> route_guides;
-  {
-    std::lock_guard<std::mutex> lock(state.route_guides_mutex);
-    route_guides = state.route_guide_net_ids;
-  }
-  const std::set<uint32_t>* route_guide_ptr
-      = route_guides.empty() ? nullptr : &route_guides;
-
-  // Parse visible layers so route guides respect layer visibility.
-  // has_vis_layers=true means the field was present (even if empty,
-  // which means "all layers hidden" — matching pin-marker semantics).
-  bool has_vis_layers = false;
-  std::set<std::string> vis_layers;
-  if (auto it = req.json.find("visible_layers"); it != req.json.end()) {
-    has_vis_layers = true;
-    const auto& arr = it->value().as_array();
-    for (const auto& elem : arr) {
-      vis_layers.emplace(elem.as_string());
-    }
-  }
-
   WebSocketResponse resp;
   resp.id = req.id;
-  resp.type = WebSocketResponse::kPng;
-  resp.payload
-      = gen_->generateOverlayTile(static_cast<int>(req.json.at("z").as_int64()),
-                                  static_cast<int>(req.json.at("x").as_int64()),
-                                  static_cast<int>(req.json.at("y").as_int64()),
-                                  rects,
-                                  polys,
-                                  colored,
-                                  lines,
-                                  route_guide_ptr,
-                                  has_vis_layers,
-                                  vis_layers);
+  // Overlay requests run on a bare io_context thread with no dispatcher-level
+  // try/catch, so convert malformed-request exceptions (e.g. a non-bool
+  // toggle flag) into an error response instead of terminating the server.
+  try {
+    // When debug renderers are active, instance positions change between
+    // frames.  Re-derive highlight shapes from the current inspected
+    // object so the selection tracks the moving instance.
+    const bool debug_renderers = jsonOr(req.json, "debug_renderers", false);
+    if (debug_renderers) {
+      std::lock_guard<std::mutex> lock(state.selection_mutex);
+      if (state.current_inspected) {
+        collectHighlightShapes(state.current_inspected,
+                               state.highlight_rects,
+                               state.highlight_polys);
+      }
+    }
+
+    // Snapshot current highlight state
+    // "Highlight selected" toggle (Misc, default on — Qt parity): gates only
+    // the current-selection highlight.  Hover is a separate state and is
+    // always drawn; the selection stays active server-side regardless.
+    const bool highlight_selected
+        = jsonOr(req.json, "highlight_selected", true);
+    std::vector<odb::Rect> rects;
+    std::vector<odb::Polygon> polys;
+    std::vector<ColoredRect> colored;
+    std::vector<FlightLine> lines;
+    {
+      std::lock_guard<std::mutex> lock(state.selection_mutex);
+      if (highlight_selected) {
+        rects = state.highlight_rects;
+        polys = state.highlight_polys;
+      }
+      rects.insert(
+          rects.end(), state.hover_rects.begin(), state.hover_rects.end());
+      colored = state.timing_rects;
+      lines = state.timing_lines;
+    }
+
+    // Merge DRC overlay shapes
+    {
+      std::lock_guard<std::mutex> lock(state.drc_mutex);
+      colored.insert(
+          colored.end(), state.drc_rects.begin(), state.drc_rects.end());
+      lines.insert(lines.end(), state.drc_lines.begin(), state.drc_lines.end());
+    }
+
+    // Snapshot the nets whose route guides should be drawn.  Always include
+    // the per-net selections (inspector "Show route guides", a web-only
+    // finer control).  When the global "Focused nets guides" toggle is on,
+    // also include every focused net — mirroring the Qt GUI toggle, which
+    // draws the guides of all focused nets at once.
+    const bool focused_nets_guides
+        = jsonOr(req.json, "focused_nets_guides", false);
+    std::set<uint32_t> route_guides;
+    {
+      std::lock_guard<std::mutex> lock(state.route_guides_mutex);
+      route_guides = state.route_guide_net_ids;
+    }
+    if (focused_nets_guides) {
+      std::lock_guard<std::mutex> lock(state.focus_nets_mutex);
+      route_guides.insert(state.focus_net_ids.begin(),
+                          state.focus_net_ids.end());
+    }
+    const std::set<uint32_t>* route_guide_ptr
+        = route_guides.empty() ? nullptr : &route_guides;
+
+    // Parse visible layers so route guides respect layer visibility.
+    // has_vis_layers=true means the field was present (even if empty,
+    // which means "all layers hidden" — matching pin-marker semantics).
+    bool has_vis_layers = false;
+    std::set<std::string> vis_layers;
+    if (auto it = req.json.find("visible_layers"); it != req.json.end()) {
+      has_vis_layers = true;
+      const auto& arr = it->value().as_array();
+      for (const auto& elem : arr) {
+        vis_layers.emplace(elem.as_string());
+      }
+    }
+
+    resp.type = WebSocketResponse::kPng;
+    resp.payload = gen_->generateOverlayTile(
+        static_cast<int>(req.json.at("z").as_int64()),
+        static_cast<int>(req.json.at("x").as_int64()),
+        static_cast<int>(req.json.at("y").as_int64()),
+        rects,
+        polys,
+        colored,
+        lines,
+        route_guide_ptr,
+        has_vis_layers,
+        vis_layers);
+  } catch (const std::exception& e) {
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
   return resp;
 }
 

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -242,6 +242,52 @@ std::string assetPathFromTarget(const std::string_view target)
   return path;
 }
 
+bool parseTileCoords(const boost::json::object& json,
+                     int& z,
+                     int& x,
+                     int& y,
+                     std::string& error)
+{
+  const auto read = [&json, &error](const char* key, int& out) {
+    const auto* v = json.if_contains(key);
+    if (v == nullptr) {
+      error = std::string("missing \"") + key + "\"";
+      return false;
+    }
+    // is_int64() and not as_int64(): a null (what a non-finite client-side
+    // number serializes to) or a fractional zoom must be reported as the
+    // contract violation it is, not converted.
+    if (!v->is_int64()) {
+      error = std::string("\"") + key + "\" must be an integer";
+      return false;
+    }
+    const int64_t value = v->get_int64();
+    if (value < std::numeric_limits<int>::min()
+        || value > std::numeric_limits<int>::max()) {
+      error = std::string("\"") + key + "\" is out of range";
+      return false;
+    }
+    out = static_cast<int>(value);
+    return true;
+  };
+
+  if (!read("z", z) || !read("x", x) || !read("y", y)) {
+    return false;
+  }
+  if (z < 0 || z > kMaxTileZoom) {
+    error = "\"z\" is outside [0, " + std::to_string(kMaxTileZoom) + "]";
+    return false;
+  }
+  // x and y are deliberately NOT range-checked against the 2^z grid.  Leaflet
+  // routinely asks for tiles off the edge of the world -- whenever the design
+  // is smaller than the viewport, or while panning at the border -- and the
+  // renderers answer those with a transparent tile.  Rejecting them turns
+  // ordinary panning into a stream of errors: a first cut of this check
+  // produced 336 refusals in one session, all of them for legitimate
+  // off-grid tiles at zoom 0.
+  return true;
+}
+
 // Store a Selected in the clickables vector and return its index.
 static int storeSelectable(std::vector<gui::Selected>& selectables,
                            const gui::Selected& sel)
@@ -2861,9 +2907,20 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
   }
 
   const std::string layer = std::string(req.json.at("layer").as_string());
-  const int z = static_cast<int>(req.json.at("z").as_int64());
-  const int x = static_cast<int>(req.json.at("x").as_int64());
-  const int y = static_cast<int>(req.json.at("y").as_int64());
+  // Validate before doing any work: a malformed request must not reach the
+  // cache-key build below, let alone the renderer.
+  int z = 0;
+  int x = 0;
+  int y = 0;
+  if (std::string coord_error;
+      !parseTileCoords(req.json, z, x, y, coord_error)) {
+    WebSocketResponse resp;
+    resp.id = req.id;
+    resp.type = WebSocketResponse::kError;
+    const std::string err = "bad tile request: " + coord_error;
+    resp.payload.assign(err.begin(), err.end());
+    return resp;
+  }
 
   // Skip a render the client abandoned while it sat queued (best-effort).
   {
@@ -3130,9 +3187,16 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
     const int tile_px
         = quantizeTilePx(jsonOr<double>(req.json, "tile_px", 0.0));
 
-    const int z = static_cast<int>(req.json.at("z").as_int64());
-    const int x = static_cast<int>(req.json.at("x").as_int64());
-    const int y = static_cast<int>(req.json.at("y").as_int64());
+    int z = 0;
+    int x = 0;
+    int y = 0;
+    if (std::string coord_error;
+        !parseTileCoords(req.json, z, x, y, coord_error)) {
+      resp.type = WebSocketResponse::kError;
+      const std::string err = "bad overlay request: " + coord_error;
+      resp.payload.assign(err.begin(), err.end());
+      return resp;
+    }
 
     resp.type = WebSocketResponse::kPng;
     resp.payload = gen_->generateOverlayTile(z,
@@ -3410,9 +3474,16 @@ WebSocketResponse TileHandler::handleHeatMapTile(const WebSocketRequest& req,
   resp.type = WebSocketResponse::kPng;
   try {
     const std::string req_name = std::string(req.json.at("name").as_string());
-    const int z = static_cast<int>(req.json.at("z").as_int64());
-    const int x = static_cast<int>(req.json.at("x").as_int64());
-    const int y = static_cast<int>(req.json.at("y").as_int64());
+    int z = 0;
+    int x = 0;
+    int y = 0;
+    if (std::string coord_error;
+        !parseTileCoords(req.json, z, x, y, coord_error)) {
+      resp.type = WebSocketResponse::kError;
+      const std::string err = "bad heat map request: " + coord_error;
+      resp.payload.assign(err.begin(), err.end());
+      return resp;
+    }
     // Same sizing contract as layer tiles: the client states the device-pixel
     // square, so the heat map is as crisp as the layers beneath it.
     const double dpr = quantizeDpr(jsonOr<double>(req.json, "dpr", 1.0));

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -242,6 +242,16 @@ std::string assetPathFromTarget(const std::string_view target)
   return path;
 }
 
+WebSocketResponse errorResponse(const uint32_t id,
+                                const std::string_view message)
+{
+  WebSocketResponse resp;
+  resp.id = id;
+  resp.type = WebSocketResponse::kError;
+  resp.payload.assign(message.begin(), message.end());
+  return resp;
+}
+
 bool parseTileCoords(const boost::json::object& json,
                      int& z,
                      int& x,
@@ -2914,12 +2924,7 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
   int y = 0;
   if (std::string coord_error;
       !parseTileCoords(req.json, z, x, y, coord_error)) {
-    WebSocketResponse resp;
-    resp.id = req.id;
-    resp.type = WebSocketResponse::kError;
-    const std::string err = "bad tile request: " + coord_error;
-    resp.payload.assign(err.begin(), err.end());
-    return resp;
+    return errorResponse(req.id, "bad tile request: " + coord_error);
   }
 
   // Skip a render the client abandoned while it sat queued (best-effort).
@@ -3084,6 +3089,17 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
   // try/catch, so convert malformed-request exceptions (e.g. a non-bool
   // toggle flag) into an error response instead of terminating the server.
   try {
+    // Validate first: below this point the handler mutates session state (the
+    // "Flywires only" latch) and takes several mutexes, and a request that is
+    // going to be refused must not do any of that.
+    int z = 0;
+    int x = 0;
+    int y = 0;
+    if (std::string coord_error;
+        !parseTileCoords(req.json, z, x, y, coord_error)) {
+      return errorResponse(req.id, "bad overlay request: " + coord_error);
+    }
+
     // Re-derive the selection highlights when either:
     //  - the "Flywires only" toggle flipped (so the change takes effect
     //    without re-selecting) — but only while the highlights are live: a
@@ -3186,17 +3202,6 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
     const double dpr = quantizeDpr(jsonOr<double>(req.json, "dpr", 1.0));
     const int tile_px
         = quantizeTilePx(jsonOr<double>(req.json, "tile_px", 0.0));
-
-    int z = 0;
-    int x = 0;
-    int y = 0;
-    if (std::string coord_error;
-        !parseTileCoords(req.json, z, x, y, coord_error)) {
-      resp.type = WebSocketResponse::kError;
-      const std::string err = "bad overlay request: " + coord_error;
-      resp.payload.assign(err.begin(), err.end());
-      return resp;
-    }
 
     resp.type = WebSocketResponse::kPng;
     resp.payload = gen_->generateOverlayTile(z,
@@ -3479,10 +3484,7 @@ WebSocketResponse TileHandler::handleHeatMapTile(const WebSocketRequest& req,
     int y = 0;
     if (std::string coord_error;
         !parseTileCoords(req.json, z, x, y, coord_error)) {
-      resp.type = WebSocketResponse::kError;
-      const std::string err = "bad heat map request: " + coord_error;
-      resp.payload.assign(err.begin(), err.end());
-      return resp;
+      return errorResponse(req.id, "bad heat map request: " + coord_error);
     }
     // Same sizing contract as layer tiles: the client states the device-pixel
     // square, so the heat map is as crisp as the layers beneath it.

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -3021,130 +3021,162 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
 WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
                                                  SessionState& state)
 {
-  // Re-derive the selection highlights when either:
-  //  - the "Flywires only" toggle flipped (so the change takes effect
-  //    without re-selecting) — but only while the highlights are live: a
-  //    flip after an explicit "clear highlights" must not resurrect them;
-  //  - debug renderers are active — instance positions change between
-  //    frames, so the highlight must track the moving instance.
-  const bool flywires_only = jsonOr(req.json, "flywires_only", false);
-  const bool debug_renderers = jsonOr(req.json, "debug_renderers", false);
-  {
-    std::lock_guard<std::mutex> lock(state.selection_mutex);
-    const bool flipped = (flywires_only != state.flywires_only);
-    state.flywires_only = flywires_only;
-    const bool live
-        = state.highlight_source != SessionState::HighlightSource::kNone;
-    if ((flipped && live) || (debug_renderers && state.current_inspected)) {
-      // Re-derive from the SAME source the shapes came from.  Preferring
-      // current_inspected unconditionally would drop every other item of a
-      // shift+click multi-selection on the first flip, with no way back.  With
-      // no prior highlight the source is kNone, which only the debug-renderer
-      // disjunct can reach — there the inspected object is what to track.
-      if (state.highlight_source
-          == SessionState::HighlightSource::kSelectionSet) {
-        setSelectionSetHighlights(state);
-      } else {
-        setSelectionHighlights(state, state.current_inspected);
-      }
-    }
-  }
-
-  // Snapshot current highlight state
-  std::vector<odb::Rect> rects;
-  std::vector<odb::Polygon> polys;
-  std::vector<ColoredRect> colored;
-  std::vector<FlightLine> lines;
-  {
-    std::lock_guard<std::mutex> lock(state.selection_mutex);
-    rects = state.highlight_rects;
-    rects.insert(
-        rects.end(), state.hover_rects.begin(), state.hover_rects.end());
-    polys = state.highlight_polys;
-    colored = state.timing_rects;
-    lines = state.highlight_lines;
-    lines.insert(
-        lines.end(), state.timing_lines.begin(), state.timing_lines.end());
-  }
-
-  // Merge DRC overlay shapes
-  {
-    std::lock_guard<std::mutex> lock(state.drc_mutex);
-    colored.insert(
-        colored.end(), state.drc_rects.begin(), state.drc_rects.end());
-    lines.insert(lines.end(), state.drc_lines.begin(), state.drc_lines.end());
-  }
-
-  // Snapshot route guide nets
-  std::set<uint32_t> route_guides;
-  {
-    std::lock_guard<std::mutex> lock(state.route_guides_mutex);
-    route_guides = state.route_guide_net_ids;
-  }
-  const std::set<uint32_t>* route_guide_ptr
-      = route_guides.empty() ? nullptr : &route_guides;
-
-  // Parse visible layers so route guides respect layer visibility.
-  // has_vis_layers=true means the field was present (even if empty,
-  // which means "all layers hidden" — matching pin-marker semantics).
-  bool has_vis_layers = false;
-  std::set<std::string> vis_layers;
-  if (auto it = req.json.find("visible_layers"); it != req.json.end()) {
-    has_vis_layers = true;
-    const auto& arr = it->value().as_array();
-    for (const auto& elem : arr) {
-      vis_layers.emplace(elem.as_string());
-    }
-  }
-
-  // Same sizing contract as layer tiles: an overlay rendered at a different
-  // size than the tiles beneath it is blurry and misregistered against them.
-  const double dpr = quantizeDpr(jsonOr<double>(req.json, "dpr", 1.0));
-  const int tile_px = quantizeTilePx(jsonOr<double>(req.json, "tile_px", 0.0));
-
-  const int z = static_cast<int>(req.json.at("z").as_int64());
-  const int x = static_cast<int>(req.json.at("x").as_int64());
-  const int y = static_cast<int>(req.json.at("y").as_int64());
-
   WebSocketResponse resp;
   resp.id = req.id;
-  resp.type = WebSocketResponse::kPng;
-  resp.payload = gen_->generateOverlayTile(z,
-                                           x,
-                                           y,
-                                           rects,
-                                           polys,
-                                           colored,
-                                           lines,
-                                           route_guide_ptr,
-                                           has_vis_layers,
-                                           vis_layers,
-                                           dpr,
-                                           tile_px);
+  // Overlay requests run on a bare io_context thread with no dispatcher-level
+  // try/catch, so convert malformed-request exceptions (e.g. a non-bool
+  // toggle flag) into an error response instead of terminating the server.
+  try {
+    // Re-derive the selection highlights when either:
+    //  - the "Flywires only" toggle flipped (so the change takes effect
+    //    without re-selecting) — but only while the highlights are live: a
+    //    flip after an explicit "clear highlights" must not resurrect them;
+    //  - debug renderers are active — instance positions change between
+    //    frames, so the highlight must track the moving instance.
+    const bool flywires_only = jsonOr(req.json, "flywires_only", false);
+    const bool debug_renderers = jsonOr(req.json, "debug_renderers", false);
+    {
+      std::lock_guard<std::mutex> lock(state.selection_mutex);
+      const bool flipped = (flywires_only != state.flywires_only);
+      state.flywires_only = flywires_only;
+      const bool live
+          = state.highlight_source != SessionState::HighlightSource::kNone;
+      if ((flipped && live) || (debug_renderers && state.current_inspected)) {
+        // Re-derive from the SAME source the shapes came from.  Preferring
+        // current_inspected unconditionally would drop every other item of a
+        // shift+click multi-selection on the first flip, with no way back. With
+        // no prior highlight the source is kNone, which only the debug-renderer
+        // disjunct can reach — there the inspected object is what to track.
+        if (state.highlight_source
+            == SessionState::HighlightSource::kSelectionSet) {
+          setSelectionSetHighlights(state);
+        } else {
+          setSelectionHighlights(state, state.current_inspected);
+        }
+      }
+    }
 
-  // The selection highlight the client draws over the layer tiles comes from
-  // here, so the shape counts say whether a "missing" highlight was never
-  // collected server-side or just not drawn.
-  debugPrint(gen_->getLogger(),
-             utl::WEB,
-             "tile",
-             1,
-             "overlay tile: id={} z/x/y={}/{}/{} dpr={} tile_px={} rects={} "
-             "polys={} colored={} lines={} route_guide_nets={} "
-             "flywires_only={} bytes={}",
-             req.id,
-             z,
-             x,
-             y,
-             dpr,
-             tile_px,
-             rects.size(),
-             polys.size(),
-             colored.size(),
-             lines.size(),
-             route_guides.size(),
-             flywires_only,
-             resp.payload.size());
+    // Snapshot current highlight state.
+    // "Highlight selected" (Misc toggle, default on — Qt parity) gates the
+    // current selection's highlight as a whole: its rects, its polys and its
+    // flywires.  Leaving the flywires in would draw half a highlight for a
+    // toggle whose label promises none.  Hover is a separate state and the
+    // timing shapes have their own controls, so both are always drawn; the
+    // selection itself stays active server-side regardless.
+    const bool highlight_selected
+        = jsonOr(req.json, "highlight_selected", true);
+    std::vector<odb::Rect> rects;
+    std::vector<odb::Polygon> polys;
+    std::vector<ColoredRect> colored;
+    std::vector<FlightLine> lines;
+    {
+      std::lock_guard<std::mutex> lock(state.selection_mutex);
+      if (highlight_selected) {
+        rects = state.highlight_rects;
+        polys = state.highlight_polys;
+        lines = state.highlight_lines;
+      }
+      rects.insert(
+          rects.end(), state.hover_rects.begin(), state.hover_rects.end());
+      colored = state.timing_rects;
+      lines.insert(
+          lines.end(), state.timing_lines.begin(), state.timing_lines.end());
+    }
+
+    // Merge DRC overlay shapes
+    {
+      std::lock_guard<std::mutex> lock(state.drc_mutex);
+      colored.insert(
+          colored.end(), state.drc_rects.begin(), state.drc_rects.end());
+      lines.insert(lines.end(), state.drc_lines.begin(), state.drc_lines.end());
+    }
+
+    // Snapshot the nets whose route guides should be drawn.  Always include
+    // the per-net selections (inspector "Show route guides", a web-only
+    // finer control).  When the global "Focused nets guides" toggle is on,
+    // also include every focused net — mirroring the Qt GUI toggle, which
+    // draws the guides of all focused nets at once.
+    const bool focused_nets_guides
+        = jsonOr(req.json, "focused_nets_guides", false);
+    std::set<uint32_t> route_guides;
+    {
+      std::lock_guard<std::mutex> lock(state.route_guides_mutex);
+      route_guides = state.route_guide_net_ids;
+    }
+    if (focused_nets_guides) {
+      std::lock_guard<std::mutex> lock(state.focus_nets_mutex);
+      route_guides.insert(state.focus_net_ids.begin(),
+                          state.focus_net_ids.end());
+    }
+    const std::set<uint32_t>* route_guide_ptr
+        = route_guides.empty() ? nullptr : &route_guides;
+
+    // Parse visible layers so route guides respect layer visibility.
+    // has_vis_layers=true means the field was present (even if empty,
+    // which means "all layers hidden" — matching pin-marker semantics).
+    bool has_vis_layers = false;
+    std::set<std::string> vis_layers;
+    if (auto it = req.json.find("visible_layers"); it != req.json.end()) {
+      has_vis_layers = true;
+      const auto& arr = it->value().as_array();
+      for (const auto& elem : arr) {
+        vis_layers.emplace(elem.as_string());
+      }
+    }
+
+    // Same sizing contract as layer tiles: an overlay rendered at a different
+    // size than the tiles beneath it is blurry and misregistered against them.
+    const double dpr = quantizeDpr(jsonOr<double>(req.json, "dpr", 1.0));
+    const int tile_px
+        = quantizeTilePx(jsonOr<double>(req.json, "tile_px", 0.0));
+
+    const int z = static_cast<int>(req.json.at("z").as_int64());
+    const int x = static_cast<int>(req.json.at("x").as_int64());
+    const int y = static_cast<int>(req.json.at("y").as_int64());
+
+    resp.type = WebSocketResponse::kPng;
+    resp.payload = gen_->generateOverlayTile(z,
+                                             x,
+                                             y,
+                                             rects,
+                                             polys,
+                                             colored,
+                                             lines,
+                                             route_guide_ptr,
+                                             has_vis_layers,
+                                             vis_layers,
+                                             dpr,
+                                             tile_px);
+
+    // The selection highlight the client draws over the layer tiles comes from
+    // here, so the shape counts say whether a "missing" highlight was never
+    // collected server-side or just not drawn.
+    debugPrint(gen_->getLogger(),
+               utl::WEB,
+               "tile",
+               1,
+               "overlay tile: id={} z/x/y={}/{}/{} dpr={} tile_px={} rects={} "
+               "polys={} colored={} lines={} route_guide_nets={} "
+               "flywires_only={} bytes={}",
+               req.id,
+               z,
+               x,
+               y,
+               dpr,
+               tile_px,
+               rects.size(),
+               polys.size(),
+               colored.size(),
+               lines.size(),
+               route_guides.size(),
+               flywires_only,
+               resp.payload.size());
+  } catch (const std::exception& e) {
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
+  return resp;
   return resp;
 }
 

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -121,6 +121,7 @@ struct WebSocketRequest
     kSelectPrev,
     kDebugContinue,
     kDebugCharts,
+    kSetDisplayState,
     kGet3DData,
     kOverlayTile,
     kUnknown

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -247,6 +247,12 @@ std::string assetPathFromTarget(std::string_view target);
 // For required fields, prefer the bare boost::json idiom
 // `obj.at(key).as_int64()` / `as_string()` / `as_bool()` / `as_double()`,
 // which throws on either missing or wrong-typed input.
+//
+// Throwing is safe here: WebSocketSession dispatches every handler through
+// invoke_handler(), which turns an escaped exception into an error response
+// for that one request.  It was not always so — the handlers ran with no
+// try/catch above them and out of io_context::run(), so a wrong-typed field
+// terminated the process.
 template <class T>
 T jsonOr(const boost::json::object& obj, std::string_view key, T default_val)
 {
@@ -255,6 +261,29 @@ T jsonOr(const boost::json::object& obj, std::string_view key, T default_val)
   }
   return default_val;
 }
+
+// Deepest tile zoom the server will address.  2^kMaxTileZoom must stay inside
+// an int, since the grid size is computed as an int in several renderers.
+constexpr int kMaxTileZoom = 30;
+
+// Read the z/x/y grid coordinates of a tile request into `z`/`x`/`y`.
+// Returns false, with `error` describing the offending field, when a
+// coordinate is missing, is not an integer, or the zoom is outside
+// [0, kMaxTileZoom].  x and y are not bounded to the grid: Leaflet asks for
+// off-grid tiles as a matter of course and the renderers answer with a
+// transparent tile.
+//
+// The type check is not paranoia about hand-written clients: JSON.stringify
+// serializes NaN and Infinity as `null`, so any client-side arithmetic that
+// goes non-finite -- an unbounded zoom being the one we hit -- reaches the
+// server as a null where a number belongs.  Reporting that as an error beats
+// rendering the transparent tiles that a degenerate zoom would otherwise
+// produce, which look to the user like the design vanished.
+bool parseTileCoords(const boost::json::object& json,
+                     int& z,
+                     int& x,
+                     int& y,
+                     std::string& error);
 
 // Handles SELECT, INSPECT, and HOVER requests.
 class SelectHandler

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -262,8 +262,14 @@ T jsonOr(const boost::json::object& obj, std::string_view key, T default_val)
   return default_val;
 }
 
+// Build a kError response carrying `message`.  The three-line
+// type/string/assign dance is easy to get subtly wrong (the payload is bytes,
+// not a string), so it lives in one place.
+WebSocketResponse errorResponse(uint32_t id, std::string_view message);
+
 // Deepest tile zoom the server will address.  2^kMaxTileZoom must stay inside
 // an int, since the grid size is computed as an int in several renderers.
+// The client mirrors this ceiling in maxUsefulZoom() (ui-utils.js).
 constexpr int kMaxTileZoom = 30;
 
 // Read the z/x/y grid coordinates of a tile request into `z`/`x`/`y`.

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -122,6 +122,7 @@ struct WebSocketRequest
     kSelectLayer,
     kDebugContinue,
     kDebugCharts,
+    kSetDisplayState,
     kGet3DData,
     kOverlayTile,
     kCancel,

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -545,28 +545,48 @@ html, body {
     pointer-events: none;
 }
 
-/* Scale bar (bottom-left, above coord bar) */
+/* Scale bar (bottom-left, above coord bar).  Content is an inline SVG
+   (bracket + ticks + 0/total labels) rebuilt by updateScaleBar. */
 #scale-bar {
     position: absolute;
     bottom: 26px;
     left: 4px;
     z-index: 900;
-    display: flex;
-    align-items: flex-end;
-    gap: 6px;
+    background: var(--bg-status);
+    color: var(--fg-secondary);  /* SVG strokes use currentColor */
+    border-radius: 3px;
+    padding: 1px 4px;
+    line-height: 0;  /* wrap the inline SVG snugly */
     pointer-events: none;
 }
-.scale-bar-line {
-    height: 8px;
-    min-width: 20px;
-    border: 2px solid white;
-    border-top: none;
-}
-.scale-bar-label {
-    color: white;
+/* Tick/label text drawn inside the scale-bar SVG. */
+.scale-bar-text {
+    fill: currentColor;
     font: 11px monospace;
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
-    line-height: 1;
+}
+
+/* Background color control in the Display Controls panel. */
+.bg-color-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    font-size: 12px;
+}
+.bg-color-row span {
+    flex: 1;
+}
+.bg-color-input {
+    width: 24px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid var(--fg-muted);
+    background: none;
+    cursor: pointer;
+}
+.bg-color-reset {
+    font-size: 11px;
+    cursor: pointer;
 }
 
 /* Loading overlay */

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -549,28 +549,48 @@ html, body {
     pointer-events: none;
 }
 
-/* Scale bar (bottom-left, above coord bar) */
+/* Scale bar (bottom-left, above coord bar).  Content is an inline SVG
+   (bracket + ticks + 0/total labels) rebuilt by updateScaleBar. */
 #scale-bar {
     position: absolute;
     bottom: 26px;
     left: 4px;
     z-index: 900;
-    display: flex;
-    align-items: flex-end;
-    gap: 6px;
+    background: var(--bg-status);
+    color: var(--fg-secondary);  /* SVG strokes use currentColor */
+    border-radius: 3px;
+    padding: 1px 4px;
+    line-height: 0;  /* wrap the inline SVG snugly */
     pointer-events: none;
 }
-.scale-bar-line {
-    height: 8px;
-    min-width: 20px;
-    border: 2px solid white;
-    border-top: none;
-}
-.scale-bar-label {
-    color: white;
+/* Tick/label text drawn inside the scale-bar SVG. */
+.scale-bar-text {
+    fill: currentColor;
     font: 11px monospace;
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
-    line-height: 1;
+}
+
+/* Background color control in the Display Controls panel. */
+.bg-color-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    font-size: 12px;
+}
+.bg-color-row span {
+    flex: 1;
+}
+.bg-color-input {
+    width: 24px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid var(--fg-muted);
+    background: none;
+    cursor: pointer;
+}
+.bg-color-reset {
+    font-size: 11px;
+    cursor: pointer;
 }
 
 /* Loading overlay */

--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -5,6 +5,8 @@
 // Cookies are used instead of localStorage because the port changes on
 // every restart (port 0 = OS-assigned) and localStorage is origin-scoped.
 
+import { cssColorToHex, isValidHexColor } from './ui-utils.js';
+
 export function getCookie(name) {
     const m = document.cookie.match('(?:^|; )' + name + '=([^;]*)');
     return m ? m[1] : null;
@@ -12,6 +14,12 @@ export function getCookie(name) {
 
 export function setCookie(name, value) {
     document.cookie = name + '=' + value + '; path=/; max-age=31536000; SameSite=Lax';
+}
+
+// Expire a cookie immediately.  The path/SameSite attributes must match
+// setCookie's for the browser to target the same cookie.
+export function deleteCookie(name) {
+    document.cookie = name + '=; path=/; max-age=0; SameSite=Lax';
 }
 
 // Enable the Golden Layout theme stylesheet matching the active theme.
@@ -23,6 +31,50 @@ export function applyGLTheme(theme) {
     light.disabled = (theme !== 'light');
 }
 
+// Optional per-user override of the layout background color (Qt GUI
+// "Background" parity).  Stored as "#rrggbb"; applied as an inline
+// --bg-map override so it survives dark/light theme toggles.  app is
+// passed so the 3D viewer (which caches --bg-map) can re-render, and
+// so the saved display state (which includes or_bg_color) is pushed to
+// the server here — callers don't need to remember to sync.
+export function setBackgroundColor(color, app) {
+    if (!isValidHexColor(color)) {
+        return;
+    }
+    document.documentElement.style.setProperty('--bg-map', color);
+    setCookie('or_bg_color', color);
+    refreshBackgroundConsumers(app);
+    app.syncDisplayState();
+}
+
+// Drop the override and fall back to the theme's --bg-map value.
+export function resetBackgroundColor(app) {
+    document.documentElement.style.removeProperty('--bg-map');
+    deleteCookie('or_bg_color');
+    refreshBackgroundConsumers(app);
+    app.syncDisplayState();
+}
+
+// The active theme's own --bg-map value in the "#rrggbb" form an
+// <input type="color"> requires (currently #111 in both themes).
+// Must be read with no inline override active — resetBackgroundColor
+// removes it — otherwise the override value is returned instead.
+export function getThemeDefaultBgColor() {
+    return cssColorToHex(
+        getComputedStyle(document.documentElement)
+            .getPropertyValue('--bg-map')) ?? '#111111';
+}
+
+// The layout container reads --bg-map live via CSS, but the 3D viewer
+// caches the resolved color in its Three.js scene, so re-render it on
+// change.  (Charts/clock use --canvas-bg, not --bg-map, so they don't
+// need refreshing here.)
+function refreshBackgroundConsumers(app) {
+    if (app && app.threeDViewerWidget && app.threeDViewerWidget.render) {
+        app.threeDViewerWidget.render();
+    }
+}
+
 if (typeof document !== 'undefined') {
     // Try cookie first (shared across ports for the live server),
     // then localStorage (works for standalone file:// reports).
@@ -31,6 +83,11 @@ if (typeof document !== 'undefined') {
         || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
     document.documentElement.dataset.theme = savedTheme;
     applyGLTheme(savedTheme);
+    // Restore a saved background-color override, if any and valid.
+    const savedBg = getCookie('or_bg_color');
+    if (isValidHexColor(savedBg)) {
+        document.documentElement.style.setProperty('--bg-map', savedBg);
+    }
 }
 
 // Read current CSS custom property values for canvas-based widgets.

--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -5,6 +5,8 @@
 // Cookies are used instead of localStorage because the port changes on
 // every restart (port 0 = OS-assigned) and localStorage is origin-scoped.
 
+import { isValidHexColor } from './ui-utils.js';
+
 export function getCookie(name) {
     const m = document.cookie.match('(?:^|; )' + name + '=([^;]*)');
     return m ? m[1] : null;
@@ -12,6 +14,12 @@ export function getCookie(name) {
 
 export function setCookie(name, value) {
     document.cookie = name + '=' + value + '; path=/; max-age=31536000; SameSite=Lax';
+}
+
+// Expire a cookie immediately.  The path/SameSite attributes must match
+// setCookie's for the browser to target the same cookie.
+export function deleteCookie(name) {
+    document.cookie = name + '=; path=/; max-age=0; SameSite=Lax';
 }
 
 // Enable the Golden Layout theme stylesheet matching the active theme.
@@ -23,6 +31,36 @@ export function applyGLTheme(theme) {
     light.disabled = (theme !== 'light');
 }
 
+// Optional per-user override of the layout background color (Qt GUI
+// "Background" parity).  Stored as "#rrggbb"; applied as an inline
+// --bg-map override so it survives dark/light theme toggles.  app is
+// passed so the 3D viewer (which caches --bg-map) can re-render.
+export function setBackgroundColor(color, app) {
+    if (!isValidHexColor(color)) {
+        return;
+    }
+    document.documentElement.style.setProperty('--bg-map', color);
+    setCookie('or_bg_color', color);
+    refreshBackgroundConsumers(app);
+}
+
+// Drop the override and fall back to the theme's --bg-map value.
+export function resetBackgroundColor(app) {
+    document.documentElement.style.removeProperty('--bg-map');
+    deleteCookie('or_bg_color');
+    refreshBackgroundConsumers(app);
+}
+
+// The layout container reads --bg-map live via CSS, but the 3D viewer
+// caches the resolved color in its Three.js scene, so re-render it on
+// change.  (Charts/clock use --canvas-bg, not --bg-map, so they don't
+// need refreshing here.)
+function refreshBackgroundConsumers(app) {
+    if (app && app.threeDViewerWidget && app.threeDViewerWidget.render) {
+        app.threeDViewerWidget.render();
+    }
+}
+
 if (typeof document !== 'undefined') {
     // Try cookie first (shared across ports for the live server),
     // then localStorage (works for standalone file:// reports).
@@ -31,6 +69,11 @@ if (typeof document !== 'undefined') {
         || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
     document.documentElement.dataset.theme = savedTheme;
     applyGLTheme(savedTheme);
+    // Restore a saved background-color override, if any and valid.
+    const savedBg = getCookie('or_bg_color');
+    if (isValidHexColor(savedBg)) {
+        document.documentElement.style.setProperty('--bg-map', savedBg);
+    }
 }
 
 // Read current CSS custom property values for canvas-based widgets.

--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -5,7 +5,7 @@
 // Cookies are used instead of localStorage because the port changes on
 // every restart (port 0 = OS-assigned) and localStorage is origin-scoped.
 
-import { isValidHexColor } from './ui-utils.js';
+import { cssColorToHex, isValidHexColor } from './ui-utils.js';
 
 export function getCookie(name) {
     const m = document.cookie.match('(?:^|; )' + name + '=([^;]*)');
@@ -34,7 +34,9 @@ export function applyGLTheme(theme) {
 // Optional per-user override of the layout background color (Qt GUI
 // "Background" parity).  Stored as "#rrggbb"; applied as an inline
 // --bg-map override so it survives dark/light theme toggles.  app is
-// passed so the 3D viewer (which caches --bg-map) can re-render.
+// passed so the 3D viewer (which caches --bg-map) can re-render, and
+// so the saved display state (which includes or_bg_color) is pushed to
+// the server here — callers don't need to remember to sync.
 export function setBackgroundColor(color, app) {
     if (!isValidHexColor(color)) {
         return;
@@ -42,6 +44,7 @@ export function setBackgroundColor(color, app) {
     document.documentElement.style.setProperty('--bg-map', color);
     setCookie('or_bg_color', color);
     refreshBackgroundConsumers(app);
+    app.syncDisplayState();
 }
 
 // Drop the override and fall back to the theme's --bg-map value.
@@ -49,6 +52,17 @@ export function resetBackgroundColor(app) {
     document.documentElement.style.removeProperty('--bg-map');
     deleteCookie('or_bg_color');
     refreshBackgroundConsumers(app);
+    app.syncDisplayState();
+}
+
+// The active theme's own --bg-map value in the "#rrggbb" form an
+// <input type="color"> requires (currently #111 in both themes).
+// Must be read with no inline override active — resetBackgroundColor
+// removes it — otherwise the override value is returned instead.
+export function getThemeDefaultBgColor() {
+    return cssColorToHex(
+        getComputedStyle(document.documentElement)
+            .getPropertyValue('--bg-map')) ?? '#111111';
 }
 
 // The layout container reads --bg-map live via CSS, but the 3D viewer

--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -22,6 +22,29 @@ export function deleteCookie(name) {
     document.cookie = name + '=; path=/; max-age=0; SameSite=Lax';
 }
 
+// The theme is persisted in TWO stores: a cookie (shared across ports for the
+// live server) and a localStorage mirror (which is all a standalone file://
+// report has).  Initialization below reads `cookie || localStorage || system`,
+// so the two must always move together — clearing only the cookie would fall
+// through to a stale mirror.  Both writers go through this pair so that rule
+// lives in exactly one place.
+//
+// Persistence only: applying the theme to the DOM is the caller's business,
+// because the display-state restore path writes storage and then reloads.
+export function persistTheme(theme) {
+    setCookie('or_theme', theme);
+    try {
+        window.localStorage.setItem('or_theme', theme);
+    } catch (_) { /* storage disabled */ }
+}
+
+export function clearPersistedTheme() {
+    deleteCookie('or_theme');
+    try {
+        window.localStorage.removeItem('or_theme');
+    } catch (_) { /* storage disabled */ }
+}
+
 // Enable the Golden Layout theme stylesheet matching the active theme.
 export function applyGLTheme(theme) {
     const dark  = document.getElementById('gl-theme-dark');
@@ -70,9 +93,7 @@ export function getThemeDefaultBgColor() {
 // change.  (Charts/clock use --canvas-bg, not --bg-map, so they don't
 // need refreshing here.)
 function refreshBackgroundConsumers(app) {
-    if (app && app.threeDViewerWidget && app.threeDViewerWidget.render) {
-        app.threeDViewerWidget.render();
-    }
+    app.threeDViewerWidget?.render?.();
 }
 
 if (typeof document !== 'undefined') {

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -3955,11 +3955,32 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                      grid != nullptr,
                      vis.tracks_pref,
                      vis.tracks_non_pref);
-          if (grid) {
+          // Clip the tracks to the die area, as the Qt GUI does
+          // (RenderThread::drawTracks: draw_bounds = die.intersect(bounds)).
+          // A track line drawn to the tile edge runs past the chip in any
+          // design whose block bbox reaches beyond the die area — and the
+          // viewport follows that bbox (see getBounds) — leaving tracks
+          // floating outside the die.  Same shape as drawGCellGridLayer.
+          const odb::Rect die_area = block->getDieArea();
+          if (grid && dbu_tile.intersects(die_area)) {
+            const odb::Rect draw_bounds = dbu_tile.intersect(die_area);
+            // Span of the clipped region in buffer pixels (Y flipped).  Shared
+            // by every track of this tile, so neighbouring tiles agree on where
+            // the lines stop and the seams stay aligned.
+            const int pxl = toPxX(draw_bounds.xMin(), frame);
+            const int pxh = toPxX(draw_bounds.xMax(), frame);
+            const int pyl = toPxY(draw_bounds.yMin(), frame, super);
+            const int pyh = toPxY(draw_bounds.yMax(), frame, super);
+
             Color track_color = color;
             track_color.a = 150;
             const bool is_horizontal
                 = tech_layer->getDirection() == odb::dbTechLayerDir::HORIZONTAL;
+            // One buffer pixel, as before this clip existed: hairlineCss()
+            // would read as a thickness change rather than the intended
+            // geometry fix.  drawLine composites with blendPixel, so the
+            // 150-alpha blend is unchanged too.
+            constexpr int kTrackWidth = 1;
 
             // X-direction tracks (vertical lines on screen)
             // Preferred for vertical layers, non-preferred for horizontal
@@ -3979,15 +4000,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                          dbu_tile.xMax(),
                          dbu_tile.yMax());
               for (int tx : x_grid) {
-                if (tx < dbu_x_min || tx > dbu_x_max) {
+                if (tx < draw_bounds.xMin() || tx > draw_bounds.xMax()) {
                   continue;
                 }
-                const int px = static_cast<int>((tx - dbu_x_min) * scale);
-                if (px >= 0 && px < super) {
-                  for (int py = 0; py < super; ++py) {
-                    blendPixel(image_buffer, px, py, track_color);
-                  }
-                }
+                const int px = toPxX(tx, frame);
+                drawLine(
+                    image_buffer, px, pyl, px, pyh, track_color, kTrackWidth);
               }
             }
 
@@ -4005,16 +4023,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                          "  y_tracks: count={}",
                          y_grid.size());
               for (int ty : y_grid) {
-                if (ty < dbu_y_min || ty > dbu_y_max) {
+                if (ty < draw_bounds.yMin() || ty > draw_bounds.yMax()) {
                   continue;
                 }
-                const int py
-                    = super - 1 - static_cast<int>((ty - dbu_y_min) * scale);
-                if (py >= 0 && py < super) {
-                  for (int px = 0; px < super; ++px) {
-                    blendPixel(image_buffer, px, py, track_color);
-                  }
-                }
+                const int py = toPxY(ty, frame, super);
+                drawLine(
+                    image_buffer, pxl, py, pxh, py, track_color, kTrackWidth);
               }
             }
           }

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -3982,13 +3982,30 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             // 150-alpha blend is unchanged too.
             constexpr int kTrackWidth = 1;
 
+            // Walk only the lines inside `draw_bounds`, over odb's own
+            // (memoized, sorted) grid vector.  dbTrackGrid offers a
+            // const-ref accessor next to the out-parameter one, so neither
+            // the copy nor the full scan is needed: metal1 of bp_quad has
+            // 18 947 x-tracks, and the copy alone was ~178 KB per layer-tile.
+            // drawGCellGridLayer keeps a cache of its own only because
+            // dbGCellGrid lacks this accessor.
+            const auto draw_clipped = [&](const std::vector<int>& lines,
+                                          const int lo,
+                                          const int hi,
+                                          const auto& draw_one) {
+              for (auto it = std::ranges::lower_bound(lines, lo);
+                   it != lines.end() && *it <= hi;
+                   ++it) {
+                draw_one(*it);
+              }
+            };
+
             // X-direction tracks (vertical lines on screen)
             // Preferred for vertical layers, non-preferred for horizontal
             // layers
             if ((!is_horizontal && vis.tracks_pref)
                 || (is_horizontal && vis.tracks_non_pref)) {
-              std::vector<int> x_grid;
-              grid->getGridX(x_grid);
+              const std::vector<int>& x_grid = grid->getGridX();
               debugPrint(logger_,
                          utl::WEB,
                          "tile",
@@ -3999,14 +4016,17 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                          dbu_tile.yMin(),
                          dbu_tile.xMax(),
                          dbu_tile.yMax());
-              for (int tx : x_grid) {
-                if (tx < draw_bounds.xMin() || tx > draw_bounds.xMax()) {
-                  continue;
-                }
-                const int px = toPxX(tx, frame);
-                drawLine(
-                    image_buffer, px, pyl, px, pyh, track_color, kTrackWidth);
-              }
+              draw_clipped(
+                  x_grid, draw_bounds.xMin(), draw_bounds.xMax(), [&](int tx) {
+                    const int px = toPxX(tx, frame);
+                    drawLine(image_buffer,
+                             px,
+                             pyl,
+                             px,
+                             pyh,
+                             track_color,
+                             kTrackWidth);
+                  });
             }
 
             // Y-direction tracks (horizontal lines on screen)
@@ -4014,22 +4034,24 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             // layers
             if ((is_horizontal && vis.tracks_pref)
                 || (!is_horizontal && vis.tracks_non_pref)) {
-              std::vector<int> y_grid;
-              grid->getGridY(y_grid);
+              const std::vector<int>& y_grid = grid->getGridY();
               debugPrint(logger_,
                          utl::WEB,
                          "tile",
                          1,
                          "  y_tracks: count={}",
                          y_grid.size());
-              for (int ty : y_grid) {
-                if (ty < draw_bounds.yMin() || ty > draw_bounds.yMax()) {
-                  continue;
-                }
-                const int py = toPxY(ty, frame, super);
-                drawLine(
-                    image_buffer, pxl, py, pxh, py, track_color, kTrackWidth);
-              }
+              draw_clipped(
+                  y_grid, draw_bounds.yMin(), draw_bounds.yMax(), [&](int ty) {
+                    const int py = toPxY(ty, frame, super);
+                    drawLine(image_buffer,
+                             pxl,
+                             py,
+                             pxh,
+                             py,
+                             track_color,
+                             kTrackWidth);
+                  });
             }
           }
         }

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -15,6 +15,26 @@ export function isValidHexColor(s) {
     return typeof s === 'string' && /^#[0-9a-fA-F]{6}$/.test(s);
 }
 
+// Normalize a CSS color to the "#rrggbb" form an <input type="color">
+// requires, or null when unrecognized.  Handles the forms a CSS custom
+// property can hold: "#rgb", "#rrggbb", and "rgb(r, g, b)".
+export function cssColorToHex(s) {
+    if (typeof s !== 'string') return null;
+    const str = s.trim();
+    if (isValidHexColor(str)) return str.toLowerCase();
+    const short = str.match(/^#([0-9a-fA-F]{3})$/);
+    if (short) {
+        return '#' + short[1].split('').map(c => c + c).join('').toLowerCase();
+    }
+    const rgb = str.match(/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/);
+    if (rgb) {
+        const parts = rgb.slice(1).map(Number);
+        if (parts.some(v => v > 255)) return null;
+        return '#' + parts.map(v => v.toString(16).padStart(2, '0')).join('');
+    }
+    return null;
+}
+
 // Wrap fn in a single-flight requestAnimationFrame scheduler: calls made
 // while a frame is already pending coalesce into one invocation of fn.
 export function rafCoalesce(fn) {
@@ -70,7 +90,11 @@ export function computeScaleBar({ targetPx, pxPerDbu, dbuPerMicron, showDbu }) {
         barPx = Math.round(nice.value * pxPerDbu);
         label = String(Math.round(nice.value));
     } else {
-        const dbuPerUm = dbuPerMicron || 1000;
+        // A corrupt (non-finite/non-positive) DBU-per-micron would send
+        // niceRoundParts a negative value and yield NaN geometry; fall
+        // back to the same default used for a missing value.
+        const dbuPerUm = (Number.isFinite(dbuPerMicron) && dbuPerMicron > 0)
+            ? dbuPerMicron : 1000;
         const pxPerUm = pxPerDbu * dbuPerUm;
         const nice = niceRoundParts(targetPx / pxPerUm);
         digit = nice.digit;

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -9,6 +9,98 @@ export function isStaticMode(app) {
     return !!app?.websocketManager?.isStaticMode;
 }
 
+// True for a "#rrggbb" hex color string (the form an <input type="color">
+// emits and the form persisted for the background color).
+export function isValidHexColor(s) {
+    return typeof s === 'string' && /^#[0-9a-fA-F]{6}$/.test(s);
+}
+
+// Wrap fn in a single-flight requestAnimationFrame scheduler: calls made
+// while a frame is already pending coalesce into one invocation of fn.
+export function rafCoalesce(fn) {
+    let pending = null;
+    return () => {
+        if (pending !== null) {
+            return;
+        }
+        pending = requestAnimationFrame(() => {
+            pending = null;
+            fn();
+        });
+    };
+}
+
+// Round a positive value to the nearest 1/2/5/10 × 10^n, returning both the
+// rounded value and the chosen leading digit (used to pick tick subdivisions).
+export function niceRoundParts(value) {
+    const mag = Math.pow(10, Math.floor(Math.log10(value)));
+    const residual = value / mag;
+    let digit;
+    if (residual < 1.5) {
+        digit = 1;
+    } else if (residual < 3.5) {
+        digit = 2;
+    } else if (residual < 7.5) {
+        digit = 5;
+    } else {
+        digit = 10;
+    }
+    return { value: digit * mag, digit };
+}
+
+// Compute the scale-bar geometry and label from the current zoom.
+//   targetPx      desired bar length in screen pixels (~15% of viewport)
+//   pxPerDbu      pixels per DBU at the current zoom
+//   dbuPerMicron  DBU per micron for the design (metric mode)
+//   showDbu       true → label in DBU (no unit suffix), false → metric
+// Returns { barPx, label, segments } or null when not drawable.
+// Pure (no DOM) so it can be unit-tested.
+export function computeScaleBar({ targetPx, pxPerDbu, dbuPerMicron, showDbu }) {
+    if (!Number.isFinite(pxPerDbu) || pxPerDbu <= 0
+        || !Number.isFinite(targetPx) || targetPx <= 0) {
+        return null;
+    }
+
+    let barPx;
+    let label;
+    let digit;
+    if (showDbu) {
+        const nice = niceRoundParts(Math.max(1, targetPx / pxPerDbu));
+        digit = nice.digit;
+        barPx = Math.round(nice.value * pxPerDbu);
+        label = String(Math.round(nice.value));
+    } else {
+        const dbuPerUm = dbuPerMicron || 1000;
+        const pxPerUm = pxPerDbu * dbuPerUm;
+        const nice = niceRoundParts(targetPx / pxPerUm);
+        digit = nice.digit;
+        const niceUm = nice.value;
+        barPx = Math.round(niceUm * pxPerUm);
+        // Pick the unit whose value comes out as a clean integer.
+        let scale;
+        let unit;
+        if (niceUm >= 1000) {
+            scale = 1 / 1000;
+            unit = 'mm';
+        } else if (niceUm >= 1) {
+            scale = 1;
+            unit = 'µm';
+        } else if (niceUm >= 0.001) {
+            scale = 1000;
+            unit = 'nm';
+        } else {
+            scale = 1e6;
+            unit = 'pm';
+        }
+        label = Math.round(niceUm * scale) + ' ' + unit;
+    }
+
+    // Interior subdivisions: 1 → 5 ticks, otherwise the leading digit
+    // (2 → 2, 5 → 5, 10 → 10), mirroring the Qt scale bar's peg count.
+    const segments = digit === 1 ? 5 : digit;
+    return { barPx, label, segments };
+}
+
 // Make table column headers resizable by dragging.
 // widths is an optional array of CSS width strings (e.g. saved from a
 // previous render); when given, it is applied directly instead of

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -130,14 +130,21 @@ export function attachGroupCollapse(header, arrow, children, collapsed) {
 // the smallest distance the database can express, so magnifying it further
 // shows nothing that was not already visible.  Returned as an integer because
 // the map rests on integer zoom levels (see buildMapOptions).
+// Must match kMaxTileZoom in request_handler.h: the server refuses a deeper
+// tile, so asking for one would only trade blank tiles for error responses.
+export const MAX_TILE_ZOOM = 30;
+
 export function maxUsefulZoom(designScale, maxPxPerDbu = 8) {
     if (!Number.isFinite(designScale) || designScale <= 0) {
-        return 20;  // no design loaded yet; a finite fallback still bounds it
+        // Callers hold off until the design bounds arrive, so this is a
+        // belt-and-braces value: still finite, so the zoom stays bounded.
+        return MAX_TILE_ZOOM;
     }
     const z = Math.ceil(Math.log2(maxPxPerDbu / designScale));
-    // Never below 1 (a design bigger than the cap would otherwise pin the user
-    // at the fit zoom), never above the server's own tile-grid ceiling.
-    return Math.max(1, Math.min(30, z));
+    // Never above the server's ceiling, and never below 1: a design so small
+    // that one DBU already fills the budget at zoom 0 would otherwise pin the
+    // user at the fit zoom with no way to zoom in at all.
+    return Math.max(1, Math.min(MAX_TILE_ZOOM, z));
 }
 
 // True for a "#rrggbb" hex color string (the form an <input type="color">

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -117,6 +117,29 @@ export function attachGroupCollapse(header, arrow, children, collapsed) {
     });
 }
 
+// Deepest zoom worth offering, given `designScale` (pixels per DBU at zoom 0).
+//
+// Leaflet's default maxZoom is Infinity unless a layer supplies one, and
+// L.GridLayer -- unlike L.TileLayer -- supplies none.  Left unbounded the zoom
+// keeps climbing past any useful magnification until the arithmetic gives out:
+// the server's tile span (maxDXDY / 2^z) underflows to zero, so tiles come back
+// empty and the design appears to vanish, and the map's own 2^z factors reach
+// Infinity, which JSON.stringify writes as `null` in the tile request.
+//
+// The cap is where one DBU already covers `maxPxPerDbu` screen pixels: a DBU is
+// the smallest distance the database can express, so magnifying it further
+// shows nothing that was not already visible.  Returned as an integer because
+// the map rests on integer zoom levels (see buildMapOptions).
+export function maxUsefulZoom(designScale, maxPxPerDbu = 8) {
+    if (!Number.isFinite(designScale) || designScale <= 0) {
+        return 20;  // no design loaded yet; a finite fallback still bounds it
+    }
+    const z = Math.ceil(Math.log2(maxPxPerDbu / designScale));
+    // Never below 1 (a design bigger than the cap would otherwise pin the user
+    // at the fit zoom), never above the server's own tile-grid ceiling.
+    return Math.max(1, Math.min(30, z));
+}
+
 // True for a "#rrggbb" hex color string (the form an <input type="color">
 // emits and the form persisted for the background color).
 export function isValidHexColor(s) {

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -117,6 +117,122 @@ export function attachGroupCollapse(header, arrow, children, collapsed) {
     });
 }
 
+// True for a "#rrggbb" hex color string (the form an <input type="color">
+// emits and the form persisted for the background color).
+export function isValidHexColor(s) {
+    return typeof s === 'string' && /^#[0-9a-fA-F]{6}$/.test(s);
+}
+
+// Normalize a CSS color to the "#rrggbb" form an <input type="color">
+// requires, or null when unrecognized.  Handles the forms a CSS custom
+// property can hold: "#rgb", "#rrggbb", and "rgb(r, g, b)".
+export function cssColorToHex(s) {
+    if (typeof s !== 'string') return null;
+    const str = s.trim();
+    if (isValidHexColor(str)) return str.toLowerCase();
+    const short = str.match(/^#([0-9a-fA-F]{3})$/);
+    if (short) {
+        return '#' + short[1].split('').map(c => c + c).join('').toLowerCase();
+    }
+    const rgb = str.match(/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/);
+    if (rgb) {
+        const parts = rgb.slice(1).map(Number);
+        if (parts.some(v => v > 255)) return null;
+        return '#' + parts.map(v => v.toString(16).padStart(2, '0')).join('');
+    }
+    return null;
+}
+
+// Wrap fn in a single-flight requestAnimationFrame scheduler: calls made
+// while a frame is already pending coalesce into one invocation of fn.
+export function rafCoalesce(fn) {
+    let pending = null;
+    return () => {
+        if (pending !== null) {
+            return;
+        }
+        pending = requestAnimationFrame(() => {
+            pending = null;
+            fn();
+        });
+    };
+}
+
+// Round a positive value to the nearest 1/2/5/10 × 10^n, returning both the
+// rounded value and the chosen leading digit (used to pick tick subdivisions).
+export function niceRoundParts(value) {
+    const mag = Math.pow(10, Math.floor(Math.log10(value)));
+    const residual = value / mag;
+    let digit;
+    if (residual < 1.5) {
+        digit = 1;
+    } else if (residual < 3.5) {
+        digit = 2;
+    } else if (residual < 7.5) {
+        digit = 5;
+    } else {
+        digit = 10;
+    }
+    return { value: digit * mag, digit };
+}
+
+// Compute the scale-bar geometry and label from the current zoom.
+//   targetPx      desired bar length in screen pixels (~15% of viewport)
+//   pxPerDbu      pixels per DBU at the current zoom
+//   dbuPerMicron  DBU per micron for the design (metric mode)
+//   showDbu       true → label in DBU (no unit suffix), false → metric
+// Returns { barPx, label, segments } or null when not drawable.
+// Pure (no DOM) so it can be unit-tested.
+export function computeScaleBar({ targetPx, pxPerDbu, dbuPerMicron, showDbu }) {
+    if (!Number.isFinite(pxPerDbu) || pxPerDbu <= 0
+        || !Number.isFinite(targetPx) || targetPx <= 0) {
+        return null;
+    }
+
+    let barPx;
+    let label;
+    let digit;
+    if (showDbu) {
+        const nice = niceRoundParts(Math.max(1, targetPx / pxPerDbu));
+        digit = nice.digit;
+        barPx = Math.round(nice.value * pxPerDbu);
+        label = String(Math.round(nice.value));
+    } else {
+        // A corrupt (non-finite/non-positive) DBU-per-micron would send
+        // niceRoundParts a negative value and yield NaN geometry; fall
+        // back to the same default used for a missing value.
+        const dbuPerUm = (Number.isFinite(dbuPerMicron) && dbuPerMicron > 0)
+            ? dbuPerMicron : 1000;
+        const pxPerUm = pxPerDbu * dbuPerUm;
+        const nice = niceRoundParts(targetPx / pxPerUm);
+        digit = nice.digit;
+        const niceUm = nice.value;
+        barPx = Math.round(niceUm * pxPerUm);
+        // Pick the unit whose value comes out as a clean integer.
+        let scale;
+        let unit;
+        if (niceUm >= 1000) {
+            scale = 1 / 1000;
+            unit = 'mm';
+        } else if (niceUm >= 1) {
+            scale = 1;
+            unit = 'µm';
+        } else if (niceUm >= 0.001) {
+            scale = 1000;
+            unit = 'nm';
+        } else {
+            scale = 1e6;
+            unit = 'pm';
+        }
+        label = Math.round(niceUm * scale) + ' ' + unit;
+    }
+
+    // Interior subdivisions: 1 → 5 ticks, otherwise the leading digit
+    // (2 → 2, 5 → 5, 10 → 10), mirroring the Qt scale bar's peg count.
+    const segments = digit === 1 ? 5 : digit;
+    return { barPx, label, segments };
+}
+
 // Make table column headers resizable by dragging.
 // widths is an optional array of CSS width strings (e.g. saved from a
 // previous render); when given, it is applied directly instead of

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <functional>
 #include <ios>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -31,6 +32,7 @@
 #include "boost/beast/websocket.hpp"
 #include "boost/json/array.hpp"
 #include "boost/json/object.hpp"
+#include "boost/json/parse.hpp"
 #include "boost/json/serialize.hpp"
 #include "boost/json/value.hpp"
 #include "clock_tree_report.h"
@@ -337,6 +339,27 @@ WebSocketSession::WebSocketSession(
         root["charts"] = std::move(charts);
         std::string s = boost::json::serialize(root);
         resp.payload.assign(s.begin(), s.end());
+        return resp;
+      },
+      /*run_inline=*/true);
+
+  // Client continuously syncs its full display-controls state here so the
+  // Tcl save_display_controls command can persist it to a file.  Runs
+  // inline (no net::post) — it only touches the mutex-guarded cache.
+  dispatcher_.add(
+      "set_display_state",
+      WebSocketRequest::kSetDisplayState,
+      [this](const WebSocketRequest& req, SessionState&) -> WebSocketResponse {
+        if (viewer_hook_ != nullptr) {
+          if (auto* state = req.json.if_contains("state")) {
+            viewer_hook_->setDisplayState(boost::json::serialize(*state));
+          }
+        }
+        WebSocketResponse resp;
+        resp.id = req.id;
+        resp.type = WebSocketResponse::kJson;
+        const std::string json = R"({"ok":1})";
+        resp.payload.assign(json.begin(), json.end());
         return resp;
       },
       /*run_inline=*/true);
@@ -1318,6 +1341,67 @@ void WebServer::saveImage(const std::string& filename,
     }
   }
   generator_->saveImage(filename, region, width_px, dbu_per_pixel, vis);
+}
+
+void WebServer::saveDisplayControls(const std::string& filename)
+{
+  if (!viewer_hook_) {
+    logger_->error(utl::WEB, 51, "Web server is not running.");
+    return;
+  }
+  const std::string state = viewer_hook_->getDisplayState();
+  if (state.empty()) {
+    logger_->warn(utl::WEB,
+                  44,
+                  "No display state has been received from a client yet; "
+                  "open the web viewer before saving.");
+    return;
+  }
+  std::ofstream out(filename);
+  if (!out) {
+    logger_->error(utl::WEB, 45, "Cannot open {} for writing.", filename);
+    return;
+  }
+  out << state;
+  logger_->info(utl::WEB, 46, "Saved display controls to {}.", filename);
+}
+
+void WebServer::restoreDisplayControls(const std::string& filename)
+{
+  if (!viewer_hook_) {
+    logger_->error(utl::WEB, 47, "Web server is not running.");
+    return;
+  }
+  std::ifstream in(filename);
+  if (!in) {
+    logger_->error(utl::WEB, 48, "Cannot open {}.", filename);
+    return;
+  }
+  const std::string state((std::istreambuf_iterator<char>(in)),
+                          std::istreambuf_iterator<char>());
+  boost::json::value parsed;
+  try {
+    parsed = boost::json::parse(state);
+  } catch (const std::exception& e) {
+    logger_->error(utl::WEB,
+                   49,
+                   "Invalid display-controls JSON in {}: {}",
+                   filename,
+                   e.what());
+    return;
+  }
+  boost::json::object msg;
+  msg["type"] = "restore_display_state";
+  msg["state"] = std::move(parsed);
+  viewer_hook_->sessions().broadcast(boost::json::serialize(msg));
+  logger_->info(utl::WEB, 50, "Restored display controls from {}.", filename);
+}
+
+void WebServer::setDisplayState(std::string json)
+{
+  if (viewer_hook_) {
+    viewer_hook_->setDisplayState(std::move(json));
+  }
 }
 
 ListenerHandle createAndRunListener(

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -519,6 +519,42 @@ void WebSocketSession::do_read()
       });
 }
 
+namespace {
+
+// Run a request handler, converting any exception into an error response.
+//
+// Handlers run either on the read thread or on a bare io_context thread, and
+// neither has a try/catch above it: the threads run io_context::run() directly
+// (see createAndRunListener), so an exception escaping a handler unwinds out of
+// the thread function and calls std::terminate -- the whole openroad process
+// dies, taking the design with it.  A malformed request must cost the client
+// one error response, never the session.
+//
+// The obvious offender is a field whose JSON type is wrong: boost::json's
+// as_int64()/as_string() throw rather than return an error.  A client cannot
+// avoid this by being careful, either -- JSON.stringify serializes NaN and
+// Infinity as `null`, so any arithmetic that goes non-finite on the client
+// (an unbounded zoom, for one) arrives here as a null where a number belongs.
+WebSocketResponse invoke_handler(const RequestDispatcher::HandleFn& handle,
+                                 const WebSocketRequest& req,
+                                 SessionState& state)
+{
+  WebSocketResponse resp;
+  try {
+    resp = handle(req, state);
+  } catch (const std::exception& e) {
+    resp = WebSocketResponse{};
+    resp.id = req.id;
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
+  resp.request_type = req.raw_type;
+  return resp;
+}
+
+}  // namespace
+
 void WebSocketSession::on_read(beast::error_code ec)
 {
   if (ec) {
@@ -542,19 +578,16 @@ void WebSocketSession::on_read(beast::error_code ec)
   const auto* entry = dispatcher_.find(req.type);
   if (entry != nullptr) {
     if (entry->run_inline) {
-      auto resp = entry->handle(req, state_);
-      resp.request_type = req.raw_type;
-      queue_response(resp);
+      queue_response(invoke_handler(entry->handle, req, state_));
     } else {
       auto handle = entry->handle;
-      net::post(websocket_.get_executor(),
-                [self = std::move(self),
-                 req = std::move(req),
-                 handle = std::move(handle)]() {
-                  auto resp = handle(req, self->state_);
-                  resp.request_type = req.raw_type;
-                  self->queue_response(resp);
-                });
+      net::post(
+          websocket_.get_executor(),
+          [self = std::move(self),
+           req = std::move(req),
+           handle = std::move(handle)]() {
+            self->queue_response(invoke_handler(handle, req, self->state_));
+          });
     }
   } else {
     // Unknown type -- return an error so the client knows the request

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <functional>
 #include <ios>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -31,6 +32,7 @@
 #include "boost/beast/websocket.hpp"
 #include "boost/json/array.hpp"
 #include "boost/json/object.hpp"
+#include "boost/json/parse.hpp"
 #include "boost/json/serialize.hpp"
 #include "boost/json/value.hpp"
 #include "clock_tree_report.h"
@@ -334,6 +336,27 @@ WebSocketSession::WebSocketSession(
         root["charts"] = std::move(charts);
         std::string s = boost::json::serialize(root);
         resp.payload.assign(s.begin(), s.end());
+        return resp;
+      },
+      /*run_inline=*/true);
+
+  // Client continuously syncs its full display-controls state here so the
+  // Tcl save_display_controls command can persist it to a file.  Runs
+  // inline (no net::post) — it only touches the mutex-guarded cache.
+  dispatcher_.add(
+      "set_display_state",
+      WebSocketRequest::kSetDisplayState,
+      [this](const WebSocketRequest& req, SessionState&) -> WebSocketResponse {
+        if (viewer_hook_ != nullptr) {
+          if (auto* state = req.json.if_contains("state")) {
+            viewer_hook_->setDisplayState(boost::json::serialize(*state));
+          }
+        }
+        WebSocketResponse resp;
+        resp.id = req.id;
+        resp.type = WebSocketResponse::kJson;
+        const std::string json = R"({"ok":1})";
+        resp.payload.assign(json.begin(), json.end());
         return resp;
       },
       /*run_inline=*/true);
@@ -1315,6 +1338,67 @@ void WebServer::saveImage(const std::string& filename,
     }
   }
   generator_->saveImage(filename, region, width_px, dbu_per_pixel, vis);
+}
+
+void WebServer::saveDisplayControls(const std::string& filename)
+{
+  if (!viewer_hook_) {
+    logger_->error(utl::WEB, 51, "Web server is not running.");
+    return;
+  }
+  const std::string state = viewer_hook_->getDisplayState();
+  if (state.empty()) {
+    logger_->warn(utl::WEB,
+                  44,
+                  "No display state has been received from a client yet; "
+                  "open the web viewer before saving.");
+    return;
+  }
+  std::ofstream out(filename);
+  if (!out) {
+    logger_->error(utl::WEB, 45, "Cannot open {} for writing.", filename);
+    return;
+  }
+  out << state;
+  logger_->info(utl::WEB, 46, "Saved display controls to {}.", filename);
+}
+
+void WebServer::restoreDisplayControls(const std::string& filename)
+{
+  if (!viewer_hook_) {
+    logger_->error(utl::WEB, 47, "Web server is not running.");
+    return;
+  }
+  std::ifstream in(filename);
+  if (!in) {
+    logger_->error(utl::WEB, 48, "Cannot open {}.", filename);
+    return;
+  }
+  const std::string state((std::istreambuf_iterator<char>(in)),
+                          std::istreambuf_iterator<char>());
+  boost::json::value parsed;
+  try {
+    parsed = boost::json::parse(state);
+  } catch (const std::exception& e) {
+    logger_->error(utl::WEB,
+                   49,
+                   "Invalid display-controls JSON in {}: {}",
+                   filename,
+                   e.what());
+    return;
+  }
+  boost::json::object msg;
+  msg["type"] = "restore_display_state";
+  msg["state"] = std::move(parsed);
+  viewer_hook_->sessions().broadcast(boost::json::serialize(msg));
+  logger_->info(utl::WEB, 50, "Restored display controls from {}.", filename);
+}
+
+void WebServer::setDisplayState(std::string json)
+{
+  if (viewer_hook_) {
+    viewer_hook_->setDisplayState(std::move(json));
+  }
 }
 
 ListenerHandle createAndRunListener(

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -530,24 +530,21 @@ namespace {
 // dies, taking the design with it.  A malformed request must cost the client
 // one error response, never the session.
 //
-// The obvious offender is a field whose JSON type is wrong: boost::json's
-// as_int64()/as_string() throw rather than return an error.  A client cannot
-// avoid this by being careful, either -- JSON.stringify serializes NaN and
-// Infinity as `null`, so any arithmetic that goes non-finite on the client
-// (an unbounded zoom, for one) arrives here as a null where a number belongs.
+// The obvious offender is a field whose JSON type is wrong -- boost::json's
+// as_int64()/as_string() throw rather than return an error.  See
+// parseTileCoords() in request_handler.h for why a careful client cannot avoid
+// this on its own.
 WebSocketResponse invoke_handler(const RequestDispatcher::HandleFn& handle,
                                  const WebSocketRequest& req,
                                  SessionState& state)
 {
   WebSocketResponse resp;
+  // `handle` returns by value, so on a throw `resp` is still the untouched
+  // default -- no partial payload to clear.
   try {
     resp = handle(req, state);
   } catch (const std::exception& e) {
-    resp = WebSocketResponse{};
-    resp.id = req.id;
-    resp.type = WebSocketResponse::kError;
-    const std::string err = std::string("server error: ") + e.what();
-    resp.payload.assign(err.begin(), err.end());
+    resp = errorResponse(req.id, std::string("server error: ") + e.what());
   }
   resp.request_type = req.raw_type;
   return resp;

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -1360,6 +1360,15 @@ void WebServer::saveDisplayControls(const std::string& filename)
     return;
   }
   out << state;
+  // Opening the file succeeding says nothing about the write: a full disk or a
+  // quota surfaces only here, and reporting success would leave a truncated
+  // file behind.  close() flushes, so check after it.
+  out.close();
+  if (!out) {
+    logger_->error(
+        utl::WEB, 53, "Failed writing display controls to {}.", filename);
+    return;
+  }
   logger_->info(utl::WEB, 46, "Saved display controls to {}.", filename);
 }
 
@@ -1387,6 +1396,49 @@ void WebServer::restoreDisplayControls(const std::string& filename)
                    e.what());
     return;
   }
+  // Validate the shape here, at the file boundary, so the client can trust
+  // what it is handed: it writes these values straight into document.cookie,
+  // where a ';' would inject cookie attributes, and a JSON number or boolean
+  // would silently change a key's meaning.  Rejecting loudly beats a restore
+  // that half-applies.
+  const auto* root = parsed.if_object();
+  const auto* entries_value
+      = root != nullptr ? root->if_contains("entries") : nullptr;
+  const boost::json::object* entries
+      = entries_value != nullptr ? entries_value->if_object() : nullptr;
+  if (entries == nullptr) {
+    logger_->error(utl::WEB,
+                   52,
+                   "Invalid display-controls state in {}: expected an "
+                   "\"entries\" object.",
+                   filename);
+    return;
+  }
+  // One error site for every way an entry can be unusable, so the reason is
+  // carried as text rather than burning a message id per case.  error() does
+  // not return, so reporting at the point of detection needs no loop-carried
+  // state.
+  for (const auto& [key, value] : *entries) {
+    const char* reason = nullptr;
+    if (!value.is_string()) {
+      reason = "is not a string";
+    } else if (const std::string_view text = value.get_string();
+               text.find_first_of(";\r\n") != std::string_view::npos) {
+      // Cookie delimiters would let the file forge attributes on the cookies
+      // the client writes these into.  No legitimate value carries them: the
+      // cookie-backed ones are URI-encoded by their writers, the rest is JSON.
+      reason = "contains a ';', CR or LF";
+    }
+    if (reason != nullptr) {
+      logger_->error(utl::WEB,
+                     54,
+                     "Invalid display-controls state in {}: entry \"{}\" {}.",
+                     filename,
+                     std::string(key),
+                     reason);
+    }
+  }
+
   boost::json::object msg;
   msg["type"] = "restore_display_state";
   msg["state"] = std::move(parsed);

--- a/src/web/src/web.i
+++ b/src/web/src/web.i
@@ -59,6 +59,20 @@ save_report_cmd(const char* filename,
   server->saveReport(filename, max_setup, max_hold);
 }
 
+void
+save_display_controls_cmd(const char* filename)
+{
+  web::WebServer *server = ord::OpenRoad::openRoad()->getWebServer();
+  server->saveDisplayControls(filename);
+}
+
+void
+restore_display_controls_cmd(const char* filename)
+{
+  web::WebServer *server = ord::OpenRoad::openRoad()->getWebServer();
+  server->restoreDisplayControls(filename);
+}
+
 } // namespace web
 
 %} // inline

--- a/src/web/src/web.tcl
+++ b/src/web/src/web.tcl
@@ -159,3 +159,23 @@ proc web_save_report { args } {
 
   web::save_report_cmd $path $max_setup $max_hold
 }
+
+sta::define_cmd_args "save_display_controls" { filename }
+
+proc save_display_controls { args } {
+  sta::parse_key_args "save_display_controls" args keys {} flags {}
+  sta::check_argc_eq1 "save_display_controls" $args
+  set path [lindex $args 0]
+
+  web::save_display_controls_cmd $path
+}
+
+sta::define_cmd_args "restore_display_controls" { filename }
+
+proc restore_display_controls { args } {
+  sta::parse_key_args "restore_display_controls" args keys {} flags {}
+  sta::check_argc_eq1 "restore_display_controls" $args
+  set path [lindex $args 0]
+
+  web::restore_display_controls_cmd $path
+}

--- a/src/web/src/web.tcl
+++ b/src/web/src/web.tcl
@@ -163,3 +163,23 @@ proc web_save_report { args } {
 
   web::save_report_cmd $path $max_setup $max_hold
 }
+
+sta::define_cmd_args "save_display_controls" { filename }
+
+proc save_display_controls { args } {
+  sta::parse_key_args "save_display_controls" args keys {} flags {}
+  sta::check_argc_eq1 "save_display_controls" $args
+  set path [lindex $args 0]
+
+  web::save_display_controls_cmd $path
+}
+
+sta::define_cmd_args "restore_display_controls" { filename }
+
+proc restore_display_controls { args } {
+  sta::parse_key_args "restore_display_controls" args keys {} flags {}
+  sta::check_argc_eq1 "restore_display_controls" $args
+  set path [lindex $args 0]
+
+  web::restore_display_controls_cmd $path
+}

--- a/src/web/src/web_viewer_hook.cpp
+++ b/src/web/src/web_viewer_hook.cpp
@@ -312,4 +312,16 @@ std::vector<WebChart*> WebViewerHook::charts() const
   return out;
 }
 
+void WebViewerHook::setDisplayState(std::string json)
+{
+  std::lock_guard<std::mutex> lock(display_state_mutex_);
+  display_state_json_ = std::move(json);
+}
+
+std::string WebViewerHook::getDisplayState() const
+{
+  std::lock_guard<std::mutex> lock(display_state_mutex_);
+  return display_state_json_;
+}
+
 }  // namespace web

--- a/src/web/src/web_viewer_hook.h
+++ b/src/web/src/web_viewer_hook.h
@@ -114,8 +114,19 @@ class WebViewerHook : public gui::HeadlessViewer
   // delete).  Holds the chart-list mutex while copying.
   std::vector<WebChart*> charts() const;
 
+  // Latest full display-controls state (JSON) pushed by a client via the
+  // "set_display_state" request.  Cached here so the Tcl
+  // save_display_controls command can persist it to a file and
+  // restore_display_controls can broadcast a saved state back.  Empty
+  // until a client has synced at least once.
+  void setDisplayState(std::string json);
+  std::string getDisplayState() const;
+
  private:
   SessionRegistry sessions_;
+
+  mutable std::mutex display_state_mutex_;
+  std::string display_state_json_;
 
   DrainLogsFn drain_logs_;
 

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -158,6 +158,8 @@ export function createOverlayTileLayer(visibility, app) {
             x: coords.x,
             y: coords.y,
             debug_renderers: !!visibility.debug_renderers,
+            focused_nets_guides: !!visibility.focused_nets_guides,
+            highlight_selected: visibility.highlight_selected !== false,
         };
         // Pass visible layers so route guides respect layer visibility.
         if (app && app.visibleLayerNames) {

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -166,6 +166,8 @@ export function createOverlayTileLayer(visibility, app) {
             ...tileSizeFields(currentDpr(), tileSize),
             debug_renderers: !!visibility.debug_renderers,
             flywires_only: !!visibility.flywires_only,
+            focused_nets_guides: !!visibility.focused_nets_guides,
+            highlight_selected: visibility.highlight_selected !== false,
         };
         // Pass visible layers so route guides respect layer visibility.
         if (app && app.visibleLayerNames) {

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -47,6 +47,7 @@ test_suite(
     name = "cpp_tests",
     tests = [
         ":request_handler_test",
+        ":save_display_controls_test",
         ":tile_generator_test",
     ],
 )
@@ -55,6 +56,13 @@ js_test(
     name = "coordinates_test",
     data = JS_FILES,
     entry_point = "js/test-coordinates.js",
+    no_copy_to_bin = JS_FILES,
+)
+
+js_test(
+    name = "ui_utils_test",
+    data = JS_FILES,
+    entry_point = "js/test-ui-utils.js",
     no_copy_to_bin = JS_FILES,
 )
 
@@ -294,6 +302,22 @@ cc_test(
         "//src/tst:nangate45_fixture",
         "//src/web",
         "@boost.json",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "save_display_controls_test",
+    srcs = ["cpp/TestSaveDisplayControls.cpp"],
+    data = [
+        "//test:nangate45_data",
+    ],
+    deps = [
+        "//src/gui:gui_stub",
+        "//src/odb/src/db",
+        "//src/tst:nangate45_fixture",
+        "//src/web",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -67,6 +67,13 @@ js_test(
 )
 
 js_test(
+    name = "display_state_test",
+    data = JS_FILES,
+    entry_point = "js/test-display-state.js",
+    no_copy_to_bin = JS_FILES,
+)
+
+js_test(
     name = "schematic_widget_test",
     data = JS_FILES,
     entry_point = "js/test-schematic-widget.js",

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -47,6 +47,7 @@ test_suite(
     name = "cpp_tests",
     tests = [
         ":request_handler_test",
+        ":save_display_controls_test",
         ":tile_generator_test",
     ],
 )
@@ -55,6 +56,13 @@ js_test(
     name = "coordinates_test",
     data = JS_FILES,
     entry_point = "js/test-coordinates.js",
+    no_copy_to_bin = JS_FILES,
+)
+
+js_test(
+    name = "ui_utils_test",
+    data = JS_FILES,
+    entry_point = "js/test-ui-utils.js",
     no_copy_to_bin = JS_FILES,
 )
 
@@ -330,6 +338,22 @@ cc_test(
         "//src/tst:nangate45_fixture",
         "//src/web",
         "@boost.json",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "save_display_controls_test",
+    srcs = ["cpp/TestSaveDisplayControls.cpp"],
+    data = [
+        "//test:nangate45_data",
+    ],
+    deps = [
+        "//src/gui:gui_stub",
+        "//src/odb/src/db",
+        "//src/tst:nangate45_fixture",
+        "//src/web",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -68,7 +68,7 @@ js_test(
 
 js_test(
     name = "display_state_test",
-    data = JS_FILES,
+    data = DOM_TEST_DATA,
     entry_point = "js/test-display-state.js",
     no_copy_to_bin = JS_FILES,
 )

--- a/src/web/test/cpp/CMakeLists.txt
+++ b/src/web/test/cpp/CMakeLists.txt
@@ -115,6 +115,28 @@ gtest_discover_tests(TestSnap
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
+# This test exercises the WebServer lifecycle (initLogger), which pulls in
+# web_serve.cpp.o and its gui::Gui::* references.  Compile the headless gui
+# stub into the test (the Qt gui library would drag in the whole
+# application), mirroring the Bazel target's gui_stub dependency.
+add_executable(TestSaveDisplayControls
+  TestSaveDisplayControls.cpp
+  ${OPENROAD_HOME}/src/gui/src/stub.cpp
+)
+
+target_link_libraries(TestSaveDisplayControls ${TEST_LIBS})
+
+target_include_directories(TestSaveDisplayControls
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${OPENROAD_HOME}/src/gui/src
+    ${TCL_INCLUDE_PATH}
+)
+
+gtest_discover_tests(TestSaveDisplayControls
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
 add_dependencies(build_and_test
   TestTileGenerator
   TestRequestHandler
@@ -124,4 +146,5 @@ add_dependencies(build_and_test
   TestClockTreeReport
   TestSaveImage
   TestSnap
+  TestSaveDisplayControls
 )

--- a/src/web/test/cpp/CMakeLists.txt
+++ b/src/web/test/cpp/CMakeLists.txt
@@ -115,6 +115,19 @@ gtest_discover_tests(TestSnap
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
+add_executable(TestSaveDisplayControls TestSaveDisplayControls.cpp)
+
+target_link_libraries(TestSaveDisplayControls ${TEST_LIBS})
+
+target_include_directories(TestSaveDisplayControls
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+)
+
+gtest_discover_tests(TestSaveDisplayControls
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
 add_dependencies(build_and_test
   TestTileGenerator
   TestRequestHandler
@@ -124,4 +137,5 @@ add_dependencies(build_and_test
   TestClockTreeReport
   TestSaveImage
   TestSnap
+  TestSaveDisplayControls
 )

--- a/src/web/test/cpp/CMakeLists.txt
+++ b/src/web/test/cpp/CMakeLists.txt
@@ -115,13 +115,22 @@ gtest_discover_tests(TestSnap
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-add_executable(TestSaveDisplayControls TestSaveDisplayControls.cpp)
+# This test exercises the WebServer lifecycle (initLogger), which pulls in
+# web_serve.cpp.o and its gui::Gui::* references.  Compile the headless gui
+# stub into the test (the Qt gui library would drag in the whole
+# application), mirroring the Bazel target's gui_stub dependency.
+add_executable(TestSaveDisplayControls
+  TestSaveDisplayControls.cpp
+  ${OPENROAD_HOME}/src/gui/src/stub.cpp
+)
 
 target_link_libraries(TestSaveDisplayControls ${TEST_LIBS})
 
 target_include_directories(TestSaveDisplayControls
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${OPENROAD_HOME}/src/gui/src
+    ${TCL_INCLUDE_PATH}
 )
 
 gtest_discover_tests(TestSaveDisplayControls

--- a/src/web/test/cpp/CMakeLists.txt
+++ b/src/web/test/cpp/CMakeLists.txt
@@ -119,9 +119,17 @@ gtest_discover_tests(TestSnap
 # web_serve.cpp.o and its gui::Gui::* references.  Compile the headless gui
 # stub into the test (the Qt gui library would drag in the whole
 # application), mirroring the Bazel target's gui_stub dependency.
+#
+# The stub's initGui() calls DescriptorRegistry::initDescriptors(), so the
+# descriptor implementations come along too.  gui_descriptors deliberately
+# holds only the registry, to keep these out of the web library; they compile
+# without Qt here, as they do in the CLI-only gui library.
 add_executable(TestSaveDisplayControls
   TestSaveDisplayControls.cpp
   ${OPENROAD_HOME}/src/gui/src/stub.cpp
+  ${OPENROAD_HOME}/src/gui/src/init_descriptors.cpp
+  ${OPENROAD_HOME}/src/gui/src/dbDescriptors.cpp
+  ${OPENROAD_HOME}/src/gui/src/staDescriptors.cpp
 )
 
 target_link_libraries(TestSaveDisplayControls ${TEST_LIBS})

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -289,6 +289,179 @@ TEST_F(TileHandlerTest, OverlayTileUsesHighlightState)
   EXPECT_FALSE(resp.payload.empty());
 }
 
+// Helper: create a placed BUF_X16 to anchor getBounds(), plus a signal net
+// carrying one route guide on metal1 across most of the die.  Returns the net.
+static odb::dbNet* makeNetWithGuide(odb::dbBlock* block,
+                                    odb::dbLib* lib,
+                                    odb::dbDatabase* db)
+{
+  odb::dbMaster* master = lib->findMaster("BUF_X16");
+  odb::dbInst* ll = odb::dbInst::create(block, master, "anchor_ll");
+  ll->setLocation(0, 0);
+  ll->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  odb::dbInst* ur = odb::dbInst::create(block, master, "anchor_ur");
+  ur->setLocation(90000, 90000);
+  ur->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+
+  odb::dbNet* net = odb::dbNet::create(block, "guided");
+  odb::dbTechLayer* metal1 = db->getTech()->findLayer("metal1");
+  odb::dbGuide::create(net,
+                       metal1,
+                       metal1,
+                       odb::Rect(10000, 10000, 90000, 90000),
+                       /*is_congested=*/false);
+  return net;
+}
+
+TEST_F(TileHandlerTest, FocusedNetsGuidesTogglesGuides)
+{
+  odb::dbNet* net = makeNetWithGuide(block_, lib_, getDb());
+  {
+    std::lock_guard<std::mutex> lock(state_.focus_nets_mutex);
+    state_.focus_net_ids.insert(net->getId());  // net is focused
+  }
+  gen_->eagerInit();
+
+  // Baseline: nothing drawn on the overlay.
+  WebSocketRequest empty_req;
+  empty_req.id = 30;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Toggle OFF: focused net has no per-net guide selection → no guides.
+  WebSocketRequest off_req;
+  off_req.id = 31;
+  off_req.type = WebSocketRequest::kOverlayTile;
+  off_req.json = parseObj(R"({"z":0,"x":0,"y":0,"focused_nets_guides":false})");
+  const auto off = handler_->handleOverlayTile(off_req, state_).payload;
+  EXPECT_EQ(off, blank)
+      << "guides must not draw when the toggle is off and no per-net selection";
+
+  // Toggle ON: the focused net's guides are drawn.
+  WebSocketRequest on_req;
+  on_req.id = 32;
+  on_req.type = WebSocketRequest::kOverlayTile;
+  on_req.json = parseObj(R"({"z":0,"x":0,"y":0,"focused_nets_guides":true})");
+  const auto on = handler_->handleOverlayTile(on_req, state_).payload;
+  EXPECT_NE(on, blank)
+      << "focused nets' guides should be drawn when the toggle is on";
+}
+
+TEST_F(TileHandlerTest, PerNetGuidesIgnoreGlobalToggle)
+{
+  odb::dbNet* net = makeNetWithGuide(block_, lib_, getDb());
+  {
+    std::lock_guard<std::mutex> lock(state_.route_guides_mutex);
+    state_.route_guide_net_ids.insert(net->getId());  // explicit per-net
+  }
+  gen_->eagerInit();
+
+  WebSocketRequest empty_req;
+  empty_req.id = 33;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Global toggle off, but the per-net selection still draws its guides.
+  WebSocketRequest req;
+  req.id = 34;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0,"focused_nets_guides":false})");
+  const auto out = handler_->handleOverlayTile(req, state_).payload;
+  EXPECT_NE(out, blank)
+      << "per-net route guides must render regardless of the global toggle";
+}
+
+TEST_F(TileHandlerTest, HighlightSelectedTogglesSelectionHighlight)
+{
+  // Anchor bounds with an instance, then put a selection highlight rect.
+  odb::dbMaster* master = lib_->findMaster("BUF_X16");
+  odb::dbInst* inst = odb::dbInst::create(block_, master, "anchor");
+  inst->setLocation(0, 0);
+  inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.highlight_rects.emplace_back(10000, 10000, 90000, 90000);
+  }
+  gen_->eagerInit();
+
+  WebSocketRequest empty_req;
+  empty_req.id = 40;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Toggle ON (default): selection highlight is drawn.
+  WebSocketRequest on_req;
+  on_req.id = 41;
+  on_req.type = WebSocketRequest::kOverlayTile;
+  on_req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":true})");
+  const auto on = handler_->handleOverlayTile(on_req, state_).payload;
+  EXPECT_NE(on, blank) << "selection highlight should draw when toggle is on";
+
+  // Toggle OFF: selection highlight suppressed.
+  WebSocketRequest off_req;
+  off_req.id = 42;
+  off_req.type = WebSocketRequest::kOverlayTile;
+  off_req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":false})");
+  const auto off = handler_->handleOverlayTile(off_req, state_).payload;
+  EXPECT_EQ(off, blank)
+      << "selection highlight must be hidden when the toggle is off";
+}
+
+TEST_F(TileHandlerTest, OverlayTileMalformedFlagReturnsError)
+{
+  // Overlay requests run on a bare io_context thread, so a malformed flag
+  // type must come back as a kError response, not an exception (which
+  // would terminate the whole server).
+  WebSocketRequest req;
+  req.id = 43;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":1})");
+
+  WebSocketResponse resp;
+  EXPECT_NO_THROW(resp = handler_->handleOverlayTile(req, state_));
+  EXPECT_EQ(resp.id, 43u);
+  EXPECT_EQ(resp.type, WebSocketResponse::kError);
+}
+
+TEST_F(TileHandlerTest, HoverNotGatedByHighlightSelected)
+{
+  odb::dbMaster* master = lib_->findMaster("BUF_X16");
+  odb::dbInst* inst = odb::dbInst::create(block_, master, "anchor");
+  inst->setLocation(0, 0);
+  inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.hover_rects.emplace_back(10000, 10000, 90000, 90000);
+  }
+  gen_->eagerInit();
+
+  WebSocketRequest empty_req;
+  empty_req.id = 43;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Hover must still render even with the selection highlight toggled off.
+  WebSocketRequest req;
+  req.id = 44;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":false})");
+  const auto out = handler_->handleOverlayTile(req, state_).payload;
+  EXPECT_NE(out, blank)
+      << "hover highlight is independent of the Highlight selected toggle";
+}
+
 TEST_F(TileHandlerTest, HeatMapsReturnsMetadata)
 {
   gui::registerBuiltinHeatMapSources(/*sta=*/nullptr, getLogger());

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -932,6 +932,229 @@ TEST_F(TileHandlerTest, FlywiresOnlySupplyNetKeepsShapes)
       << "a selected supply net must still be highlighted by its SWires";
 }
 
+// Helper: create a placed BUF_X16 to anchor getBounds(), plus a signal net
+// carrying one route guide on metal1 across most of the die.  Returns the net.
+static odb::dbNet* makeNetWithGuide(odb::dbBlock* block,
+                                    odb::dbLib* lib,
+                                    odb::dbDatabase* db)
+{
+  odb::dbMaster* master = lib->findMaster("BUF_X16");
+  odb::dbInst* ll = odb::dbInst::create(block, master, "anchor_ll");
+  ll->setLocation(0, 0);
+  ll->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  odb::dbInst* ur = odb::dbInst::create(block, master, "anchor_ur");
+  ur->setLocation(90000, 90000);
+  ur->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+
+  odb::dbNet* net = odb::dbNet::create(block, "guided");
+  odb::dbTechLayer* metal1 = db->getTech()->findLayer("metal1");
+  odb::dbGuide::create(net,
+                       metal1,
+                       metal1,
+                       odb::Rect(10000, 10000, 90000, 90000),
+                       /*is_congested=*/false);
+  return net;
+}
+
+TEST_F(TileHandlerTest, FocusedNetsGuidesTogglesGuides)
+{
+  odb::dbNet* net = makeNetWithGuide(block_, lib_, getDb());
+  {
+    std::lock_guard<std::mutex> lock(state_.focus_nets_mutex);
+    state_.focus_net_ids.insert(net->getId());  // net is focused
+  }
+  gen_->eagerInit();
+
+  // Baseline: nothing drawn on the overlay.
+  WebSocketRequest empty_req;
+  empty_req.id = 30;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Toggle OFF: focused net has no per-net guide selection → no guides.
+  WebSocketRequest off_req;
+  off_req.id = 31;
+  off_req.type = WebSocketRequest::kOverlayTile;
+  off_req.json = parseObj(R"({"z":0,"x":0,"y":0,"focused_nets_guides":false})");
+  const auto off = handler_->handleOverlayTile(off_req, state_).payload;
+  EXPECT_EQ(off, blank)
+      << "guides must not draw when the toggle is off and no per-net selection";
+
+  // Toggle ON: the focused net's guides are drawn.
+  WebSocketRequest on_req;
+  on_req.id = 32;
+  on_req.type = WebSocketRequest::kOverlayTile;
+  on_req.json = parseObj(R"({"z":0,"x":0,"y":0,"focused_nets_guides":true})");
+  const auto on = handler_->handleOverlayTile(on_req, state_).payload;
+  EXPECT_NE(on, blank)
+      << "focused nets' guides should be drawn when the toggle is on";
+}
+
+TEST_F(TileHandlerTest, PerNetGuidesIgnoreGlobalToggle)
+{
+  odb::dbNet* net = makeNetWithGuide(block_, lib_, getDb());
+  {
+    std::lock_guard<std::mutex> lock(state_.route_guides_mutex);
+    state_.route_guide_net_ids.insert(net->getId());  // explicit per-net
+  }
+  gen_->eagerInit();
+
+  WebSocketRequest empty_req;
+  empty_req.id = 33;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Global toggle off, but the per-net selection still draws its guides.
+  WebSocketRequest req;
+  req.id = 34;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0,"focused_nets_guides":false})");
+  const auto out = handler_->handleOverlayTile(req, state_).payload;
+  EXPECT_NE(out, blank)
+      << "per-net route guides must render regardless of the global toggle";
+}
+
+TEST_F(TileHandlerTest, HighlightSelectedTogglesSelectionHighlight)
+{
+  // Anchor bounds with an instance, then put a selection highlight rect.
+  odb::dbMaster* master = lib_->findMaster("BUF_X16");
+  odb::dbInst* inst = odb::dbInst::create(block_, master, "anchor");
+  inst->setLocation(0, 0);
+  inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.highlight_rects.emplace_back(10000, 10000, 90000, 90000);
+  }
+  gen_->eagerInit();
+
+  WebSocketRequest empty_req;
+  empty_req.id = 40;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Toggle ON (default): selection highlight is drawn.
+  WebSocketRequest on_req;
+  on_req.id = 41;
+  on_req.type = WebSocketRequest::kOverlayTile;
+  on_req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":true})");
+  const auto on = handler_->handleOverlayTile(on_req, state_).payload;
+  EXPECT_NE(on, blank) << "selection highlight should draw when toggle is on";
+
+  // Toggle OFF: selection highlight suppressed.
+  WebSocketRequest off_req;
+  off_req.id = 42;
+  off_req.type = WebSocketRequest::kOverlayTile;
+  off_req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":false})");
+  const auto off = handler_->handleOverlayTile(off_req, state_).payload;
+  EXPECT_EQ(off, blank)
+      << "selection highlight must be hidden when the toggle is off";
+}
+
+// The two Misc toggles meet here: "Flywires only" turns the selection's
+// highlight into driver->sink lines, and "Highlight selected" must hide the
+// selection's highlight as a whole.  Gating only the rects and polys would
+// leave the flywires on screen — half a highlight for a toggle that promises
+// none.
+TEST_F(TileHandlerTest, HighlightSelectedAlsoGatesSelectionFlywires)
+{
+  odb::dbNet* net = makeConnectedNet("gated_sig");
+  ASSERT_NE(net, nullptr);
+
+  static FakeNetDescriptor net_descriptor;
+  primeInspected(net_descriptor.makeSelected(std::any(net)));
+
+  // Flywires on: the selection is now carried by highlight_lines.
+  WebSocketRequest fly_req = overlayRequest(45, /*flywires_only=*/true);
+  const auto with_flywires
+      = handler_->handleOverlayTile(fly_req, state_).payload;
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    ASSERT_FALSE(state_.highlight_lines.empty())
+        << "precondition: flywires_only must produce driver->sink lines";
+  }
+
+  WebSocketRequest empty_req;
+  empty_req.id = 46;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+  ASSERT_NE(with_flywires, blank)
+      << "precondition: the flywires must actually draw something";
+
+  // "Highlight selected" off: the flywires go with the rest of the highlight.
+  WebSocketRequest off_req;
+  off_req.id = 47;
+  off_req.type = WebSocketRequest::kOverlayTile;
+  off_req.json = parseObj(
+      R"({"z":0,"x":0,"y":0,"flywires_only":true,"highlight_selected":false})");
+  const auto off = handler_->handleOverlayTile(off_req, state_).payload;
+  EXPECT_EQ(off, blank)
+      << "selection flywires must be hidden when the toggle is off";
+
+  // The selection itself survives, so turning the toggle back on restores it.
+  WebSocketRequest on_req = overlayRequest(48, /*flywires_only=*/true);
+  const auto back_on = handler_->handleOverlayTile(on_req, state_).payload;
+  EXPECT_NE(back_on, blank)
+      << "the flywires must come back when the toggle is on again";
+}
+
+TEST_F(TileHandlerTest, OverlayTileMalformedFlagReturnsError)
+{
+  // Overlay requests run on a bare io_context thread, so a malformed flag
+  // type must come back as a kError response, not an exception (which
+  // would terminate the whole server).
+  WebSocketRequest req;
+  req.id = 43;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":1})");
+
+  WebSocketResponse resp;
+  EXPECT_NO_THROW(resp = handler_->handleOverlayTile(req, state_));
+  EXPECT_EQ(resp.id, 43u);
+  EXPECT_EQ(resp.type, WebSocketResponse::kError);
+}
+
+TEST_F(TileHandlerTest, HoverNotGatedByHighlightSelected)
+{
+  odb::dbMaster* master = lib_->findMaster("BUF_X16");
+  odb::dbInst* inst = odb::dbInst::create(block_, master, "anchor");
+  inst->setLocation(0, 0);
+  inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.hover_rects.emplace_back(10000, 10000, 90000, 90000);
+  }
+  gen_->eagerInit();
+
+  WebSocketRequest empty_req;
+  empty_req.id = 43;
+  empty_req.type = WebSocketRequest::kOverlayTile;
+  empty_req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+  SessionState empty_state;
+  const auto blank
+      = handler_->handleOverlayTile(empty_req, empty_state).payload;
+
+  // Hover must still render even with the selection highlight toggled off.
+  WebSocketRequest req;
+  req.id = 44;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0,"highlight_selected":false})");
+  const auto out = handler_->handleOverlayTile(req, state_).payload;
+  EXPECT_NE(out, blank)
+      << "hover highlight is independent of the Highlight selected toggle";
+}
+
 TEST_F(TileHandlerTest, HeatMapsReturnsMetadata)
 {
   gui::registerBuiltinHeatMapSources(/*sta=*/nullptr, getLogger());

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -1125,6 +1125,66 @@ TEST_F(TileHandlerTest, OverlayTileMalformedFlagReturnsError)
   EXPECT_EQ(resp.type, WebSocketResponse::kError);
 }
 
+// A zoom that is not an integer is the shape a non-finite client-side number
+// arrives in: JSON.stringify writes NaN and Infinity as `null`.  Reaching
+// as_int64() with one of those threw, and with no try/catch between the
+// handler and io_context::run() that killed the whole openroad process --
+// observed as the design vanishing and the session dropping after zooming in
+// to the limit and pressing F.  Each case must now be an error response.
+TEST_F(TileHandlerTest, TileRejectsNonIntegerZoomInsteadOfThrowing)
+{
+  struct Case
+  {
+    const char* what;
+    const char* json;
+  };
+  const Case cases[] = {
+      {"null zoom (a non-finite number after JSON.stringify)",
+       R"({"layer":"metal1","z":null,"x":0,"y":0})"},
+      {"fractional zoom", R"({"layer":"metal1","z":1.5,"x":0,"y":0})"},
+      {"null x", R"({"layer":"metal1","z":1,"x":null,"y":0})"},
+      {"zoom past the tile-grid ceiling",
+       R"({"layer":"metal1","z":60,"x":0,"y":0})"},
+      {"missing zoom", R"({"layer":"metal1","x":0,"y":0})"},
+  };
+
+  uint32_t id = 700;
+  for (const Case& c : cases) {
+    WebSocketRequest req;
+    req.id = id++;
+    req.type = WebSocketRequest::kTile;
+    req.json = parseObj(c.json);
+
+    WebSocketResponse resp;
+    EXPECT_NO_THROW(resp = handler_->handleTile(req, state_)) << c.what;
+    EXPECT_EQ(resp.type, WebSocketResponse::kError) << c.what;
+    EXPECT_EQ(resp.id, req.id) << c.what;
+  }
+}
+
+// Leaflet asks for tiles beyond the 2^z grid whenever the design is smaller
+// than the viewport or while panning at the border, and the renderers answer
+// those with a transparent tile.  A range check here would turn ordinary
+// panning into a stream of errors, so off-grid coordinates must still render.
+TEST_F(TileHandlerTest, TileStillServesOffGridCoordinates)
+{
+  gen_->eagerInit();
+
+  for (const char* json : {R"({"layer":"metal1","z":0,"x":-1,"y":0})",
+                           R"({"layer":"metal1","z":0,"x":3,"y":7})",
+                           R"({"layer":"metal1","z":2,"x":9999,"y":0})"}) {
+    WebSocketRequest req;
+    req.id = 710;
+    req.type = WebSocketRequest::kTile;
+    req.json = parseObj(json);
+
+    WebSocketResponse resp;
+    EXPECT_NO_THROW(resp = handler_->handleTile(req, state_)) << json;
+    EXPECT_EQ(resp.type, WebSocketResponse::kPng)
+        << "off-grid tiles are transparent, not errors: " << json;
+  }
+}
+
 TEST_F(TileHandlerTest, HoverNotGatedByHighlightSelected)
 {
   odb::dbMaster* master = lib_->findMaster("BUF_X16");

--- a/src/web/test/cpp/TestSaveDisplayControls.cpp
+++ b/src/web/test/cpp/TestSaveDisplayControls.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tst/nangate45_fixture.h"
+#include "web/web.h"
+
+namespace web {
+namespace {
+
+// ─── Fixture ────────────────────────────────────────────────────────────────
+
+class SaveDisplayControlsTest : public tst::Nangate45Fixture
+{
+ protected:
+  void TearDown() override
+  {
+    for (const auto& path : output_files_) {
+      std::filesystem::remove(path);
+    }
+  }
+
+  std::string tempJson(const std::string& label)
+  {
+    std::string path
+        = std::filesystem::temp_directory_path()
+          / ("web_dc_" + label + "_" + std::to_string(::getpid()) + ".json");
+    output_files_.push_back(path);
+    return path;
+  }
+
+  static std::string readFile(const std::string& path)
+  {
+    std::ifstream f(path);
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+  }
+
+  static void writeFile(const std::string& path, const std::string& content)
+  {
+    std::ofstream f(path);
+    f << content;
+  }
+
+  std::vector<std::string> output_files_;
+};
+
+// ─── Save ─────────────────────────────────────────────────────────────────
+
+TEST_F(SaveDisplayControlsTest, SavesStateToFileVerbatim)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();  // creates the viewer hook that holds the cache
+
+  const std::string state
+      = R"({"version":1,"cookies":{"or_bg_color":"%23202020"}})";
+  server.setDisplayState(state);
+
+  const std::string path = tempJson("save");
+  server.saveDisplayControls(path);
+
+  ASSERT_TRUE(std::filesystem::exists(path));
+  EXPECT_EQ(readFile(path), state);
+}
+
+TEST_F(SaveDisplayControlsTest, SaveWithoutStateWritesNothing)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();  // hook exists but no client ever synced a state
+
+  const std::string path = tempJson("empty");
+  server.saveDisplayControls(path);
+
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST_F(SaveDisplayControlsTest, SaveWithoutServerThrows)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  // No initLogger()/serve(): the viewer hook was never created.  logger_->
+  // error() throws, surfacing a clear "server not running" error to Tcl.
+  const std::string path = tempJson("noserver");
+  EXPECT_ANY_THROW(server.saveDisplayControls(path));
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+// ─── Restore ────────────────────────────────────────────────────────────────
+
+TEST_F(SaveDisplayControlsTest, RestoreValidJsonSucceeds)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string path = tempJson("valid");
+  writeFile(path, R"({"version":1,"cookies":{"or_show_dbu":"1"}})");
+
+  // No clients connected: the broadcast is a no-op but must not throw.
+  EXPECT_NO_THROW(server.restoreDisplayControls(path));
+}
+
+TEST_F(SaveDisplayControlsTest, RestoreMissingFileThrows)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  // A missing file surfaces a clear Tcl error (logger_->error throws).
+  EXPECT_ANY_THROW(
+      server.restoreDisplayControls("/nonexistent/web_dc_missing.json"));
+}
+
+TEST_F(SaveDisplayControlsTest, RestoreInvalidJsonThrows)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string path = tempJson("invalid");
+  writeFile(path, "{ this is not valid json ");
+
+  EXPECT_ANY_THROW(server.restoreDisplayControls(path));
+}
+
+// ─── Round-trip ─────────────────────────────────────────────────────────────
+
+TEST_F(SaveDisplayControlsTest, SaveThenRestoreRoundTrip)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string state
+      = R"({"version":1,"cookies":{"or_visibility":"%7B%22rows%22%3Atrue%7D"}})";
+  server.setDisplayState(state);
+
+  const std::string path = tempJson("roundtrip");
+  server.saveDisplayControls(path);
+  ASSERT_TRUE(std::filesystem::exists(path));
+  EXPECT_EQ(readFile(path), state);
+
+  // The saved file is valid JSON and restores without throwing.
+  EXPECT_NO_THROW(server.restoreDisplayControls(path));
+}
+
+}  // namespace
+}  // namespace web

--- a/src/web/test/cpp/TestSaveDisplayControls.cpp
+++ b/src/web/test/cpp/TestSaveDisplayControls.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tst/nangate45_fixture.h"
+#include "web/web.h"
+
+namespace web {
+namespace {
+
+// ─── Fixture ────────────────────────────────────────────────────────────────
+
+class SaveDisplayControlsTest : public tst::Nangate45Fixture
+{
+ protected:
+  void TearDown() override
+  {
+    for (const auto& path : output_files_) {
+      std::filesystem::remove(path);
+    }
+  }
+
+  std::string tempJson(const std::string& label)
+  {
+    std::string path
+        = std::filesystem::temp_directory_path()
+          / ("web_dc_" + label + "_" + std::to_string(::getpid()) + ".json");
+    output_files_.push_back(path);
+    return path;
+  }
+
+  static std::string readFile(const std::string& path)
+  {
+    std::ifstream f(path);
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+  }
+
+  static void writeFile(const std::string& path, const std::string& content)
+  {
+    std::ofstream f(path);
+    f << content;
+  }
+
+  std::vector<std::string> output_files_;
+};
+
+// ─── Save ─────────────────────────────────────────────────────────────────
+
+TEST_F(SaveDisplayControlsTest, SavesStateToFileVerbatim)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();  // creates the viewer hook that holds the cache
+
+  const std::string state
+      = R"({"version":1,"entries":{"or_bg_color":"%23202020"}})";
+  server.setDisplayState(state);
+
+  const std::string path = tempJson("save");
+  server.saveDisplayControls(path);
+
+  ASSERT_TRUE(std::filesystem::exists(path));
+  EXPECT_EQ(readFile(path), state);
+}
+
+TEST_F(SaveDisplayControlsTest, SaveWithoutStateWritesNothing)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();  // hook exists but no client ever synced a state
+
+  const std::string path = tempJson("empty");
+  server.saveDisplayControls(path);
+
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST_F(SaveDisplayControlsTest, SaveWithoutServerThrows)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  // No initLogger()/serve(): the viewer hook was never created.  logger_->
+  // error() throws, surfacing a clear "server not running" error to Tcl.
+  const std::string path = tempJson("noserver");
+  EXPECT_ANY_THROW(server.saveDisplayControls(path));
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+// ─── Restore ────────────────────────────────────────────────────────────────
+
+TEST_F(SaveDisplayControlsTest, RestoreValidJsonSucceeds)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string path = tempJson("valid");
+  writeFile(path, R"({"version":1,"entries":{"or_show_dbu":"1"}})");
+
+  // No clients connected: the broadcast is a no-op but must not throw.
+  EXPECT_NO_THROW(server.restoreDisplayControls(path));
+}
+
+TEST_F(SaveDisplayControlsTest, RestoreMissingFileThrows)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  // A missing file surfaces a clear Tcl error (logger_->error throws).
+  EXPECT_ANY_THROW(
+      server.restoreDisplayControls("/nonexistent/web_dc_missing.json"));
+}
+
+TEST_F(SaveDisplayControlsTest, RestoreInvalidJsonThrows)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string path = tempJson("invalid");
+  writeFile(path, "{ this is not valid json ");
+
+  EXPECT_ANY_THROW(server.restoreDisplayControls(path));
+}
+
+// ─── Round-trip ─────────────────────────────────────────────────────────────
+
+TEST_F(SaveDisplayControlsTest, SaveThenRestoreRoundTrip)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string state
+      = R"({"version":1,"entries":{"or_visibility":"%7B%22rows%22%3Atrue%7D"}})";
+  server.setDisplayState(state);
+
+  const std::string path = tempJson("roundtrip");
+  server.saveDisplayControls(path);
+  ASSERT_TRUE(std::filesystem::exists(path));
+  EXPECT_EQ(readFile(path), state);
+
+  // The saved file is valid JSON and restores without throwing.
+  EXPECT_NO_THROW(server.restoreDisplayControls(path));
+}
+
+}  // namespace
+}  // namespace web

--- a/src/web/test/cpp/TestSaveDisplayControls.cpp
+++ b/src/web/test/cpp/TestSaveDisplayControls.cpp
@@ -93,6 +93,22 @@ TEST_F(SaveDisplayControlsTest, SaveWithoutServerThrows)
   EXPECT_FALSE(std::filesystem::exists(path));
 }
 
+// Opening the target succeeding says nothing about the write: reporting success
+// after a failed one would leave a truncated file behind.  /dev/full accepts
+// the open and fails every write with ENOSPC, which is the cheapest way to
+// reach that path without filling a disk.
+TEST_F(SaveDisplayControlsTest, SaveReportsWriteFailure)
+{
+  if (!std::filesystem::exists("/dev/full")) {
+    GTEST_SKIP() << "/dev/full is Linux-specific";
+  }
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+  server.setDisplayState(R"({"version":1,"entries":{"or_show_dbu":"1"}})");
+
+  EXPECT_ANY_THROW(server.saveDisplayControls("/dev/full"));
+}
+
 // ─── Restore ────────────────────────────────────────────────────────────────
 
 TEST_F(SaveDisplayControlsTest, RestoreValidJsonSucceeds)
@@ -124,6 +140,48 @@ TEST_F(SaveDisplayControlsTest, RestoreInvalidJsonThrows)
 
   const std::string path = tempJson("invalid");
   writeFile(path, "{ this is not valid json ");
+
+  EXPECT_ANY_THROW(server.restoreDisplayControls(path));
+}
+
+// The client writes these entries straight into document.cookie and Web
+// Storage, so the shape is validated here, at the file boundary, and a bad file
+// is rejected loudly instead of half-applying.
+
+TEST_F(SaveDisplayControlsTest, RestoreRejectsMissingEntriesObject)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  const std::string path = tempJson("no_entries");
+  writeFile(path, R"({"version":1})");
+
+  EXPECT_ANY_THROW(server.restoreDisplayControls(path));
+}
+
+TEST_F(SaveDisplayControlsTest, RestoreRejectsNonStringEntry)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  // A JSON number is not interchangeable with the string the readers compare
+  // against ("1" === "1"), so coercing it would silently change the setting.
+  const std::string path = tempJson("number_entry");
+  writeFile(path, R"({"version":1,"entries":{"or_show_dbu":1}})");
+
+  EXPECT_ANY_THROW(server.restoreDisplayControls(path));
+}
+
+TEST_F(SaveDisplayControlsTest, RestoreRejectsCookieDelimiterInValue)
+{
+  WebServer server(getDb(), /*sta=*/nullptr, getLogger(), /*interp=*/nullptr);
+  server.initLogger();
+
+  // A ';' would let the file forge attributes on the cookie the client writes.
+  const std::string path = tempJson("cookie_inject");
+  writeFile(
+      path,
+      R"({"version":1,"entries":{"or_bg_color":"#fff; Domain=evil.test"}})");
 
   EXPECT_ANY_THROW(server.restoreDisplayControls(path));
 }

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -2495,6 +2495,167 @@ TEST_F(TileGeneratorTest, NoOutlineOnTechLayerTiles)
 }
 
 //------------------------------------------------------------------------------
+// Track rendering: the tracks must stop at the die area, as in the Qt GUI
+// (RenderThread::drawTracks clips to block->getDieArea()).
+//------------------------------------------------------------------------------
+
+namespace {
+constexpr int kTrackDieSide = 40000;  // die: (0,0)-(40000,40000)
+constexpr int kTrackPitch = 2000;     // 21 tracks per axis across the die
+}  // namespace
+
+// Build a track grid on metal1 covering the die, and return the visibility
+// that draws tracks and nothing else.
+static TileVisibility trackOnlyVisibility()
+{
+  TileVisibility vis;
+  vis.stdcells = false;
+  vis.routing = false;
+  vis.special_nets = false;
+  vis.pins = false;
+  vis.inst_pins = false;
+  vis.blockages = false;
+  vis.tracks_pref = true;
+  vis.tracks_non_pref = true;
+  return vis;
+}
+
+TEST_F(TileGeneratorTest, TracksAreClippedToTheDieArea)
+{
+  block_->setDieArea(odb::Rect(0, 0, kTrackDieSide, kTrackDieSide));
+  // getBounds() follows the block bbox, and dbBlock::getBBox() covers the
+  // SHAPES, not the die area: an instance at the origin anchors the viewport
+  // to the die, and a second one beyond the die stretches the bbox past it.
+  // That gap outside the die is where the tracks used to run on, drawn to the
+  // tile edge instead of stopping at the die boundary.
+  placeInst("BUF_X16", "inside", 0, 0);
+  placeInst("BUF_X16", "outside", kTrackDieSide + 20000, kTrackDieSide + 20000);
+
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  odb::dbTrackGrid* grid = odb::dbTrackGrid::create(block_, metal1);
+  grid->addGridPatternX(0, kTrackDieSide / kTrackPitch + 1, kTrackPitch);
+  grid->addGridPatternY(0, kTrackDieSide / kTrackPitch + 1, kTrackPitch);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  ASSERT_NE(block_->findTrackGrid(metal1), nullptr)
+      << "precondition: the track grid must be reachable from the block";
+
+  auto png = tile_gen_->generateTile("metal1", 0, 0, 0, trackOnlyVisibility());
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  ASSERT_GT(w, 0u);
+
+  // Map pixels back to DBU exactly as the renderer does at z=0: one tile
+  // spanning getBounds().maxDXDY(), Y flipped.
+  const odb::Rect bounds = tile_gen_->getBounds();
+  const double dbu_per_px = static_cast<double>(bounds.maxDXDY()) / w;
+  ASSERT_GT(dbu_per_px, 0.0);
+  // Three pixels of slack.  The tile is rasterized supersampled and then
+  // Lanczos-2 decimated, and that filter spreads a hairline about two output
+  // pixels either way, so a track sitting on the die edge tints just past it.
+  // The defect this guards against is nothing like that: it drew tracks to the
+  // tile edge, tens of pixels beyond the die.
+  const double slack = 3 * dbu_per_px;
+
+  size_t inside = 0;
+  size_t outside = 0;
+  double worst_x = 0;
+  double worst_y = 0;
+  double min_x = 1e18;
+  double min_y = 1e18;
+  for (unsigned py = 0; py < h; ++py) {
+    for (unsigned px = 0; px < w; ++px) {
+      if (pixels[4UL * (py * w + px) + 3] == 0) {
+        continue;
+      }
+      const double dbu_x = bounds.xMin() + px * dbu_per_px;
+      const double dbu_y = bounds.yMin() + (h - 1 - py) * dbu_per_px;
+      const bool in_die = dbu_x >= -slack && dbu_x <= kTrackDieSide + slack
+                          && dbu_y >= -slack && dbu_y <= kTrackDieSide + slack;
+      if (in_die) {
+        ++inside;
+      } else {
+        ++outside;
+        worst_x = std::max(worst_x, dbu_x);
+        worst_y = std::max(worst_y, dbu_y);
+        min_x = std::min(min_x, dbu_x);
+        min_y = std::min(min_y, dbu_y);
+      }
+    }
+  }
+
+  EXPECT_EQ(outside, 0u) << "tracks must stop at the die area (die side "
+                         << kTrackDieSide << ", slack " << slack
+                         << " dbu; stray x in [" << min_x << "," << worst_x
+                         << "], y in [" << min_y << "," << worst_y
+                         << "], inside=" << inside << ")";
+  EXPECT_GT(inside, 0u) << "the tracks inside the die must still be drawn";
+}
+
+TEST_F(TileGeneratorTest, TracksSpanTheWholeTileWhenTheDieCoversIt)
+{
+  // The common case — every design in the flow has die == bbox — must be
+  // untouched by the clip: the tracks still run edge to edge.
+  // Anchor the viewport to the die corners (the bbox covers shapes, not the
+  // die area).
+  placeInst("BUF_X16", "ll", 0, 0);
+  placeInst("BUF_X16", "ur", 90000, 90000);
+
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  odb::dbTrackGrid* grid = odb::dbTrackGrid::create(block_, metal1);
+  // The fixture's die is (0,0)-(100000,100000); cover it entirely.
+  grid->addGridPatternX(0, 100000 / kTrackPitch + 1, kTrackPitch);
+  grid->addGridPatternY(0, 100000 / kTrackPitch + 1, kTrackPitch);
+
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  auto png = tile_gen_->generateTile("metal1", 0, 0, 0, trackOnlyVisibility());
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  ASSERT_GT(w, 0u);
+
+  const auto row_has_pixel = [&](unsigned py) {
+    for (unsigned px = 0; px < w; ++px) {
+      if (pixels[4UL * (py * w + px) + 3] > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const auto col_has_pixel = [&](unsigned px) {
+    for (unsigned py = 0; py < h; ++py) {
+      if (pixels[4UL * (py * w + px) + 3] > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // getBounds() adds a symmetric pin-label margin, so the die does not reach
+  // the tile edge; sample just inside each die border instead of at pixel 0.
+  const odb::Rect bounds = tile_gen_->getBounds();
+  const double dbu_per_px = static_cast<double>(bounds.maxDXDY()) / w;
+  const auto col_of = [&](int dbu) {
+    const double px = (dbu - bounds.xMin()) / dbu_per_px;
+    return static_cast<unsigned>(std::clamp(px, 0.0, w - 1.0));
+  };
+  const auto row_of = [&](int dbu) {
+    const double py = (h - 1) - (dbu - bounds.yMin()) / dbu_per_px;
+    return static_cast<unsigned>(std::clamp(py, 0.0, h - 1.0));
+  };
+
+  EXPECT_TRUE(row_has_pixel(row_of(2000)) && row_has_pixel(row_of(98000)))
+      << "horizontal tracks must still reach both ends of the die";
+  EXPECT_TRUE(col_has_pixel(col_of(2000)) && col_has_pixel(col_of(98000)))
+      << "vertical tracks must still reach both ends of the die";
+}
+
+//------------------------------------------------------------------------------
 // GCell-grid overlay tests (_gcell_grid pseudo-layer)
 //------------------------------------------------------------------------------
 

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -2499,14 +2499,12 @@ TEST_F(TileGeneratorTest, NoOutlineOnTechLayerTiles)
 // (RenderThread::drawTracks clips to block->getDieArea()).
 //------------------------------------------------------------------------------
 
-namespace {
 constexpr int kTrackDieSide = 40000;  // die: (0,0)-(40000,40000)
 constexpr int kTrackPitch = 2000;     // 21 tracks per axis across the die
-}  // namespace
 
-// Build a track grid on metal1 covering the die, and return the visibility
-// that draws tracks and nothing else.
-static TileVisibility trackOnlyVisibility()
+// Visibility that draws the tracks and nothing else, so any lit pixel in the
+// assertions below is a track.
+TileVisibility trackOnlyVisibility()
 {
   TileVisibility vis;
   vis.stdcells = false;
@@ -2562,10 +2560,10 @@ TEST_F(TileGeneratorTest, TracksAreClippedToTheDieArea)
 
   size_t inside = 0;
   size_t outside = 0;
-  double worst_x = 0;
-  double worst_y = 0;
-  double min_x = 1e18;
-  double min_y = 1e18;
+  // First offender only: enough to point at the failure, and cheaper than
+  // tracking the whole bounding box of the strays.
+  double stray_x = 0;
+  double stray_y = 0;
   for (unsigned py = 0; py < h; ++py) {
     for (unsigned px = 0; px < w; ++px) {
       if (pixels[4UL * (py * w + px) + 3] == 0) {
@@ -2577,21 +2575,17 @@ TEST_F(TileGeneratorTest, TracksAreClippedToTheDieArea)
                           && dbu_y >= -slack && dbu_y <= kTrackDieSide + slack;
       if (in_die) {
         ++inside;
-      } else {
-        ++outside;
-        worst_x = std::max(worst_x, dbu_x);
-        worst_y = std::max(worst_y, dbu_y);
-        min_x = std::min(min_x, dbu_x);
-        min_y = std::min(min_y, dbu_y);
+      } else if (outside++ == 0) {
+        stray_x = dbu_x;
+        stray_y = dbu_y;
       }
     }
   }
 
   EXPECT_EQ(outside, 0u) << "tracks must stop at the die area (die side "
                          << kTrackDieSide << ", slack " << slack
-                         << " dbu; stray x in [" << min_x << "," << worst_x
-                         << "], y in [" << min_y << "," << worst_y
-                         << "], inside=" << inside << ")";
+                         << " dbu; first stray pixel at " << stray_x << ","
+                         << stray_y << "; inside=" << inside << ")";
   EXPECT_GT(inside, 0u) << "the tracks inside the die must still be drawn";
 }
 
@@ -2607,9 +2601,10 @@ TEST_F(TileGeneratorTest, TracksSpanTheWholeTileWhenTheDieCoversIt)
   odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
   ASSERT_NE(metal1, nullptr);
   odb::dbTrackGrid* grid = odb::dbTrackGrid::create(block_, metal1);
-  // The fixture's die is (0,0)-(100000,100000); cover it entirely.
-  grid->addGridPatternX(0, 100000 / kTrackPitch + 1, kTrackPitch);
-  grid->addGridPatternY(0, 100000 / kTrackPitch + 1, kTrackPitch);
+  // The fixture's die, set in SetUp(); cover it entirely.
+  constexpr int kFixtureDieSide = 100000;
+  grid->addGridPatternX(0, kFixtureDieSide / kTrackPitch + 1, kTrackPitch);
+  grid->addGridPatternY(0, kFixtureDieSide / kTrackPitch + 1, kTrackPitch);
 
   makeTileGen();
   tile_gen_->eagerInit();
@@ -2619,14 +2614,9 @@ TEST_F(TileGeneratorTest, TracksSpanTheWholeTileWhenTheDieCoversIt)
   auto pixels = decodePng(png, w, h);
   ASSERT_GT(w, 0u);
 
-  const auto row_has_pixel = [&](unsigned py) {
-    for (unsigned px = 0; px < w; ++px) {
-      if (pixels[4UL * (py * w + px) + 3] > 0) {
-        return true;
-      }
-    }
-    return false;
-  };
+  // Rows reuse the fixture's coveredColumns(); columns have no equivalent.
+  const auto row_has_pixel
+      = [&](unsigned py) { return coveredColumns(pixels, w, py) > 0; };
   const auto col_has_pixel = [&](unsigned px) {
     for (unsigned py = 0; py < h; ++py) {
       if (pixels[4UL * (py * w + px) + 3] > 0) {

--- a/src/web/test/js/test-display-state.js
+++ b/src/web/test/js/test-display-state.js
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+// Fresh DOM + fresh module instance per test.  display-state.js imports
+// theme.js, which runs initialization code at import time and would otherwise
+// be served from the ES module cache, so the import is cache-busted the same
+// way test-theme.js does it.
+async function loadDisplayState({ cookie, session, local } = {}) {
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+        url: 'http://localhost/',
+    });
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window;
+    globalThis.localStorage = dom.window.localStorage;
+    globalThis.matchMedia = () => ({
+        matches: false,
+        addListener() {}, removeListener() {},
+        addEventListener() {}, removeEventListener() {},
+        dispatchEvent() { return false; },
+    });
+
+    for (const [k, v] of Object.entries(cookie ?? {})) {
+        dom.window.document.cookie = `${k}=${v}`;
+    }
+    for (const [k, v] of Object.entries(session ?? {})) {
+        dom.window.sessionStorage.setItem(k, v);
+    }
+    for (const [k, v] of Object.entries(local ?? {})) {
+        dom.window.localStorage.setItem(k, v);
+    }
+
+    // Same suffix for both so they share one theme.js instance, and read
+    // cookies through the product's own getCookie rather than a look-alike.
+    const suffix = '?t=' + Date.now() + Math.random();
+    const mod = await import('../../src/display-state.js' + suffix);
+    const { getCookie } = await import('../../src/theme.js' + suffix);
+    return { dom, mod, getCookie };
+}
+
+describe('serializeDisplayState', () => {
+    it('reads each key from its own store', async () => {
+        const { mod } = await loadDisplayState({
+            cookie: { or_visibility: '%7B%22rows%22%3Atrue%7D',
+                      or_show_dbu: '1' },
+            session: { or_hidden_layers: '["layers_parent/metal1"]',
+                       or_layer_patterns: '{"metal1":2}' },
+        });
+        const { entries, version } = mod.serializeDisplayState();
+        assert.equal(version, 1);
+        assert.equal(entries.or_visibility, '%7B%22rows%22%3Atrue%7D');
+        assert.equal(entries.or_show_dbu, '1');
+        assert.equal(entries.or_hidden_layers, '["layers_parent/metal1"]');
+        assert.equal(entries.or_layer_patterns, '{"metal1":2}');
+    });
+
+    it('omits unset keys so restore can tell them from empty', async () => {
+        const { mod } = await loadDisplayState({ cookie: { or_theme: 'dark' } });
+        const { entries } = mod.serializeDisplayState();
+        assert.deepEqual(Object.keys(entries), ['or_theme']);
+    });
+
+    // A cookie-only read would silently return nothing for the three
+    // sessionStorage-backed keys, which is what shipped before this was
+    // dispatched per store.
+    it('does not lose the sessionStorage-backed keys', async () => {
+        const { mod } = await loadDisplayState({
+            session: { or_hidden_layers: '["a"]',
+                       or_nonselectable_layers: '["b"]',
+                       or_layer_patterns: '{"c":2}' },
+        });
+        const { entries } = mod.serializeDisplayState();
+        assert.deepEqual(Object.keys(entries).sort(), [
+            'or_hidden_layers', 'or_layer_patterns', 'or_nonselectable_layers',
+        ]);
+    });
+});
+
+describe('applyDisplayStateEntries', () => {
+    it('round-trips every key through its own store', async () => {
+        const all = {
+            or_visibility: '%7B%22rows%22%3Atrue%7D',
+            or_selectability: '%7B%7D',
+            or_hidden_layers: '["layers_parent/metal1"]',
+            or_nonselectable_layers: '["metal2"]',
+            or_layer_patterns: '{"metal1":2}',
+            or_hidden_chiplets: '%5B%5D',
+            or_bg_color: '#202020',
+            or_show_dbu: '1',
+            or_theme: 'dark',
+            or_use_true_z: '1',
+        };
+        const { dom, mod } = await loadDisplayState();
+        mod.applyDisplayStateEntries(all);
+        assert.deepEqual(mod.serializeDisplayState().entries, all);
+        // And clearing everything really clears both stores.
+        mod.applyDisplayStateEntries({});
+        assert.deepEqual(mod.serializeDisplayState().entries, {});
+    });
+
+    // The theme is mirrored into localStorage for standalone file:// reports,
+    // and theme.js reads `cookie || localStorage || system`.  Clearing only the
+    // cookie left the stale mirror winning, so restoring a state without
+    // or_theme silently kept the old theme.
+    it('clears the localStorage theme mirror, not just the cookie',
+       async () => {
+        const { dom, mod, getCookie } = await loadDisplayState({
+            cookie: { or_theme: 'dark' }, local: { or_theme: 'dark' },
+        });
+        mod.applyDisplayStateEntries({});
+        assert.equal(getCookie('or_theme'), null);
+        assert.equal(dom.window.localStorage.getItem('or_theme'), null,
+                     'stale mirror would override the restored default');
+    });
+
+    it('writes the theme to both cookie and mirror', async () => {
+        const { dom, mod, getCookie } = await loadDisplayState();
+        mod.applyDisplayStateEntries({ or_theme: 'light' });
+        assert.equal(getCookie('or_theme'), 'light');
+        assert.equal(dom.window.localStorage.getItem('or_theme'), 'light');
+    });
+
+    // These values land verbatim in document.cookie, so a ';' would inject
+    // cookie attributes and a number/boolean would change a key's meaning for
+    // readers comparing with ===.  The server rejects such a file (WEB-0052);
+    // this is the second line of defence.
+    it('drops non-string values instead of coercing them', async () => {
+        const { mod, getCookie } = await loadDisplayState();
+        mod.applyDisplayStateEntries({
+            or_show_dbu: 1,
+            or_theme: true,
+            or_bg_color: { nope: 1 },
+        });
+        assert.equal(getCookie('or_show_dbu'), null);
+        assert.equal(getCookie('or_theme'), null);
+        assert.equal(getCookie('or_bg_color'), null);
+    });
+
+    // Same guard, delimiter case.
+    it('drops values carrying cookie delimiters', async () => {
+        const { dom, mod, getCookie } = await loadDisplayState();
+        mod.applyDisplayStateEntries({
+            or_bg_color: '#fff; Domain=evil.test',
+            or_theme: 'dark\r\nSet-Cookie: x=y',
+        });
+        assert.equal(getCookie('or_bg_color'), null);
+        assert.equal(getCookie('or_theme'), null);
+    });
+});
+
+describe('storage failures', () => {
+    it('survives sessionStorage throwing', async () => {
+        const { dom, mod } = await loadDisplayState();
+        Object.defineProperty(dom.window, 'sessionStorage', {
+            get() { throw new Error('storage disabled'); },
+        });
+        assert.doesNotThrow(() => mod.applyDisplayStateEntries({
+            or_hidden_layers: '["a"]',
+        }));
+        assert.doesNotThrow(() => mod.serializeDisplayState());
+    });
+});

--- a/src/web/test/js/test-ui-utils.js
+++ b/src/web/test/js/test-ui-utils.js
@@ -3,7 +3,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { computeScaleBar, niceRoundParts, isValidHexColor }
+import { computeScaleBar, cssColorToHex, niceRoundParts, isValidHexColor }
     from '../../src/ui-utils.js';
 
 describe('isValidHexColor', () => {
@@ -18,6 +18,24 @@ describe('isValidHexColor', () => {
         assert.equal(isValidHexColor(''), false);
         assert.equal(isValidHexColor(null), false);
         assert.equal(isValidHexColor(undefined), false);
+    });
+});
+
+describe('cssColorToHex', () => {
+    it('normalizes the forms a CSS custom property can hold', () => {
+        assert.equal(cssColorToHex('#111'), '#111111');       // 3-digit hex
+        assert.equal(cssColorToHex('#a1B2c3'), '#a1b2c3');    // 6-digit hex
+        assert.equal(cssColorToHex(' #111 '), '#111111');     // padded
+        assert.equal(cssColorToHex('rgb(17, 17, 17)'), '#111111');
+        assert.equal(cssColorToHex('rgb(255,0,10)'), '#ff000a');
+    });
+    it('returns null for unrecognized values', () => {
+        assert.equal(cssColorToHex(''), null);
+        assert.equal(cssColorToHex('red'), null);
+        assert.equal(cssColorToHex('rgba(1, 2, 3, 0.5)'), null);
+        assert.equal(cssColorToHex('rgb(999, 0, 0)'), null);  // out of range
+        assert.equal(cssColorToHex(null), null);
+        assert.equal(cssColorToHex(undefined), null);
     });
 });
 
@@ -87,5 +105,19 @@ describe('computeScaleBar', () => {
     it('falls back to 1000 dbu/micron when unset', () => {
         const sb = computeScaleBar({ targetPx: 60, pxPerDbu: 0.001 });
         assert.equal(sb.label, '50 µm');
+    });
+
+    it('treats a corrupt dbu/micron like the missing-value fallback', () => {
+        // A negative value would otherwise reach niceRoundParts and yield
+        // NaN geometry (Math.log10 of a negative is NaN).
+        const expected = computeScaleBar({ targetPx: 60, pxPerDbu: 0.001 });
+        assert.deepEqual(
+            computeScaleBar(
+                { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: -2000 }),
+            expected);
+        assert.deepEqual(
+            computeScaleBar(
+                { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: NaN }),
+            expected);
     });
 });

--- a/src/web/test/js/test-ui-utils.js
+++ b/src/web/test/js/test-ui-utils.js
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeScaleBar, niceRoundParts, isValidHexColor }
+    from '../../src/ui-utils.js';
+
+describe('isValidHexColor', () => {
+    it('accepts #rrggbb', () => {
+        assert.equal(isValidHexColor('#0a0a0a'), true);
+        assert.equal(isValidHexColor('#FFFFFF'), true);
+    });
+    it('rejects malformed / short / non-strings', () => {
+        assert.equal(isValidHexColor('#fff'), false);       // 3-digit
+        assert.equal(isValidHexColor('111111'), false);     // no #
+        assert.equal(isValidHexColor('#gggggg'), false);    // non-hex
+        assert.equal(isValidHexColor(''), false);
+        assert.equal(isValidHexColor(null), false);
+        assert.equal(isValidHexColor(undefined), false);
+    });
+});
+
+describe('niceRoundParts', () => {
+    it('rounds to 1/2/5/10 x 10^n with the leading digit', () => {
+        assert.deepEqual(niceRoundParts(1), { value: 1, digit: 1 });
+        assert.deepEqual(niceRoundParts(2), { value: 2, digit: 2 });
+        assert.deepEqual(niceRoundParts(6), { value: 5, digit: 5 });
+        assert.deepEqual(niceRoundParts(9), { value: 10, digit: 10 });
+        assert.deepEqual(niceRoundParts(60), { value: 50, digit: 5 });
+        assert.deepEqual(niceRoundParts(120), { value: 100, digit: 1 });
+    });
+});
+
+describe('computeScaleBar', () => {
+    it('returns null for non-drawable inputs', () => {
+        assert.equal(
+            computeScaleBar({ targetPx: 60, pxPerDbu: 0, dbuPerMicron: 1000 }),
+            null);
+        assert.equal(
+            computeScaleBar({ targetPx: 0, pxPerDbu: 1, dbuPerMicron: 1000 }),
+            null);
+        assert.equal(
+            computeScaleBar({ targetPx: 60, pxPerDbu: NaN, dbuPerMicron: 1000 }),
+            null);
+    });
+
+    it('DBU mode: nice length, integer label, no unit', () => {
+        const sb = computeScaleBar(
+            { targetPx: 60, pxPerDbu: 1, dbuPerMicron: 1000, showDbu: true });
+        assert.equal(sb.barPx, 50);
+        assert.equal(sb.label, '50');
+        assert.equal(sb.segments, 5);  // leading digit 5
+    });
+
+    it('metric mode: micron label', () => {
+        // pxPerUm = pxPerDbu * dbuPerMicron = 0.001 * 1000 = 1.
+        const sb = computeScaleBar(
+            { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(sb.label, '50 µm');
+        assert.equal(sb.barPx, 50);
+        assert.equal(sb.segments, 5);
+    });
+
+    it('unit switches across magnitudes (mm / nm / pm)', () => {
+        // pxPerUm = 1 in every case; vary targetPx.
+        const mm = computeScaleBar(
+            { targetPx: 1000, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(mm.label, '1 mm');
+
+        const nm = computeScaleBar(
+            { targetPx: 0.6, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(nm.label, '500 nm');
+
+        const pm = computeScaleBar(
+            { targetPx: 0.0006, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(pm.label, '500 pm');
+    });
+
+    it('segment count follows the leading digit (2 -> 2)', () => {
+        const sb = computeScaleBar(
+            { targetPx: 20, pxPerDbu: 1, dbuPerMicron: 1000, showDbu: true });
+        assert.equal(sb.label, '20');
+        assert.equal(sb.segments, 2);
+    });
+
+    it('falls back to 1000 dbu/micron when unset', () => {
+        const sb = computeScaleBar({ targetPx: 60, pxPerDbu: 0.001 });
+        assert.equal(sb.label, '50 µm');
+    });
+});

--- a/src/web/test/js/test-ui-utils.js
+++ b/src/web/test/js/test-ui-utils.js
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeScaleBar, cssColorToHex, niceRoundParts, isValidHexColor }
+    from '../../src/ui-utils.js';
+
+describe('isValidHexColor', () => {
+    it('accepts #rrggbb', () => {
+        assert.equal(isValidHexColor('#0a0a0a'), true);
+        assert.equal(isValidHexColor('#FFFFFF'), true);
+    });
+    it('rejects malformed / short / non-strings', () => {
+        assert.equal(isValidHexColor('#fff'), false);       // 3-digit
+        assert.equal(isValidHexColor('111111'), false);     // no #
+        assert.equal(isValidHexColor('#gggggg'), false);    // non-hex
+        assert.equal(isValidHexColor(''), false);
+        assert.equal(isValidHexColor(null), false);
+        assert.equal(isValidHexColor(undefined), false);
+    });
+});
+
+describe('cssColorToHex', () => {
+    it('normalizes the forms a CSS custom property can hold', () => {
+        assert.equal(cssColorToHex('#111'), '#111111');       // 3-digit hex
+        assert.equal(cssColorToHex('#a1B2c3'), '#a1b2c3');    // 6-digit hex
+        assert.equal(cssColorToHex(' #111 '), '#111111');     // padded
+        assert.equal(cssColorToHex('rgb(17, 17, 17)'), '#111111');
+        assert.equal(cssColorToHex('rgb(255,0,10)'), '#ff000a');
+    });
+    it('returns null for unrecognized values', () => {
+        assert.equal(cssColorToHex(''), null);
+        assert.equal(cssColorToHex('red'), null);
+        assert.equal(cssColorToHex('rgba(1, 2, 3, 0.5)'), null);
+        assert.equal(cssColorToHex('rgb(999, 0, 0)'), null);  // out of range
+        assert.equal(cssColorToHex(null), null);
+        assert.equal(cssColorToHex(undefined), null);
+    });
+});
+
+describe('niceRoundParts', () => {
+    it('rounds to 1/2/5/10 x 10^n with the leading digit', () => {
+        assert.deepEqual(niceRoundParts(1), { value: 1, digit: 1 });
+        assert.deepEqual(niceRoundParts(2), { value: 2, digit: 2 });
+        assert.deepEqual(niceRoundParts(6), { value: 5, digit: 5 });
+        assert.deepEqual(niceRoundParts(9), { value: 10, digit: 10 });
+        assert.deepEqual(niceRoundParts(60), { value: 50, digit: 5 });
+        assert.deepEqual(niceRoundParts(120), { value: 100, digit: 1 });
+    });
+});
+
+describe('computeScaleBar', () => {
+    it('returns null for non-drawable inputs', () => {
+        assert.equal(
+            computeScaleBar({ targetPx: 60, pxPerDbu: 0, dbuPerMicron: 1000 }),
+            null);
+        assert.equal(
+            computeScaleBar({ targetPx: 0, pxPerDbu: 1, dbuPerMicron: 1000 }),
+            null);
+        assert.equal(
+            computeScaleBar({ targetPx: 60, pxPerDbu: NaN, dbuPerMicron: 1000 }),
+            null);
+    });
+
+    it('DBU mode: nice length, integer label, no unit', () => {
+        const sb = computeScaleBar(
+            { targetPx: 60, pxPerDbu: 1, dbuPerMicron: 1000, showDbu: true });
+        assert.equal(sb.barPx, 50);
+        assert.equal(sb.label, '50');
+        assert.equal(sb.segments, 5);  // leading digit 5
+    });
+
+    it('metric mode: micron label', () => {
+        // pxPerUm = pxPerDbu * dbuPerMicron = 0.001 * 1000 = 1.
+        const sb = computeScaleBar(
+            { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(sb.label, '50 µm');
+        assert.equal(sb.barPx, 50);
+        assert.equal(sb.segments, 5);
+    });
+
+    it('unit switches across magnitudes (mm / nm / pm)', () => {
+        // pxPerUm = 1 in every case; vary targetPx.
+        const mm = computeScaleBar(
+            { targetPx: 1000, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(mm.label, '1 mm');
+
+        const nm = computeScaleBar(
+            { targetPx: 0.6, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(nm.label, '500 nm');
+
+        const pm = computeScaleBar(
+            { targetPx: 0.0006, pxPerDbu: 0.001, dbuPerMicron: 1000 });
+        assert.equal(pm.label, '500 pm');
+    });
+
+    it('segment count follows the leading digit (2 -> 2)', () => {
+        const sb = computeScaleBar(
+            { targetPx: 20, pxPerDbu: 1, dbuPerMicron: 1000, showDbu: true });
+        assert.equal(sb.label, '20');
+        assert.equal(sb.segments, 2);
+    });
+
+    it('falls back to 1000 dbu/micron when unset', () => {
+        const sb = computeScaleBar({ targetPx: 60, pxPerDbu: 0.001 });
+        assert.equal(sb.label, '50 µm');
+    });
+
+    it('treats a corrupt dbu/micron like the missing-value fallback', () => {
+        // A negative value would otherwise reach niceRoundParts and yield
+        // NaN geometry (Math.log10 of a negative is NaN).
+        const expected = computeScaleBar({ targetPx: 60, pxPerDbu: 0.001 });
+        assert.deepEqual(
+            computeScaleBar(
+                { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: -2000 }),
+            expected);
+        assert.deepEqual(
+            computeScaleBar(
+                { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: NaN }),
+            expected);
+    });
+});

--- a/src/web/test/js/test-ui-utils.js
+++ b/src/web/test/js/test-ui-utils.js
@@ -4,7 +4,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { computeScaleBar, cssColorToHex, niceRoundParts, isValidHexColor,
-         maxUsefulZoom }
+         maxUsefulZoom, MAX_TILE_ZOOM }
     from '../../src/ui-utils.js';
 
 describe('isValidHexColor', () => {
@@ -125,7 +125,7 @@ describe('computeScaleBar', () => {
 
 describe('maxUsefulZoom', () => {
     // designScale is pixels per DBU at zoom 0 (tileSize / maxDXDY), so these
-    // are the real values for a 256 px tile: gcd is 71510 DBU across, swerv
+    // are real die widths: gcd is 71510 DBU across, swerv
     // 962800, microwatt 3610000.
     const scaleFor = (maxDXDY) => 256 / maxDXDY;
 
@@ -146,7 +146,8 @@ describe('maxUsefulZoom', () => {
         for (const maxDXDY of [888, 71510, 3610000, 1e9]) {
             const z = maxUsefulZoom(scaleFor(maxDXDY));
             assert.equal(z, Math.trunc(z), 'zoom levels are integers');
-            assert.ok(z >= 1 && z <= 30, `z=${z} outside [1, 30]`);
+            assert.ok(z >= 1 && z <= MAX_TILE_ZOOM,
+                      `z=${z} outside [1, ${MAX_TILE_ZOOM}]`);
         }
     });
 

--- a/src/web/test/js/test-ui-utils.js
+++ b/src/web/test/js/test-ui-utils.js
@@ -3,7 +3,8 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { computeScaleBar, cssColorToHex, niceRoundParts, isValidHexColor }
+import { computeScaleBar, cssColorToHex, niceRoundParts, isValidHexColor,
+         maxUsefulZoom }
     from '../../src/ui-utils.js';
 
 describe('isValidHexColor', () => {
@@ -119,5 +120,48 @@ describe('computeScaleBar', () => {
             computeScaleBar(
                 { targetPx: 60, pxPerDbu: 0.001, dbuPerMicron: NaN }),
             expected);
+    });
+});
+
+describe('maxUsefulZoom', () => {
+    // designScale is pixels per DBU at zoom 0 (tileSize / maxDXDY), so these
+    // are the real values for a 256 px tile: gcd is 71510 DBU across, swerv
+    // 962800, microwatt 3610000.
+    const scaleFor = (maxDXDY) => 256 / maxDXDY;
+
+    it('caps where one DBU covers the pixel budget', () => {
+        // At the cap, designScale * 2^z must be at or just past maxPxPerDbu
+        // (8 by default) and one level lower must still be under it.
+        for (const maxDXDY of [71510, 962800, 3610000]) {
+            const scale = scaleFor(maxDXDY);
+            const z = maxUsefulZoom(scale);
+            assert.ok(scale * Math.pow(2, z) >= 8,
+                      `z=${z} should reach the budget for ${maxDXDY} DBU`);
+            assert.ok(scale * Math.pow(2, z - 1) < 8,
+                      `z=${z} should be the first level to reach it`);
+        }
+    });
+
+    it('returns an integer within the server tile-grid ceiling', () => {
+        for (const maxDXDY of [888, 71510, 3610000, 1e9]) {
+            const z = maxUsefulZoom(scaleFor(maxDXDY));
+            assert.equal(z, Math.trunc(z), 'zoom levels are integers');
+            assert.ok(z >= 1 && z <= 30, `z=${z} outside [1, 30]`);
+        }
+    });
+
+    it('bounds the zoom even before a design is loaded', () => {
+        // The whole point is that no path leaves maxZoom at Infinity.
+        for (const bad of [undefined, null, 0, -1, NaN, Infinity]) {
+            const z = maxUsefulZoom(bad);
+            assert.ok(Number.isFinite(z) && z > 0,
+                      `maxUsefulZoom(${bad}) must be finite and positive`);
+        }
+    });
+
+    it('honours a caller-supplied pixel budget', () => {
+        const scale = scaleFor(71510);
+        assert.ok(maxUsefulZoom(scale, 64) > maxUsefulZoom(scale, 8),
+                  'a larger budget allows deeper zoom');
     });
 });


### PR DESCRIPTION
Addresses a portion of https://github.com/The-OpenROAD-Project/OpenROAD/issues/10619

### 2.5 Display controls — overlays, grids & misc

| Feature | GUI | Web | Status |
|---|---|---|---|
| **Focused-nets guides** toggle | yes | `focused_nets_guides` toggle (Misc); the overlay draws guides for `route_guide_net_ids ∪ focus_net_ids`, keeping the inspector's per-net "Show route guides" as a finer web-only control | 🟡 → ✅ |
| **Highlight selected** | `drawSelected` gate | `highlight_selected` toggle (Misc, default on); gates the selection highlight on the server overlay and the client outline/pulse — hover stays independent, and the outline is preserved across off→on | 🟡 → ✅ |
| **Scale bar** | `drawScaleBar` | Qt-style SVG bracket with interior ticks and 0/total labels; pure `computeScaleBar()` helper (unit-tested), smooth rAF updates during zoom | 🟡 → ✅ |
| **Background color** | Background swatch | color picker + Reset in the Display Controls panel; overrides `--bg-map`, persists in the `or_bg_color` cookie, re-renders the 3D viewer | 🟡 → ✅ |
| **Save/restore display state via Tcl** | `save/restore_display_controls` | `save_display_controls` / `restore_display_controls` commands; clients continuously sync their state (`set_display_state`), restore broadcasts the saved JSON and reloads with the camera preserved | ❌ → ✅ |



