### PR TITLE
dbSta/odb: flatten brackets in punched hierarchical port/net names

### DIFF
--- a/src/dbSta/src/dbEditHierarchy.cc
+++ b/src/dbSta/src/dbEditHierarchy.cc
@@ -20,6 +20,28 @@
 
 namespace sta {
 
+// Keep in sync with the identical helper in odb dbInsertBuffer.cpp: escaped
+// brackets ("\[") collapse to a single underscore, bare brackets become
+// underscores.
+static std::string replaceBracketsWithUnderscores(std::string_view name)
+{
+  std::string sanitized_name;
+  sanitized_name.reserve(name.size());
+
+  for (size_t i = 0; i < name.size(); i++) {
+    const char ch = name[i];
+    if (ch == '\\' && i + 1 < name.size()
+        && (name[i + 1] == '[' || name[i + 1] == ']')) {
+      sanitized_name += '_';
+      i++;
+      continue;
+    }
+    sanitized_name += (ch == '[' || ch == ']') ? '_' : ch;
+  }
+
+  return sanitized_name;
+}
+
 void dbEditHierarchy::getParentHierarchy(
     odb::dbModule* start_module,
     std::vector<odb::dbModule*>& parent_hierarchy) const
@@ -618,6 +640,16 @@ std::string dbEditHierarchy::makeUniqueName(odb::dbModule* module,
   } else {
     base_name = name;
   }
+
+  // The name is usually derived from a flat net, whose base name may be a
+  // bus bit like "data[5]".  A dbModBTerm/dbModITerm/dbModNet carrying
+  // literal brackets is ambiguous downstream: Verilog emission and name-based
+  // pin lookup (sta::parseBusName) read "data[5]" as a select of a bus
+  // "data" that does not exist in the module, so the port declaration, its
+  // references and the parent instance connection disagree (undriven cones in
+  // the written netlist).  Hierarchical ports and nets created here are
+  // synthetic, so flatten the brackets into plain scalar names instead.
+  base_name = replaceBracketsWithUnderscores(base_name);
 
   odb::dbBlock* block = db_network_->block();
   std::string full = block->makeNewNetName(

--- a/src/odb/src/db/dbInsertBuffer.cpp
+++ b/src/odb/src/db/dbInsertBuffer.cpp
@@ -1243,7 +1243,7 @@ dbModBTerm* dbInsertBuffer::findOrCreateTracePort(dbModule* current_mod,
   dbModule* parent_module = mod_net->getParent();
   assert(parent_module == current_mod);
 
-  std::string port_name = mod_net->getName();
+  std::string port_name = replaceBracketsWithUnderscores(mod_net->getName());
   dbModInst* mod_inst = current_mod->getModInst();
   if (parent_module->findModBTerm(port_name.c_str()) != nullptr
       || (mod_inst != nullptr


### PR DESCRIPTION
We're using this locally as a workaround: same fix as #10815, applied to the two remaining places that mint hierarchical port/net names from flat bus-bit names — `dbEditHierarchy::makeUniqueName` and `dbInsertBuffer::findOrCreateTracePort`. Without it, timing-driven place repair on our hierarchical design punches ports named like `data[5]`, which write_verilog / `sta::parseBusName` read as a select of a non-existent bus, leaving dropped instance connections and undriven cones in the written netlist.

Does this make sense from the code changes alone, given #10815? Or would you prefer a test case and an issue over a PR to debug it?