### PR TITLE
ord: register Tech for Python global APIs

### DIFF
--- a/python/openroad/BUILD
+++ b/python/openroad/BUILD
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2025, The OpenROAD Authors
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -20,6 +21,11 @@ py_library(
         "//src/odb:odb_py",
         "//src/utl:utl_py",
     ],
+)
+
+regression_test(
+    name = "tech_lifecycle",
+    check_log = False,
 )
 
 py_package(

--- a/python/openroad/tech_lifecycle.py
+++ b/python/openroad/tech_lifecycle.py
@@ -1,0 +1,5 @@
+from openroad import Tech, set_thread_count, thread_count
+
+tech = Tech()
+set_thread_count(1)
+assert thread_count() == 1

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -273,7 +273,6 @@ int main(int argc, char* argv[])
     the_tech_and_design->tech = std::make_unique<ord::Tech>(interp);
     the_tech_and_design->design
         = std::make_unique<ord::Design>(the_tech_and_design->tech.get());
-    ord::OpenRoad::setOpenRoad(the_tech_and_design->design->getOpenRoad());
     const bool exit = findCmdLineFlag(cmd_argc, cmd_argv, "-exit");
     ord::initOpenRoad(interp, log_filename, metrics_filename, exit);
     if (!findCmdLineFlag(cmd_argc, cmd_argv, "-no_splash")) {
@@ -523,7 +522,6 @@ int ord::tclAppInit(Tcl_Interp* interp)
   the_tech_and_design->tech = std::make_unique<ord::Tech>(interp);
   the_tech_and_design->design
       = std::make_unique<ord::Design>(the_tech_and_design->tech.get());
-  ord::OpenRoad::setOpenRoad(the_tech_and_design->design->getOpenRoad());
 
   // This is to enable Design.i where a design arg can be
   // retrieved from the interpreter.  This is necessary for

--- a/src/Tech.cc
+++ b/src/Tech.cc
@@ -22,6 +22,7 @@ Tech::Tech(Tcl_Interp* interp,
            const char* metrics_filename)
     : app_(new OpenRoad())
 {
+  OpenRoad::setOpenRoad(app_, /* reinit_ok */ true);
   if (!interp) {
     interp = Tcl_CreateInterp();
     Tcl_Init(interp);
@@ -31,6 +32,9 @@ Tech::Tech(Tcl_Interp* interp,
 
 Tech::~Tech()
 {
+  if (OpenRoad::openRoad() == app_) {
+    OpenRoad::setOpenRoad(nullptr, /* reinit_ok */ true);
+  }
   delete app_;
 }
 

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -6,7 +6,7 @@
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//test:regression.bzl", "doc_check_test", "regression_rule_test", "regression_test")
+load("//test:regression.bzl", "doc_check_test", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -222,19 +222,15 @@ doc_check_test(
     visibility = ["//visibility:public"],
 )
 
-regression_rule_test(
-    name = "aes_nangate45-py_test",
-    bazel_test_sh = "//test:bazel_test.sh",
+regression_test(
+    name = "aes_nangate45",
+    timeout = "long",
     check_log = False,
     data = [
         "aes_nangate45.route_guide",
         "aes_nangate45_preroute.def",
         ":regression_resources",
     ],
-    openroad = "//:openroad",
-    regression_test = "//test:regression_test.sh",
     tags = ["manual"],
-    test_file = "aes_nangate45.py",
-    test_name = "aes_nangate45",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Direct Python users can construct a `Tech` object and then call module-level APIs such as `set_thread_count()`. Those APIs use the process-wide OpenROAD instance, but `Tech` did not register the instance it owns. The result was a null dereference.

The DRT AES Python target also did not carry the OpenROAD Python runfiles, so it failed at import time and never reached this crash.

This change registers the `Tech` instance during construction and clears it during destruction when it is still active. It adds a small lifecycle regression and moves the AES target through the standard Python regression macro.

Follow-up for the lifecycle review: the regression now requests one thread and asserts one, so it is valid on single-core CI runners as well as larger machines.

VM testing:
- `bazel test //python/openroad:tech_lifecycle-py_test --test_output=errors`
- Clean Ubuntu 24.04 container build on the GCP VM
- The lifecycle test passed after the complete Bazel build