### PR TITLE
rsz: Rename `strongerCellLess` to `weakerCellFirst()`

### DIFF
--- a/src/rsz/src/move/MoveGenerator.cc
+++ b/src/rsz/src/move/MoveGenerator.cc
@@ -15,23 +15,25 @@ namespace rsz {
 const sta::LibertyPort* MoveGenerator::findScenePort(
     const sta::LibertyCell* cell,
     const std::string& port_name,
-    const int lib_ap) const
+    const int lib_ap_index) const
 {
   if (cell == nullptr) {
     return nullptr;
   }
 
   const sta::LibertyPort* port = cell->findLibertyPort(port_name);
-  return port != nullptr ? port->scenePort(lib_ap) : nullptr;
+  return port != nullptr ? port->scenePort(lib_ap_index) : nullptr;
 }
 
 bool MoveGenerator::strongerCellFirst(const sta::LibertyCell* lhs,
                                       const sta::LibertyCell* rhs,
                                       const std::string& drvr_port_name,
-                                      const int lib_ap) const
+                                      const int lib_ap_index) const
 {
-  const sta::LibertyPort* lhs_port = findScenePort(lhs, drvr_port_name, lib_ap);
-  const sta::LibertyPort* rhs_port = findScenePort(rhs, drvr_port_name, lib_ap);
+  const sta::LibertyPort* lhs_port
+      = findScenePort(lhs, drvr_port_name, lib_ap_index);
+  const sta::LibertyPort* rhs_port
+      = findScenePort(rhs, drvr_port_name, lib_ap_index);
   if ((lhs_port != nullptr) != (rhs_port != nullptr)) {
     return lhs_port != nullptr;
   }

--- a/src/rsz/src/move/MoveGenerator.cc
+++ b/src/rsz/src/move/MoveGenerator.cc
@@ -25,10 +25,10 @@ const sta::LibertyPort* MoveGenerator::findScenePort(
   return port != nullptr ? port->scenePort(lib_ap) : nullptr;
 }
 
-bool MoveGenerator::strongerCellLess(const sta::LibertyCell* lhs,
-                                     const sta::LibertyCell* rhs,
-                                     const std::string& drvr_port_name,
-                                     const int lib_ap) const
+bool MoveGenerator::strongerCellFirst(const sta::LibertyCell* lhs,
+                                      const sta::LibertyCell* rhs,
+                                      const std::string& drvr_port_name,
+                                      const int lib_ap) const
 {
   const sta::LibertyPort* lhs_port = findScenePort(lhs, drvr_port_name, lib_ap);
   const sta::LibertyPort* rhs_port = findScenePort(rhs, drvr_port_name, lib_ap);
@@ -47,8 +47,8 @@ bool MoveGenerator::strongerCellLess(const sta::LibertyCell* lhs,
       = rhs_port->intrinsicDelay(resizer_.staState());
   const float lhs_capacitance = lhs_port->capacitance();
   const float rhs_capacitance = rhs_port->capacitance();
-  return std::tie(rhs_drive, lhs_intrinsic, lhs_capacitance)
-         < std::tie(lhs_drive, rhs_intrinsic, rhs_capacitance);
+  return std::tie(lhs_drive, lhs_intrinsic, lhs_capacitance)
+         < std::tie(rhs_drive, rhs_intrinsic, rhs_capacitance);
 }
 
 }  // namespace rsz

--- a/src/rsz/src/move/MoveGenerator.cc
+++ b/src/rsz/src/move/MoveGenerator.cc
@@ -47,8 +47,8 @@ bool MoveGenerator::weakerCellFirst(const sta::LibertyCell* lhs,
       = lhs_port->intrinsicDelay(resizer_.staState());
   const sta::ArcDelay rhs_intrinsic
       = rhs_port->intrinsicDelay(resizer_.staState());
-  return std::tie(rhs_drive_resistance, lhs_intrinsic)
-         < std::tie(lhs_drive_resistance, rhs_intrinsic);
+  return std::tie(lhs_drive_resistance, lhs_intrinsic)
+         > std::tie(rhs_drive_resistance, rhs_intrinsic);
 }
 
 }  // namespace rsz

