### PR TITLE
rsz: repair_timing -effort policy (tapeout|explore)

### DIFF
--- a/src/rsz/BUILD
+++ b/src/rsz/BUILD
@@ -134,6 +134,7 @@ cc_library(
         "src/policy/SetupWnsPolicy.hh",
     ],
     hdrs = [
+        "include/rsz/EffortPolicy.hh",
         "include/rsz/GlobalSizingConfig.hh",
         "include/rsz/OdbCallBack.hh",
         "include/rsz/Resizer.hh",
@@ -224,6 +225,7 @@ tcl_wrap_cc(
 python_wrap_cc(
     name = "swig-py",
     srcs = [
+        "include/rsz/EffortPolicy.hh",
         "include/rsz/GlobalSizingConfig.hh",
         "include/rsz/Resizer.hh",
         "src/Resizer-py.i",

--- a/src/rsz/README.md
+++ b/src/rsz/README.md
@@ -238,6 +238,7 @@ repair_timing
     [-max_utilization util]
     [-max_buffer_percent buffer_percent]
     [-match_cell_footprint]
+    [-effort directives]
     [-verbose]
 ```
 
@@ -267,6 +268,7 @@ repair_timing
 | `-max_iterations` | Defines the maximum number of iterations executed when repairing setup and hold violations. The default is `-1`, which disables the limit of iterations. |
 | `-max_buffer_percent` | Specify a maximum number of buffers to insert to repair hold violations as a percentage of the number of instances in the design. The default value is `20`, and the allowed values are integers `[0, 100]`. |
 | `-match_cell_footprint` | Obey the Liberty cell footprint when swapping gates. |
+| `-effort` | Coarse optimization policy, analogous to compiler driver `-O` flags: the caller states intent and the tool owns the mapping to internal heuristics. Directives apply left to right and a later directive overrides an earlier one, so an explicit `-hold` to the right of `-effort explore` re-enables hold repair. Defined directives: `tapeout` (default) targets timing closure with unbounded effort; `explore` targets design-space exploration — setup repair may stop as soon as its marginal progress plateaus, and hold repair is not run. |
 | `-verbose` | Enable verbose logging of the repair progress. |
 
 Use`-recover_power` to specify the percent of paths with positive slack which

--- a/src/rsz/include/rsz/EffortPolicy.hh
+++ b/src/rsz/include/rsz/EffortPolicy.hh
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#pragma once
+
+#include <string>
+
+namespace rsz {
+
+// Coarse optimization policy for repair_timing, analogous to compiler
+// driver -O flags (POLA): the caller states intent, the tool owns the
+// mapping to internal heuristics. Directives apply left to right; a later
+// directive overrides an earlier one, as in "gcc -O0 -O2".
+//
+// Defined directives:
+//   tapeout  historical behavior: unbounded effort toward the timing
+//            targets, hold repaired (default).
+//   explore  design-space exploration: setup repair may stop as soon as
+//            its marginal progress plateaus, hold repair is not run at
+//            all (hold closure is period-independent and adds no
+//            exploration information, only runtime).
+//   -hold    position marker for an explicit repair_timing -hold flag:
+//            to the right of "explore" it re-enables hold repair.
+//
+// Graded effort levels between the two are intentionally not defined here.
+struct EffortPolicy
+{
+  // Setup repair's marginal-progress stop may fire once the optimization
+  // iteration exceeds plateau_start_iteration and the incremental TNS fix
+  // rate drops below min_inc_fix_rate. The defaults reproduce the
+  // historical hardcoded 1000 / 0.0001 gate.
+  int plateau_start_iteration = 1000;
+  float min_inc_fix_rate = 0.0001f;
+  bool repair_hold = true;
+
+  bool operator==(const EffortPolicy&) const = default;
+
+  // Returns false on an unknown directive.
+  bool apply(const std::string& directive)
+  {
+    if (directive == "tapeout") {
+      *this = EffortPolicy();
+      return true;
+    }
+    if (directive == "explore") {
+      plateau_start_iteration = 0;
+      min_inc_fix_rate = 0.05f;
+      repair_hold = false;
+      return true;
+    }
+    if (directive == "-hold") {
+      repair_hold = true;
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace rsz

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -31,6 +31,7 @@
 #include "odb/dbObject.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "rsz/EffortPolicy.hh"
 #include "rsz/GlobalSizingConfig.hh"
 #include "rsz/OdbCallBack.hh"
 #include "sta/Delay.hh"
@@ -340,6 +341,12 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
   float targetLoadCap(sta::LibertyCell* cell);
 
   ////////////////////////////////////////////////////////////////
+  // Resolve repair_timing -effort directives (left to right, later wins)
+  // into the policy consulted by repairSetup and the hold-repair decision.
+  // Errors on an unknown directive.
+  void setRepairEffort(const char* directives);
+  bool repairEffortRepairsHold() const { return repair_effort_.repair_hold; }
+
   bool repairSetup(double setup_margin,
                    double repair_tns_end_percent,
                    int max_passes,
@@ -949,6 +956,8 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
   // Layer RC per wire length indexed by layer->getNumber(), corner->index
   sta::LibertyCellSet dont_use_;
   double max_area_ = 0.0;
+
+  EffortPolicy repair_effort_;
 
   utl::Logger* logger_ = nullptr;
   est::EstimateParasitics* estimate_parasitics_ = nullptr;

--- a/src/rsz/src/OptimizerTypes.hh
+++ b/src/rsz/src/OptimizerTypes.hh
@@ -412,6 +412,12 @@ struct OptimizerRunConfig
   int max_iterations{0};
   int max_passes{100};
   int max_repairs_per_pass{1};
+  // Setup repair's marginal-progress stop: it may fire once opto_iteration
+  // exceeds plateau_start_iteration and the incremental TNS fix rate drops
+  // below min_inc_fix_rate. Populated from the repair_timing -effort policy
+  // (rsz/EffortPolicy.hh); the defaults are the tapeout values.
+  int plateau_start_iteration{1000};
+  float min_inc_fix_rate{0.0001f};
   bool match_cell_footprint{false};
   bool verbose{false};
   bool skip_pin_swap{false};

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -5067,6 +5067,22 @@ void Resizer::cloneClkInverter(sta::Instance* inv)
 
 ////////////////////////////////////////////////////////////////
 
+void Resizer::setRepairEffort(const char* directives)
+{
+  repair_effort_ = EffortPolicy();
+  std::istringstream stream(directives != nullptr ? directives : "");
+  std::string directive;
+  while (stream >> directive) {
+    if (!repair_effort_.apply(directive)) {
+      logger_->error(RSZ,
+                     3302,
+                     "unknown -effort directive '{}'; defined directives are "
+                     "tapeout and explore.",
+                     directive);
+    }
+  }
+}
+
 bool Resizer::repairSetup(double setup_margin,
                           double repair_tns_end_percent,
                           int max_passes,
@@ -5105,6 +5121,8 @@ bool Resizer::repairSetup(double setup_margin,
   config.skip_last_gasp = skip_last_gasp;
   config.skip_vt_swap = skip_vt_swap;
   config.skip_crit_vt_swap = skip_crit_vt_swap;
+  config.plateau_start_iteration = repair_effort_.plateau_start_iteration;
+  config.min_inc_fix_rate = repair_effort_.min_inc_fix_rate;
 
   rsz::Optimizer optimizer(this);
   optimizer.configure(config);

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -357,6 +357,22 @@ repair_net_cmd(Net *net,
   resizer->repairNet(net, max_length, slew_margin, cap_margin);
 }
 
+void
+set_repair_effort(const char* directives)
+{
+  ensureLinked();
+  Resizer *resizer = getResizer();
+  resizer->setRepairEffort(directives);
+}
+
+bool
+repair_effort_repairs_hold()
+{
+  ensureLinked();
+  Resizer *resizer = getResizer();
+  return resizer->repairEffortRepairsHold();
+}
+
 bool
 repair_setup(double setup_margin,
              double repair_tns_end_percent,

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -259,9 +259,32 @@ sta::define_cmd_args "repair_timing" {[-setup] [-hold]\
                                         [-max_utilization util] \
                                         [-match_cell_footprint] \
                                         [-max_repairs_per_pass max_repairs_per_pass]\
+                                        [-effort directives]\
                                         [-verbose]}
 
 proc repair_timing { args } {
+  # -effort is a coarse optimization policy in the spirit of compiler driver
+  # -O flags (POLA): directives apply left to right and a later directive
+  # overrides an earlier one, so an explicit -hold to the right of
+  # "-effort explore" re-enables hold repair. Scanned from the raw argument
+  # list because position carries meaning; resolution lives in
+  # rsz::EffortPolicy.
+  set effort_directives {}
+  for { set i 0 } { $i < [llength $args] } { incr i } {
+    set arg [lindex $args $i]
+    if { [string length $arg] >= 2 && [string match "$arg*" "-effort"] } {
+      # Unique-prefix abbreviation, as honored by parse_key_args below.
+      incr i
+      foreach directive [lindex $args $i] {
+        lappend effort_directives $directive
+      }
+    } elseif { $arg eq "-hold" } {
+      # Shorter prefixes resolve to -hold_margin, so exact match only.
+      lappend effort_directives -hold
+    }
+  }
+  rsz::set_repair_effort $effort_directives
+
   # `-phases` is the public spelling listed in -help / define_cmd_args.
   # `-policy` and `-policies` are accepted-but-undocumented aliases for the
   # same phase sequence; only one of the three may be supplied per call.
@@ -269,7 +292,8 @@ proc repair_timing { args } {
     keys {-setup_margin -hold_margin -slack_margin \
             -libraries -max_utilization -max_buffer_percent -sequence \
             -phases -policy -policies \
-            -recover_power -repair_tns -max_passes -max_iterations -max_repairs_per_pass} \
+            -recover_power -repair_tns -max_passes -max_iterations -max_repairs_per_pass \
+            -effort} \
     flags {-setup -hold -allow_setup_violations -skip_pin_swap -skip_gate_cloning \
              -skip_size_down -skip_buffering -skip_buffer_removal -skip_last_gasp \
              -skip_vt_swap -skip_crit_vt_swap -match_cell_footprint -verbose}
@@ -391,9 +415,13 @@ proc repair_timing { args } {
         $skip_buffer_removal $skip_last_gasp $skip_vt_swap $skip_crit_vt_swap]
     }
     if { $hold } {
-      set repaired_hold [rsz::repair_hold $setup_margin $hold_margin \
-        $allow_setup_violations $max_buffer_percent $max_passes \
-        $max_iterations $match_cell_footprint $verbose]
+      if { [rsz::repair_effort_repairs_hold] } {
+        set repaired_hold [rsz::repair_hold $setup_margin $hold_margin \
+          $allow_setup_violations $max_buffer_percent $max_passes \
+          $max_iterations $match_cell_footprint $verbose]
+      } else {
+        utl::info RSZ 3303 "-effort explore: hold repair not run."
+      }
     }
   }
 

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -272,7 +272,10 @@ proc repair_timing { args } {
   set effort_directives {}
   for { set i 0 } { $i < [llength $args] } { incr i } {
     set arg [lindex $args $i]
-    if { [string length $arg] >= 2 && [string match "$arg*" "-effort"] } {
+    if {
+      [string length $arg] >= 2
+      && [string equal -length [string length $arg] $arg "-effort"]
+    } {
       # Unique-prefix abbreviation, as honored by parse_key_args below.
       incr i
       foreach directive [lindex $args $i] {

--- a/src/rsz/src/policy/SetupLastGaspPolicy.cc
+++ b/src/rsz/src/policy/SetupLastGaspPolicy.cc
@@ -118,7 +118,7 @@ bool SetupLastGaspPolicy::initializeLastGaspRepair(
   last_gasp_state.initial_tns = setup_context_.initial_tns;
   last_gasp_state.prev_tns = curr_tns;
   last_gasp_state.prev_worst_slack = violating_ends.front().second;
-  last_gasp_state.fix_rate_threshold = inc_fix_rate_threshold_;
+  last_gasp_state.fix_rate_threshold = config_.min_inc_fix_rate;
 
   debugPrint(logger_,
              RSZ,

--- a/src/rsz/src/policy/SetupLegacyBase.cc
+++ b/src/rsz/src/policy/SetupLegacyBase.cc
@@ -909,7 +909,8 @@ bool SetupLegacyBase::terminateProgress(const int iteration,
     float curr_tns = sta_->totalNegativeSlack(max_);
     float inc_fix_rate = (prev_tns - curr_tns) / initial_tns;
     prev_tns = curr_tns;
-    if (iteration > 1000 && inc_fix_rate < fix_rate_threshold) {
+    if (iteration > config_.plateau_start_iteration
+        && inc_fix_rate < fix_rate_threshold) {
       debugPrint(logger_,
                  RSZ,
                  "repair_setup",

--- a/src/rsz/src/policy/SetupLegacyBase.hh
+++ b/src/rsz/src/policy/SetupLegacyBase.hh
@@ -211,7 +211,6 @@ class SetupLegacyBase : public OptimizationPolicy
   static constexpr int print_interval_ = 10;
   static constexpr int opto_small_interval_ = 100;
   static constexpr int opto_large_interval_ = 1000;
-  static constexpr float inc_fix_rate_threshold_ = 0.0001;
 };
 
 }  // namespace rsz

--- a/src/rsz/src/policy/SetupLegacyPolicy.cc
+++ b/src/rsz/src/policy/SetupLegacyPolicy.cc
@@ -93,7 +93,7 @@ bool SetupLegacyPolicy::initializeMainRepair(MainRepairState& main_state,
   main_state.initial_tns = sta_->totalNegativeSlack(max_);
   main_state.prev_tns = main_state.initial_tns;
   main_state.num_viols = violating_ends.size();
-  main_state.fix_rate_threshold = inc_fix_rate_threshold_;
+  main_state.fix_rate_threshold = config_.min_inc_fix_rate;
 
   printProgress(main_state.opto_iteration, false, main_state.phase_marker);
 

--- a/src/rsz/src/policy/SetupWnsPolicy.cc
+++ b/src/rsz/src/policy/SetupWnsPolicy.cc
@@ -94,7 +94,7 @@ void SetupWnsPolicy::repairSetupWns(const float setup_slack_margin,
   std::map<const sta::Pin*, int> endpoint_pass_limits;
   bool any_improvement_this_round = false;
   int total_decreasing_slack_passes = 0;
-  float fix_rate_threshold = inc_fix_rate_threshold_;
+  float fix_rate_threshold = config_.min_inc_fix_rate;
   sta::Slack target_end_slack = 0.0;
   sta::Slack target_worst_slack = 0.0;
   sta::Slack target_tns_local = 0.0;

--- a/src/rsz/test/cpp/CMakeLists.txt
+++ b/src/rsz/test/cpp/CMakeLists.txt
@@ -201,3 +201,21 @@ gtest_discover_tests(TestResizerMt
 
 add_dependencies(build_and_test TestResizerMt
 )
+
+add_executable(TestEffortPolicy TestEffortPolicy.cc)
+target_link_libraries(TestEffortPolicy
+        GTest::gtest
+        GTest::gtest_main
+)
+
+target_include_directories(TestEffortPolicy
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/rsz/include
+)
+
+gtest_discover_tests(TestEffortPolicy
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+add_dependencies(build_and_test TestEffortPolicy
+)

--- a/src/rsz/test/cpp/TestEffortPolicy.cc
+++ b/src/rsz/test/cpp/TestEffortPolicy.cc
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+// repair_timing -effort policy resolution: directives apply left to
+// right, later directives override earlier ones (compiler driver -O
+// semantics).
+
+#include "gtest/gtest.h"
+#include "rsz/EffortPolicy.hh"
+
+namespace rsz {
+
+TEST(EffortPolicy, DefaultIsTapeout)
+{
+  EffortPolicy policy;
+  EXPECT_EQ(policy.plateau_start_iteration, 1000);
+  EXPECT_FLOAT_EQ(policy.min_inc_fix_rate, 0.0001f);
+  EXPECT_TRUE(policy.repair_hold);
+}
+
+TEST(EffortPolicy, TapeoutIsExplicitDefault)
+{
+  EffortPolicy policy;
+  ASSERT_TRUE(policy.apply("tapeout"));
+  EXPECT_EQ(policy, EffortPolicy());
+}
+
+TEST(EffortPolicy, ExploreBoundsSetupAndDisablesHold)
+{
+  EffortPolicy policy;
+  ASSERT_TRUE(policy.apply("explore"));
+  EXPECT_EQ(policy.plateau_start_iteration, 0);
+  EXPECT_FLOAT_EQ(policy.min_inc_fix_rate, 0.05f);
+  EXPECT_FALSE(policy.repair_hold);
+}
+
+TEST(EffortPolicy, LaterDirectiveWins)
+{
+  EffortPolicy policy;
+  ASSERT_TRUE(policy.apply("explore"));
+  ASSERT_TRUE(policy.apply("tapeout"));
+  EXPECT_EQ(policy, EffortPolicy());
+
+  ASSERT_TRUE(policy.apply("tapeout"));
+  ASSERT_TRUE(policy.apply("explore"));
+  EXPECT_FALSE(policy.repair_hold);
+}
+
+TEST(EffortPolicy, ExplicitHoldAfterExploreReenablesHoldRepair)
+{
+  EffortPolicy policy;
+  ASSERT_TRUE(policy.apply("explore"));
+  ASSERT_TRUE(policy.apply("-hold"));
+  EXPECT_TRUE(policy.repair_hold);
+  // The setup bound is unaffected.
+  EXPECT_EQ(policy.plateau_start_iteration, 0);
+  EXPECT_FLOAT_EQ(policy.min_inc_fix_rate, 0.05f);
+}
+
+TEST(EffortPolicy, ExploreAfterExplicitHoldWins)
+{
+  EffortPolicy policy;
+  ASSERT_TRUE(policy.apply("-hold"));
+  ASSERT_TRUE(policy.apply("explore"));
+  EXPECT_FALSE(policy.repair_hold);
+}
+
+TEST(EffortPolicy, UnknownDirectiveIsRejectedAndIgnored)
+{
+  EffortPolicy policy;
+  EXPECT_FALSE(policy.apply("medium"));
+  EXPECT_EQ(policy, EffortPolicy());
+}
+
+}  // namespace rsz


### PR DESCRIPTION
`repair_timing` has one built-in policy: work toward tape-out closure. During design space exploration that is the wrong policy — on WNS-dominated designs setup repair grinds for hours toward targets it cannot reach, and hold repair spends hours inserting buffers that carry no exploration information (hold closes at any clock period). Users end up hand-rolling workarounds out of slack margins and skip flags, per stage, per design.

This PR adds `repair_timing -effort <directives>`: a policy interface analogous to the compiler driver `-O` flags (POLA). The caller states intent; the tool owns the mapping to its internal heuristics. Directives compose left to right and a later directive overrides an earlier one, like `-O0 -O2`. Two directives are defined:

* `tapeout` (default) — the exact historical behavior.
* `explore` — setup repair may stop when its marginal progress plateaus; hold repair is not run. An explicit `-hold` to the right of `-effort explore` re-enables it.

The plateau heuristic behind `explore` is a strawman. The ask of this PR is not the heuristic: it is that we agree OpenROAD accepts the policy *interface* and the responsibility for the mapping behind it. Graded levels between the two (`-O1`/`-O2`/`-Os` analogues) are intentionally not introduced; that is left for people who understand those use cases.

Resolution is implemented in `rsz::EffortPolicy` with a gtest unit test; `tapeout` reproduces the previous hardcoded values bit-for-bit, so behavior without `-effort` is unchanged.

Measured on the nightly CI of an industrial RISC-V design at three sizes of the same microarchitecture (S/M/L), route stage (global route + `repair_timing`). Before = the hand-rolled bounding workarounds that design carried (per-stage slack margins, skip flags); after = those replaced by the `explore` semantics of this PR. Detailed routing downstream is unchanged between the two runs (~100 min at S in both), the delta is repair:

| design | global route + repair, before | after | WNS before | after |
|--------|------------------------------|-------|------------|-------|
| S | 140 min | 52 min | −284 ps | −358 ps |
| M | 226 min | 104 min | −470 ps | −560 ps |
| L | 317 min | not measured | −479 ps | not measured |

The two runs are one night apart on actively developed RTL, so the WNS deltas include design churn (S's TNS improved while its WNS regressed); the runtime deltas are the policy.
