### PR TITLE
docs: eliminate troff warnings in man page generation

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -7,6 +7,7 @@ man_pages(
     name = "man_pages",
     docs_srcs = [
         "Makefile",
+        "src/man_fontfix.tmac",
     ] + glob(["md/**/*.md"]),
     messages = [
         "//src/ant:messages_txt",

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,15 +9,24 @@
 # | |  / ____ \| |\  | |__| | |__| | |____ 
 # |_| /_/    \_\_| \_|_____/ \____/ \_____|
 
-# Run the whole build in a UTF-8 locale so groff/preconv and col treat page
+# Render the man pages in a UTF-8 locale so groff/preconv and col treat page
 # bytes as UTF-8 rather than Latin-1. Without this, non-ASCII characters in the
 # READMEs (e.g. accented author names) render as mojibake or trigger troff
 # "character with input code N not defined" warnings on the 7-bit ascii device.
-export LC_ALL := C.UTF-8
+# Detect an installed UTF-8 locale instead of hard-coding one (C.UTF-8 is not
+# present on every host, e.g. stock macOS); fall back to the user's locale if
+# none is found rather than exporting an invalid LC_ALL.
+UTF8_LOCALE := $(shell locale -a 2>/dev/null | grep -iE '^(C|en_US)\.utf-?8$$' | head -1)
+ifeq ($(UTF8_LOCALE),)
+UTF8_LOCALE := $(shell locale -a 2>/dev/null | grep -iE 'utf-?8$$' | head -1)
+endif
+ifneq ($(UTF8_LOCALE),)
+export LC_ALL := $(UTF8_LOCALE)
+endif
 
 # Define variables
 PANDOC = pandoc
-NROFF = nroff
+GROFF ?= groff
 # Roff snippet injected into every man page to remap Pandoc's Courier-based
 # code/verbatim fonts on devices that lack them, silencing troff "cannot
 # select font" warnings (see the file for details).
@@ -125,11 +134,11 @@ $(HTML3_DIR)/%.html: $(MAN3_DIR)/%.3 | $(HTML3_DIR)
 # -rIN=4n narrows the body indent (default 7n) so Pandoc's full-width tables fit
 # within the line length, avoiding "table wider than line length" warnings.
 $(CAT1_DIR)/%.md: $(MAN1_DIR)/%.1 | $(CAT1_DIR)
-	groff -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
+	$(GROFF) -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
 $(CAT2_DIR)/%.md: $(MAN2_DIR)/%.2 | $(CAT2_DIR)
-	groff -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
+	$(GROFF) -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
 $(CAT3_DIR)/%.md: $(MAN3_DIR)/%.3 | $(CAT3_DIR)
-	groff -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
+	$(GROFF) -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
 #$(PANDOC) -s -o markdown $< -o $@
 #sed -i 's/\\\[/\[/g; s/\\]/\]/g; s/\\_/_/g' $@
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,9 +9,19 @@
 # | |  / ____ \| |\  | |__| | |__| | |____ 
 # |_| /_/    \_\_| \_|_____/ \____/ \_____|
 
+# Run the whole build in a UTF-8 locale so groff/preconv and col treat page
+# bytes as UTF-8 rather than Latin-1. Without this, non-ASCII characters in the
+# READMEs (e.g. accented author names) render as mojibake or trigger troff
+# "character with input code N not defined" warnings on the 7-bit ascii device.
+export LC_ALL := C.UTF-8
+
 # Define variables
 PANDOC = pandoc
 NROFF = nroff
+# Roff snippet injected into every man page to remap Pandoc's Courier-based
+# code/verbatim fonts on devices that lack them, silencing troff "cannot
+# select font" warnings (see the file for details).
+FONTFIX = src/man_fontfix.tmac
 SRC_DIR = md
 MAN_ROOT_DIR = man
 HTML_ROOT_DIR = html
@@ -92,12 +102,12 @@ $(CAT3_DIR):
 	mkdir -p $(CAT3_DIR)
 
 # Rule to generate a roff file from a corresponding Markdown file
-$(MAN1_DIR)/%.1: $(SRC1_DIR)/%.md | $(MAN1_DIR)
-	$(PANDOC) -s -t man $< -o $@ --quiet
-$(MAN2_DIR)/%.2: $(SRC2_DIR)/%.md | $(MAN2_DIR)
-	$(PANDOC) -s -t man $< -o $@ --quiet
-$(MAN3_DIR)/%.3: $(SRC3_DIR)/%.md | $(MAN3_DIR)
-	$(PANDOC) -s -t man $< -o $@ --quiet
+$(MAN1_DIR)/%.1: $(SRC1_DIR)/%.md $(FONTFIX) | $(MAN1_DIR)
+	$(PANDOC) -s -t man --include-in-header=$(FONTFIX) $< -o $@ --quiet
+$(MAN2_DIR)/%.2: $(SRC2_DIR)/%.md $(FONTFIX) | $(MAN2_DIR)
+	$(PANDOC) -s -t man --include-in-header=$(FONTFIX) $< -o $@ --quiet
+$(MAN3_DIR)/%.3: $(SRC3_DIR)/%.md $(FONTFIX) | $(MAN3_DIR)
+	$(PANDOC) -s -t man --include-in-header=$(FONTFIX) $< -o $@ --quiet
 
 # Rule to generate a html file from a corresponding roff file
 $(HTML1_DIR)/%.html: $(MAN1_DIR)/%.1 | $(HTML1_DIR)
@@ -107,13 +117,19 @@ $(HTML2_DIR)/%.html: $(MAN2_DIR)/%.2 | $(HTML2_DIR)
 $(HTML3_DIR)/%.html: $(MAN3_DIR)/%.3 | $(HTML3_DIR)
 	$(PANDOC) -s -o html $< -o $@ --quiet
 
-# Rule to generate a cat file from a corresponding roff file
+# Rule to generate a cat file from a corresponding roff file.
+# -t runs the tbl preprocessor so the OPTIONS tables (the '\" t directive in
+# the Pandoc output) render instead of warning about missing TW registers.
+# -Kutf8 runs preconv to decode UTF-8 input and -Tutf8 emits UTF-8, so non-ASCII
+# characters render correctly instead of warning/mangling on the ascii device.
+# -rIN=4n narrows the body indent (default 7n) so Pandoc's full-width tables fit
+# within the line length, avoiding "table wider than line length" warnings.
 $(CAT1_DIR)/%.md: $(MAN1_DIR)/%.1 | $(CAT1_DIR)
-	nroff -man $< | col -b > $@
+	groff -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
 $(CAT2_DIR)/%.md: $(MAN2_DIR)/%.2 | $(CAT2_DIR)
-	nroff -man $< | col -b > $@
+	groff -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
 $(CAT3_DIR)/%.md: $(MAN3_DIR)/%.3 | $(CAT3_DIR)
-	nroff -man $< | col -b > $@
+	groff -Kutf8 -t -man -Tutf8 -rIN=4n $< | col -b > $@
 #$(PANDOC) -s -o markdown $< -o $@
 #sed -i 's/\\\[/\[/g; s/\\]/\]/g; s/\\_/_/g' $@
 

--- a/docs/src/man_fontfix.tmac
+++ b/docs/src/man_fontfix.tmac
@@ -1,0 +1,20 @@
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\" Copyright (c) 2026, The OpenROAD Authors
+.\"
+.\" Pandoc renders code and verbatim text in the Courier (CR) font family.
+.\" Output devices that lack Courier (e.g. nroff/tty) emit "cannot select
+.\" font" warnings when those fonts are selected, so on such devices remap
+.\" them to fonts that always exist. Devices that do provide Courier keep
+.\" monospaced rendering. Pandoc injects this file via --include-in-header,
+.\" after its own font setup and before the document body, so these
+.\" translations take precedence.
+.if !F CR .ftr C R
+.if !F CR .ftr CR R
+.if !F CR .ftr CI I
+.if !F CR .ftr CB B
+.if !F CR .ftr CBI BI
+.if !F CR .ftr V R
+.if !F CR .ftr VI I
+.if !F CR .ftr VB B
+.if !F CR .ftr VBI BI
+.if F CR .ftr C CR

--- a/src/README.md
+++ b/src/README.md
@@ -389,11 +389,6 @@ place_inst -name inst_name \
 | `-status` | The placement status of the instance. Default is PLACED |
 
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+openroad+in%3Atitle)
-about this tool.
-
 ## License
 
 BSD 3-Clause License.

--- a/src/ant/README.md
+++ b/src/ant/README.md
@@ -56,11 +56,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+antenna+in%3Atitle)
-about this tool.
-
 ## Algorithm
 
 | <img src="./doc/images/example_ant.png" width=400px> | <img src="./doc/images/step1.png" width=400px> |

