### PR TITLE
odb: guard instance module reassignment

### DIFF
--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -398,9 +398,20 @@ bool dbInst::rename(const char* name)
 
   std::string old_name(inst->name_);
   block->inst_hash_.remove(inst);
+
+  _dbModule* module = nullptr;
+  if (inst->getModuleId() != 0) {
+    module = (_dbModule*) dbModule::getModule((dbBlock*) block,
+                                              inst->getModuleId());
+    module->dbinst_hash_.erase(old_name);
+  }
+
   free((void*) inst->name_);
   inst->name_ = safe_strdup(name);
   block->inst_hash_.insert(inst);
+  if (module != nullptr) {
+    module->dbinst_hash_[name] = dbId<_dbInst>(inst->getOID());
+  }
 
   for (dbBlockCallBackObj* cb : block->callbacks_) {
     cb->inDbPostInstRename(this, old_name.c_str());

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -74,6 +74,24 @@ class sortITerm
   }
 };
 
+void _dbInst::setModule(dbId<_dbModule> module)
+{
+  const dbId<_dbModule> previous = module_;
+  if (previous == module) {
+    return;
+  }
+
+  module_ = module;
+  if (previous == 0 || module == 0) {
+    return;
+  }
+
+  _dbBlock* block = (_dbBlock*) getOwner();
+  for (dbBlockCallBackObj* callback : block->callbacks_) {
+    callback->inDbPostInstParentChange((dbInst*) this);
+  }
+}
+
 void _dbInst::setInstBBox(_dbInst* inst)
 {
   _dbBlock* block = (_dbBlock*) inst->getOwner();
@@ -866,12 +884,12 @@ dbModule* dbInst::getModule()
 {
   _dbInst* inst = (_dbInst*) this;
 
-  if (inst->module_ == 0) {
+  if (inst->getModuleId() == 0) {
     return nullptr;
   }
 
   _dbBlock* block = (_dbBlock*) inst->getOwner();
-  _dbModule* module = block->module_tbl_->getPtr(inst->module_);
+  _dbModule* module = block->module_tbl_->getPtr(inst->getModuleId());
   return (dbModule*) module;
 }
 
@@ -1072,7 +1090,7 @@ bool dbInst::isPhysicalOnly()
 {
   _dbInst* inst = (_dbInst*) this;
 
-  return inst->module_ == 0;
+  return inst->getModuleId() == 0;
 }
 
 dbInst* dbInst::getParent()
@@ -1589,7 +1607,7 @@ void dbInst::destroy(dbInst* inst_)
     block->journal_->pushParam(inst->x_);
     block->journal_->pushParam(inst->y_);
     block->journal_->pushParam(inst->group_);
-    block->journal_->pushParam(inst->module_);
+    block->journal_->pushParam(inst->getModuleId());
     block->journal_->pushParam(inst->region_);
     block->journal_->endAction();
   }

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -380,9 +380,16 @@ bool dbInst::rename(const char* name)
 
   std::string old_name(inst->name_);
   block->inst_hash_.remove(inst);
+  dbModule* module = getModule();
+  if (module) {
+    ((_dbModule*) module)->dbinst_hash_.erase(old_name);
+  }
   free((void*) inst->name_);
   inst->name_ = safe_strdup(name);
   block->inst_hash_.insert(inst);
+  if (module) {
+    ((_dbModule*) module)->dbinst_hash_[name] = dbId<_dbInst>(inst->getOID());
+  }
 
   for (dbBlockCallBackObj* cb : block->callbacks_) {
     cb->inDbPostInstRename(this, old_name.c_str());
@@ -1565,9 +1572,6 @@ void dbInst::destroy(dbInst* inst_)
   inst->iterms_.clear();
 
   dbModule* module = inst_->getModule();
-  if (module) {
-    ((_dbModule*) module)->dbinst_hash_.erase(inst_->getName());
-  }
 
   debugPrint(block->getImpl()->getLogger(),
              utl::ODB,

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -82,7 +82,10 @@ void _dbInst::setModule(dbId<_dbModule> module)
   }
 
   module_ = module;
-  if (previous == 0 || module == 0) {
+  // Initial assignment during dbInst::create is not a hierarchy change.
+  // Clearing an existing module is a hierarchy change and must notify
+  // callbacks so consumers can invalidate cached hierarchical paths.
+  if (previous == 0) {
     return;
   }
 

--- a/src/odb/src/db/dbInst.h
+++ b/src/odb/src/db/dbInst.h
@@ -14,6 +14,7 @@
 namespace odb {
 
 class _dbBox;
+class _dbBlock;
 class _dbInstHdr;
 class _dbHier;
 class _dbITerm;
@@ -72,14 +73,17 @@ class _dbInst : public _dbObject
   dbId<_dbInstHdr> inst_hdr_;
   dbId<_dbBox> bbox_;
   dbId<_dbRegion> region_;
-  // WARNING: re-parenting an existing instance changes its full SDC
-  // path. dbModule::addInst() fires inDbPostInstParentChange in that
-  // case so downstream caches (e.g., dbSdcNetwork's path-to-instance
-  // map) stay consistent. The callback is suppressed on the initial
-  // assignment during dbInst::create -- that path's accounting belongs
-  // to inDbInstCreate. Prefer dbModule::addInst() over assigning this
-  // field directly.
+
+  dbId<_dbModule> getModuleId() const { return module_; }
+  void setModule(dbId<_dbModule> module);
+
+ private:
   dbId<_dbModule> module_;
+  friend dbIStream& operator>>(dbIStream& stream, _dbBlock& block);
+  friend dbIStream& operator>>(dbIStream& stream, _dbInst& inst);
+  friend dbOStream& operator<<(dbOStream& stream, const _dbInst& inst);
+
+ public:
   dbId<_dbGroup> group_;
   dbId<_dbInst> region_next_;
   dbId<_dbInst> module_next_;

--- a/src/odb/src/db/dbModule.cpp
+++ b/src/odb/src/db/dbModule.cpp
@@ -224,7 +224,7 @@ void dbModule::addInst(dbInst* inst)
         getName());
   }
 
-  if (_inst->module_ == module->getOID()) {
+  if (_inst->getModuleId() == module->getOID()) {
     return;  // already in this module
   }
 
@@ -240,13 +240,12 @@ void dbModule::addInst(dbInst* inst)
   // initial assignment during dbInst::create (module_ is unset). Only
   // the former should fire inDbPostInstParentChange -- otherwise every
   // create would falsely trigger downstream subtree-invalidation paths.
-  const bool is_reparent = (_inst->module_ != 0);
+  const bool is_reparent = (_inst->getModuleId() != 0);
   if (is_reparent) {
-    dbModule* mod = dbModule::getModule((dbBlock*) block, _inst->module_);
-    ((_dbModule*) mod)->removeInst(inst);
+    dbModule* mod = dbModule::getModule((dbBlock*) block, _inst->getModuleId());
+    ((_dbModule*) mod)->removeInst(inst, false);
   }
 
-  _inst->module_ = module->getOID();
   module->dbinst_hash_[inst->getName()] = dbId<_dbInst>(_inst->getOID());
 
   if (module->insts_ == 0) {
@@ -260,20 +259,16 @@ void dbModule::addInst(dbInst* inst)
     cur_head->module_prev_ = _inst->getOID();
   }
 
-  if (is_reparent) {
-    for (dbBlockCallBackObj* cb : block->callbacks_) {
-      cb->inDbPostInstParentChange(inst);
-    }
-  }
+  _inst->setModule(module->getOID());
 }
 
-void _dbModule::removeInst(dbInst* inst)
+void _dbModule::removeInst(dbInst* inst, bool clear_module)
 {
   _dbModule* module = (_dbModule*) this;
   _dbInst* _inst = (_dbInst*) inst;
   uint32_t id = _inst->getOID();
 
-  if (_inst->module_ != getOID()) {
+  if (_inst->getModuleId() != getOID()) {
     return;
   }
 
@@ -286,6 +281,7 @@ void _dbModule::removeInst(dbInst* inst)
   }
 
   _dbBlock* block = (_dbBlock*) getOwner();
+  module->dbinst_hash_.erase(inst->getName());
 
   if (module->insts_ == id) {
     module->insts_ = _inst->module_next_;
@@ -305,7 +301,9 @@ void _dbModule::removeInst(dbInst* inst)
       prev->module_next_ = _inst->module_next_;
     }
   }
-  _inst->module_ = 0;
+  if (clear_module) {
+    _inst->setModule(dbId<_dbModule>());
+  }
   _inst->module_next_ = 0;
   _inst->module_prev_ = 0;
 }

--- a/src/odb/src/db/dbModule.cpp
+++ b/src/odb/src/db/dbModule.cpp
@@ -243,7 +243,7 @@ void dbModule::addInst(dbInst* inst)
   const bool is_reparent = (_inst->module_ != 0);
   if (is_reparent) {
     dbModule* mod = dbModule::getModule((dbBlock*) block, _inst->module_);
-    ((_dbModule*) mod)->removeInst(inst);
+    ((_dbModule*) mod)->removeInst(inst, false);
   }
 
   _inst->module_ = module->getOID();
@@ -267,7 +267,7 @@ void dbModule::addInst(dbInst* inst)
   }
 }
 
