### PR TITLE
bazel: fix hermetic ASan builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -120,7 +120,11 @@ build:macos --host_macos_minimum_os=13.3
 
 # Settings for --config=asan address sanitizer build
 build:asan --strip=never
-build:asan --copt=-fsanitize=address
+# Use hermetic LLVM's sanitizer setting so compiler-rt is built and staged in
+# the toolchain resource directory. external_include_paths is incompatible
+# with compiler-rt's internal LLVM header dependencies.
+build:asan --@llvm//config:asan=true
+build:asan --features=-external_include_paths
 build:asan --copt=-DADDRESS_SANITIZER
 build:asan --copt=-O1
 build:asan --copt=-g
@@ -128,7 +132,6 @@ build:asan --copt=-fno-omit-frame-pointer
 # Compress the DWARF debug sections (transparent to gdb/perf/addr2line).
 build:asan --copt=-gz=zlib
 build:asan --linkopt=-gz=zlib
-build:asan --linkopt=-fsanitize=address
 # TCMalloc is incompatible with ASan: __asan_init's interceptor setup calls
 # dlsym -> malloc before TCMalloc is initialized, segfaulting at startup.
 # Override the per-target malloc attribute to use the system allocator, which

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 # Test Parity Note: All tests from CMakeLists.txt are included in this BUILD file.
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "doc_check_test", "openroad_py_test", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -26,7 +26,7 @@ py_library(
     imports = ["."],
 )
 
