### PR TITLE
rcx: make setBlockFromChip actually have a chip argument

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2094,8 +2094,7 @@ class extMain
   uint32_t getMultiples(uint32_t cnt, uint32_t base);
   uint32_t getExtLayerCnt(odb::dbTech* tech);
 
-  void setBlockFromChip();
-  void setBlock(odb::dbBlock* block);
+  void setBlockFromChip(odb::dbChip* chip);
   odb::dbBlock* getBlock() { return _block; }
   odb::dbTech* getTech() { return _tech; }
   extRCModel* getRCModel() { return _modelTable->get(0); }

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -43,7 +43,7 @@ void Ext::setLogger(Logger* logger)
 }
 void Ext::write_rules(const std::string& name, const std::string& file)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   _ext->writeRules(name.c_str(), file.c_str());
 }
 void Ext::bench_wires(const BenchWiresOptions& bwo)
@@ -148,7 +148,7 @@ void Ext::bench_wires_gen(const PatternOptions& opt)
 
 void Ext::bench_verilog(const std::string& file)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   char* filename = (char*) file.c_str();
   if (!filename || !filename[0]) {
     logger_->error(RCX, 147, "bench_verilog: file is not defined!");
@@ -162,7 +162,7 @@ void Ext::bench_verilog(const std::string& file)
 
 void Ext::define_process_corner(int ext_model_index, const std::string& name)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   char* cornerName = _ext->addRCCorner(name.c_str(), ext_model_index);
 
   if (cornerName != nullptr) {
@@ -211,7 +211,7 @@ void Ext::get_ext_db_corner(int& index, const std::string& name)
 
 void Ext::extract(ExtractOptions options)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   odb::dbBlock* block = _ext->getBlock();
 
   odb::orderWires(logger_, block);
@@ -250,13 +250,13 @@ void Ext::write_spef_nets(odb::dbObject* block,
                           bool parallel,
                           int corner)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   _ext->write_spef_nets(flatten, parallel);
 }
 
 void Ext::write_spef(const SpefOptions& options)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   if (options.end) {
     _ext->writeSPEF(true);
     return;
@@ -299,7 +299,7 @@ void Ext::write_spef(const SpefOptions& options)
 
 void Ext::read_spef(ReadSpefOpts& opt)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   logger_->info(RCX, 1, "Reading SPEF file: {}", opt.file);
 
   bool stampWire = opt.stamp_wire;
@@ -352,7 +352,7 @@ void Ext::read_spef(ReadSpefOpts& opt)
 
 void Ext::diff_spef(const DiffOptions& opt)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
   std::string filename(opt.file);
   if (filename.empty()) {
     logger_->error(
@@ -430,7 +430,7 @@ bool Ext::gen_rcx_model(const std::string& spef_file_list,
                         const std::string& version,
                         int pattern)
 {
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
 
   if (spef_file_list.empty()) {
     logger_->error(
@@ -474,7 +474,7 @@ bool Ext::define_rcx_corners(const std::string& corner_list)
         RCX, 146, "\nCorner List option -corner_list  is required\n");
   }
 
-  _ext->setBlockFromChip();
+  _ext->setBlockFromChip(_db->getChip());
 
   Parser parser(logger_);
   int n1 = parser.mkWords(corner_list.c_str());

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -392,37 +392,23 @@ double extMain::getResistance(const uint32_t level,
   return getLefResistance(level, width, len, model);
 }
 
-void extMain::setBlockFromChip()
+void extMain::setBlockFromChip(odb::dbChip* chip)
 {
-  if (_db->getChip() == nullptr) {
+  if (!chip) {
     logger_->error(RCX, 497, "No design is loaded.");
   }
-  _tech = _db->getTech();
-  _block = _db->getChip()->getBlock();
+
+  _tech = chip->getTech();
+  _block = chip->getBlock();
   _blockId = _block->getId();
   _prevControl = _block->getExtControl();
   _block->setExtmi(this);
 
-  if (_spef != nullptr) {
-    _spef = nullptr;
-    _extracted = false;
-  }
-
-  _bufSpefCnt = 0;
-  _origSpefFilePrefix = nullptr;
-  _newSpefFilePrefix = nullptr;
-}
-
-void extMain::setBlock(dbBlock* block)
-{
-  _block = block;
-  _prevControl = _block->getExtControl();
-  _block->setExtmi(this);
-  _blockId = _block->getId();
   if (_spef) {
     _spef = nullptr;
     _extracted = false;
   }
+
   _bufSpefCnt = 0;
   _origSpefFilePrefix = nullptr;
   _newSpefFilePrefix = nullptr;

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -400,6 +400,11 @@ void extMain::setBlockFromChip(odb::dbChip* chip)
 
   _tech = chip->getTech();
   _block = chip->getBlock();
+
+  if (!_block) {
+    logger_->error(RCX, 14, "Could not get the block from the chip.");
+  }
+
   _blockId = _block->getId();
   _prevControl = _block->getExtControl();
   _block->setExtmi(this);


### PR DESCRIPTION
## Summary
Replaces #10912.

With the changes here, it will be possible to use `setBlockFromChip` in the multi chip extraction pass begin built.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**