### PR TITLE
dpl: register multi_height_power_align regression test in Bazel

### DIFF
--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -54,6 +54,7 @@ COMPULSORY_TESTS = [
     "mirror2",
     "mirror3",
     "multi_height_one_site_gap_disallow",
+    "multi_height_power_align",
     "multi_height_rows",
     "negotiation01",
     "negotiation_multi_height",


### PR DESCRIPTION
## Summary

While auditing CMake/Bazel test parity, I found that `dpl`'s `multi_height_power_align` regression test was registered in `src/dpl/test/CMakeLists.txt` but missing from `src/dpl/test/BUILD`, so it only ran under CMake.

This adds it to `COMPULSORY_TESTS` (positioned to match the CMake ordering). No resource-dict entry is needed — the test's inputs (`multi_height_power_align.*`, `Nangate45/Nangate45.lef`, `helpers.tcl`) are all covered by the default glob plus the shared `regression_resources`.

Verified passing under Bazel:

```
//src/dpl/test:multi_height_power_align-tcl_test    PASSED in 0.3s
```

This was the only genuine (non-GPU) parity gap found in the audit. The remaining CMake-only tests (gpl's `fft_gpu_test`, `wl_gpu_test`, `region01_gpu`, `region01_gpu_asym`) are all `ENABLE_GPU`-gated and intentionally have no Bazel equivalent.