--- a/src/rsz/src/move/MoveGenerator.cc
+++ b/src/rsz/src/move/MoveGenerator.cc
@@ -25,10 +25,10 @@ const sta::LibertyPort* MoveGenerator::findScenePort(
   return port != nullptr ? port->scenePort(lib_ap_index) : nullptr;
 }
 
-bool MoveGenerator::strongerCellFirst(const sta::LibertyCell* lhs,
-                                      const sta::LibertyCell* rhs,
-                                      const std::string& drvr_port_name,
-                                      const int lib_ap_index) const
+bool MoveGenerator::weakerCellFirst(const sta::LibertyCell* lhs,
+                                    const sta::LibertyCell* rhs,
+                                    const std::string& drvr_port_name,
+                                    const int lib_ap_index) const
 {
   const sta::LibertyPort* lhs_port
       = findScenePort(lhs, drvr_port_name, lib_ap_index);
@@ -47,8 +47,8 @@ bool MoveGenerator::strongerCellFirst(const sta::LibertyCell* lhs,
       = lhs_port->intrinsicDelay(resizer_.staState());
   const sta::ArcDelay rhs_intrinsic
       = rhs_port->intrinsicDelay(resizer_.staState());
-  return std::tie(lhs_drive_resistance, lhs_intrinsic)
-         < std::tie(rhs_drive_resistance, rhs_intrinsic);
+  return std::tie(rhs_drive_resistance, lhs_intrinsic)
+         < std::tie(lhs_drive_resistance, rhs_intrinsic);
 }
 
 }  // namespace rsz

--- a/src/rsz/src/move/MoveGenerator.cc
+++ b/src/rsz/src/move/MoveGenerator.cc
@@ -39,16 +39,14 @@ bool MoveGenerator::strongerCellFirst(const sta::LibertyCell* lhs,
     return lhs->name() < rhs->name();
   }
 
-  const float lhs_drive = lhs_port->driveResistance();
-  const float rhs_drive = rhs_port->driveResistance();
+  const float lhs_drive_resistance = lhs_port->driveResistance();
+  const float rhs_drive_resistance = rhs_port->driveResistance();
   const sta::ArcDelay lhs_intrinsic
       = lhs_port->intrinsicDelay(resizer_.staState());
   const sta::ArcDelay rhs_intrinsic
       = rhs_port->intrinsicDelay(resizer_.staState());
-  const float lhs_capacitance = lhs_port->capacitance();
-  const float rhs_capacitance = rhs_port->capacitance();
-  return std::tie(lhs_drive, lhs_intrinsic, lhs_capacitance)
-         < std::tie(rhs_drive, rhs_intrinsic, rhs_capacitance);
+  return std::tie(lhs_drive_resistance, lhs_intrinsic)
+         < std::tie(rhs_drive_resistance, rhs_intrinsic);
 }
 
 }  // namespace rsz

--- a/src/rsz/src/move/MoveGenerator.hh
+++ b/src/rsz/src/move/MoveGenerator.hh
@@ -104,11 +104,11 @@ class MoveGenerator
   // === Shared Liberty-cell ordering helpers ================================
   const sta::LibertyPort* findScenePort(const sta::LibertyCell* cell,
                                         const std::string& port_name,
-                                        int lib_ap) const;
+                                        int lib_ap_index) const;
   bool strongerCellFirst(const sta::LibertyCell* lhs,
                          const sta::LibertyCell* rhs,
                          const std::string& drvr_port_name,
-                         int lib_ap) const;
+                         int lib_ap_index) const;
 
   // === Shared generator dependencies =======================================
   Resizer& resizer_;

