### PR TITLE
Add missing dependency and document a cyclic dependency.

### DIFF
--- a/src/syn/src/elab/BUILD
+++ b/src/syn/src/elab/BUILD
@@ -20,6 +20,11 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/syn/src/ir",
+        # TODO: backend_builder.h includes slang_frontend.h, so we need
+        # :slang_frontend, but that indirectly depends on this, creating cycle.
+        # So can't add the following dependency right now.
+        #"//third-party/slang-elab/src:slang_frontend",
+        "@slang",
     ],
 )
 


### PR DESCRIPTION
backend_builder.h includes
  * `slang/ast/expressions/Operator.h` so needs to depend on `@slang`
  * `slang_frontend.h` so needs to depend on `//third-party/slang-elab/src:slang_frontend`, but that creates a cyclic dependency. This should be properly layered and fixed.
