### PR TITLE
Fix Bazel flow (BIG_TESTS) integration tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -209,5 +209,5 @@ py_test(
 test_suite(
     name = "flow_tests",
     tags = ["manual"],
-    tests = [test_name + "-tcl" for test_name in BIG_TESTS],
+    tests = [test_name + "-tcl_test" for test_name in BIG_TESTS],
 )

--- a/test/flow_helpers.tcl
+++ b/test/flow_helpers.tcl
@@ -13,7 +13,7 @@ proc read_libraries { } {
   set corners [sta::scenes]
   if { [llength $corners] > 1 } {
     foreach corner $corners {
-      set corner_name [$corner name]
+      set corner_name [get_name $corner]
       set corner_index [lsearch $liberty_files $corner_name]
       if { $corner_index == -1 } {
         error "No liberty file in \$liberty_files for corner $corner_name."


### PR DESCRIPTION
## Summary

The Bazel flow tests (BIG_TESTS in `test/BUILD`) could not be run:

- **`test/flow_helpers.tcl`**: `read_libraries` used the pre-multi-mode STA
  idiom `[$corner name]` to get a corner's name, but `Scene` is now an opaque
  SWIG handle with no `name` method, so the call errored (`Invalid method.
  Must be one of: configure cget -acquire -disown -delete`). Switched to
  `[get_name $corner]`, matching upstream OpenSTA. Only `gcd_sky130hd_fast_slow`
  (the sole multi-corner test) exercised this path.
- **`test/BUILD`**: the `flow_tests` suite listed `<name>-tcl`, but
  `regression_test` creates `<name>-tcl_test` targets, so
  `bazel test //test:flow_tests` resolved to no tests. Point the suite at the
  real target names.

All 14 BIG_TESTS now pass via `bazel test //test:flow_tests`.
