### PR TITLE
bazel: add coverage config and lcov to bazel-ci image

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -144,6 +144,44 @@ build:profile --copt -fno-omit-frame-pointer --host_copt -fno-omit-frame-pointer
 build:profile --copt=-gz=zlib --host_copt=-gz=zlib
 build:profile --linkopt=-gz=zlib
 
+# Settings for --config=coverage C++ coverage build (LLVM source-based).
+# Usage: bazel coverage --config=coverage //...
+# `bazel coverage` already layers the `test` config on top of `build`, so this
+# only adds the coverage-specific bits. --combined_report=lcov merges every
+# test's per-target lcov into one file at
+# bazel-out/_coverage/_coverage_report.dat, which CI renders with genhtml
+# (lcov is installed in bazel/Dockerfile). The instrumentation_filter mirrors
+# the exclusions of the retired cmake/lcov flow (etc/CodeCoverage.sh _lcov):
+# instrument OpenROAD's own //src/... code, minus OpenSTA (src/sta, which has
+# its own private test suite) and drt's unused global-routing code. Third-party
+# deps live under external repos / //third-party and are simply never matched
+# by //src, so they need no explicit exclusion.
+#
+# The hermetic-llvm cc_toolchain implements no coverage feature: it applies
+# zero instrumentation flags under `bazel coverage` and its declared gcov tool
+# (a symlink onto the multiplexed `llvm` binary) is broken/undeclared, so both
+# the gcov and the default LLVM paths silently produce empty reports. Hence:
+#   - instrument explicitly with clang source-based coverage
+#     (-fprofile-instr-generate -fcoverage-mapping); gcov-style -fprofile-arcs
+#     is not an option, its objects break ld.lld ('.eh_frame: relocation is
+#     not in any piece' as of LLVM 22.1.8);
+#   - point the collector at llvm-profdata/llvm-cov via --test_env (the
+#     toolchain does not export them; keep the path in sync with the `llvm`
+#     bazel_dep version in MODULE.bazel);
+#   - run test actions unsandboxed (--strategy=TestRunner=local): the sandbox
+#     omits the coverage tools because the toolchain never declares them as
+#     test inputs. Compile actions stay sandboxed.
+coverage:coverage --combined_report=lcov
+coverage:coverage --instrumentation_filter=//src[/:],-//src/sta[/:],-//src/drt/src/gr[/:],-//src/drt/src/db/grObj[/:]
+coverage:coverage --copt=-fprofile-instr-generate
+coverage:coverage --copt=-fcoverage-mapping
+coverage:coverage --linkopt=-fprofile-instr-generate
+coverage:coverage --experimental_generate_llvm_lcov
+coverage:coverage --experimental_use_llvm_covmap
+coverage:coverage --strategy=TestRunner=local
+coverage:coverage --test_env=LLVM_PROFDATA=external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64/bin/llvm-profdata
+coverage:coverage --test_env=LLVM_COV=external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64/bin/llvm-cov
+
 # Improve hermeticity by disallowing user envars and network access
 build --incompatible_strict_action_env
 build --nosandbox_default_allow_network

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -213,6 +213,11 @@ git_override(
 ## binaries and a zero-sysroot cc_toolchain: no host compiler, linker,
 ## libxml2 or /usr/include involved, and it runs unmodified on distros
 ## without FHS paths (e.g. NixOS).
+# NOTE when bumping: the LLVM release embedded in this module version is
+# hardcoded in .bazelrc's coverage:coverage --test_env=LLVM_PROFDATA/LLVM_COV
+# paths (external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-<ver>-
+# linux-amd64/bin). Update those lines in the same commit, or the nightly
+# coverage job fails on its next run.
 bazel_dep(name = "llvm", version = "0.8.11", dev_dependency = True)
 
 # --- Dev dependencies (not propagated to downstream consumers) ---

--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -27,10 +27,13 @@ RUN apt-get -y update \
       docker-ce \
       docker-ce-cli \
       groff \
+      lcov \
       openjdk-21-jre-headless \
       pandoc \
+      parallel \
       python3 \
       python3-yaml \
+      tcl \
       time
 
 # Runtime X11/xcb libraries for the Qt GUI build (--//:platform=gui).


### PR DESCRIPTION
Add a --config=coverage so `bazel coverage --config=coverage` emits one combined lcov file (bazel-out/_coverage/_coverage_report.dat) that CI renders with genhtml. The instrumentation_filter reproduces the exclusions of the retired cmake/lcov flow (etc/CodeCoverage.sh _lcov).

The hermetic-llvm toolchain implements no coverage feature (no instrumentation flags, broken/undeclared gcov tool), so the config instruments explicitly with clang source-based coverage and points the collector at llvm-profdata/llvm-cov via --test_env; test actions run unsandboxed because the sandbox omits the undeclared coverage tools. gcov-style -fprofile-arcs is not usable: its objects break ld.lld ('.eh_frame: relocation is not in any piece' as of LLVM 22.1.8).

Verified on //src/utl/test:cpp_tests: combined report carries real DA data (1464 lines, all SF entries under src/) and genhtml renders it (39.6% lines, 44.2% functions).

Install lcov (provides genhtml) in bazel/Dockerfile so the report can be rendered inside the bazel-ci image the Jenkins coverage pipeline runs in. Also install parallel and tcl: the migrated nightly pipeline runs src/drt/test/run-ispd.py (shells out to GNU parallel) and src/gpl/test/regression-large (an `exec tclsh` script) inside this image, both previously provided by the ubuntu22.04-dev image.