--- a/src/rsz/src/move/MoveGenerator.hh
+++ b/src/rsz/src/move/MoveGenerator.hh
@@ -105,10 +105,10 @@ class MoveGenerator
   const sta::LibertyPort* findScenePort(const sta::LibertyCell* cell,
                                         const std::string& port_name,
                                         int lib_ap) const;
-  bool strongerCellLess(const sta::LibertyCell* lhs,
-                        const sta::LibertyCell* rhs,
-                        const std::string& drvr_port_name,
-                        int lib_ap) const;
+  bool strongerCellFirst(const sta::LibertyCell* lhs,
+                         const sta::LibertyCell* rhs,
+                         const std::string& drvr_port_name,
+                         int lib_ap) const;
 
   // === Shared generator dependencies =======================================
   Resizer& resizer_;

--- a/src/rsz/src/move/MoveGenerator.hh
+++ b/src/rsz/src/move/MoveGenerator.hh
@@ -105,10 +105,10 @@ class MoveGenerator
   const sta::LibertyPort* findScenePort(const sta::LibertyCell* cell,
                                         const std::string& port_name,
                                         int lib_ap_index) const;
-  bool strongerCellFirst(const sta::LibertyCell* lhs,
-                         const sta::LibertyCell* rhs,
-                         const std::string& drvr_port_name,
-                         int lib_ap_index) const;
+  bool weakerCellFirst(const sta::LibertyCell* lhs,
+                       const sta::LibertyCell* rhs,
+                       const std::string& drvr_port_name,
+                       int lib_ap_index) const;
 
   // === Shared generator dependencies =======================================
   Resizer& resizer_;

--- a/src/rsz/src/move/SizeUpGenerator.cc
+++ b/src/rsz/src/move/SizeUpGenerator.cc
@@ -179,8 +179,8 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
   const float delay = resizer_.gateDelay(drvr_port, load_cap, scene, min_max)
                       + prev_drive * scene_input_port->capacitance();
 
-  // Accept the first cell that improves both drive resistance and estimated
-  // stage delay.
+  // Accept the first cell that does not weaken drive resistance and improves
+  // estimated stage delay.
   for (sta::LibertyCell* swappable : swappable_cells) {
     sta::LibertyCell* swappable_corner = swappable->sceneCell(lib_ap);
     if (swappable_corner == nullptr) {
@@ -197,7 +197,7 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
     const float swappable_delay
         = resizer_.gateDelay(swappable_drvr, load_cap, scene, min_max)
           + prev_drive * swappable_input->capacitance();
-    if (swappable_drive < drive && swappable_delay < delay) {
+    if (swappable_drive <= drive && swappable_delay < delay) {
       return swappable;
     }
   }

--- a/src/rsz/src/move/SizeUpGenerator.cc
+++ b/src/rsz/src/move/SizeUpGenerator.cc
@@ -164,7 +164,7 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
       swappable_cells.end(),
       [this, &drvr_port_name, lib_ap](const sta::LibertyCell* cell1,
                                       const sta::LibertyCell* cell2) {
-        return strongerCellLess(cell1, cell2, drvr_port_name, lib_ap);
+        return strongerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
       });
 
   const sta::LibertyPort* scene_drvr_port

--- a/src/rsz/src/move/SizeUpGenerator.cc
+++ b/src/rsz/src/move/SizeUpGenerator.cc
@@ -175,7 +175,7 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
     return nullptr;
   }
 
-  const float drive = scene_drvr_port->driveResistance();
+  const float drive_r = scene_drvr_port->driveResistance();
   const float delay = resizer_.gateDelay(drvr_port, load_cap, scene, min_max)
                       + prev_drive * scene_input_port->capacitance();
 
@@ -193,11 +193,11 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
     if (swappable_drvr == nullptr || swappable_input == nullptr) {
       continue;
     }
-    const float swappable_drive = swappable_drvr->driveResistance();
+    const float swappable_drive_r = swappable_drvr->driveResistance();
     const float swappable_delay
         = resizer_.gateDelay(swappable_drvr, load_cap, scene, min_max)
           + prev_drive * swappable_input->capacitance();
