### PR TITLE
bazel: pass external headers as -isystem to silence third-party warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -83,6 +83,20 @@ build --cxxopt "-Wno-deprecated-copy-with-user-provided-copy"  --host_cxxopt "-W
 build --per_file_copt=.*external/.*@-w
 build --host_per_file_copt=.*external/.*@-w
 
+# Treat include paths into external/ (bzlmod/BCR deps) as -isystem so clang
+# suppresses ALL warnings from third-party headers pulled into our TUs (boost,
+# Eigen, googletest, ...), regardless of the specific warning. The
+# per_file_copt -w above only covers compiling external *source* files; this
+# covers external *headers* included by our own sources.
+#
+# The feature is global (target and exec config) and also demotes a from-source
+# dep's own -iquote entries to -isystem. Tools that rely on -iquote precedence
+# to shadow libc headers are patched to restore it -- e.g. git's
+# builtin/get-tar-commit-id.c includes git's own tar.h, which must win over
+# glibc's <tar.h>. See the git single_version_override in MODULE.bazel (same
+# class of fix as the bison/sed/gawk/m4 -I-over-isystem overrides).
+build --features=external_include_paths
+
 # This avoid problems with building -c dbg which enables asserts.
 # Without this libstdc++ vs libc++ differences cause link errors.
 build --per_file_copt=.*external/abc.*@-stdlib=libc++

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -128,6 +128,21 @@ single_version_override(
 )
 
 bazel_dep(name = "git", version = "2.54.0")
+
+# We enable the external_include_paths feature globally (see .bazelrc), which
+# demotes a repo's own -iquote entries to -isystem. git relies on -iquote
+# precedence for its quoted includes (builtin/get-tar-commit-id.c includes
+# git's own tar.h, which must shadow glibc's <tar.h>); the patch re-adds the
+# repo root as -iquote in GIT_COPTS so those includes keep precedence.
+single_version_override(
+    module_name = "git",
+    patch_strip = 1,
+    patches = [
+        "//bazel/git-patches:0001-iquote-own-headers-over-external_include_paths.patch",
+    ],
+    version = "2.54.0",
+)
+
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 
 # m4 is transitive (rules_bison/rules_flex -> m4). Same gnulib libc-header
@@ -178,9 +193,16 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.8")
 # allow openroad to link, but will search on the system at runtime for
 # the correct system libs.
 bazel_dep(name = "qt-bazel")
+
+# external_include_paths (see .bazelrc) moves Qt's external-repo include dirs
+# into compilation_context.external_includes. The moc rule at the older pin did
+# not gather those, so moc lost Qt's own header search paths and failed under
+# --config=lint (qtextimagehandler_p.h "Undefined interface", qfilesystemmodel.h
+# "Parse error at QT7_ONLY"). 541ebf6d teaches the moc rule to also collect
+# external_includes.
 git_override(
     module_name = "qt-bazel",
-    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
+    commit = "541ebf6df76eef96c4de6343316b1c9d63e296f6",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/bazel/git-patches/0001-iquote-own-headers-over-external_include_paths.patch
+++ b/bazel/git-patches/0001-iquote-own-headers-over-external_include_paths.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: OpenROAD <openroad@openroad.tools>
+Date: Sat, 11 Jul 2026 00:00:00 +0000
+Subject: [PATCH] bazel: keep git's own -iquote precedence under
+ external_include_paths
+
+OpenROAD enables the external_include_paths toolchain feature globally to pass
+include paths into external/ deps as -isystem (silencing third-party header
+warnings pulled into our TUs). That feature also demotes a repo's own -iquote
+entries to -isystem. git relies on -iquote precedence for its quoted includes:
+builtin/get-tar-commit-id.c does #include "tar.h" and git ships its own tar.h
+(struct ustar_header, TYPEFLAG_GLOBAL_HEADER) at the repo root. Once demoted to
+-isystem, glibc's <tar.h> (injected earlier via the hermetic toolchain's
+sysroot -isystem) shadows git's, leaving the struct incomplete.
+
+Re-add the repo root (source and generated trees) as -iquote in GIT_COPTS so
+git's own quoted includes keep precedence. The feature stays on for git so its
+external deps (openssl, curl, ...) still resolve via -isystem.
+---
+diff --git a/contrib/bazel/defs.bzl b/contrib/bazel/defs.bzl
+--- a/contrib/bazel/defs.bzl
++++ b/contrib/bazel/defs.bzl
+@@ -82,7 +82,23 @@
+     "//conditions:default": [],
+ })
+ 
+-GIT_COPTS = _GIT_BASE_COPTS + _GIT_CPU_DEFINES + _GIT_OS_DEFINES
++# OpenROAD enables the external_include_paths toolchain feature globally
++# (see .bazelrc), which demotes this repo's own -iquote entries to -isystem.
++# git relies on -iquote precedence for its quoted includes: e.g.
++# builtin/get-tar-commit-id.c does #include "tar.h" and git ships its own
++# tar.h (struct ustar_header, TYPEFLAG_GLOBAL_HEADER) at the repo root, which
++# must win over glibc's <tar.h> (injected earlier as -isystem by the
++# hermetic toolchain sysroot). Re-add the repo root (source and generated
++# trees) as -iquote so those includes resolve to git's own headers. Same
++# class of fix as the bison/sed/gawk -I-over-isystem overrides.
++_GIT_IQUOTE_COPTS = [
++    "-iquote",
++    "external/git+",
++    "-iquote",
++    "$(BINDIR)/external/git+",
++]
++
++GIT_COPTS = _GIT_IQUOTE_COPTS + _GIT_BASE_COPTS + _GIT_CPU_DEFINES + _GIT_OS_DEFINES
+ 
+ GIT_LINKOPTS = ["-lpthread"] + select({
+     "@platforms//os:macos": [

--- a/bazel/git-patches/BUILD.bazel
+++ b/bazel/git-patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))


### PR DESCRIPTION
## Summary

Enable the `external_include_paths` toolchain feature so include paths into `external/` (bzlmod/BCR deps) are passed as `-isystem` instead of `-I`. Clang suppresses diagnostics from system headers, so warnings from third-party headers pulled into our TUs via template instantiation are silenced at the source — e.g. boost.polygon's `-Wbitwise-instead-of-logical`, hit through `gtl::bloat`/`gtl::extents` in cts (`TreeBuilder.cpp`).

The existing `.*external/.*@-w` per_file_copt only covers compiling external *source* files; it does not cover external *headers* included by our own sources.

## Why target config only

Scoped to the target config (`--features`), **not** `--host_features`. gnulib-based build tools such as m4 build in the exec config and rely on `-I` ordering to override glibc headers (`error.h`/`verror.h`); demoting those to `-isystem` breaks their compile. Verified: a full `bazel build //:openroad` passes with this scoping, and the cts boost warning count drops from 6 to 0.