--- a/src/cgt/README.md
+++ b/src/cgt/README.md
@@ -52,7 +52,7 @@ clock_gating
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| ------------- | ----------------------------------------------- |
 | `-min_instances` | Minimum number of instances that should be gated by a single clock gate. |
 | `-max_cover` | Maximum number of initial gate condition candidate nets per instance. |
 | `-dump_dir` | Directory for debug dumps. |
@@ -78,11 +78,6 @@ Simply run the following script:
 ## Limitations
 
 Clock gating is currently not available for designs that contain HA and FA cells which are not supported by ABC.
-
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+clock-gating)
-about this tool.
 
 ## References
 

--- a/src/cts/README.md
+++ b/src/cts/README.md
@@ -250,11 +250,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out
-[GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+cts) about this tool.
-
 ## References
 
 1.   [LEMON](https://lemon.cs.elte.hu/trac/lemon) - **L**ibrary for

--- a/src/dpl/README.md
+++ b/src/dpl/README.md
@@ -228,11 +228,6 @@ The following limitations apply when using the NegotiationLegalizer (default):
    VDD/VSS. Replace with actual LEF pg_pin parsing once available in the
    build context.
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+opendp+in%3Atitle)
-about this tool.
-
 ## Authors
 
 -   SangGi Do and Mingyu Woo (respective Ph. D. advisors: Seokhyeong Kang,

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -255,11 +255,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+tritonroute+in%3Atitle)
-about this tool.
-
 ## References
 
 Please cite the following paper(s) for publication:

