### PR TITLE
gui: load heatmap before onShow

### DIFF
--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -48,6 +48,7 @@ class HeatMapRenderer : public Renderer
 
     if (first_paint_) {
       first_paint_ = false;
+      datasource_.ensureMap();
       datasource_.onShow();
     }
 


### PR DESCRIPTION
## Summary
Closes [#4181](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/4181)

The warning GUI-0066 was caused by calling onShow (which checks if the heatmap is loaded) before loading the heatmap.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
[How does this change the tool's behavior?]
Now the warning isn't raised.

## Verification
- [ X ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ X ] I have run the relevant tests and they pass.
- [ X ] My code follows the repository's formatting guidelines.
<!-- Delete next item if this PR is not a bug fix or new feature -->
- [ ] I have included tests to prevent regressions.
- [ X ] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]
[#4181](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/4181)