-py_test(
+openroad_py_test(
     name = "test_block",
     srcs = [
         "test_block.py",
@@ -39,7 +39,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_bterm",
     srcs = [
         "test_bterm.py",
@@ -52,7 +52,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_destroy",
     srcs = [
         "test_destroy.py",
@@ -65,7 +65,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_group",
     srcs = [
         "test_group.py",
@@ -78,7 +78,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_inst",
     srcs = [
         "test_inst.py",
@@ -91,7 +91,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_iterm",
     srcs = [
         "test_iterm.py",
@@ -104,7 +104,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_module",
     srcs = [
         "test_module.py",
@@ -117,7 +117,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_net",
     srcs = [
         "test_net.py",
@@ -130,7 +130,7 @@ py_test(
     ],
 )
 
-py_test(
+openroad_py_test(
     name = "test_wire_codec",
     srcs = [
         "test_wire_codec.py",

--- a/test/bazel_test.sh
+++ b/test/bazel_test.sh
@@ -16,7 +16,7 @@ if [ -n "${ASAN_PRELOAD:-}" ]; then
 		resolved_preload="${resolved_preload:+${resolved_preload}:}${runtime}"
 	done
 	IFS="${old_ifs}"
-	export LD_PRELOAD="${resolved_preload}${LD_PRELOAD:+:${LD_PRELOAD}}"
+	export ASAN_PRELOAD="${resolved_preload}"
 fi
 if [ -n "${TEST_SRCDIR:-}" ]; then
 	export BAZEL_TEST=1

--- a/test/bazel_test.sh
+++ b/test/bazel_test.sh
@@ -7,6 +7,17 @@ export TEST_NAME=$(basename "$TEST_FILE" .$TEST_EXT)
 [ -n "$OPENROAD_EXE" ] && export OPENROAD_EXE=$(realpath $OPENROAD_EXE)
 export RESULTS_DIR="${TEST_UNDECLARED_OUTPUTS_DIR}/results"
 export REGRESSION_TEST=$(realpath $REGRESSION_TEST)
+if [ -n "${ASAN_PRELOAD:-}" ]; then
+	resolved_preload=""
+	old_ifs="${IFS}"
+	IFS=:
+	for runtime in ${ASAN_PRELOAD}; do
+		runtime=$(realpath "${runtime}")
+		resolved_preload="${resolved_preload:+${resolved_preload}:}${runtime}"
+	done
+	IFS="${old_ifs}"
+	export LD_PRELOAD="${resolved_preload}${LD_PRELOAD:+:${LD_PRELOAD}}"
+fi
 if [ -n "${TEST_SRCDIR:-}" ]; then
 	export BAZEL_TEST=1
 	# Tests cd into their source directory, so importing a shared helper

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -11,9 +11,10 @@ and messages_txt for generating messages.txt from source files."""
 load("@rules_python//python:defs.bzl", "py_test")
 
 _ASAN_RUNTIMES = [
+    "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
+    "@llvm//runtimes/libunwind:libunwind.shared",
     "@llvm//runtimes/libcxx:libcxxabi.shared",
     "@llvm//runtimes/libcxx:libcxx.shared",
-    "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
 ]
 
 def openroad_py_test(name, data = [], **kwargs):

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -8,6 +8,34 @@ Also provides doc_check_test for lightweight Python-only
 documentation tests that do not require the OpenROAD binary,
 and messages_txt for generating messages.txt from source files."""
 
+load("@rules_python//python:defs.bzl", "py_test")
+
+_ASAN_RUNTIMES = [
+    "@llvm//runtimes/libcxx:libcxxabi.shared",
+    "@llvm//runtimes/libcxx:libcxx.shared",
+    "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
+]
+
+def openroad_py_test(name, data = [], **kwargs):
+    """Define a Python test that can load ASan-instrumented OpenROAD modules."""
+    py_test(
+        name = name,
+        data = data + select({
+            "@llvm//config:asan_enabled": _ASAN_RUNTIMES,
+            "//conditions:default": [],
+        }),
+        env = select({
+            "@llvm//config:asan_enabled": {
+                "LD_PRELOAD": ":".join([
+                    "$(rootpath {})".format(runtime)
+                    for runtime in _ASAN_RUNTIMES
+                ]),
+            },
+            "//conditions:default": {},
+        }),
+        **kwargs
+    )
+
 def _regression_test_impl(ctx):
     # Declare the test script output
     test_script = ctx.actions.declare_file(ctx.label.name + "_test.sh")
@@ -33,6 +61,7 @@ export TEST_GOLDEN_FILE={TEST_GOLDEN_FILE}
 export TEST_CHECK_LOG={TEST_CHECK_LOG}
 export TEST_CHECK_PASSFAIL={TEST_CHECK_PASSFAIL}
 export TEST_EXPECTED_EXIT_CODE={TEST_EXPECTED_EXIT_CODE}
+export ASAN_PRELOAD={ASAN_PRELOAD}
 exec "{bazel_test_sh}" "$@"
 """.format(
             bazel_test_sh = ctx.file.bazel_test_sh.short_path,
@@ -45,6 +74,7 @@ exec "{bazel_test_sh}" "$@"
             TEST_CHECK_LOG = "True" if ctx.attr.check_log else "False",
             TEST_CHECK_PASSFAIL = "True" if ctx.attr.check_passfail else "False",
             TEST_EXPECTED_EXIT_CODE = str(ctx.attr.expected_exit_code),
+            ASAN_PRELOAD = ":".join([runtime.short_path for runtime in ctx.files.asan_runtimes]),
         ),
         is_executable = True,
     )
@@ -61,7 +91,7 @@ exec "{bazel_test_sh}" "$@"
         ctx.file.bazel_test_sh,
         ctx.file.regression_test,
         ctx.executable.openroad,
-    ] + ctx.files.data
+    ] + ctx.files.data + ctx.files.asan_runtimes
     if ctx.file.golden_file:
         runfiles_files.append(ctx.file.golden_file)
 
@@ -75,6 +105,10 @@ exec "{bazel_test_sh}" "$@"
 regression_rule_test = rule(
     implementation = _regression_test_impl,
     attrs = {
+        "asan_runtimes": attr.label_list(
+            doc = "Runtime libraries preloaded for ASan-instrumented Python modules.",
+            allow_files = True,
+        ),
         "bazel_test_sh": attr.label(
             doc = "The Bazel test shell script.",
             allow_single_file = True,
@@ -329,6 +363,7 @@ def regression_test(
     tags = _pop(kwargs, "tags", [])
     for test_file in test_files:
         ext = test_file.split(".")[-1]
+        asan_runtimes = []
 
         test_data = [
             "//test:regression_resources",
@@ -337,6 +372,10 @@ def regression_test(
         if ext == "py" and not effective_test_type:
             effective_test_type = "python"
             test_data += native.glob(["*.py"]) + ["//python/openroad:openroadpy"]
+            asan_runtimes = select({
+                "@llvm//config:asan_enabled": _ASAN_RUNTIMES,
+                "//conditions:default": [],
+            })
         test_data = _dedupe_list(test_data)
 
         regression_rule_test(
@@ -344,6 +383,7 @@ def regression_test(
             test_file = test_file,
             test_name = name,
             test_type = effective_test_type,
+            asan_runtimes = asan_runtimes,
             data = test_data,
             bazel_test_sh = "//test:bazel_test.sh",
             openroad = "//:openroad",

--- a/test/regression_test.sh
+++ b/test/regression_test.sh
@@ -30,7 +30,11 @@ esac
 echo "Command: $CMD"
 EXPECTED_EXIT_CODE="${TEST_EXPECTED_EXIT_CODE:-0}"
 set +e
-$CMD 2>&1 | tee $LOG_FILE
+if [ -n "${ASAN_PRELOAD:-}" ]; then
+    LD_PRELOAD="${ASAN_PRELOAD}${LD_PRELOAD:+:${LD_PRELOAD}}" $CMD 2>&1 | tee $LOG_FILE
+else
+    $CMD 2>&1 | tee $LOG_FILE
+fi
 CMD_EXIT=${PIPESTATUS[0]}
 set -e
 


### PR DESCRIPTION
Fixes #7754.

Address sanitizer builds stopped linking after the hermetic LLVM migration because the raw compiler flags did not stage compiler-rt in the toolchain resource directory.

Use the hermetic toolchain ASan setting so it builds and stages the runtime libraries. Disable `external_include_paths` for this config because that feature prevents compiler-rt from finding its internal LLVM headers.

Tests run on Linux:
- `bazel build --config=asan -c dbg :openroad`
- `bazel test --config=asan //src/cts/test:cts_unittest`
- `bazel test --config=asan --test_env=ASAN_OPTIONS=detect_leaks=0 //src/cts/test:cts_unittest //src/cts/test:simple_test-tcl_test //src/rsz/test:TestBufRem1 //src/rsz/test:TestBufferRemoval2 //src/rsz/test:TestBufferRemoval3 //src/rsz/test:TestInsertBuffer //src/rsz/test:TestNestedJournal //src/rsz/test:TestResizer //src/rsz/test:TestResizerMt`
- `bazel test //src/cts/test:cts_unittest //src/cts/test:simple_test-tcl_test`

Leak detection was disabled in the broader run to exclude the existing process-lifetime allocations created by `sta::TimingArcSet::init()`.