### PR TITLE
rcx: refactor to isolate extraction rules parsing logic into its own function

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1827,7 +1827,7 @@ class extMain
                                const char* prefix,
                                const char* postfix,
                                bool v = false);
-  bool modelExists(const char* extRules);
+  bool modelExists();
 
   void addInstsGeometries(const Array1D<uint32_t>* instTable,
                           Array1D<uint32_t>* tmpInstIdTable,
@@ -2719,7 +2719,6 @@ class extMain
   int _ccMaxY;
   double _mergeResBound = 0.0;
   bool _mergeViaRes = false;
-  const char* rules_file_{nullptr};
   const char* target_nets_names_{nullptr};
   bool _mergeParallelCC = false;
   bool _reportNetNoWire = false;

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2267,7 +2267,14 @@ class extMain
   void cleanCornerTables();
   int getDbCornerIndex(const char* name);
   int getDbCornerModel(const char* name);
-  bool setCorners(const char* rulesFileName);
+  void resetState();
+  static std::unique_ptr<extRCModel> parseRules(
+      const char* rules_file_path,
+      odb::dbTech* tech,
+      const Array1D<extCorner*>* process_corner_table,
+      bool is_v2,
+      utl::Logger* logger);
+  void registerRulesModel(std::unique_ptr<extRCModel> rules_model);
   int getProcessCornerDbIndex(int pcidx);
   void getScaledCornerDbIndex(int pcidx, int& scidx, int& scdbIdx);
   void getScaledRC(int sidx, double& res, double& cap);

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2267,13 +2267,7 @@ class extMain
   void cleanCornerTables();
   int getDbCornerIndex(const char* name);
   int getDbCornerModel(const char* name);
-  void resetState();
-  static std::unique_ptr<extRCModel> parseRules(
-      odb::dbTech* tech,
-      const Array1D<extCorner*>* process_corner_table,
-      bool is_v2,
-      utl::Logger* logger);
-  void registerRulesModel(std::unique_ptr<extRCModel> rules_model);
+  void registerRulesModel(extRCModel* rules_model);
   int getProcessCornerDbIndex(int pcidx);
   void getScaledCornerDbIndex(int pcidx, int& scidx, int& scdbIdx);
   void getScaledRC(int sidx, double& res, double& cap);
@@ -2833,5 +2827,11 @@ class extMain
                              dbCreateNetUtil* db_net_util);  // 061123
   // ---------------------------------------------------------
 };