--- a/src/est/README.md
+++ b/src/est/README.md
@@ -55,7 +55,7 @@ set_wire_rc
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| ------------- | ----------------------------------------------- |
 | `-clock` | Enable setting of RC for clock nets. |
 | `-signal` | Enable setting of RC for signal nets. |
 | `-layers` | Use the LEF technology resistance and area/edge capacitance values for the layers. The values for each layers will be used for wires with the prefered layer direction, if 2 or more layers have the same prefered direction the avarege value is used for wires with that direction. This is used for a default width wire on the layer. |
@@ -85,7 +85,7 @@ set_layer_rc
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| ----------- | ------------------------------------------------- |
 | `-layer` | Set layer name to modify. Note that the layer must be a routing layer. |
 | `-via` | Select via layer name. Note that via resistance is per cut/via, not area-based. |
 | `-resistance` | Resistance per unit length, same convention as `set_wire_rc`. |
@@ -135,7 +135,7 @@ estimate_parasitics
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| -------------- | ---------------------------------------------- |
 | `-placement` or `-global_routing` | Either of these flags must be set. Parasitics are estimated based after placement stage versus after global routing stage. |
 | `-spef_file` | Optional. File name to write SPEF files. If more than one corner is available for the design, the files will be written as filename_corner.spef. |
 
