### PR TITLE
Fix dependencies in `:acd_test`

### DIFF
--- a/src/syn/test/BUILD
+++ b/src/syn/test/BUILD
@@ -128,7 +128,6 @@ cc_test(
         "//src/dbSta",
         "//src/sta:opensta_lib",
         "//src/syn",
-        "//src/syn/src/ir",
         "//src/tst",
         "@googletest//:gtest",
     ],


### PR DESCRIPTION
By running the build-cleaner:

```
source <(etc/run-build-cleaner.sh //src/syn/test:acd_test)
```
