### PR TITLE
cmake: fix a redundant flag causing the build to fail with newer GCC versions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,7 +151,7 @@ add_compile_options(
   -Wredundant-decls
   -Wformat-security
   -Wno-sign-compare
-  -Wp,-D_GLIBCXX_ASSERTIONS
+  -D_GLIBCXX_ASSERTIONS
   $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>
   # Needed for floating point stability in FFT (fft_test will check this).
   # See also https://kristerw.github.io/2021/11/09/fp-contract/


### PR DESCRIPTION
## Summary
Passing `-D_GLIBCXX_ASSERTIONS` directly to the preprocessor results in an error compiling with GCC 14 or 15 (14.3.1 and 15.3.0) , simply removing `-Wp` fixes this and causes no compile time errors/warnings. Tests also pass with the flag changed. 

## Type of Change
- Bug fix

## Impact
Adds support for GCC 14 and 15 (probably other versions, too) while causing no observable functionality changes. 

## Verification
- [x] I have verified that the local build succeeds (`ran cmake manually`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