@@ -170,11 +170,6 @@ Simply run the following script:
 ```
 
 ## Limitations
-
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+resizer)
-about this tool.
 
 ## License
 

--- a/src/fin/README.md
+++ b/src/fin/README.md
@@ -84,11 +84,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+metal%20fill+in%3Atitle)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -297,11 +297,6 @@ There are some useful Python functions located in the file
 [grt_aux.py](test/grt_aux.py) but these are not considered a part of the *final*
 API and they may change.
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+replace+in%3Atitle)
-about this tool.
-
 ## References
 
 -   C.-K. Cheng, A. B. Kahng, I. Kang and L. Wang, "RePlAce: Advancing

--- a/src/grt/README.md
+++ b/src/grt/README.md
@@ -465,12 +465,6 @@ the current `C++` / `Python` API, that might be an issue to deal
 with. There are also some useful `Python` functions located in the `grt_aux.py` [file](./test/grt_aux.py)
 but these are not considered a part of the *final* API and may be subject to change.
 
-## FAQs
-
-Check out
-[GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+fastroute+in%3Atitle)
-about this tool.
-
 ## References
 
 -   Database comes from [OpenDB](https://github.com/The-OpenROAD-Project/OpenDB)

--- a/src/ifp/README.md
+++ b/src/ifp/README.md
@@ -203,12 +203,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out
-[GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+ifp+in%3Atitle)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/mpl/README.md
+++ b/src/mpl/README.md
@@ -196,10 +196,6 @@ Simply run the following script:
 "Hier-RTLMP: A hierarchical automatic macro placer for large-scale complex IP blocks.",
 [(.pdf)](https://arxiv.org/pdf/2304.11761.pdf), arXiv preprint arXiv:2304.11761, 2023.
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+hier-rtlmp+OR+hier+OR+mpl) about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/odb/README.md
+++ b/src/odb/README.md
@@ -576,13 +576,6 @@ DRC on the whole chip).
 
 ## Limitations
 
-## FAQs
-
-Check out
-[GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+odb+in%3Atitle)
-about this tool.
-
-
 ## LICENSE
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/pad/README.md
+++ b/src/pad/README.md
@@ -470,11 +470,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+pad)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/pdn/README.md
+++ b/src/pdn/README.md
@@ -472,10 +472,6 @@ Currently the following assumptions are made:
 1. The input floorplan includes the stdcell rows, placement of all macro blocks and IO pins.
 1. The stdcells rows will be cut around macro placements
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+pdn) about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/ppl/README.md
+++ b/src/ppl/README.md
@@ -366,11 +366,6 @@ Simply run the following script:
 
 - This code depends on [Munkres](src/munkres/README.txt).
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+ioplacer+in%3Atitle)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/psm/README.md
+++ b/src/psm/README.md
@@ -232,11 +232,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+psm+in%3Atitle)
-about this tool.
-
 ## References
 
 1. PDNSIM [documentation](doc/PDNSim-documentation.pdf)

--- a/src/ram/README.md
+++ b/src/ram/README.md
@@ -58,7 +58,7 @@ generate_ram [-mask_size bits]
 #### Options
 
 | Switch Name | Description | 
-| ----- | ----- |
+| ---------------------- | -------------------------------------- |
 | `-mask_size` | Determines the number of bits which are grouped together for masking during writes. For example, a mask size of `8` will enable each 8 bits of the word to be masked when writing (commonly known as byte masking). A mask size of `1` will enable each bit to be individually masked. The write enable signal for each port will be `(word_size / mask_size)` bits wide. The word size must be a multiple of the mask size. Default: equal to `-word_size`. |
 | `-word_size` | Size of each word in bits. |
 | `-num_words` | Number of words in the array. |
@@ -97,11 +97,6 @@ Simply run the following script:
 ## Limitations
 
 This is an experimental module and many basic features may not work yet. Please see [#9392](https://github.com/The-OpenROAD-Project/OpenROAD/issues/9392) for ongoing and future work.
-
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+ram+in%3Atitle)
-about this tool.
 
 ## Authors
 

--- a/src/rcx/README.md
+++ b/src/rcx/README.md
@@ -519,11 +519,6 @@ The detailed documentation can be found [here](doc/calibration.md).
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+rcx)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/rmp/README.md
+++ b/src/rmp/README.md
@@ -155,11 +155,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+restructure)
-about this tool.
-
 ## Authors
 
 -   Sanjiv Mathur

--- a/src/rsz/README.md
+++ b/src/rsz/README.md
@@ -782,11 +782,6 @@ wrappers with unit conversions (microns → metres, nanoseconds → seconds,
 percentages → fractions), but these are not considered part of the *final*
 API and may be subject to change.
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+resizer)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/stt/README.md
+++ b/src/stt/README.md
@@ -62,11 +62,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+stt+in%3Atitle)
-about this tool.
-
 ## References
 
 ## License

--- a/src/syn/README.md
+++ b/src/syn/README.md
@@ -24,7 +24,7 @@ synthesize
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| --------------- | --------------------------------------------- |
 | `-reduce_name_loss` | Disable any optimization steps which would cause mass loss of intermediate signal names. This option trades away quality of results for interpretability. |
 
 ## Limitations

--- a/src/tap/README.md
+++ b/src/tap/README.md
@@ -52,7 +52,7 @@ tapcell
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| ---------------------- | -------------------------------------- |
 | `[-cnrcap_nwin_master]` | Macro cell placed at the corners the core area according the row orientation. |
 | `[-cnrcap_nwout_master]` | Macro cell placed at the corners the core area according the row orientation. |
 | `[-disallow_one_site_gaps]` | Option is deprecated. |
@@ -91,7 +91,7 @@ cut_rows
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| --------------- | --------------------------------------------- |
 | `[-endcap_master]` | Master used as an endcap. |
 | `[-halo_width_x]` | Horizontal halo size (in microns) around macros during cut rows. |
 | `[-halo_width_y]` | Vertical halo size (in microns) around macros during cut rows. |
@@ -127,7 +127,7 @@ place_endcaps
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| -------------------- | ---------------------------------------- |
 | `[-bottom_edge]` | List of masters for the bottom row endcaps. (overrides `-endcap_horizontal`). |
 | `[-corner]` | Master for the corner cells on the outer corners. |
 | `[-edge_corner]` | Master for the corner cells on the inner corners. |
@@ -178,7 +178,7 @@ tapcell_ripup
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| --------------- | --------------------------------------------- |
 | `[-endcap_prefix]` | Remove endcaps with said prefix. The default value is `PHY_`. |
 | `[-tap_prefix]` | Remove tapcells with said prefix. The default value is `TAP_`. |
 
@@ -202,11 +202,6 @@ Simply run the following script:
 ```
 
 ## Limitations
