### PR TITLE
drt: check spacing from concave corners

### DIFF
--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -37,29 +37,44 @@ namespace drt {
 using polygon_t = bg::model::polygon<point_t>;
 using mpolygon_t = bg::model::multi_polygon<polygon_t>;
 
+namespace {
+bool isConcaveCornerOverlap(gcCorner* corner,
+                            frCoord cornerX,
+                            frCoord cornerY,
+                            frCoord xMin,
+                            frCoord yMin,
+                            frCoord xMax,
+                            frCoord yMax)
+{
+  const bool withinX = xMin <= cornerX && cornerX <= xMax;
+  const bool withinY = yMin <= cornerY && cornerY <= yMax;
+  switch (corner->getDir()) {
+    case frCornerDirEnum::NE:
+      return (cornerX == xMax && withinY) || (cornerY == yMax && withinX);
+    case frCornerDirEnum::SE:
+      return (cornerX == xMax && withinY) || (cornerY == yMin && withinX);
+    case frCornerDirEnum::SW:
+      return (cornerX == xMin && withinY) || (cornerY == yMin && withinX);
+    case frCornerDirEnum::NW:
+      return (cornerX == xMin && withinY) || (cornerY == yMax && withinX);
+    default:
+      return false;
+  }
+}
+}  // namespace
+
 bool FlexGCWorker::Impl::isCornerOverlap(gcCorner* corner, const odb::Rect& box)
 {
   frCoord cornerX = corner->getNextEdge()->low().x();
   frCoord cornerY = corner->getNextEdge()->low().y();
   if (corner->getType() == frCornerTypeEnum::CONCAVE) {
-    const bool withinX = box.xMin() <= cornerX && cornerX <= box.xMax();
-    const bool withinY = box.yMin() <= cornerY && cornerY <= box.yMax();
-    switch (corner->getDir()) {
-      case frCornerDirEnum::NE:
-        return (cornerX == box.xMax() && withinY)
-               || (cornerY == box.yMax() && withinX);
-      case frCornerDirEnum::SE:
-        return (cornerX == box.xMax() && withinY)
-               || (cornerY == box.yMin() && withinX);
-      case frCornerDirEnum::SW:
-        return (cornerX == box.xMin() && withinY)
-               || (cornerY == box.yMin() && withinX);
-      case frCornerDirEnum::NW:
-        return (cornerX == box.xMin() && withinY)
-               || (cornerY == box.yMax() && withinX);
-      default:
-        return false;
-    }
+    return isConcaveCornerOverlap(corner,
+                                  cornerX,
+                                  cornerY,
+                                  box.xMin(),
+                                  box.yMin(),
+                                  box.xMax(),
+                                  box.yMax());
   }
   switch (corner->getDir()) {
     case frCornerDirEnum::NE:
@@ -93,6 +108,15 @@ bool FlexGCWorker::Impl::isCornerOverlap(
 {
   frCoord cornerX = corner->getNextEdge()->low().x();
   frCoord cornerY = corner->getNextEdge()->low().y();
+  if (corner->getType() == frCornerTypeEnum::CONCAVE) {
+    return isConcaveCornerOverlap(corner,
+                                  cornerX,
+                                  cornerY,
+                                  gtl::xl(rect),
+                                  gtl::yl(rect),
+                                  gtl::xh(rect),
+                                  gtl::yh(rect));
+  }
   switch (corner->getDir()) {
     case frCornerDirEnum::NE:
       if (cornerX == gtl::xh(rect) && cornerY == gtl::yh(rect)) {

--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -41,6 +41,26 @@ bool FlexGCWorker::Impl::isCornerOverlap(gcCorner* corner, const odb::Rect& box)
 {
   frCoord cornerX = corner->getNextEdge()->low().x();
   frCoord cornerY = corner->getNextEdge()->low().y();
+  if (corner->getType() == frCornerTypeEnum::CONCAVE) {
+    const bool withinX = box.xMin() <= cornerX && cornerX <= box.xMax();
+    const bool withinY = box.yMin() <= cornerY && cornerY <= box.yMax();
+    switch (corner->getDir()) {
+      case frCornerDirEnum::NE:
+        return (cornerX == box.xMax() && withinY)
+               || (cornerY == box.yMax() && withinX);
+      case frCornerDirEnum::SE:
+        return (cornerX == box.xMax() && withinY)
+               || (cornerY == box.yMin() && withinX);
+      case frCornerDirEnum::SW:
+        return (cornerX == box.xMin() && withinY)
+               || (cornerY == box.yMin() && withinX);
+      case frCornerDirEnum::NW:
+        return (cornerX == box.xMin() && withinY)
+               || (cornerY == box.yMax() && withinX);
+      default:
+        return false;
+    }
+  }
   switch (corner->getDir()) {
     case frCornerDirEnum::NE:
       if (cornerX == box.xMax() && cornerY == box.yMax()) {

--- a/src/drt/test/gcTest.cpp
+++ b/src/drt/test/gcTest.cpp
@@ -343,29 +343,52 @@ INSTANTIATE_TEST_SUITE_P(CornerToCornerSuite,
                          CornerToCornerFixture,
                          testing::Values(true, false));
 
-// Check violation for corner spacing on a concave corner
-TEST_F(GCFixture, DISABLED_corner_concave)
+using ConcaveCornerFixture = FixtureWithParam<std::pair<int, int>>;
+
+// Check violations for corner spacing on concave corners in every orientation.
+TEST_P(ConcaveCornerFixture, corner_concave)
 {
-  // Setup
+  const auto [x_sign, y_sign] = GetParam();
   makeCornerConstraint(2, /* no eol */ -1, frCornerTypeEnum::CONCAVE);
 
   frNet* n1 = makeNet("n1");
 
-  makePathsegExt(n1, 2, {0, 0}, {500, 0});
-  makePathsegExt(n1, 2, {0, 0}, {0, 500});
-  makePathseg(n1, 2, {200, 200}, {1000, 200});
+  constexpr int base = 1000;
+
+  makePathsegExt(n1,
+                 2,
+                 {std::min(base, base + x_sign * 500), base},
+                 {std::max(base, base + x_sign * 500), base});
+  makePathsegExt(n1,
+                 2,
+                 {base, std::min(base, base + y_sign * 500)},
+                 {base, std::max(base, base + y_sign * 500)});
+  makePathseg(n1,
+              2,
+              {std::min(base + x_sign * 200, base + x_sign * 1000),
+               base + y_sign * 200},
+              {std::max(base + x_sign * 200, base + x_sign * 1000),
+               base + y_sign * 200});
 
   runGC();
 
-  // Test the results
   auto& markers = worker.getMarkers();
-
-  EXPECT_EQ(worker.getMarkers().size(), 1);
+  ASSERT_EQ(markers.size(), 1);
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58CornerSpacingConstraint,
-             odb::Rect(50, 50, 200, 200));
+             odb::Rect(std::min(base + x_sign * 50, base + x_sign * 200),
+                       std::min(base + y_sign * 50, base + y_sign * 150),
+                       std::max(base + x_sign * 50, base + x_sign * 200),
+                       std::max(base + y_sign * 50, base + y_sign * 150)));
 }
+
+INSTANTIATE_TEST_SUITE_P(ConcaveCornerSuite,
+                         ConcaveCornerFixture,
+                         testing::Values(std::make_pair(1, 1),
+                                         std::make_pair(1, -1),
+                                         std::make_pair(-1, 1),
+                                         std::make_pair(-1, -1)));
 
 // Check violation for parallel-run-length (PRL) spacing tables
 // This test runs over a variety of width / prl / spacing values


### PR DESCRIPTION
Concave LEF58 corner-spacing checks never reached the distance test. The code required the corner to be an exact corner of a maximal rectangle, but a concave point sits on the boundary of the two rectangles that form the notch.

Match concave corners against those boundary edges based on their orientation. Convex corner handling stays unchanged. The old disabled regression is enabled and expanded to cover all four notch orientations.

Testing on the GCP VM:
- `bazel test //src/drt/test:gc_unittest //src/drt/test:ta_unittest`
- `bazel build --config=lint //src/drt //src/drt/test:gc_unittest`
- `bazel test --config=asan //src/drt/test:gc_unittest --test_env=ASAN_OPTIONS=detect_leaks=0` with the ASan setup from #10911 layered locally

The ASan run covered all 105 geometry-check tests.