### PR TITLE
rcx: separate parse and setup logic from the actual extraction pass

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1725,6 +1725,8 @@ class extMain
 {
   // --------------------- dkf 092024 ------------------------
  public:
+  void run();
+
   extSolverGen* _currentSolverGen;
 
   // v2 -----------------------------------------------------
@@ -2054,14 +2056,6 @@ class extMain
   void updateCCCap(odb::dbRSeg* rseg1, odb::dbRSeg* rseg2, double ccCap);
   double measureOverUnderCap(extMeasure* m, int x1, int y1, int x2, int y2);
 
-  int setMinTypMax(bool min,
-                   bool typ,
-                   bool max,
-                   int setMin,
-                   int setTyp,
-                   int setMax,
-                   uint32_t extDbCnt);
-
   extRCModel* getRCmodel(uint32_t n);
 
   void calcRes0(double* deltaRes,
@@ -2124,7 +2118,9 @@ class extMain
   void updatePrevControl();
   void getPrevControl();
 
-  void makeBlockRCsegs();
+  void setCornerCount();
+
+  Array1D<extCorner*>* getProcessCornerTable() { return _processCornerTable; }
 
   uint32_t getShortSrcJid(uint32_t jid);
   void make1stRSeg(odb::dbNet* net,

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -246,7 +246,15 @@ void Ext::extract(ExtractOptions options)
     _ext->makeBlockRCsegs_v2(options.net, options.ext_model_file);
   } else {
     _ext->setExtractionOptions(options);
-    _ext->makeBlockRCsegs();
+
+    if (_ext->modelExists()) {
+      std::unique_ptr<extRCModel> rules_model
+          = parseRules(tech, _ext->getProcessCornerTable(), _ext->_v2, logger_);
+
+      _ext->registerRulesModel(rules_model.release());
+      _ext->setCornerCount();
+      _ext->run();
+    }
   }
 }
 

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1070,48 +1070,6 @@ void extMain::removeExt(std::vector<dbNet*>& nets)
 void extCompute(CoupleOptions& inputTable, void* extModel);
 void extCompute1(CoupleOptions& inputTable, void* extModel);
 
-int extMain::setMinTypMax(bool min,
-                          bool typ,
-                          bool max,
-                          int setMin,
-                          int setTyp,
-                          int setMax,
-                          uint32_t extDbCnt)
-{
-  _modelMap.resetCnt(0);
-  _metRCTable.resetCnt(0);
-  _currentModel = nullptr;
-  if ((setMin >= 0) || (setMax >= 0) || (setTyp >= 0)) {
-    if (setMin >= 0) {
-      _modelMap.add(setMin);
-    }
-    if (setTyp >= 0) {
-      _modelMap.add(setTyp);
-    }
-    if (setMax >= 0) {
-      _modelMap.add(setMax);
-    }
-    _extDbCnt = _modelMap.getCnt();
-
-    _block->setCornerCount(_extDbCnt);
-  } else if (extDbCnt == 1) {  // extract first <extDbCnt>
-    _block->setCornerCount(extDbCnt);
-    _extDbCnt = extDbCnt;
-    _modelMap.add(0);
-  }
-
-  if (_currentModel == nullptr) {
-    _currentModel = getRCmodel(0);
-    for (uint32_t ii = 0; ii < _modelMap.getCnt(); ii++) {
-      uint32_t jj = _modelMap.get(ii);
-      _metRCTable.add(_currentModel->getMetRCTable(jj));
-    }
-  }
-  _cornerCnt = _extDbCnt;  // the Cnt's are the same in the old flow
-
-  return 0;
-}
-
 extCorner::extCorner()
 {
   _name = nullptr;
@@ -1671,46 +1629,32 @@ bool extMain::modelExists()
   return true;
 }
 
-void extMain::makeBlockRCsegs()
+void extMain::setCornerCount()
 {
-  if (!modelExists()) {
-    return;
+  uint32_t scaled_corner_count = 0;
+  if (_scaledCornerTable != nullptr) {
+    scaled_corner_count = _scaledCornerTable->getCnt();
   }
 
+  if (_cornerCnt != _extDbCnt + scaled_corner_count) {
+    logger_->error(RCX,
+                   16,
+                   "Corner count invariant violated: total corners ({}) != "
+                   "process corners ({}) + scaled corners ({})",
+                   _cornerCnt,
+                   _extDbCnt,
+                   scaled_corner_count);
+  }
+
+  _block->setCornerCount(_cornerCnt, _extDbCnt, nullptr);
+}
+
+void extMain::run()
+{
   uint32_t debugNetId = 0;
 
   _diagFlow = true;
   _usingMetalPlanes = true;
-
-  odb::dbTech* tech = _block->getTech();
-  const bool has_rules_file = !tech->getExtractionRulesFile().empty();
-
-  if ((_processCornerTable != nullptr)
-      || ((_processCornerTable == nullptr) && has_rules_file)) {
-    std::unique_ptr<extRCModel> rules_model
-        = parseRules(tech, _processCornerTable, _v2, logger_);
-    registerRulesModel(rules_model.release());
-
-    uint32_t scaled_corner_count = 0;
-    if (_scaledCornerTable != nullptr) {
-      scaled_corner_count = _scaledCornerTable->getCnt();
-    }
-
-    if (_cornerCnt != _extDbCnt + scaled_corner_count) {
-      logger_->error(RCX,
-                     16,
-                     "Corner count invariant violated: total corners ({}) != "
-                     "process corners ({}) + scaled corners ({})",
-                     _cornerCnt,
-                     _extDbCnt,
-                     scaled_corner_count);
-    }
-
-    _block->setCornerCount(_cornerCnt, _extDbCnt, nullptr);
-  } else if (setMinTypMax(false, false, false, -1, -1, -1, 1) < 0) {
-    logger_->warn(RCX, 129, "Wrong combination of corner related options!");
-    return;
-  }
 
   _foreign = false;  // extract after read_spef
 


### PR DESCRIPTION
## Summary
 - `makeBlockRCsegs` is now called `run` and does not contain anything apart from the extraction logic.
 - `setMinTypMax` was removed. It was dead code.
 - The logic that sets up the corner count data inside the block was moved to `setCornerCount`. **This is a legacy mechanism that should go away when the time comes to rethink our architecture w.r.t. process corners.**
 - I needed to add `getProcessCornerTable` API as there was no way to access the table from outside `extMain`. I don't like that parsing requires data from the extractor, but that's for the next chapters.

With the changes here, it will be possible to register a different set of extraction rules before each extraction.

## Type of Change
- Refactoring

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