-    if (swappable_drive <= drive && swappable_delay < delay) {
+    if (swappable_drive_r <= drive_r && swappable_delay < delay) {
       return swappable;
     }
   }

--- a/src/rsz/src/move/SizeUpGenerator.cc
+++ b/src/rsz/src/move/SizeUpGenerator.cc
@@ -155,8 +155,8 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
     return nullptr;
   }
 
-  // Evaluate stronger equivalent cells first so the search stops on the best
-  // local replacement.
+  // Evaluate weaker equivalent cells first so the search stops on the smallest
+  // local size-up step.
   const std::string& in_port_name = in_port->name();
   const std::string& drvr_port_name = drvr_port->name();
   std::ranges::sort(
@@ -164,7 +164,7 @@ sta::LibertyCell* SizeUpGenerator::upsizeCell(sta::LibertyPort* in_port,
       swappable_cells.end(),
       [this, &drvr_port_name, lib_ap](const sta::LibertyCell* cell1,
                                       const sta::LibertyCell* cell2) {
-        return strongerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
+        return weakerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
       });
 
   const sta::LibertyPort* scene_drvr_port

--- a/src/rsz/src/move/SizeUpMtGenerator.cc
+++ b/src/rsz/src/move/SizeUpMtGenerator.cc
@@ -81,15 +81,15 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
     return replacements;
   }
 
-  // Rank equivalent cells from strongest to weakest so the first legal win is
-  // the best gain.
+  // Rank equivalent cells from weakest to strongest so equal timing scores
+  // prefer the smallest size-up step.
   const std::string& drvr_port_name = drvr_port->name();
   std::ranges::sort(
       swappable_cells.begin(),
       swappable_cells.end(),
       [this, &drvr_port_name, lib_ap](const sta::LibertyCell* cell1,
                                       const sta::LibertyCell* cell2) {
-        return strongerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
+        return weakerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
       });
 
   const sta::LibertyPort* scene_drvr_port = drvr_port->scenePort(lib_ap);

--- a/src/rsz/src/move/SizeUpMtGenerator.cc
+++ b/src/rsz/src/move/SizeUpMtGenerator.cc
@@ -3,7 +3,6 @@
 
 #include "SizeUpMtGenerator.hh"
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -81,16 +80,7 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
     return replacements;
   }
 
-  // Rank equivalent cells from weakest to strongest so equal timing scores
-  // prefer the smallest size-up step.
   const std::string& drvr_port_name = drvr_port->name();
-  std::ranges::sort(
-      swappable_cells.begin(),
-      swappable_cells.end(),
-      [this, &drvr_port_name, lib_ap](const sta::LibertyCell* cell1,
-                                      const sta::LibertyCell* cell2) {
-        return weakerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
-      });
 
   const sta::LibertyPort* scene_drvr_port = drvr_port->scenePort(lib_ap);
   if (scene_drvr_port == nullptr) {

--- a/src/rsz/src/move/SizeUpMtGenerator.cc
+++ b/src/rsz/src/move/SizeUpMtGenerator.cc
@@ -87,7 +87,7 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
     return replacements;
   }
 
-  const float drive = scene_drvr_port->driveResistance();
+  const float drive_r = scene_drvr_port->driveResistance();
   // Keep every equivalent cell that does not weaken drive resistance and let
   // candidate::estimate require a strict delay improvement.
   odb::dbMaster* current_master = resizer_.dbNetwork()->staToDb(cell);
@@ -115,8 +115,8 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
     if (swappable_drvr == nullptr) {
       continue;
     }
-    const float swappable_drive = swappable_drvr->driveResistance();
-    if (swappable_drive <= drive) {
+    const float swappable_drive_r = swappable_drvr->driveResistance();
+    if (swappable_drive_r <= drive_r) {
       replacements.push_back(swappable);
     }
   }

--- a/src/rsz/src/move/SizeUpMtGenerator.cc
+++ b/src/rsz/src/move/SizeUpMtGenerator.cc
@@ -98,10 +98,13 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
   }
 
   const float drive = scene_drvr_port->driveResistance();
