### PR TITLE
Always write the `buildcleaner: keep` comment the same way.

### DIFF
--- a/src/cgt/BUILD
+++ b/src/cgt/BUILD
@@ -45,7 +45,7 @@ cc_library(
         "//src/utl",
         "@abc",
         "@boost.stacktrace",
-        "@tcl_lang//:tcl",  # build_cleaner keep swig.cc bracket-includes <tcl.h>
+        "@tcl_lang//:tcl",
     ],
 )
 

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -166,7 +166,7 @@ cc_test(
         "../src",
     ],
     deps = [
-        "//src/drt",  # build_cleaner: keep for private headers
+        "//src/drt",  # buildcleaner: keep for private headers
         "//src/drt:base_types",
         "//src/drt:db_hdrs",
         "//src/drt:drt_private_hdrs",
@@ -194,7 +194,7 @@ cc_test(
     ],
     deps = [
         # drt only exports header TritonRoute.h, but we need other symbols
-        "//src/drt",  # build_cleaner: keep
+        "//src/drt",  # buildcleaner: keep
         "//src/drt:base_types",
         "//src/drt:db_hdrs",
         "//src/drt:drt_private_hdrs",

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -146,7 +146,7 @@ cc_test(
     srcs = ["fft_test.cc"],
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
-        "//src/gpl",  # buildcleaner keep: needs fixing gpl layering first.
+        "//src/gpl",  # buildcleaner: keep: needs fixing gpl layering first.
         "//src/gpl:gpl_private_hdrs",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -481,7 +481,7 @@ cc_test(
     features = ["-layering_check"],  # TODO: includes private headers
     deps = [
         "//src/odb/src/db",
-        "//src/rsz",  # build_cleaner keep provides the private headers
+        "//src/rsz",  # buildcleaner: keep provides the private headers
         "//src/sta:opensta_lib",
         "//src/tst:integrated_fixture",
         "@googletest//:gtest",

--- a/src/syn/test/BUILD
+++ b/src/syn/test/BUILD
@@ -42,7 +42,7 @@ cc_test(
     # No gtest_main: ABC ships its own main() that wins over gtest_main;
     # the TU defines its own.
     deps = [
-        "//src/syn",  # buildcleaner keep: needs fixing syn layering first.
+        "//src/syn",  # buildcleaner: keep: needs fixing syn layering first.
         "//src/syn/src/ir",
         "//src/utl",
         "@googletest//:gtest",


### PR DESCRIPTION
There were several ways the `keep` annotation was written

  * `build_cleaner: keep`
  * `build_cleaner keep`
  * `buildcleaner keep`
  * `buildcleaner: keep`

This unifies it to always be `buildcleaner: keep`.

Also, remove the `keep` comment in target `//src/cgt` as `bant dwyu` can recognize now the wrong from of including headers with angle brackets (here, it was `<tcl.h>`), and won't remove the dependency.
