### PR TITLE
docs: keep manpage parser compatible with Python 3.9

### DIFF
--- a/docs/src/scripts/manpage.py
+++ b/docs/src/scripts/manpage.py
@@ -4,6 +4,8 @@
 # This code describes the ManPage class, which consists of the data classes
 #  as well as the code needed to write the roff-compatible manpage file.
 
+from __future__ import annotations
+
 import io
 import datetime
 

--- a/docs/src/scripts/manpage.py
+++ b/docs/src/scripts/manpage.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import io
 import datetime
+import os
+import tempfile
 
 
 # identify key section and stored in ManPage class.


### PR DESCRIPTION
`odb_readme_msgs_check` runs the shared manpage parser with the host Python. On systems where `python3` is 3.9, importing the parser fails while evaluating the `str | None` annotations.

Postpone annotation evaluation so the same parser works with the host Python used by the regression wrapper. This does not change the generated manpage output.

Tests run on Linux with Python 3.9.2:
- `python3 -m py_compile docs/src/scripts/manpage.py`
- import `ManPage` and call `add_example`
- `bazel test //docs/src/scripts:all //src/odb/test:odb_readme_msgs_check-py_test`
- `git diff --check`