-  // Keep every stronger equivalent cell and let candidate::estimate do the
-  // exact timing check.
+  // Keep every equivalent cell that does not weaken drive resistance and let
+  // candidate::estimate require a strict delay improvement.
   odb::dbMaster* current_master = resizer_.dbNetwork()->staToDb(cell);
   for (sta::LibertyCell* swappable : swappable_cells) {
+    if (swappable == cell) {
+      continue;
+    }
     odb::dbMaster* swappable_master = resizer_.dbNetwork()->staToDb(swappable);
     if (current_master == nullptr || swappable_master == nullptr) {
       continue;
@@ -123,7 +126,7 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
       continue;
     }
     const float swappable_drive = swappable_drvr->driveResistance();
-    if (swappable_drive < drive) {
+    if (swappable_drive <= drive) {
       replacements.push_back(swappable);
     }
   }

--- a/src/rsz/src/move/SizeUpMtGenerator.cc
+++ b/src/rsz/src/move/SizeUpMtGenerator.cc
@@ -89,7 +89,7 @@ std::vector<sta::LibertyCell*> SizeUpMtGenerator::findSizeUpOptions(
       swappable_cells.end(),
       [this, &drvr_port_name, lib_ap](const sta::LibertyCell* cell1,
                                       const sta::LibertyCell* cell2) {
-        return strongerCellLess(cell1, cell2, drvr_port_name, lib_ap);
+        return strongerCellFirst(cell1, cell2, drvr_port_name, lib_ap);
       });
 
   const sta::LibertyPort* scene_drvr_port = drvr_port->scenePort(lib_ap);

--- a/src/rsz/src/move/SizeUpMtGenerator.hh
+++ b/src/rsz/src/move/SizeUpMtGenerator.hh
@@ -21,8 +21,8 @@ class Instance;
 
 namespace rsz {
 
-// MT-safe generator that enumerates all same-VT stronger cells for one
-// target using a prepared ArcDelayState.
+// MT-safe generator that enumerates same-VT cells that do not weaken output
+// drive for one target using a prepared ArcDelayState.
 //
 // prepareRequirements() requests kArcDelayState so worker threads can read the
 // prepared timing snapshot without touching shared STA state. Produces multiple

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -483,7 +483,10 @@ cc_test(
     name = "TestResizer",
     srcs = ["cpp/TestResizer.cc"],
     copts = ["-Isrc/rsz/src"],
-    data = glob(["cpp/TestResizer*.v"]) + [
+    data = glob([
+        "cpp/TestResizer*.lib",
+        "cpp/TestResizer*.v",
+    ]) + [
         "inferred_clock_gator_time_borrow.def",
         "latch_borrow_chain.def",
     ],

--- a/src/rsz/test/cpp/TestResizer.cc
+++ b/src/rsz/test/cpp/TestResizer.cc
@@ -5,8 +5,11 @@
 #include <string>
 #include <vector>
 
+#include "MoveCommitter.hh"
+#include "OptimizerTypes.hh"
 #include "RepairTargetCollector.hh"
 #include "gtest/gtest.h"
+#include "move/MoveGenerator.hh"
 #include "odb/db.h"
 #include "odb/defin.h"
 #include "sta/Clock.hh"
@@ -15,6 +18,7 @@
 #include "sta/MinMax.hh"
 #include "sta/Mode.hh"
 #include "sta/NetworkClass.hh"
+#include "sta/Scene.hh"
 #include "sta/Sdc.hh"
 #include "sta/Sta.hh"
 #include "sta/Transition.hh"
@@ -22,6 +26,24 @@
 #include "tst/IntegratedFixture.h"
 
 namespace rsz {
+
+class TestMoveGenerator : public MoveGenerator
+{
+ public:
+  explicit TestMoveGenerator(const GeneratorContext& context)
+      : MoveGenerator(context)
+  {
+  }
+
+  MoveType type() const override { return MoveType::kSizeUp; }
+
+  std::vector<std::unique_ptr<MoveCandidate>> generate(const Target&) override
+  {
+    return {};
+  }
+
+  using MoveGenerator::strongerCellFirst;
+};
 
 class TestResizer : public tst::IntegratedFixture
 {
@@ -200,6 +222,42 @@ class TestResizer : public tst::IntegratedFixture
     return nullptr;
   }
 };
+
+TEST_F(TestResizer, StrongerCellFirstOrdersLowerDriveResistanceFirst)
+{
+  const sta::LibertyCell* weaker_cell
+      = sta_->network()->findLibertyCell("BUF_X1");
+  const sta::LibertyCell* stronger_cell
+      = sta_->network()->findLibertyCell("BUF_X16");
+  ASSERT_NE(weaker_cell, nullptr);
+  ASSERT_NE(stronger_cell, nullptr);
+
+  const int lib_ap = sta_->cmdScene()->libertyIndex(sta::MinMax::max());
+  const sta::LibertyPort* weaker_base_port = weaker_cell->findLibertyPort("Z");
+  const sta::LibertyPort* stronger_base_port
+      = stronger_cell->findLibertyPort("Z");
+  ASSERT_NE(weaker_base_port, nullptr);
+  ASSERT_NE(stronger_base_port, nullptr);
+  const sta::LibertyPort* weaker_port = weaker_base_port->scenePort(lib_ap);
+  const sta::LibertyPort* stronger_port = stronger_base_port->scenePort(lib_ap);
+  ASSERT_NE(weaker_port, nullptr);
+  ASSERT_NE(stronger_port, nullptr);
+  ASSERT_LT(stronger_port->driveResistance(), weaker_port->driveResistance());
+
+  MoveCommitter committer(resizer_);
+  const OptimizerRunConfig run_config;
+  const OptimizationPolicyConfig policy_config;
+  const GeneratorContext context{.resizer = resizer_,
+                                 .committer = committer,
+                                 .run_config = run_config,
+                                 .policy_config = policy_config};
+  const TestMoveGenerator generator(context);
+
+  EXPECT_TRUE(
+      generator.strongerCellFirst(stronger_cell, weaker_cell, "Z", lib_ap));
+  EXPECT_FALSE(
+      generator.strongerCellFirst(weaker_cell, stronger_cell, "Z", lib_ap));
+}
 
 TEST_F(TestResizer, SwapPinsFeedthroughModNet)
 {

--- a/src/rsz/test/cpp/TestResizer.cc
+++ b/src/rsz/test/cpp/TestResizer.cc
@@ -42,7 +42,7 @@ class TestMoveGenerator : public MoveGenerator
     return {};
   }
 
-  using MoveGenerator::strongerCellFirst;
+  using MoveGenerator::weakerCellFirst;
 };
 
 class TestResizer : public tst::IntegratedFixture
@@ -223,7 +223,7 @@ class TestResizer : public tst::IntegratedFixture
   }
 };
 
-TEST_F(TestResizer, StrongerCellFirstOrdersLowerDriveResistanceFirst)
+TEST_F(TestResizer, WeakerCellFirstOrdersHigherDriveResistanceFirst)
 {
   const sta::LibertyCell* weaker_cell
       = sta_->network()->findLibertyCell("BUF_X1");
@@ -254,9 +254,9 @@ TEST_F(TestResizer, StrongerCellFirstOrdersLowerDriveResistanceFirst)
   const TestMoveGenerator generator(context);
 
   EXPECT_TRUE(
-      generator.strongerCellFirst(stronger_cell, weaker_cell, "Z", lib_ap));
+      generator.weakerCellFirst(weaker_cell, stronger_cell, "Z", lib_ap));
   EXPECT_FALSE(
-      generator.strongerCellFirst(weaker_cell, stronger_cell, "Z", lib_ap));
+      generator.weakerCellFirst(stronger_cell, weaker_cell, "Z", lib_ap));
 }
 
 TEST_F(TestResizer, SwapPinsFeedthroughModNet)