-
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+tap+in%3Atitle)
-about this tool.
 
 ## License
 

--- a/src/upf/README.md
+++ b/src/upf/README.md
@@ -302,11 +302,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out [GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+upf)
-about this tool.
-
 ## License
 
 BSD 3-Clause License. See [LICENSE](../../LICENSE) file.

--- a/src/utl/README.md
+++ b/src/utl/README.md
@@ -123,11 +123,6 @@ Simply run the following script:
 
 ## Limitations
 
-## FAQs
-
-Check out
-[GitHub discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/categories/q-a?discussions_q=category%3AQ%26A+utl) about this tool.
-
 ## References
 
 ## Authors

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -26,7 +26,7 @@ web_server
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| ---------- | -------------------------------------------------- |
 | `-port` | TCP port to listen on. Default: `8080`. |
 | `-dir` | Path to the document root directory containing the web assets (`index.html`, `*.js`, `*.css`). |
 
@@ -49,7 +49,7 @@ save_image
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| -------------- | ---------------------------------------------- |
 | `-web` | Use the web tile renderer instead of the GUI renderer. Does not require a display or a running web server. |
 | `-area` | Bounding box in microns `{x0 y0 x1 y1}`. Default: die area (with 5% margin in `-web` mode). |
 | `-width` | Output image width in pixels. Cannot be used with `-resolution`. |
@@ -122,7 +122,7 @@ web_save_report
 #### Options
 
 | Switch Name | Description |
-| ----- | ----- |
+| ----------- | ------------------------------------------------- |
 | `-setup_paths` | Maximum number of setup timing paths to include. Default: `100`. |
 | `-hold_paths` | Maximum number of hold timing paths to include. Default: `100`. |
 | `path` | Output HTML file path. |


### PR DESCRIPTION
## Summary

The man page (`cat`) build emitted several classes of troff/groff warnings. This makes the doc build warning-free and improves the rendered tables.

### Build tooling (`docs/`)
- **`cannot select font 'C'/'V'`** — Pandoc renders code/verbatim text in the Courier font family, which the nroff/tty device lacks. Added `docs/src/man_fontfix.tmac` (injected via `--include-in-header`) to remap those fonts to ones available on devices without Courier. Registered as a Bazel input for `//docs:man_pages`.
- **`tbl preprocessor failed`** — the OPTIONS tables need `tbl`; added `-t`.
- **`character with input code N not defined` / mojibake** — non-ASCII README content (e.g. accented author names like "Povišer") was decoded as Latin-1. The build now runs in a UTF-8 locale and renders with `groff -Kutf8 … -Tutf8`.
- **`table wider than line length`** — Pandoc sizes tables at nearly full width while the man body is indented; narrowed the body indent with `-rIN=4n` so they fit.

### README content
- Pandoc derives table column widths from the relative number of dashes in the Markdown separator row. The uniform `| ----- | ----- |` separators forced a 50/50 split, leaving the short `Switch Name` column half-empty in rendered man pages. Column 1 is now sized per-table to its longest switch name (147 tables).
- Dropped the `Check out GitHub discussion` FAQ footers, whose long inline URLs were not usable as links in man/cat output.

### Verification
Full `make doc cat` under a CI-like `C` locale now emits **0 warnings of any class**.