### PR TITLE
odb: give PtrSetMap one Bazel owner

### DIFF
--- a/src/odb/src/gdsin/BUILD
+++ b/src/odb/src/gdsin/BUILD
@@ -12,7 +12,6 @@ cc_library(
     name = "gdsin",
     srcs = glob(["*.cpp"]),
     hdrs = [
-        "//src/odb:include/odb/PtrSetMap.h",
         "//src/odb:include/odb/gdsUtil.h",
         "//src/odb:include/odb/gdsin.h",
     ],


### PR DESCRIPTION
`PtrSetMap.h` is exported by both `//src/odb/src/db` and `//src/odb/src/gdsin`. GDS input already depends on the db target, so its second export leaves Bazel with two owners for the same public header.

Keep the header owned by OpenDB core and let GDS input receive it through that dependency. This removes the remaining `PtrSetMap.h` duplicate reported by Bant and covers one item from #10409.

Testing on the GCP VM:
- `bazel test //src/odb/test:cpp_tests`, all 23 C++ tests pass
- `bazel build --config=lint //src/odb/src/gdsin`
- `bazel test --config=asan //src/odb/test/cpp:TestGDSIn --test_env=ASAN_OPTIONS=detect_leaks=0` with #10911 layered locally
- `bant target-hdrs -e -d //src/odb/...` no longer reports `PtrSetMap.h`