--- a/src/rsz/test/cpp/TestResizer.cc
+++ b/src/rsz/test/cpp/TestResizer.cc
@@ -232,14 +232,16 @@ TEST_F(TestResizer, WeakerCellFirstOrdersHigherDriveResistanceFirst)
   ASSERT_NE(weaker_cell, nullptr);
   ASSERT_NE(stronger_cell, nullptr);
 
-  const int lib_ap = sta_->cmdScene()->libertyIndex(sta::MinMax::max());
+  const int lib_ap_index = sta_->cmdScene()->libertyIndex(sta::MinMax::max());
   const sta::LibertyPort* weaker_base_port = weaker_cell->findLibertyPort("Z");
   const sta::LibertyPort* stronger_base_port
       = stronger_cell->findLibertyPort("Z");
   ASSERT_NE(weaker_base_port, nullptr);
   ASSERT_NE(stronger_base_port, nullptr);
-  const sta::LibertyPort* weaker_port = weaker_base_port->scenePort(lib_ap);
-  const sta::LibertyPort* stronger_port = stronger_base_port->scenePort(lib_ap);
+  const sta::LibertyPort* weaker_port
+      = weaker_base_port->scenePort(lib_ap_index);
+  const sta::LibertyPort* stronger_port
+      = stronger_base_port->scenePort(lib_ap_index);
   ASSERT_NE(weaker_port, nullptr);
   ASSERT_NE(stronger_port, nullptr);
   ASSERT_LT(stronger_port->driveResistance(), weaker_port->driveResistance());
