### PR TITLE
stt: drop unused dbDatabase* from SteinerTreeBuilder

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -215,7 +215,7 @@ void OpenRoad::init(Tcl_Interp* tcl_interp,
   sta_ = new sta::dbSta(tcl_interp, db_, logger_);
   verilog_network_ = new dbVerilogNetwork(sta_);
   ioPlacer_ = new ppl::IOPlacer(db_, logger_);
-  stt_builder_ = new stt::SteinerTreeBuilder(db_, logger_);
+  stt_builder_ = new stt::SteinerTreeBuilder(logger_);
   antenna_checker_ = new ant::AntennaChecker(db_, logger_);
   opendp_ = new dpl::Opendp(db_, logger_);
   global_router_ = new grt::GlobalRouter(logger_,

--- a/src/gpl/test/mbff_test.cpp
+++ b/src/gpl/test/mbff_test.cpp
@@ -44,7 +44,7 @@ class MBFFTestFixture : public tst::Fixture
     logger_ = getLogger();
     service_registry_ = std::make_unique<utl::ServiceRegistry>(logger_);
     verilog_network_ = std::make_unique<ord::dbVerilogNetwork>(getSta());
-    stt_builder_ = std::make_unique<stt::SteinerTreeBuilder>(getDb(), logger_);
+    stt_builder_ = std::make_unique<stt::SteinerTreeBuilder>(logger_);
     antenna_checker_ = std::make_unique<ant::AntennaChecker>(getDb(), logger_);
     opendp_ = std::make_unique<dpl::Opendp>(getDb(), logger_);
     global_router_

--- a/src/rsz/test/cpp/TestBufferRemoval.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval.cc
@@ -36,7 +36,7 @@ class BufRemTest : public tst::Nangate45Fixture
  protected:
   BufRemTest()
       :  // initializer resizer
-        stt_(db_.get(), &logger_),
+        stt_(&logger_),
         service_registry_(&logger_),
         dp_(db_.get(), &logger_),
         ant_(db_.get(), &logger_),

--- a/src/rsz/test/cpp/TestBufferRemoval2.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval2.cc
@@ -30,7 +30,7 @@ class BufRemTest2 : public tst::Nangate45Fixture
 {
  protected:
   BufRemTest2()
-      : stt_(db_.get(), &logger_),
+      : stt_(&logger_),
         service_registry_(&logger_),
         dp_(db_.get(), &logger_),
         ant_(db_.get(), &logger_),

--- a/src/stt/include/stt/SteinerTreeBuilder.h
+++ b/src/stt/include/stt/SteinerTreeBuilder.h
@@ -49,7 +49,7 @@ struct Tree
 class SteinerTreeBuilder
 {
  public:
-  SteinerTreeBuilder(odb::dbDatabase* db, utl::Logger* logger);
+  explicit SteinerTreeBuilder(utl::Logger* logger);
   ~SteinerTreeBuilder();
 
   Tree makeSteinerTree(const std::vector<int>& x,
@@ -96,7 +96,6 @@ class SteinerTreeBuilder
   std::pair<int, float> min_hpwl_alpha_;
 
   utl::Logger* logger_;
-  odb::dbDatabase* db_;
   std::unique_ptr<flt::Flute> flute_;
 };
 

--- a/src/stt/src/SteinerTreeBuilder.cpp
+++ b/src/stt/src/SteinerTreeBuilder.cpp
@@ -22,12 +22,11 @@ namespace stt {
 
 static void reportSteinerBranches(const stt::Tree& tree, utl::Logger* logger);
 
-SteinerTreeBuilder::SteinerTreeBuilder(odb::dbDatabase* db, utl::Logger* logger)
+SteinerTreeBuilder::SteinerTreeBuilder(utl::Logger* logger)
     : alpha_(0.3),
       min_fanout_alpha_({0, -1}),
       min_hpwl_alpha_({0, -1}),
       logger_(logger),
-      db_(db),
       flute_(new flt::Flute())
 {
 }

--- a/src/tst/src/IntegratedFixture.cpp
+++ b/src/tst/src/IntegratedFixture.cpp
@@ -31,7 +31,7 @@ namespace tst {
 
 IntegratedFixture::IntegratedFixture(Technology tech,
                                      const std::string& test_root_path)
-    : stt_(db_.get(), &logger_),
+    : stt_(&logger_),
       service_registry_(&logger_),
       dp_(db_.get(), &logger_),
       ant_(db_.get(), &logger_),


### PR DESCRIPTION
## Summary

`SteinerTreeBuilder` stored a `dbDatabase*` that was never used. Remove the constructor parameter and the `db_` member, and update both callers to match:

- `OpenRoad::init` (`src/OpenRoad.cc`)
- the gpl mbff unit test (`src/gpl/test/mbff_test.cpp`)