-void _dbModule::removeInst(dbInst* inst)
+void _dbModule::removeInst(dbInst* inst, bool notify)
 {
   _dbModule* module = (_dbModule*) this;
   _dbInst* _inst = (_dbInst*) inst;
@@ -286,6 +286,7 @@ void _dbModule::removeInst(dbInst* inst)
   }
 
   _dbBlock* block = (_dbBlock*) getOwner();
+  module->dbinst_hash_.erase(inst->getName());
 
   if (module->insts_ == id) {
     module->insts_ = _inst->module_next_;
@@ -308,6 +309,12 @@ void _dbModule::removeInst(dbInst* inst)
   _inst->module_ = 0;
   _inst->module_next_ = 0;
   _inst->module_prev_ = 0;
+
+  if (notify) {
+    for (dbBlockCallBackObj* callback : block->callbacks_) {
+      callback->inDbPostInstParentChange(inst);
+    }
+  }
 }
 
 dbSet<dbModInst> dbModule::getChildren() const

--- a/src/odb/src/db/dbModule.h
+++ b/src/odb/src/db/dbModule.h
@@ -49,8 +49,7 @@ class _dbModule : public _dbObject
   void collectMemInfo(MemInfo& info);
   // User Code Begin Methods
 
-  // This is only used when destroying an inst
-  void removeInst(dbInst* inst);
+  void removeInst(dbInst* inst, bool clear_module = true);
 
   // Copy and uniquify a given module based on current instance
   using modBTMap = odb::PtrMap<dbModBTerm, dbModBTerm*>;

