### PR TITLE
grt: erase destroyed net from dirty set in CUGR path

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4799,6 +4799,10 @@ void GlobalRouter::removeNet(odb::dbNet* db_net)
     return;
   }
 
+  // Drop the destroyed net from the dirty set for both routers so
+  // updateDirtyRoutes never dereferences a dangling dbNet.
+  dirty_nets_.erase(db_net);
+
   if (use_cugr_) {
     cugr_->removeNet(db_net);
   } else {
@@ -4858,7 +4862,6 @@ void GlobalRouter::removeNet(odb::dbNet* db_net)
     }
     delete deleted_net;
     db_net_map_.erase(db_net);
-    dirty_nets_.erase(db_net);
     routes_.erase(db_net);
   }
 }


### PR DESCRIPTION
## Summary

`GlobalRouter::removeNet` erased the destroyed net from `dirty_nets_` only in the FastRoute (non-CUGR) branch. When `use_cugr_` is true, a net destroyed during incremental routing stayed in `dirty_nets_`, so `updateDirtyRoutes` later passed the dangling `dbNet*` to `CUGR::updateNet`, which dereferenced it via `Design::updateNet` (`db_net->getSigType()`).

This is a use-after-free. In release builds (`NDEBUG`) it is silent, so `grt.incremental_deleted_net.tcl` passed. With assertions enabled (coverage / `RELEASEWITHASSERTS` builds) the stale sig type tripped `dbSigType::isSupply()`'s `assert(false)` and aborted:

```
openroad: src/odb/src/db/dbTypes.cpp:406: bool odb::dbSigType::isSupply() const: Assertion `false' failed.
 7# odb::dbSigType::isSupply() const
 8# grt::Design::updateNet(odb::dbNet*)
 9# grt::CUGR::updateNet(odb::dbNet*)
10# grt::GlobalRouter::updateDirtyRoutes(bool)
11# grt::GlobalRouter::endIncremental(bool)
```

The fix moves `dirty_nets_.erase(db_net)` to the top of `removeNet` so it runs for both routers.

## Verification

Built with `RELEASEWITHASSERTS` (mirrors the coverage build's `-UNDEBUG`):
- Without the fix: reproduced the exact crash above (exit 134).
- With the fix: `grt.incremental_deleted_net.tcl` passes and the full 144-test GRT suite passes.
- No regression in the default asserts-off build.