### PR TITLE
rcx: remove hard-coded min/typ/max model indices

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2682,9 +2682,6 @@ class extMain
   double* _tmpResTable = new double[10];
   double* _tmpSumResTable = new double[10];
   int _sumUpdated;
-  int _minModelIndex;  // TO_TEST
-  int _typModelIndex;  //
-  int _maxModelIndex;  //
 
   odb::dbDatabase* _db = nullptr;
   odb::dbTech* _tech = nullptr;

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -700,7 +700,7 @@ void extMain::measureRC(CoupleOptions& options)
 
       _totCCcnt++;  // TO_TEST
 
-      if (m._rc[_minModelIndex]->coupling_ < _coupleThreshold) {  // TO_TEST
+      if (m._rc[0]->coupling_ < _coupleThreshold) {
         updateTotalCap(rseg1, &m, deltaFr, m._metRCTable.getCnt(), true);
         updateTotalCap(rseg2, &m, deltaFr, m._metRCTable.getCnt(), true);
 

--- a/src/rcx/src/extmain_v2.cpp
+++ b/src/rcx/src/extmain_v2.cpp
@@ -987,10 +987,6 @@ extRCModel* extMain::createCornerMap(const char* rulesFileName)
   // uint32_t cornerTable[10];
   uint32_t extCornerDbCnt = 0;
 
-  _minModelIndex = 0;
-  _maxModelIndex = 0;
-  _typModelIndex = 0;
-
   if (_processCornerTable != nullptr) {
     // User define process corners using <ext define_process_corner>
     for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1081,31 +1081,7 @@ int extMain::setMinTypMax(bool min,
   _modelMap.resetCnt(0);
   _metRCTable.resetCnt(0);
   _currentModel = nullptr;
-  if (extDbCnt > 1) {  // extract first <extDbCnt>
-    _block->setCornerCount(extDbCnt);
-    _extDbCnt = extDbCnt;
-
-    _modelMap.add(_minModelIndex);
-
-    _modelMap.add(_typModelIndex);
-
-    if (extDbCnt > 2) {
-      _modelMap.add(_maxModelIndex);
-    }
-  } else if (min || max || typ) {
-    if (min) {
-      _modelMap.add(_minModelIndex);
-    }
-    if (typ) {
-      _modelMap.add(_typModelIndex);
-    }
-    if (max) {
-      _modelMap.add(_maxModelIndex);
-    }
-    _extDbCnt = _modelMap.getCnt();
-
-    _block->setCornerCount(_extDbCnt);
-  } else if ((setMin >= 0) || (setMax >= 0) || (setTyp >= 0)) {
+  if ((setMin >= 0) || (setMax >= 0) || (setTyp >= 0)) {
     if (setMin >= 0) {
       _modelMap.add(setMin);
     }
@@ -1512,9 +1488,6 @@ bool extMain::setCorners(const char* rulesFileName)
     uint32_t cornerTable[10];
     uint32_t extDbCnt = 0;
 
-    _minModelIndex = 0;
-    _maxModelIndex = 0;
-    _typModelIndex = 0;
     if (_processCornerTable != nullptr) {
       for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {
         extCorner* s = _processCornerTable->get(ii);


### PR DESCRIPTION
## Summary
We have a somewhat hard-coded mechanism for single corner - the existence of these variable is not only conceptually odd, but also very confusing.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