@@ -254,9 +256,56 @@ TEST_F(TestResizer, WeakerCellFirstOrdersHigherDriveResistanceFirst)
   const TestMoveGenerator generator(context);
 
   EXPECT_TRUE(
-      generator.weakerCellFirst(weaker_cell, stronger_cell, "Z", lib_ap));
+      generator.weakerCellFirst(weaker_cell, stronger_cell, "Z", lib_ap_index));
   EXPECT_FALSE(
-      generator.weakerCellFirst(stronger_cell, weaker_cell, "Z", lib_ap));
+      generator.weakerCellFirst(stronger_cell, weaker_cell, "Z", lib_ap_index));
+}
+
+TEST_F(TestResizer, WeakerCellFirstOrdersHigherIntrinsicDelayFirst)
+{
+  sta::LibertyLibrary* library
+      = readLiberty(test_root_path_ + "cpp/TestResizerIntrinsic.lib");
+  ASSERT_NE(library, nullptr);
+
+  const sta::LibertyCell* faster_cell
+      = library->findLibertyCell("INTRINSIC_FAST");
+  const sta::LibertyCell* slower_cell
+      = library->findLibertyCell("INTRINSIC_SLOW");
+  ASSERT_NE(faster_cell, nullptr);
+  ASSERT_NE(slower_cell, nullptr);
+
+  const int lib_ap_index = sta_->cmdScene()->libertyIndex(sta::MinMax::max());
+  const sta::LibertyPort* faster_base_port = faster_cell->findLibertyPort("Z");
+  const sta::LibertyPort* slower_base_port = slower_cell->findLibertyPort("Z");
+  ASSERT_NE(faster_base_port, nullptr);
+  ASSERT_NE(slower_base_port, nullptr);
+  const sta::LibertyPort* faster_port
+      = faster_base_port->scenePort(lib_ap_index);
+  const sta::LibertyPort* slower_port
+      = slower_base_port->scenePort(lib_ap_index);
+  ASSERT_NE(faster_port, nullptr);
+  ASSERT_NE(slower_port, nullptr);
+  ASSERT_FLOAT_EQ(faster_port->driveResistance(),
+                  slower_port->driveResistance());
+  const sta::ArcDelay faster_intrinsic
+      = faster_port->intrinsicDelay(resizer_.staState());
+  const sta::ArcDelay slower_intrinsic
+      = slower_port->intrinsicDelay(resizer_.staState());
+  ASSERT_LT(faster_intrinsic, slower_intrinsic);
+
+  MoveCommitter committer(resizer_);
+  const OptimizerRunConfig run_config;
+  const OptimizationPolicyConfig policy_config;
+  const GeneratorContext context{.resizer = resizer_,
+                                 .committer = committer,
+                                 .run_config = run_config,
+                                 .policy_config = policy_config};
+  const TestMoveGenerator generator(context);
+
+  EXPECT_TRUE(
+      generator.weakerCellFirst(slower_cell, faster_cell, "Z", lib_ap_index));
+  EXPECT_FALSE(
+      generator.weakerCellFirst(faster_cell, slower_cell, "Z", lib_ap_index));
 }
 
 TEST_F(TestResizer, SwapPinsFeedthroughModNet)

