### PR TITLE
test: suppress .pyc writeback in bazel test runs

### DIFF
--- a/test/bazel_test.sh
+++ b/test/bazel_test.sh
@@ -9,6 +9,12 @@ export RESULTS_DIR="${TEST_UNDECLARED_OUTPUTS_DIR}/results"
 export REGRESSION_TEST=$(realpath $REGRESSION_TEST)
 if [ -n "${TEST_SRCDIR:-}" ]; then
 	export BAZEL_TEST=1
+	# Tests cd into their source directory, so importing a shared helper
+	# (helpers.py, ppl_aux.py, ...) makes CPython write __pycache__ .pyc
+	# files back into the source tree mid-action. Bazel then sees a
+	# concurrent modification and skips caching the result
+	# (--guard_against_concurrent_changes). Suppress bytecode writing.
+	export PYTHONDONTWRITEBYTECODE=1
 	workspace_root="${TEST_SRCDIR}/${TEST_WORKSPACE:-_main}"
 	python_paths="${workspace_root}"
 	if [ -d "${workspace_root}/python" ]; then


### PR DESCRIPTION
## Problem

Running `bazelisk test //src/...` emits many warnings like:

```
WARNING: //src/ppl/test:exclude3-py_test: Skipping uploading outputs because of
concurrent modifications with --guard_against_concurrent_changes enabled:
.../src/ppl/test/__pycache__/helpers.cpython-312.pyc was modified during execution
```

The regression tests `cd` into their source directory before running. When a test
imports a shared helper (`helpers.py`, `ppl_aux.py`, ...), CPython compiles it and
writes `__pycache__/*.pyc` back into the source tree — inside Bazel's execroot,
during the action. Bazel's `--guard_against_concurrent_changes` detects the
mid-action modification and refuses to upload the result to the cache, so those
tests re-run on every invocation.

## Fix

Set `PYTHONDONTWRITEBYTECODE=1` in `test/bazel_test.sh`, inside the Bazel-only
`BAZEL_TEST=1` block. This is the single wrapper every Bazel `-py_test`/`-tcl`
target `exec`s, and it is not used by the CMake/ctest path, so the change is
scoped precisely to Bazel runs. No bytecode is written, so nothing changes
mid-action: the warnings disappear and results cache normally.

## Verification

Fresh (`--nocache_test_results`) run of `//src/ppl/test:all`: 0 concurrent-modification
warnings and 0 `.pyc` files leaked into the source tree.