--- a/src/odb/src/db/dbModule.h
+++ b/src/odb/src/db/dbModule.h
@@ -49,8 +49,7 @@ class _dbModule : public _dbObject
   void collectMemInfo(MemInfo& info);
   // User Code Begin Methods
 
-  // This is only used when destroying an inst
-  void removeInst(dbInst* inst);
+  void removeInst(dbInst* inst, bool notify = true);
 
   // Copy and uniquify a given module based on current instance
   using modBTMap = odb::PtrMap<dbModBTerm, dbModBTerm*>;

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -277,6 +277,22 @@ TEST_F(ModuleFixture, reparent_updates_index_and_fires_callback)
   EXPECT_EQ(top->findDbInst("inst"), inst);
 }
 
+TEST_F(ModuleFixture, rename_updates_module_index)
+{
+  dbModule* top = block_->getTopModule();
+  dbInst* inst = dbInst::create(block_, lib_->findMaster("and2"), "old_name");
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(top->findDbInst("old_name"), inst);
+
+  ASSERT_TRUE(inst->rename("new_name"));
+  EXPECT_EQ(top->findDbInst("old_name"), nullptr);
+  EXPECT_EQ(top->findDbInst("new_name"), inst);
+
+  dbInst::destroy(inst);
+  EXPECT_EQ(top->findDbInst("old_name"), nullptr);
+  EXPECT_EQ(top->findDbInst("new_name"), nullptr);
+}
+
 TEST_F(ModuleFixture, test_default)
 {
   // dbModule::create() Succeed

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 #include "helper.h"
 #include "odb/db.h"
+#include "odb/dbBlockCallBackObj.h"
 #include "odb/dbSet.h"
 
 namespace odb {
@@ -234,6 +235,47 @@ class ModuleFixture : public SimpleDbFixture
   dbLib* lib_;
   dbBlock* block_;
 };
+
+class ParentChangeCallback : public dbBlockCallBackObj
+{
+ public:
+  void inDbPostInstParentChange(dbInst* inst) override
+  {
+    calls++;
+    observed_module = inst->getModule();
+  }
+
+  int calls = 0;
+  dbModule* observed_module = nullptr;
+};
+
+TEST_F(ModuleFixture, reparent_updates_index_and_fires_callback)
+{
+  dbModule* top = block_->getTopModule();
+  dbModule* child = dbModule::create(block_, "child");
+  dbInst* inst = dbInst::create(block_, lib_->findMaster("and2"), "inst");
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(top->findDbInst("inst"), inst);
+
+  ParentChangeCallback callback;
+  callback.addOwner(block_);
+
+  child->addInst(inst);
+  EXPECT_EQ(callback.calls, 1);
+  EXPECT_EQ(callback.observed_module, child);
+  EXPECT_EQ(inst->getModule(), child);
+  EXPECT_EQ(top->findDbInst("inst"), nullptr);
+  EXPECT_EQ(child->findDbInst("inst"), inst);
+
+  child->addInst(inst);
+  EXPECT_EQ(callback.calls, 1);
+
+  top->addInst(inst);
+  EXPECT_EQ(callback.calls, 2);
+  EXPECT_EQ(callback.observed_module, top);
+  EXPECT_EQ(child->findDbInst("inst"), nullptr);
+  EXPECT_EQ(top->findDbInst("inst"), inst);
+}
 
 TEST_F(ModuleFixture, test_default)
 {

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 #include "helper.h"
 #include "odb/db.h"
+#include "odb/dbBlockCallBackObj.h"
 #include "odb/dbSet.h"
 #include "odb/util.h"
 
@@ -246,6 +247,83 @@ TEST_F(ModuleFixture, getBaseNamePreservesEscapedDelimiters)
 {
   EXPECT_STREQ(block_->getBaseName(R"(parent/path\/leaf)"), R"(path\/leaf)");
   EXPECT_STREQ(block_->getBaseName(R"(parent/path\\/leaf)"), "leaf");
+}
+
+class ParentChangeCallback : public dbBlockCallBackObj
+{
+ public:
+  void inDbPostInstParentChange(dbInst* inst) override
+  {
+    calls++;
+    observed_module = inst->getModule();
+  }
+
+  int calls = 0;
+  dbModule* observed_module = nullptr;
+};
+
+TEST_F(ModuleFixture, ReparentUpdatesIndexAndFiresCallback)
+{
+  dbModule* top = block_->getTopModule();
+  dbModule* child = dbModule::create(block_, "child");
+  dbInst* inst = dbInst::create(block_, lib_->findMaster("and2"), "inst");
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(top->findDbInst("inst"), inst);
+
+  ParentChangeCallback callback;
+  callback.addOwner(block_);
+
+  child->addInst(inst);
+  EXPECT_EQ(callback.calls, 1);
+  EXPECT_EQ(callback.observed_module, child);
+  EXPECT_EQ(inst->getModule(), child);
+  EXPECT_EQ(top->findDbInst("inst"), nullptr);
+  EXPECT_EQ(child->findDbInst("inst"), inst);
+
+  child->addInst(inst);
+  EXPECT_EQ(callback.calls, 1);
+
+  top->addInst(inst);
+  EXPECT_EQ(callback.calls, 2);
+  EXPECT_EQ(callback.observed_module, top);
+  EXPECT_EQ(child->findDbInst("inst"), nullptr);
+  EXPECT_EQ(top->findDbInst("inst"), inst);
+}
+
+TEST_F(ModuleFixture, RemovingModuleFiresCallback)
+{
+  dbModule* child = dbModule::create(block_, "child");
+  dbInst* inst = dbInst::create(block_, lib_->findMaster("and2"), "inst");
+  ASSERT_NE(inst, nullptr);
+
+  ParentChangeCallback callback;
+  callback.addOwner(block_);
+
+  child->addInst(inst);
+  ASSERT_EQ(callback.calls, 1);
+  ASSERT_EQ(inst->getModule(), child);
+
+  dbInst::destroy(inst);
+  EXPECT_EQ(callback.calls, 2);
+  EXPECT_EQ(callback.observed_module, nullptr);
+  EXPECT_EQ(child->findDbInst("inst"), nullptr);
+}
+
+TEST_F(ModuleFixture, RenameUpdatesModuleIndex)
+{
+  dbModule* child = dbModule::create(block_, "child");
+  dbInst* inst = dbInst::create(block_, lib_->findMaster("and2"), "old_name");
+  ASSERT_NE(inst, nullptr);
+  child->addInst(inst);
+  ASSERT_EQ(child->findDbInst("old_name"), inst);
+
+  ASSERT_TRUE(inst->rename("new_name"));
+  EXPECT_EQ(child->findDbInst("old_name"), nullptr);
+  EXPECT_EQ(child->findDbInst("new_name"), inst);
+
+  dbInst::destroy(inst);
+  EXPECT_EQ(child->findDbInst("old_name"), nullptr);
+  EXPECT_EQ(child->findDbInst("new_name"), nullptr);
 }
 
 TEST_F(ModuleFixture, test_default)

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -277,6 +277,26 @@ TEST_F(ModuleFixture, reparent_updates_index_and_fires_callback)
   EXPECT_EQ(top->findDbInst("inst"), inst);
 }
 
+TEST_F(ModuleFixture, removing_module_fires_callback)
+{
+  dbModule* top = block_->getTopModule();
+  dbModule* child = dbModule::create(block_, "child");
+  dbInst* inst = dbInst::create(block_, lib_->findMaster("and2"), "inst");
+  ASSERT_NE(inst, nullptr);
+
+  ParentChangeCallback callback;
+  callback.addOwner(block_);
+
+  child->addInst(inst);
+  ASSERT_EQ(callback.calls, 1);
+  ASSERT_EQ(inst->getModule(), child);
+
+  dbInst::destroy(inst);
+  EXPECT_EQ(callback.calls, 2);
+  EXPECT_EQ(callback.observed_module, nullptr);
+  EXPECT_EQ(child->findDbInst("inst"), nullptr);
+}
+
 TEST_F(ModuleFixture, rename_updates_module_index)
 {
   dbModule* top = block_->getTopModule();


### PR DESCRIPTION
Fixes #10282.

`_dbInst::module_` could be assigned directly, so a parent change could skip `inDbPostInstParentChange` and leave hierarchical path caches stale. This routes normal changes through `setModule()` and keeps the existing module index maintenance.

The follow-up now distinguishes initial assignment during instance creation from clearing an existing module. Initial assignment stays quiet, while removal notifies callbacks so consumers can invalidate cached hierarchical paths. The regression destroys a module-owned instance and checks the callback, module lookup, and removal from the module index.

Tested on the GCP VM in a clean Ubuntu 24.04 container:

`bazel test --jobs=32 --test_output=errors //src/odb/test/cpp:TestModule`

The target passed with 1 test passing.