--- a/src/rsz/test/cpp/TestResizerIntrinsic.lib
+++ b/src/rsz/test/cpp/TestResizerIntrinsic.lib
@@ -1,0 +1,92 @@
+library (TestResizerIntrinsic) {
+  delay_model : table_lookup;
+  time_unit : "1ns";
+  voltage_unit : "1V";
+  current_unit : "1mA";
+  pulling_resistance_unit : "1kohm";
+  capacitive_load_unit (1, pf);
+
+  input_threshold_pct_rise : 50.0;
+  input_threshold_pct_fall : 50.0;
+  output_threshold_pct_rise : 50.0;
+  output_threshold_pct_fall : 50.0;
+  slew_lower_threshold_pct_rise : 20.0;
+  slew_lower_threshold_pct_fall : 20.0;
+  slew_upper_threshold_pct_rise : 80.0;
+  slew_upper_threshold_pct_fall : 80.0;
+
+  lu_table_template (output_slew) {
+    variable_1 : total_output_net_capacitance;
+    index_1 ("1.0, 2.0");
+  }
+
+  cell (INTRINSIC_FAST) {
+    area : 1.0;
+    cell_footprint : intrinsic_tie;
+
+    pin (A) {
+      direction : input;
+      capacitance : 0.1;
+    }
+
+    pin (Z) {
+      direction : output;
+      function : "A";
+      max_capacitance : 2.0;
+
+      timing () {
+        related_pin : "A";
+        timing_sense : positive_unate;
+        cell_rise (scalar) {
+          values ("0.1");
+        }
+        cell_fall (scalar) {
+          values ("0.1");
+        }
+        rise_transition (output_slew) {
+          index_1 ("1.0, 2.0");
+          values ("1.0, 2.0");
+        }
+        fall_transition (output_slew) {
+          index_1 ("1.0, 2.0");
+          values ("1.0, 2.0");
+        }
+      }
+    }
+  }
+
+  cell (INTRINSIC_SLOW) {
+    area : 1.0;
+    cell_footprint : intrinsic_tie;
+
+    pin (A) {
+      direction : input;
+      capacitance : 0.1;
+    }
+
+    pin (Z) {
+      direction : output;
+      function : "A";
+      max_capacitance : 2.0;
+
+      timing () {
+        related_pin : "A";
+        timing_sense : positive_unate;
+        cell_rise (scalar) {
+          values ("0.2");
+        }
+        cell_fall (scalar) {
+          values ("0.2");
+        }
+        rise_transition (output_slew) {
+          index_1 ("1.0, 2.0");
+          values ("1.0, 2.0");
+        }
+        fall_transition (output_slew) {
+          index_1 ("1.0, 2.0");
+          values ("1.0, 2.0");
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Simple refactoring w/ minor tie-break logic change.
- Rename `strongerCellLess()` to `weakerCellFirst()` w/ a tie-breaker logic change.
- Rename the comparator and Liberty AP index arguments for clarity.
- Add TestResizer coverage for drive-resistance and intrinsic-delay ordering.
- No QoR impact (tested locally)