+
+std::unique_ptr<extRCModel> parseRules(
+    odb::dbTech* tech,
+    const Array1D<extCorner*>* extractor_corner_table,
+    bool is_v2,
+    utl::Logger* logger);
 
 }  // namespace rcx

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2269,7 +2269,6 @@ class extMain
   int getDbCornerModel(const char* name);
   void resetState();
   static std::unique_ptr<extRCModel> parseRules(
-      const char* rules_file,
       odb::dbTech* tech,
       const Array1D<extCorner*>* process_corner_table,
       bool is_v2,

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2269,7 +2269,7 @@ class extMain
   int getDbCornerModel(const char* name);
   void resetState();
   static std::unique_ptr<extRCModel> parseRules(
-      const char* rules_file_path,
+      const char* rules_file,
       odb::dbTech* tech,
       const Array1D<extCorner*>* process_corner_table,
       bool is_v2,
@@ -2720,7 +2720,7 @@ class extMain
   int _ccMaxY;
   double _mergeResBound = 0.0;
   bool _mergeViaRes = false;
-  const char* rules_file_path_{nullptr};
+  const char* rules_file_{nullptr};
   const char* target_nets_names_{nullptr};
   bool _mergeParallelCC = false;
   bool _reportNetNoWire = false;

--- a/src/rcx/src/OpenRCX.tcl
+++ b/src/rcx/src/OpenRCX.tcl
@@ -83,13 +83,7 @@ proc extract_parasitics { args } {
 
   set ext_model_file ""
   if { [info exists keys(-ext_model_file)] } {
-    utl::warn RCX 514 "The -ext_model_file option is deprecated. Use\
-                       set_extraction_rules_file command instead."
-
-    # We may have multiple technologies loaded, so use the current block's
-    # tech to prevent an error resolving an ambiguous default tech.
-    set tech [[ord::get_db_block] getTech]
-    set_extraction_rules_file -tech [$tech getName] $keys(-ext_model_file)
+    set ext_model_file $keys(-ext_model_file)
   }
 
   set corner_cnt 1

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -216,7 +216,17 @@ void Ext::extract(ExtractOptions options)
 
   odb::orderWires(logger_, block);
 
-  std::string rules_file = block->getTech()->getExtractionRulesFile();
+  odb::dbTech* tech = block->getTech();
+  if (options.ext_model_file != nullptr && options.ext_model_file[0] != '\0') {
+    logger_->warn(RCX,
+                  514,
+                  "The ext_model_file option is deprecated. Use "
+                  "set_extraction_rules_file command instead.");
+
+    tech->setExtractionRulesFile(options.ext_model_file);
+  }
+
+  std::string rules_file = tech->getExtractionRulesFile();
   if (!rules_file.empty()) {
     options.ext_model_file = rules_file.c_str();
   }

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -43,7 +43,7 @@ void extMain::setExtractionOptions(const ExtractOptions& options)
   _lef_res = options.lef_res;
   _lefRC = options.lef_rc;
   _dbgOption = options._dbg;
-  rules_file_path_ = options.ext_model_file;
+  rules_file_ = options.ext_model_file;
   target_nets_names_ = options.net;
 }
 

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -43,7 +43,6 @@ void extMain::setExtractionOptions(const ExtractOptions& options)
   _lef_res = options.lef_res;
   _lefRC = options.lef_rc;
   _dbgOption = options._dbg;
-  rules_file_ = options.ext_model_file;
   target_nets_names_ = options.net;
 }
 

--- a/src/rcx/src/extmain_v2.cpp
+++ b/src/rcx/src/extmain_v2.cpp
@@ -72,7 +72,7 @@ void extMain::makeBlockRCsegs_v2(const char* netNames, const char* extRules)
   // Model file is required if not option _lefRC is used.
   // _lefRC option requires Resistance and Capacitance values per Layer and
   // Technology to be taken from LEF file.
-  if (!_lefRC && !modelExists(extRules)) {
+  if (!_lefRC && !modelExists()) {
     return;
   }
 

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1509,6 +1509,12 @@ std::unique_ptr<extRCModel> extMain::parseRules(
   }
 
   const std::string rules_file = tech->getExtractionRulesFile();
+  if (rules_file.empty()) {
+    logger->error(RCX,
+                  17,
+                  "Could not parse extraction rules. No extraction rules file "
+                  "specified. Use set_extraction_rules_file to specify it.");
+  }
 
   logger->info(RCX, 435, "Reading extraction model file {} ...", rules_file);
 
@@ -1655,10 +1661,10 @@ void extMain::getPrevControl()
   _ccNoPowerTarget = _prevControl->_ccNoPowerTarget;
   _usingMetalPlanes = _prevControl->_usingMetalPlanes;
 }
-bool extMain::modelExists(const char* extRules)
+bool extMain::modelExists()
 {
   if ((_prevControl->_ruleFileName.empty()) && (getRCmodel(0) == nullptr)
-      && (extRules == nullptr)) {
+      && (_block->getTech()->getExtractionRulesFile().empty())) {
     logger_->warn(RCX,
                   127,
                   "No RC model was read with command <load_model>, "
@@ -1670,7 +1676,7 @@ bool extMain::modelExists(const char* extRules)
 
 void extMain::makeBlockRCsegs()
 {
-  if (!modelExists(rules_file_)) {
+  if (!modelExists()) {
     return;
   }
 
@@ -1679,8 +1685,10 @@ void extMain::makeBlockRCsegs()
   _diagFlow = true;
   _usingMetalPlanes = true;
 
+  const bool has_rules_file
+      = !_block->getTech()->getExtractionRulesFile().empty();
   if ((_processCornerTable != nullptr)
-      || ((_processCornerTable == nullptr) && (rules_file_ != nullptr))) {
+      || ((_processCornerTable == nullptr) && has_rules_file)) {
     resetState();
 
     std::unique_ptr<extRCModel> rules_model

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1479,7 +1479,7 @@ void extMain::resetState()
 }
 
 std::unique_ptr<extRCModel> extMain::parseRules(
-    const char* rules_file_path,
+    const char* rules_file,
     odb::dbTech* tech,
     const Array1D<extCorner*>* process_corner_table,
     bool is_v2,
@@ -1509,23 +1509,21 @@ std::unique_ptr<extRCModel> extMain::parseRules(
     }
   }
 
-  logger->info(
-      RCX, 435, "Reading extraction model file {} ...", rules_file_path);
+  logger->info(RCX, 435, "Reading extraction model file {} ...", rules_file);
 
-  FILE* rules_file = fopen(rules_file_path, "r");
-  if (rules_file == nullptr) {
-    logger->error(
-        RCX, 468, "Can't open extraction model file {}", rules_file_path);
+  FILE* file = fopen(rules_file, "r");
+  if (file == nullptr) {
+    logger->error(RCX, 468, "Can't open extraction model file {}", rules_file);
   }
 
-  fclose(rules_file);
+  fclose(file);
 
   const bool is_v2_rules_file
-      = model->isRulesFile_v2((char*) rules_file_path, false);
+      = model->isRulesFile_v2((char*) rules_file, false);
 
   if (is_v2 || is_v2_rules_file) {
     model->_v2_flow = is_v2;
-    if (!model->readRules((char*) rules_file_path,
+    if (!model->readRules((char*) rules_file,
                           false,
                           true,
                           true,
@@ -1534,13 +1532,11 @@ std::unique_ptr<extRCModel> extMain::parseRules(
                           corner_count,
                           corner_table,
                           rules_to_dbu_scale)) {
-      logger->error(RCX,
-                    14,
-                    "Failed to parse extraction model file {}",
-                    rules_file_path);
+      logger->error(
+          RCX, 14, "Failed to parse extraction model file {}", rules_file);
     }
   } else {
-    if (!model->readRules_v1((char*) rules_file_path,
+    if (!model->readRules_v1((char*) rules_file,
                              false,
                              true,
                              true,
@@ -1549,10 +1545,8 @@ std::unique_ptr<extRCModel> extMain::parseRules(
                              corner_count,
                              corner_table,
                              rules_to_dbu_scale)) {
-      logger->error(RCX,
-                    15,
-                    "Failed to parse extraction model file {}",
-                    rules_file_path);
+      logger->error(
+          RCX, 15, "Failed to parse extraction model file {}", rules_file);
     }
   }
 
@@ -1675,7 +1669,7 @@ bool extMain::modelExists(const char* extRules)
 
 void extMain::makeBlockRCsegs()
 {
-  if (!modelExists(rules_file_path_)) {
+  if (!modelExists(rules_file_)) {
     return;
   }
 
@@ -1685,15 +1679,14 @@ void extMain::makeBlockRCsegs()
   _usingMetalPlanes = true;
 
   if ((_processCornerTable != nullptr)
-      || ((_processCornerTable == nullptr) && (rules_file_path_ != nullptr))) {
-    const char* rules_file_path = rules_file_path_
-                                      ? rules_file_path_
-                                      : _prevControl->_ruleFileName.c_str();
+      || ((_processCornerTable == nullptr) && (rules_file_ != nullptr))) {
+    const char* rules_file
+        = rules_file_ ? rules_file_ : _prevControl->_ruleFileName.c_str();
 
     resetState();
 
     std::unique_ptr<extRCModel> rules_model = parseRules(
-        rules_file_path, _block->getTech(), _processCornerTable, _v2, logger_);
+        rules_file, _block->getTech(), _processCornerTable, _v2, logger_);
     registerRulesModel(std::move(rules_model));
 
     uint32_t scaled_corner_count = 0;

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1489,13 +1489,11 @@ std::unique_ptr<extRCModel> parseRules(
 
   auto model = std::make_unique<extRCModel>("MINTYPMAX", logger);
 
-  constexpr int max_corners = 10;
-  uint32_t corner_table[max_corners];
-  uint32_t corner_count = 0;
+  std::vector<uint32_t> corner_table;
   if (extractor_corner_table) {
     for (uint32_t ii = 0; ii < extractor_corner_table->getCnt(); ii++) {
       extCorner* corner = extractor_corner_table->get(ii);
-      corner_table[corner_count++] = corner->_model;
+      corner_table.push_back(corner->_model);
     }
   }
 
@@ -1527,8 +1525,8 @@ std::unique_ptr<extRCModel> parseRules(
                           true,
                           true,
                           true,
-                          corner_count,
-                          corner_table,
+                          corner_table.size(),
+                          corner_table.data(),
                           rules_to_dbu_scale)) {
       logger->error(
           RCX, 14, "Failed to parse extraction model file {}", rules_file);
@@ -1540,8 +1538,8 @@ std::unique_ptr<extRCModel> parseRules(
                              true,
                              true,
                              true,
-                             corner_count,
-                             corner_table,
+                             corner_table.size(),
+                             corner_table.data(),
                              rules_to_dbu_scale)) {
       logger->error(
           RCX, 15, "Failed to parse extraction model file {}", rules_file);

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1479,7 +1479,6 @@ void extMain::resetState()
 }
 
 std::unique_ptr<extRCModel> extMain::parseRules(
-    const char* rules_file,
     odb::dbTech* tech,
     const Array1D<extCorner*>* process_corner_table,
     bool is_v2,
@@ -1509,9 +1508,11 @@ std::unique_ptr<extRCModel> extMain::parseRules(
     }
   }
 
+  const std::string rules_file = tech->getExtractionRulesFile();
+
   logger->info(RCX, 435, "Reading extraction model file {} ...", rules_file);
 
-  FILE* file = fopen(rules_file, "r");
+  FILE* file = fopen(rules_file.c_str(), "r");
   if (file == nullptr) {
     logger->error(RCX, 468, "Can't open extraction model file {}", rules_file);
   }
@@ -1519,11 +1520,11 @@ std::unique_ptr<extRCModel> extMain::parseRules(
   fclose(file);
 
   const bool is_v2_rules_file
-      = model->isRulesFile_v2((char*) rules_file, false);
+      = model->isRulesFile_v2((char*) rules_file.c_str(), false);
 
   if (is_v2 || is_v2_rules_file) {
     model->_v2_flow = is_v2;
-    if (!model->readRules((char*) rules_file,
+    if (!model->readRules((char*) rules_file.c_str(),
                           false,
                           true,
                           true,
@@ -1536,7 +1537,7 @@ std::unique_ptr<extRCModel> extMain::parseRules(
           RCX, 14, "Failed to parse extraction model file {}", rules_file);
     }
   } else {
-    if (!model->readRules_v1((char*) rules_file,
+    if (!model->readRules_v1((char*) rules_file.c_str(),
                              false,
                              true,
                              true,
@@ -1680,13 +1681,10 @@ void extMain::makeBlockRCsegs()
 
   if ((_processCornerTable != nullptr)
       || ((_processCornerTable == nullptr) && (rules_file_ != nullptr))) {
-    const char* rules_file
-        = rules_file_ ? rules_file_ : _prevControl->_ruleFileName.c_str();
-
     resetState();
 
-    std::unique_ptr<extRCModel> rules_model = parseRules(
-        rules_file, _block->getTech(), _processCornerTable, _v2, logger_);
+    std::unique_ptr<extRCModel> rules_model
+        = parseRules(_block->getTech(), _processCornerTable, _v2, logger_);
     registerRulesModel(std::move(rules_model));
 
     uint32_t scaled_corner_count = 0;

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1469,88 +1469,123 @@ void extMain::makeCornerNameMap()
   updatePrevControl();
 }
 
-bool extMain::setCorners(const char* rulesFileName)
+void extMain::resetState()
 {
   _modelMap.resetCnt(0);
   _metRCTable.resetCnt(0);
+  _minModelIndex = 0;
+  _maxModelIndex = 0;
+  _typModelIndex = 0;
+}
 
-  if (rulesFileName != nullptr) {  // read rules
+std::unique_ptr<extRCModel> extMain::parseRules(
+    const char* rules_file_path,
+    odb::dbTech* tech,
+    const Array1D<extCorner*>* process_corner_table,
+    bool is_v2,
+    utl::Logger* logger)
+{
+  // Rules files are written assuming this DBU-per-micron resolution; the
+  // tech may use a finer one, in which case rules-file values are scaled
+  // up when read.
+  constexpr int rules_file_dbu_per_micron = 1000;
+  const int tech_dbu_per_micron = tech->getDbUnitsPerMicron();
+  double rules_to_dbu_scale = 1.0;
 
-    int dbunit = _block->getDbUnitsPerMicron();
-    double dbFactor = 1;
-    if (dbunit > 1000) {
-      dbFactor = dbunit * 0.001;
-    }
+  if (tech_dbu_per_micron > rules_file_dbu_per_micron) {
+    rules_to_dbu_scale
+        = static_cast<double>(tech_dbu_per_micron) / rules_file_dbu_per_micron;
+  }
 
-    extRCModel* m = new extRCModel("MINTYPMAX", logger_);
-    _modelTable->add(m);
+  auto model = std::make_unique<extRCModel>("MINTYPMAX", logger);
 
-    uint32_t cornerTable[10];
-    uint32_t extDbCnt = 0;
-
-    if (_processCornerTable != nullptr) {
-      for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {
-        extCorner* s = _processCornerTable->get(ii);
-        cornerTable[extDbCnt++] = s->_model;
-        _modelMap.add(ii);
-      }
-    }
-
-    logger_->info(
-        RCX, 435, "Reading extraction model file {} ...", rulesFileName);
-
-    FILE* rules_file = fopen(rulesFileName, "r");
-    if (rules_file == nullptr) {
-      logger_->error(
-          RCX, 468, "Can't open extraction model file {}", rulesFileName);
-    }
-    fclose(rules_file);
-    bool v2_rules_file = m->isRulesFile_v2((char*) rulesFileName, false);
-
-    if (_v2 || v2_rules_file) {
-      m->_v2_flow = _v2;
-
-      if (!(m->readRules((char*) rulesFileName,
-                         false,
-                         true,
-                         true,
-                         true,
-                         true,
-                         extDbCnt,
-                         cornerTable,
-                         dbFactor))) {
-        return false;
-      }
-    } else {
-      if (!(m->readRules_v1((char*) rulesFileName,
-                            false,
-                            true,
-                            true,
-                            true,
-                            true,
-                            extDbCnt,
-                            cornerTable,
-                            dbFactor))) {
-        return false;
-      }
-    }
-    int modelCnt = getRCmodel(0)->getModelCnt();
-
-    // If RCX reads wrong extRules file format
-    if (modelCnt == 0) {
-      logger_->error(RCX,
-                     487,
-                     "No RC model read from the extraction model! "
-                     "Ensure the right extRules file is used!");
-    }
-    if (_processCornerTable == nullptr) {
-      for (int ii = 0; ii < modelCnt; ii++) {
-        addRCCorner(nullptr, ii, 0);
-        _modelMap.add(ii);
-      }
+  constexpr int max_corners = 10;
+  uint32_t corner_table[max_corners];
+  uint32_t corner_count = 0;
+  if (process_corner_table != nullptr) {
+    for (uint32_t ii = 0; ii < process_corner_table->getCnt(); ii++) {
+      extCorner* corner = process_corner_table->get(ii);
+      corner_table[corner_count++] = corner->_model;
     }
   }
+
+  logger->info(
+      RCX, 435, "Reading extraction model file {} ...", rules_file_path);
+
+  FILE* rules_file = fopen(rules_file_path, "r");
+  if (rules_file == nullptr) {
+    logger->error(
+        RCX, 468, "Can't open extraction model file {}", rules_file_path);
+  }
+
+  fclose(rules_file);
+
+  const bool is_v2_rules_file
+      = model->isRulesFile_v2((char*) rules_file_path, false);
+
+  if (is_v2 || is_v2_rules_file) {
+    model->_v2_flow = is_v2;
+    if (!model->readRules((char*) rules_file_path,
+                          false,
+                          true,
+                          true,
+                          true,
+                          true,
+                          corner_count,
+                          corner_table,
+                          rules_to_dbu_scale)) {
+      logger->error(RCX,
+                    14,
+                    "Failed to parse extraction model file {}",
+                    rules_file_path);
+    }
+  } else {
+    if (!model->readRules_v1((char*) rules_file_path,
+                             false,
+                             true,
+                             true,
+                             true,
+                             true,
+                             corner_count,
+                             corner_table,
+                             rules_to_dbu_scale)) {
+      logger->error(RCX,
+                    15,
+                    "Failed to parse extraction model file {}",
+                    rules_file_path);
+    }
+  }
+
+  if (model->getModelCnt() == 0) {
+    logger->error(RCX,
+                  487,
+                  "No RC model read from the extraction model! "
+                  "Ensure the right extRules file is used!");
+  }
+
+  return model;
+}
+
+void extMain::registerRulesModel(std::unique_ptr<extRCModel> rules_model)
+{
+  if (_processCornerTable != nullptr) {
+    for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {
+      _modelMap.add(ii);
+    }
+  }
+
+  _modelTable->add(rules_model.release());
+
+  if (_processCornerTable == nullptr) {
+    const int modelCnt = getRCmodel(0)->getModelCnt();
+    for (int ii = 0; ii < modelCnt; ii++) {
+      addRCCorner(nullptr, ii, 0);
+      _modelMap.add(ii);
+    }
+  }
+
   _currentModel = getRCmodel(0);
+
   if (_v2) {
     if (_processCornerTable != nullptr && _couplingFlag > 0) {
       for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {
@@ -1566,18 +1601,8 @@ bool extMain::setCorners(const char* rulesFileName)
       _metRCTable.add(_currentModel->getMetRCTable(jj));
     }
   }
+
   _extDbCnt = _processCornerTable->getCnt();
-
-#ifndef NDEBUG
-  uint32_t scaleCornerCnt = 0;
-  if (_scaledCornerTable != nullptr) {
-    scaleCornerCnt = _scaledCornerTable->getCnt();
-  }
-  assert(_cornerCnt == _extDbCnt + scaleCornerCnt);
-#endif
-
-  _block->setCornerCount(_cornerCnt, _extDbCnt, nullptr);
-  return true;
 }
 
 void extMain::addDummyCorners(uint32_t cornerCnt)
@@ -1665,11 +1690,28 @@ void extMain::makeBlockRCsegs()
                                       ? rules_file_path_
                                       : _prevControl->_ruleFileName.c_str();
 
-    // Reading model file
-    if (!setCorners(rules_file_path)) {
-      logger_->info(RCX, 128, "skipping Extraction ...");
-      return;
+    resetState();
+
+    std::unique_ptr<extRCModel> rules_model = parseRules(
+        rules_file_path, _block->getTech(), _processCornerTable, _v2, logger_);
+    registerRulesModel(std::move(rules_model));
+
+    uint32_t scaled_corner_count = 0;
+    if (_scaledCornerTable != nullptr) {
+      scaled_corner_count = _scaledCornerTable->getCnt();
     }
+
+    if (_cornerCnt != _extDbCnt + scaled_corner_count) {
+      logger_->error(RCX,
+                     16,
+                     "Corner count invariant violated: total corners ({}) != "
+                     "process corners ({}) + scaled corners ({})",
+                     _cornerCnt,
+                     _extDbCnt,
+                     scaled_corner_count);
+    }
+
+    _block->setCornerCount(_cornerCnt, _extDbCnt, nullptr);
   } else if (setMinTypMax(false, false, false, -1, -1, -1, 1) < 0) {
     logger_->warn(RCX, 129, "Wrong combination of corner related options!");
     return;

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1469,18 +1469,9 @@ void extMain::makeCornerNameMap()
   updatePrevControl();
 }
 
-void extMain::resetState()
-{
-  _modelMap.resetCnt(0);
-  _metRCTable.resetCnt(0);
-  _minModelIndex = 0;
-  _maxModelIndex = 0;
-  _typModelIndex = 0;
-}
-
-std::unique_ptr<extRCModel> extMain::parseRules(
+std::unique_ptr<extRCModel> parseRules(
     odb::dbTech* tech,
-    const Array1D<extCorner*>* process_corner_table,
+    const Array1D<extCorner*>* extractor_corner_table,
     bool is_v2,
     utl::Logger* logger)
 {
@@ -1501,9 +1492,9 @@ std::unique_ptr<extRCModel> extMain::parseRules(
   constexpr int max_corners = 10;
   uint32_t corner_table[max_corners];
   uint32_t corner_count = 0;
-  if (process_corner_table != nullptr) {
-    for (uint32_t ii = 0; ii < process_corner_table->getCnt(); ii++) {
-      extCorner* corner = process_corner_table->get(ii);
+  if (extractor_corner_table) {
+    for (uint32_t ii = 0; ii < extractor_corner_table->getCnt(); ii++) {
+      extCorner* corner = extractor_corner_table->get(ii);
       corner_table[corner_count++] = corner->_model;
     }
   }
@@ -1567,15 +1558,23 @@ std::unique_ptr<extRCModel> extMain::parseRules(
   return model;
 }
 
-void extMain::registerRulesModel(std::unique_ptr<extRCModel> rules_model)
+void extMain::registerRulesModel(extRCModel* rules_model)
 {
+  // Differently from the other corner-related structures, the
+  // list of models is cleared at the end of the extraction flow.
+  _modelTable->add(rules_model);
+
+  // Clear rules data per corner.
+  _metRCTable.resetCnt(0);
+
+  // Clear corner -> model mapping.
+  _modelMap.resetCnt(0);
+
   if (_processCornerTable != nullptr) {
     for (uint32_t ii = 0; ii < _processCornerTable->getCnt(); ii++) {
       _modelMap.add(ii);
     }
   }
-
-  _modelTable->add(rules_model.release());
 
   if (_processCornerTable == nullptr) {
     const int modelCnt = getRCmodel(0)->getModelCnt();
@@ -1685,15 +1684,14 @@ void extMain::makeBlockRCsegs()
   _diagFlow = true;
   _usingMetalPlanes = true;
 
-  const bool has_rules_file
-      = !_block->getTech()->getExtractionRulesFile().empty();
+  odb::dbTech* tech = _block->getTech();
+  const bool has_rules_file = !tech->getExtractionRulesFile().empty();
+
   if ((_processCornerTable != nullptr)
       || ((_processCornerTable == nullptr) && has_rules_file)) {
-    resetState();
-
     std::unique_ptr<extRCModel> rules_model
-        = parseRules(_block->getTech(), _processCornerTable, _v2, logger_);
-    registerRulesModel(std::move(rules_model));
+        = parseRules(tech, _processCornerTable, _v2, logger_);
+    registerRulesModel(rules_model.release());
 
     uint32_t scaled_corner_count = 0;
     if (_scaledCornerTable != nullptr) {

--- a/src/rcx/test/rcx_aux.py
+++ b/src/rcx/test/rcx_aux.py
@@ -1,4 +1,3 @@
-import utl
 import rcx
 
 # Thin wrapper over api defined in ext.i (and reused by ext-py.i)
@@ -28,20 +27,10 @@ def extract_parasitics(
     dbg=0
 ):
 
-    if ext_model_file is not None:
-        utl.warn(
-            utl.RCX,
-            514,
-            "The ext_model_file option is deprecated. Use "
-            "set_extraction_rules_file command instead.",
-        )
-
-        # We may have multiple technologies loaded, so use the current block's
-        # tech to prevent an error resolving an ambiguous default tech.
-        db_tech = design.getBlock().getTech()
-        db_tech.setExtractionRulesFile(ext_model_file)
-
     opts = rcx.ExtractOptions()
+
+    if ext_model_file is not None:
+        opts.ext_model_file = ext_model_file
 
     opts.corner_cnt = corner_cnt
     opts.corner = corner


### PR DESCRIPTION
## Summary
The multi chip extractor will be the owner of the rules model (the internal representation of the extraction rules).

What's really going on here is: the function `setCorners` is being split as it was doing several things at the same time:
1. Parsing extraction rules. **Now isolated in `parseRules`.**
2. Initializing the internal structures according to the number of corners and the rules data. **Now isolated in `registerRulesModel`.**
3. Scaled corner count assertion. **This was under a debug flag - I made it an actual error.**
4. Setting the number of process corners inside ODB. **This is a legacy operation that, once we redefine the architecture used for the process corners, should go away.**

This PR also:
 - Makes `dbTech` the source of truth for the extraction rules file.
 - Moves the deprecation warning from .tcl / .py into the extract pass to both remove duplicated warnings and guarantee that, if the user calls the SWIG API directly, we fallback accordingly.

The result of this refactoring is far from ideal. In other to fully address the multiple inconsistencies that exist in the code, we'll need considerably more refactoring rounds. As the current priority is 3D extraction, I'll tackle this in the future.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**