### PR TITLE
grt/cugr: keep GlobalRouter net state consistent on the CUGR incremental path

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -6369,12 +6369,20 @@ std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)
 
   if (use_cugr_) {
     cugr_->setVerbose(false);
-    for (odb::dbNet* net : dirty_nets_) {
-      cugr_->updateNet(net);
+    for (odb::dbNet* db_net : dirty_nets_) {
+      // Rebuild the GlobalRouter pin set from the netlist (as updateDirtyNets
+      // does for FastRoute); updatePinAccessPoints below fixes the positions.
+      Net* net = getNet(db_net);
+      updateNetPins(net);
+      net->setDirtyNet(false);
+      net->clearLastPinPositions();
+      cugr_->updateNet(db_net);
     }
     dirty_nets_.clear();
     cugr_->routeIncremental();
     routes_ = cugr_->getRoutes();
+    // Sync pin access points with CUGR's routing, as the full route does.
+    updatePinAccessPoints();
     return {};
   }
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -6369,6 +6369,8 @@ std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)
 
   if (use_cugr_) {
     cugr_->setVerbose(false);
+    std::vector<Net*> dirty_nets;
+    dirty_nets.reserve(dirty_nets_.size());
     for (odb::dbNet* db_net : dirty_nets_) {
       // Rebuild the GlobalRouter pin set from the netlist (as updateDirtyNets
       // does for FastRoute); updatePinAccessPoints below fixes the positions.
@@ -6377,13 +6379,14 @@ std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)
       net->setDirtyNet(false);
       net->clearLastPinPositions();
       cugr_->updateNet(db_net);
+      dirty_nets.push_back(net);
     }
     dirty_nets_.clear();
     cugr_->routeIncremental();
     routes_ = cugr_->getRoutes();
     // Sync pin access points with CUGR's routing, as the full route does.
     updatePinAccessPoints();
-    return {};
+    return dirty_nets;
   }
 
   std::vector<Net*> dirty_nets;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4805,6 +4805,12 @@ void GlobalRouter::removeNet(odb::dbNet* db_net)
 
   if (use_cugr_) {
     cugr_->removeNet(db_net);
+    auto it = db_net_map_.find(db_net);
+    if (it != db_net_map_.end()) {
+      delete it->second;
+      db_net_map_.erase(it);
+    }
+    routes_.erase(db_net);
   } else {
     auto it = db_net_map_.find(db_net);
     if (it == db_net_map_.end() || it->second == nullptr) {

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -1223,7 +1223,13 @@ void CUGR::getITermsAccessPoints(
     odb::dbNet* net,
     odb::PtrMap<odb::dbITerm, odb::Point3D>& access_points)
 {
-  GRNet* gr_net = db_net_map_.at(net);
+  // Nets absent from the map (e.g. < 2 pins, skipped by updateNet) have no
+  // CUGR access points; leave the output empty.
+  auto it = db_net_map_.find(net);
+  if (it == db_net_map_.end()) {
+    return;
+  }
+  GRNet* gr_net = it->second;
   for (const auto& [iterm, ap] : gr_net->getITermAccessPoints()) {
     const int x = grid_graph_->getGridline(0, ap.point.x());
     const int y = grid_graph_->getGridline(1, ap.point.y());
@@ -1235,7 +1241,11 @@ void CUGR::getBTermsAccessPoints(
     odb::dbNet* net,
     odb::PtrMap<odb::dbBTerm, odb::Point3D>& access_points)
 {
-  GRNet* gr_net = db_net_map_.at(net);
+  auto it = db_net_map_.find(net);
+  if (it == db_net_map_.end()) {
+    return;
+  }
+  GRNet* gr_net = it->second;
   for (const auto& [bterm, ap] : gr_net->getBTermAccessPoints()) {
     const int x = grid_graph_->getGridline(0, ap.point.x());
     const int y = grid_graph_->getGridline(1, ap.point.y());


### PR DESCRIPTION
## Summary
When CUGR is the incremental global router, `GlobalRouter` keeps its own per-net state (`db_net_map_`, `routes_`, and the `grt::Net` pin/access-point data) in parallel with CUGR's. On the `use_cugr_` branch this state was not fully synchronized when nets are destroyed or updated during incremental routing. This PR fixes this desync issue.

- **`removeNet` (CUGR path):** after `cugr_->removeNet()`, release the GlobalRouter-side state too — delete the `grt::Net` and erase the net's `db_net_map_` and `routes_` entries. Previously these lingered after a net was destroyed (e.g. buffer removal during an rsz journal restore), leaving a dangling `grt::Net*` and stale route/map entries.

- **`updateDirtyRoutes` (CUGR path):** rebuild each dirty net's pin set with `updateNetPins()` and clear its dirty flags before `cugr_->updateNet()`, then call `updatePinAccessPoints()` after `routeIncremental()` — mirroring the full-route path and FastRoute's `updateDirtyNets()`, so GlobalRouter's pin positions/layers match the route CUGR actually produced.

This is the base of a stacked series that builds out CUGR incremental routing.

## Type of Change
- Bug fix

## Impact
Correctness/consistency only — no routing-algorithm change and no QoR impact.
Removes a dangling `grt::Net*` and stale `db_net_map_`/`routes_` entries after
CUGR net destruction, and keeps GlobalRouter pin state aligned with CUGR after
incremental updates. Behavior on the FastRoute path is unchanged (all edits are
under `use_cugr_`).

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ ] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
