### PR TITLE
ci: revert first-interaction to v1.3.0 (fix false first-PR greetings)

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Greet First-Time Contributor
-        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3.1.0
+        uses: actions/first-interaction@34f15e814fe48ac9312ccf29db4e74fa767cbab7  # v1.3.0
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
             Welcome to OpenROAD! Thanks for opening your first issue.
             To get started:
             - Build Instructions: https://openroad.readthedocs.io/en/latest/contrib/BuildWithCMake.html
@@ -25,7 +25,7 @@ jobs:
 
             Please search existing issues before submitting to avoid duplicates.
             A maintainer will get back to you soon!
-          pr_message: |
+          pr-message: |
             Welcome to OpenROAD! Thanks for opening your first PR.
             Before we review:
             - Contribution Guide: https://openroad.readthedocs.io/en/latest/contrib/contributing.html


### PR DESCRIPTION
## Problem

Since the dependabot bump to `actions/first-interaction@v3.1.0` (30efff68ee, 2026-07-09), the First-Time Contributor Bot greets established contributors as first-time PR authors (e.g. PR #3596).

## Root cause

v3 rewrote the detection logic and introduced two regressions vs. v1.3.0:

1. **OR-combines both checks on every event.** It greets unless *both* `isFirstIssue` **and** `isFirstPullRequest` are false ([src/main.ts#L40-L42](https://github.com/actions/first-interaction/blob/1c4688942c71f71d4f5502a26ea67c331730fa4d/src/main.ts#L40-L42)). On a PR event it still consults `isFirstIssue`, so any contributor who has opened PRs but never a plain *issue* in this repo is flagged as first-time.
2. **The PR check dropped author filtering.** `isFirstPullRequest` no longer matches `login === sender`; it only checks PR number, which is meaningless for detecting a specific user.

v1.3.0 branches on event type (PR event → PR check only) and matches PRs by author, so it does not misfire.

This is tracked upstream in [actions/first-interaction#369](https://github.com/actions/first-interaction/issues/369) (and related #364, #365), all currently open/unresolved.

## Change

Pin `actions/first-interaction` back to v1.3.0 (`34f15e814f`) and restore its kebab-case input names (`repo-token`, `issue-message`, `pr-message`). This reverts 30efff68ee and 044941116f. Message contents are unchanged.

Recommend also adding a dependabot `ignore` for this action's major versions until upstream fixes #369.