### PR TITLE
drt: make guide and GR pin query order deterministic

### DIFF
--- a/src/drt/CMakeLists.txt
+++ b/src/drt/CMakeLists.txt
@@ -153,7 +153,7 @@ target_compile_options(drt
 if(ENABLE_TESTS)
   enable_testing()
 
-  foreach(test_name gcTest taTest)
+  foreach(test_name frRegionQueryTest gcTest taTest)
     add_executable(${test_name}
       ${FLEXROUTE_HOME}/test/${test_name}.cpp
       ${FLEXROUTE_HOME}/test/fixture.cpp

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -12,9 +12,9 @@
 
 #include "boost/geometry/geometry.hpp"
 #include "boost/polygon/polygon.hpp"
+#include "db/obj/frBTerm.h"
 #include "db/obj/frBlockObject.h"
 #include "db/obj/frBlockage.h"
-#include "db/obj/frBTerm.h"
 #include "db/obj/frGuide.h"
 #include "db/obj/frInstBlockage.h"
 #include "db/obj/frInstTerm.h"
@@ -40,14 +40,14 @@ bool guideLess(const frGuide* lhs, const frGuide* rhs)
 {
   const auto [lhs_begin, lhs_end] = lhs->getPoints();
   const auto [rhs_begin, rhs_end] = rhs->getPoints();
-  return std::make_tuple(lhs->getNet()->getName(),
+  return std::make_tuple(lhs->getNet()->getId(),
                          lhs->getLayerNum(),
                          lhs_begin.x(),
                          lhs_begin.y(),
                          lhs_end.x(),
                          lhs_end.y(),
                          lhs->getIndexInOwner())
-         < std::make_tuple(rhs->getNet()->getName(),
+         < std::make_tuple(rhs->getNet()->getId(),
                            rhs->getLayerNum(),
                            rhs_begin.x(),
                            rhs_begin.y(),
@@ -64,18 +64,17 @@ bool grPinLess(const frBlockObject* lhs, const frBlockObject* rhs)
   if (lhs->typeId() == frcInstTerm) {
     const auto* lhs_term = static_cast<const frInstTerm*>(lhs);
     const auto* rhs_term = static_cast<const frInstTerm*>(rhs);
-    return std::make_tuple(lhs_term->getInst()->getName(),
-                           lhs_term->getTerm()->getName(),
+    return std::make_tuple(lhs_term->getInst()->getId(),
+                           lhs_term->getTerm()->getId(),
                            lhs_term->getId())
-           < std::make_tuple(rhs_term->getInst()->getName(),
-                             rhs_term->getTerm()->getName(),
+           < std::make_tuple(rhs_term->getInst()->getId(),
+                             rhs_term->getTerm()->getId(),
                              rhs_term->getId());
   }
   if (lhs->typeId() == frcBTerm) {
     const auto* lhs_term = static_cast<const frBTerm*>(lhs);
     const auto* rhs_term = static_cast<const frBTerm*>(rhs);
-    return std::make_tuple(lhs_term->getName(), lhs_term->getId())
-           < std::make_tuple(rhs_term->getName(), rhs_term->getId());
+    return lhs_term->getId() < rhs_term->getId();
   }
   return lhs->getId() < rhs->getId();
 }

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -13,7 +14,11 @@
 #include "boost/polygon/polygon.hpp"
 #include "db/obj/frBlockObject.h"
 #include "db/obj/frBlockage.h"
+#include "db/obj/frBTerm.h"
+#include "db/obj/frGuide.h"
 #include "db/obj/frInstBlockage.h"
+#include "db/obj/frInstTerm.h"
+#include "db/obj/frNet.h"
 #include "drt-global.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
@@ -28,6 +33,54 @@ class FlexDR;
 
 using utl::enumerate;
 namespace gtl = boost::polygon;
+
+namespace {
+
+bool guideLess(const frGuide* lhs, const frGuide* rhs)
+{
+  const auto [lhs_begin, lhs_end] = lhs->getPoints();
+  const auto [rhs_begin, rhs_end] = rhs->getPoints();
+  return std::make_tuple(lhs->getNet()->getName(),
+                         lhs->getLayerNum(),
+                         lhs_begin.x(),
+                         lhs_begin.y(),
+                         lhs_end.x(),
+                         lhs_end.y(),
+                         lhs->getIndexInOwner())
+         < std::make_tuple(rhs->getNet()->getName(),
+                           rhs->getLayerNum(),
+                           rhs_begin.x(),
+                           rhs_begin.y(),
+                           rhs_end.x(),
+                           rhs_end.y(),
+                           rhs->getIndexInOwner());
+}
+
+bool grPinLess(const frBlockObject* lhs, const frBlockObject* rhs)
+{
+  if (lhs->typeId() != rhs->typeId()) {
+    return lhs->typeId() < rhs->typeId();
+  }
+  if (lhs->typeId() == frcInstTerm) {
+    const auto* lhs_term = static_cast<const frInstTerm*>(lhs);
+    const auto* rhs_term = static_cast<const frInstTerm*>(rhs);
+    return std::make_tuple(lhs_term->getInst()->getName(),
+                           lhs_term->getTerm()->getName(),
+                           lhs_term->getId())
+           < std::make_tuple(rhs_term->getInst()->getName(),
+                             rhs_term->getTerm()->getName(),
+                             rhs_term->getId());
+  }
+  if (lhs->typeId() == frcBTerm) {
+    const auto* lhs_term = static_cast<const frBTerm*>(lhs);
+    const auto* rhs_term = static_cast<const frBTerm*>(rhs);
+    return std::make_tuple(lhs_term->getName(), lhs_term->getId())
+           < std::make_tuple(rhs_term->getName(), rhs_term->getId());
+  }
+  return lhs->getId() < rhs->getId();
+}
+
+}  // namespace
 
 struct frRegionQuery::Impl
 {
@@ -500,7 +553,13 @@ void frRegionQuery::queryGuide(const odb::Rect& box,
                                const frLayerNum layerNum,
                                Objects<frGuide>& result) const
 {
+  const size_t first_result = result.size();
   impl_->guides.at(layerNum).query(bgi::intersects(box), back_inserter(result));
+  std::sort(result.begin() + first_result,
+            result.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return guideLess(lhs.second, rhs.second);
+            });
 }
 
 void frRegionQuery::queryGuide(const odb::Rect& box,
@@ -520,6 +579,9 @@ void frRegionQuery::queryGuide(const odb::Rect& box,
   for (auto& m : impl_->guides) {
     m.query(bgi::intersects(box), back_inserter(temp));
   }
+  std::sort(temp.begin(), temp.end(), [](const auto& lhs, const auto& rhs) {
+    return guideLess(lhs.second, rhs.second);
+  });
   std::ranges::transform(
       temp, back_inserter(result), [](auto& kv) { return kv.second; });
 }
@@ -535,10 +597,12 @@ void frRegionQuery::queryOrigGuide(const odb::Rect& box,
 void frRegionQuery::queryGRPin(const odb::Rect& box,
                                std::vector<frBlockObject*>& result) const
 {
+  const size_t first_result = result.size();
   Objects<frBlockObject> temp;
   impl_->grPins.query(bgi::intersects(box), back_inserter(temp));
   std::ranges::transform(
       temp, back_inserter(result), [](auto& kv) { return kv.second; });
+  std::sort(result.begin() + first_result, result.end(), grPinLess);
 }
 
 void frRegionQuery::queryDRObj(const box_t& boostb,

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -6,14 +6,19 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
 #include "boost/geometry/geometry.hpp"
 #include "boost/polygon/polygon.hpp"
+#include "db/obj/frBTerm.h"
 #include "db/obj/frBlockObject.h"
 #include "db/obj/frBlockage.h"
+#include "db/obj/frGuide.h"
 #include "db/obj/frInstBlockage.h"
+#include "db/obj/frInstTerm.h"
+#include "db/obj/frNet.h"
 #include "drt-global.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
@@ -28,6 +33,38 @@ class FlexDR;
 
 using utl::enumerate;
 namespace gtl = boost::polygon;
+
+namespace {
+
+bool guideLess(const frGuide* lhs, const frGuide* rhs)
+{
+  return lhs->getId() < rhs->getId();
+}
+
+bool grPinLess(const frBlockObject* lhs, const frBlockObject* rhs)
+{
+  if (lhs->typeId() != rhs->typeId()) {
+    return lhs->typeId() < rhs->typeId();
+  }
+  if (lhs->typeId() == frcInstTerm) {
+    const auto* lhs_term = static_cast<const frInstTerm*>(lhs);
+    const auto* rhs_term = static_cast<const frInstTerm*>(rhs);
+    return std::make_tuple(lhs_term->getInst()->getId(),
+                           lhs_term->getTerm()->getId(),
+                           lhs_term->getId())
+           < std::make_tuple(rhs_term->getInst()->getId(),
+                             rhs_term->getTerm()->getId(),
+                             rhs_term->getId());
+  }
+  if (lhs->typeId() == frcBTerm) {
+    const auto* lhs_term = static_cast<const frBTerm*>(lhs);
+    const auto* rhs_term = static_cast<const frBTerm*>(rhs);
+    return lhs_term->getId() < rhs_term->getId();
+  }
+  return lhs->getId() < rhs->getId();
+}
+
+}  // namespace
 
 struct frRegionQuery::Impl
 {
@@ -500,7 +537,13 @@ void frRegionQuery::queryGuide(const odb::Rect& box,
                                const frLayerNum layerNum,
                                Objects<frGuide>& result) const
 {
+  const size_t first_result = result.size();
   impl_->guides.at(layerNum).query(bgi::intersects(box), back_inserter(result));
+  std::sort(result.begin() + first_result,
+            result.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return guideLess(lhs.second, rhs.second);
+            });
 }
 
 void frRegionQuery::queryGuide(const odb::Rect& box,
@@ -520,6 +563,9 @@ void frRegionQuery::queryGuide(const odb::Rect& box,
   for (auto& m : impl_->guides) {
     m.query(bgi::intersects(box), back_inserter(temp));
   }
+  std::sort(temp.begin(), temp.end(), [](const auto& lhs, const auto& rhs) {
+    return guideLess(lhs.second, rhs.second);
+  });
   std::ranges::transform(
       temp, back_inserter(result), [](auto& kv) { return kv.second; });
 }
@@ -528,17 +574,34 @@ void frRegionQuery::queryOrigGuide(const odb::Rect& box,
                                    const frLayerNum layerNum,
                                    Objects<frNet>& result) const
 {
+  const size_t first_result = result.size();
   impl_->origGuides.at(layerNum).query(bgi::intersects(box),
                                        back_inserter(result));
+  std::sort(result.begin() + first_result,
+            result.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return std::make_tuple(lhs.second->getId(),
+                                     lhs.first.xMin(),
+                                     lhs.first.yMin(),
+                                     lhs.first.xMax(),
+                                     lhs.first.yMax())
+                     < std::make_tuple(rhs.second->getId(),
+                                       rhs.first.xMin(),
+                                       rhs.first.yMin(),
+                                       rhs.first.xMax(),
+                                       rhs.first.yMax());
+            });
 }
 
 void frRegionQuery::queryGRPin(const odb::Rect& box,
                                std::vector<frBlockObject*>& result) const
 {
+  const size_t first_result = result.size();
   Objects<frBlockObject> temp;
   impl_->grPins.query(bgi::intersects(box), back_inserter(temp));
   std::ranges::transform(
       temp, back_inserter(result), [](auto& kv) { return kv.second; });
+  std::sort(result.begin() + first_result, result.end(), grPinLess);
 }
 
 void frRegionQuery::queryDRObj(const box_t& boostb,

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -38,22 +38,7 @@ namespace {
 
 bool guideLess(const frGuide* lhs, const frGuide* rhs)
 {
-  const auto [lhs_begin, lhs_end] = lhs->getPoints();
-  const auto [rhs_begin, rhs_end] = rhs->getPoints();
-  return std::make_tuple(lhs->getNet()->getId(),
-                         lhs->getLayerNum(),
-                         lhs_begin.x(),
-                         lhs_begin.y(),
-                         lhs_end.x(),
-                         lhs_end.y(),
-                         lhs->getIndexInOwner())
-         < std::make_tuple(rhs->getNet()->getId(),
-                           rhs->getLayerNum(),
-                           rhs_begin.x(),
-                           rhs_begin.y(),
-                           rhs_end.x(),
-                           rhs_end.y(),
-                           rhs->getIndexInOwner());
+  return lhs->getId() < rhs->getId();
 }
 
 bool grPinLess(const frBlockObject* lhs, const frBlockObject* rhs)

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -156,6 +156,33 @@ py_library(
 ]
 
 test_suite(
+    name = "region_query_test",
+    tests = [":fr_region_query_unittest"],
+)
+
+cc_test(
+    name = "fr_region_query_unittest",
+    srcs = [
+        "fixture.cpp",
+        "fixture.h",
+        "frRegionQueryTest.cpp",
+    ],
+    includes = [
+        "../src",
+    ],
+    deps = [
+        "//src/drt",  # buildcleaner: keep
+        "//src/drt:base_types",
+        "//src/drt:db_hdrs",
+        "//src/drt:drt_private_hdrs",
+        "//src/odb/src/db",
+        "//src/utl",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+test_suite(
     name = "gc_test",
     tests = [":gc_unittest"],
 )

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -151,6 +151,33 @@ py_library(
 ]
 
 test_suite(
+    name = "region_query_test",
+    tests = [":fr_region_query_unittest"],
+)
+
+cc_test(
+    name = "fr_region_query_unittest",
+    srcs = [
+        "fixture.cpp",
+        "fixture.h",
+        "frRegionQueryTest.cpp",
+    ],
+    includes = [
+        "../src",
+    ],
+    deps = [
+        "//src/drt",  # buildcleaner: keep
+        "//src/drt:base_types",
+        "//src/drt:db_hdrs",
+        "//src/drt:drt_private_hdrs",
+        "//src/odb/src/db",
+        "//src/utl",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+test_suite(
     name = "gc_test",
     tests = [":gc_unittest"],
 )

--- a/src/drt/test/frRegionQueryTest.cpp
+++ b/src/drt/test/frRegionQueryTest.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include <array>
+#include <memory>
+#include <string>
+
+#include "db/obj/frGuide.h"
+#include "db/obj/frNet.h"
+#include "db/obj/frShape.h"
+#include "fixture.h"
+#include "frRegionQuery.h"
+#include "gtest/gtest.h"
+#include "odb/geom.h"
+
+namespace drt {
+
+struct RegionQueryFixture : public Fixture
+{
+  frGuide* makeGuide(frNet* net,
+                     frLayerNum layer_num,
+                     const odb::Point& begin,
+                     const odb::Point& end)
+  {
+    auto guide = std::make_unique<frGuide>(begin, layer_num, end);
+    auto* ptr = guide.get();
+    net->addGuide(std::move(guide));
+    return ptr;
+  }
+
+  void initGuideQuery()
+  {
+    initRegionQuery();
+    design->getRegionQuery()->initGuide();
+  }
+
+  void initOrigGuideQuery(frOrderedIdMap<frNet*, std::vector<frRect>>& guides)
+  {
+    initRegionQuery();
+    design->getRegionQuery()->initOrigGuide(guides);
+  }
+};
+
+TEST_F(RegionQueryFixture, guide_query_uses_guide_id_order)
+{
+  frNet* n1 = makeNet("n1");
+  frNet* n2 = makeNet("n2");
+  frGuide* g1 = makeGuide(n1, /*layer_num=*/2, {500, 500}, {1500, 500});
+  frGuide* g2 = makeGuide(n2, /*layer_num=*/2, {500, 500}, {1500, 500});
+  g1->setId(0);
+  g2->setId(1);
+
+  initGuideQuery();
+
+  frRegionQuery::Objects<frGuide> result;
+  design->getRegionQuery()->queryGuide(
+      odb::Rect(0, 0, 2000, 2000), /*layerNum=*/2, result);
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_LT(result[0].second->getId(), result[1].second->getId());
+  EXPECT_EQ(result[0].second->getNet()->getName(), "n1");
+  EXPECT_EQ(result[1].second->getNet()->getName(), "n2");
+}
+
+TEST_F(RegionQueryFixture, original_guide_query_uses_canonical_order)
+{
+  constexpr int num_nets = 17;
+  std::array<frNet*, num_nets> nets;
+  frOrderedIdMap<frNet*, std::vector<frRect>> guides;
+  for (int i = 0; i < num_nets; i++) {
+    nets[i] = makeNet(("n" + std::to_string(i)).c_str());
+    const int x = (num_nets - i - 1) * 1000;
+    guides[nets[i]].emplace_back(
+        x, 0, x + 1000, 1000, /*layer_num=*/2, nullptr);
+  }
+  guides[nets[0]].emplace_back(0, 1000, 1000, 2000, /*layer_num=*/2, nullptr);
+
+  initOrigGuideQuery(guides);
+
+  frRegionQuery::Objects<frNet> result;
+  design->getRegionQuery()->queryOrigGuide(
+      odb::Rect(0, 0, num_nets * 1000, 2000), /*layerNum=*/2, result);
+
+  ASSERT_EQ(result.size(), num_nets + 1);
+  EXPECT_EQ(result[0].second->getId(), 0);
+  EXPECT_EQ(result[0].first, odb::Rect(0, 1000, 1000, 2000));
+  EXPECT_EQ(result[1].second->getId(), 0);
+  EXPECT_EQ(result[1].first, odb::Rect(16000, 0, 17000, 1000));
+  for (int i = 1; i < num_nets; i++) {
+    EXPECT_EQ(result[i + 1].second->getId(), i);
+    EXPECT_EQ(result[i + 1].second->getName(), "n" + std::to_string(i));
+  }
+}
+
+}  // namespace drt

--- a/src/drt/test/frRegionQueryTest.cpp
+++ b/src/drt/test/frRegionQueryTest.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include <memory>
+
+#include "db/obj/frGuide.h"
+#include "db/obj/frNet.h"
+#include "fixture.h"
+#include "frRegionQuery.h"
+#include "gtest/gtest.h"
+#include "odb/geom.h"
+
+namespace drt {
+
+struct RegionQueryFixture : public Fixture
+{
+  frGuide* makeGuide(frNet* net,
+                     frLayerNum layer_num,
+                     const odb::Point& begin,
+                     const odb::Point& end)
+  {
+    auto guide = std::make_unique<frGuide>(begin, layer_num, end);
+    auto* ptr = guide.get();
+    net->addGuide(std::move(guide));
+    return ptr;
+  }
+
+  void initGuideQuery()
+  {
+    initRegionQuery();
+    design->getRegionQuery()->initGuide();
+  }
+};
+
+TEST_F(RegionQueryFixture, guide_query_uses_guide_id_order)
+{
+  frNet* n1 = makeNet("n1");
+  frNet* n2 = makeNet("n2");
+  frGuide* g1
+      = makeGuide(n1, /*layer_num=*/2, {500, 500}, {1500, 500});
+  frGuide* g2
+      = makeGuide(n2, /*layer_num=*/2, {500, 500}, {1500, 500});
+  g1->setId(0);
+  g2->setId(1);
+
+  initGuideQuery();
+
+  frRegionQuery::Objects<frGuide> result;
+  design->getRegionQuery()->queryGuide(
+      odb::Rect(0, 0, 2000, 2000), /*layerNum=*/2, result);
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_LT(result[0].second->getId(), result[1].second->getId());
+  EXPECT_EQ(result[0].second->getNet()->getName(), "n1");
+  EXPECT_EQ(result[1].second->getNet()->getName(), "n2");
+}
+
+}  // namespace drt

--- a/src/drt/test/taTest.cpp
+++ b/src/drt/test/taTest.cpp
@@ -156,8 +156,8 @@ TEST_F(TAFixture, single_horizontal_iroute_assigned)
 
 TEST_F(TAFixture, guide_query_has_canonical_order)
 {
-  frNet* n2 = makeNet("n2");
   frNet* n1 = makeNet("n1");
+  frNet* n2 = makeNet("n2");
   makeGuide(n2, /*layer_num=*/2, {500, 500}, {1500, 500});
   makeGuide(n1, /*layer_num=*/2, {500, 500}, {1500, 500});
 

--- a/src/drt/test/taTest.cpp
+++ b/src/drt/test/taTest.cpp
@@ -154,6 +154,24 @@ TEST_F(TAFixture, single_horizontal_iroute_assigned)
   EXPECT_EQ(bp.y(), expected_tracks[2]);
 }
 
+TEST_F(TAFixture, guide_query_has_canonical_order)
+{
+  frNet* n2 = makeNet("n2");
+  frNet* n1 = makeNet("n1");
+  makeGuide(n2, /*layer_num=*/2, {500, 500}, {1500, 500});
+  makeGuide(n1, /*layer_num=*/2, {500, 500}, {1500, 500});
+
+  initTAQueries();
+
+  frRegionQuery::Objects<frGuide> result;
+  design->getRegionQuery()->queryGuide(
+      odb::Rect(0, 0, 2000, 2000), /*layerNum=*/2, result);
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].second->getNet()->getName(), "n1");
+  EXPECT_EQ(result[1].second->getNet()->getName(), "n2");
+}
+
 TEST_F(TAFixture, two_parallel_no_coupling)
 {
   setDieArea(0, 0, 21000, 2000);

--- a/src/drt/test/taTest.cpp
+++ b/src/drt/test/taTest.cpp
@@ -154,24 +154,6 @@ TEST_F(TAFixture, single_horizontal_iroute_assigned)
   EXPECT_EQ(bp.y(), expected_tracks[2]);
 }
 
-TEST_F(TAFixture, guide_query_has_canonical_order)
-{
-  frNet* n1 = makeNet("n1");
-  frNet* n2 = makeNet("n2");
-  makeGuide(n2, /*layer_num=*/2, {500, 500}, {1500, 500});
-  makeGuide(n1, /*layer_num=*/2, {500, 500}, {1500, 500});
-
-  initTAQueries();
-
-  frRegionQuery::Objects<frGuide> result;
-  design->getRegionQuery()->queryGuide(
-      odb::Rect(0, 0, 2000, 2000), /*layerNum=*/2, result);
-
-  ASSERT_EQ(result.size(), 2);
-  EXPECT_EQ(result[0].second->getNet()->getName(), "n1");
-  EXPECT_EQ(result[1].second->getNet()->getName(), "n2");
-}
-
 TEST_F(TAFixture, two_parallel_no_coupling)
 {
   setDieArea(0, 0, 21000, 2000);


### PR DESCRIPTION
Make guide query order follow the guide IDs assigned by GuideProcessor. The previous comparator rebuilt a multi-field key and still left equal entries dependent on R-tree iteration order.

The regression now lives in a standalone `frRegionQuery` unit test. It assigns the same global guide IDs used by GuideProcessor and checks that two equal-geometry guides are returned in ID order. The existing TA unit test stays focused on track assignment.

Tested on the GCP VM in a clean Ubuntu 24.04 container:

`bazel test --jobs=32 --test_output=errors //src/drt/test:fr_region_query_unittest //src/drt/test:ta_unittest`

Both targets passed.