### PR TITLE
rsz: Avoid SIGILL in net tree stitching if subtree can't build

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -6751,6 +6751,9 @@ bool Resizer::estimateSlewsAfterBufferRemoval(
 
   BnetPtr tree1 = makeBufferedNet(drvr_pin, corner);
   BnetPtr tree2 = makeBufferedNet(buffer_drvr_pin, corner);
+  if (!tree1 || !tree2) {
+    return false;
+  }
   BnetPtr stitched_tree = stitchTrees(tree1, buffer_load_pin, tree2);
 
   if (stitched_tree == tree1) {


### PR DESCRIPTION
## Summary
This can happen when calling repair_timing on a pre-placement netlist where buffered nets can fail to build if estimate_parasitics -placement was called.

## Type of Change
- Bug fix

## Impact
[How does this change the tool's behavior?]
Avoids crashes of the form:
```
[INFO RSZ-0099] Repairing XXX out of XXX (100.00%) violating endpoints...
   Iter   | Removed | Resized | Inserted | Cloned |  Pin  |   Area   |    WNS   |   StTNS    |   EnTNS    |  Viol  |  Worst  
          | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |          |            |            | Endpts | St/EnPt 
------------------------------------------------------------------------------------------------------------------------------
       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -X.XXX |     -XXX.X |     -XXX.X |    XXX | X
[WARNING RSZ-0075] makeBufferedNet failed for driver gain22/Z
[WARNING RSZ-0075] makeBufferedNet failed for driver _34181_/ZN
[WARNING RSZ-0075] makeBufferedNet failed for driver _34273_/ZN
SIGSEGV (@0x4)
rsz::Resizer::stitchTrees()::$_0::operator()<>()
rsz::Resizer::stitchTrees()::$_0::operator()<>()
rsz::Resizer::stitchTrees()::$_0::operator()<>()
rsz::Resizer::stitchTrees()
rsz::Resizer::estimateSlewsAfterBufferRemoval()
rsz::Resizer::estimatedSlackOK()
rsz::(anonymous namespace)::passesSlackGuard()
rsz::UnbufferGenerator::generate()
rsz::SetupLegacyBase::tryCandidateSequence()
rsz::SetupLegacyBase::tryRepairTarget()
rsz::SetupLegacyBase::repairPath()
rsz::SetupLegacyPolicy::repairEndpoint()
rsz::SetupLegacyPolicy::runMainRepairLoop()
rsz::SetupLegacyPolicy::iterate()
rsz::Optimizer::run()
rsz::Resizer::repairSetup()
_wrap_repair_setup()
TclEvalEx
Tcl_Eval
sta::sourceTclFile()
ord::tclInit()
ord::tclAppInit()
Tcl_MainEx
main
```

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
