### PR TITLE
odb: support embedded chiplets via internal-side regions

### DIFF
--- a/src/odb/src/3dblox/3dblox.cpp
+++ b/src/odb/src/3dblox/3dblox.cpp
@@ -564,8 +564,25 @@ void ThreeDBlox::createRegion(const ChipletRegion& region, dbChip* chip)
       layer = tech->findLayer(region.layer.c_str());
     }
   }
-  dbChipRegion* chip_region = dbChipRegion::create(
-      chip, region.name, getChipRegionSide(region.side, logger_), layer);
+  const auto side = getChipRegionSide(region.side, logger_);
+  if (side == odb::dbChipRegion::Side::INTERNAL
+      || side == odb::dbChipRegion::Side::INTERNAL_EXT) {
+    const auto chip_type = chip->getChipType();
+    if (chip_type != odb::dbChip::ChipType::RDL
+        && chip_type != odb::dbChip::ChipType::SUBSTRATE) {
+      logger_->error(
+          utl::ODB,
+          564,
+          "3DBV Parser Error: region {} of type {} is not allowed for "
+          "chiplet {} (only for RTL/SUBSTRATE chiplets)",
+          region.name,
+          region.side,
+          chip->getName());
+    }
+  }
+  dbChipRegion* chip_region
+      = dbChipRegion::create(chip, region.name, side, layer);
+
   Rect box;
   box.mergeInit();
   const int dbu_per_micron = db_->getDbuPerMicron();

--- a/src/odb/src/3dblox/3dblox.cpp
+++ b/src/odb/src/3dblox/3dblox.cpp
@@ -574,7 +574,7 @@ void ThreeDBlox::createRegion(const ChipletRegion& region, dbChip* chip)
           utl::ODB,
           564,
           "3DBV Parser Error: region {} of type {} is not allowed for "
-          "chiplet {} (only for RTL/SUBSTRATE chiplets)",
+          "chiplet {} (only for RDL/SUBSTRATE chiplets)",
           region.name,
           region.side,
           chip->getName());

--- a/src/odb/src/3dblox/checker.cpp
+++ b/src/odb/src/3dblox/checker.cpp
@@ -347,6 +347,28 @@ void Checker::checkOverlappingChips(dbMarkerCategory* top_cat)
     return a->getCuboid().xMin() < b->getCuboid().xMin();
   });
 
+  // An embedded chiplet may only intrude within the mating cavity declared by
+  // an internal_ext connection. Precompute the cavity footprint(s) for every
+  // chip pair once, keyed by an order-independent pair, so the overlap scan is
+  // a lookup instead of a rescan of all connections per pair.
+  auto pair_key = [](dbUnfoldedChipInst* a, dbUnfoldedChipInst* b) {
+    return a->getId() < b->getId() ? std::pair(a, b) : std::pair(b, a);
+  };
+  std::map<std::pair<dbUnfoldedChipInst*, dbUnfoldedChipInst*>,
+           std::vector<Rect>>
+      cavities;
+  for (dbUnfoldedChipConn* conn : db_->getUnfoldedChipConns()) {
+    auto* bot = conn->getBottomRegion();
+    auto* top = conn->getTopRegion();
+    if (!bot || !top || (!bot->isInternalExt() && !top->isInternalExt())) {
+      continue;
+    }
+    const Rect cavity = bot->getCuboid().getEnclosingRect().intersect(
+        top->getCuboid().getEnclosingRect());
+    cavities[pair_key(bot->getParentChip(), top->getParentChip())].push_back(
+        cavity);
+  }
+
   std::vector<std::pair<dbUnfoldedChipInst*, dbUnfoldedChipInst*>> overlaps;
   for (size_t i = 0; i < chips.size(); ++i) {
     auto* c1 = chips[i];
@@ -355,39 +377,19 @@ void Checker::checkOverlappingChips(dbMarkerCategory* top_cat)
       if (c2->getCuboid().xMin() >= c1->getCuboid().xMax()) {
         break;
       }
-      if (c1->getCuboid().overlaps(c2->getCuboid())) {
-        const Rect overlap
-            = c1->getCuboid().intersect(c2->getCuboid()).getEnclosingRect();
-        bool embedded_chiplet = false;
-        for (const auto* conn : db_->getUnfoldedChipConns()) {
-          const auto* bot_region = conn->getBottomRegion();
-          const auto* top_region = conn->getTopRegion();
-          if (bot_region == nullptr || top_region == nullptr) {
-            continue;
-          }
-          const auto* bot_chip = bot_region->getParentChip();
-          const auto* top_chip = top_region->getParentChip();
-          if (!((bot_chip == c1 && top_chip == c2)
-                || (bot_chip == c2 && top_chip == c1))) {
-            continue;
-          }
-          if (bot_region->getChipRegionInst()->getChipRegion()->getSide()
-                  != odb::dbChipRegion::Side::INTERNAL_EXT
-              && top_region->getChipRegionInst()->getChipRegion()->getSide()
-                     != odb::dbChipRegion::Side::INTERNAL_EXT) {
-            continue;
-          }
-          const Rect conn_rect
-              = bot_region->getCuboid().getEnclosingRect().intersect(
-                  top_region->getCuboid().getEnclosingRect());
-          if (conn_rect.contains(overlap)) {
-            embedded_chiplet = true;
-            break;
-          }
-        }
-        if (!embedded_chiplet) {
-          overlaps.emplace_back(c1, c2);
-        }
+      if (!c1->getCuboid().overlaps(c2->getCuboid())) {
+        continue;
+      }
+      const Rect overlap
+          = c1->getCuboid().intersect(c2->getCuboid()).getEnclosingRect();
+      auto it = cavities.find(pair_key(c1, c2));
+      const bool embedded_chiplet
+          = it != cavities.end()
+            && std::ranges::any_of(it->second, [&](const Rect& cavity) {
+                 return cavity.contains(overlap);
+               });
+      if (!embedded_chiplet) {
+        overlaps.emplace_back(c1, c2);
       }
     }
   }

--- a/src/odb/src/3dblox/checker.cpp
+++ b/src/odb/src/3dblox/checker.cpp
@@ -356,7 +356,38 @@ void Checker::checkOverlappingChips(dbMarkerCategory* top_cat)
         break;
       }
       if (c1->getCuboid().overlaps(c2->getCuboid())) {
-        overlaps.emplace_back(c1, c2);
+        const Rect overlap
+            = c1->getCuboid().intersect(c2->getCuboid()).getEnclosingRect();
+        bool embedded_chiplet = false;
+        for (const auto* conn : db_->getUnfoldedChipConns()) {
+          const auto* bot_region = conn->getBottomRegion();
+          const auto* top_region = conn->getTopRegion();
+          if (bot_region == nullptr || top_region == nullptr) {
+            continue;
+          }
+          const auto* bot_chip = bot_region->getParentChip();
+          const auto* top_chip = top_region->getParentChip();
+          if (!((bot_chip == c1 && top_chip == c2)
+                || (bot_chip == c2 && top_chip == c1))) {
+            continue;
+          }
+          if (bot_region->getChipRegionInst()->getChipRegion()->getSide()
+                  != odb::dbChipRegion::Side::INTERNAL_EXT
+              && top_region->getChipRegionInst()->getChipRegion()->getSide()
+                     != odb::dbChipRegion::Side::INTERNAL_EXT) {
+            continue;
+          }
+          const Rect conn_rect
+              = bot_region->getCuboid().getEnclosingRect().intersect(
+                  top_region->getCuboid().getEnclosingRect());
+          if (conn_rect.contains(overlap)) {
+            embedded_chiplet = true;
+            break;
+          }
+        }
+        if (!embedded_chiplet) {
+          overlaps.emplace_back(c1, c2);
+        }
       }
     }
   }

--- a/src/odb/src/db/dbChipRegion.cpp
+++ b/src/odb/src/db/dbChipRegion.cpp
@@ -223,6 +223,24 @@ dbChipRegion* dbChipRegion::create(dbChip* chip,
         name,
         chip->getName());
   }
+  if (chip->getChipType() == dbChip::ChipType::HIER) {
+    logger->error(utl::ODB,
+                  565,
+                  "Cannot create chip region {} for hierarchical chip {}",
+                  name,
+                  chip->getName());
+  }
+  if ((side == dbChipRegion::Side::INTERNAL_EXT
+       || side == dbChipRegion::Side::INTERNAL)
+      && (chip->getChipType() != dbChip::ChipType::RDL
+          || chip->getChipType() != dbChip::ChipType::SUBSTRATE)) {
+    logger->error(utl::ODB,
+                  566,
+                  "Cannot create chip region {} of type INTERNAL/INTERNAL_EXT "
+                  "for chip {}(allowed only for RDL or SUBSTRATE)",
+                  name,
+                  chip->getName());
+  }
 
   // Create a new chip region
   _dbChipRegion* chip_region = _chip->chip_region_tbl_->create();

--- a/src/odb/src/db/dbChipRegion.cpp
+++ b/src/odb/src/db/dbChipRegion.cpp
@@ -233,7 +233,7 @@ dbChipRegion* dbChipRegion::create(dbChip* chip,
   if ((side == dbChipRegion::Side::INTERNAL_EXT
        || side == dbChipRegion::Side::INTERNAL)
       && (chip->getChipType() != dbChip::ChipType::RDL
-          || chip->getChipType() != dbChip::ChipType::SUBSTRATE)) {
+          && chip->getChipType() != dbChip::ChipType::SUBSTRATE)) {
     logger->error(utl::ODB,
                   566,
                   "Cannot create chip region {} of type INTERNAL/INTERNAL_EXT "

--- a/src/odb/src/db/dbChipRegion.cpp
+++ b/src/odb/src/db/dbChipRegion.cpp
@@ -237,7 +237,7 @@ dbChipRegion* dbChipRegion::create(dbChip* chip,
     logger->error(utl::ODB,
                   566,
                   "Cannot create chip region {} of type INTERNAL/INTERNAL_EXT "
-                  "for chip {}(allowed only for RDL or SUBSTRATE)",
+                  "for chip {} (allowed only for RDL or SUBSTRATE)",
                   name,
                   chip->getName());
   }

--- a/src/odb/test/cpp/Test3DBloxChecker.cpp
+++ b/src/odb/test/cpp/Test3DBloxChecker.cpp
@@ -184,9 +184,10 @@ TEST_F(CheckerFixture, test_z_separation_no_overlap)
   EXPECT_TRUE(getMarkers(overlapping_chips_category).empty());
 }
 
-TEST_F(CheckerFixture, test_overlap_despite_valid_connection)
+TEST_F(CheckerFixture, test_embedded_chiplet_masks_overlap)
 {
-  // Create INTERNAL_EXT regions for masking
+  // Chips connected through an INTERNAL_EXT region are an embedded chiplet;
+  // their geometric overlap is expected and must not be flagged.
   auto r1_int = dbChipRegion::create(
       chip1_, "r1_int", dbChipRegion::Side::INTERNAL_EXT, nullptr);
   r1_int->setBox(Rect(0, 0, 2000, 2000));
@@ -210,12 +211,14 @@ TEST_F(CheckerFixture, test_overlap_despite_valid_connection)
   conn->setThickness(0);
 
   check();
-  EXPECT_EQ(getMarkers(overlapping_chips_category).size(), 1);
+  EXPECT_TRUE(getMarkers(overlapping_chips_category).empty());
 }
 
-TEST_F(CheckerFixture, test_overlap_partially_covered_by_connection)
+TEST_F(CheckerFixture, test_embedded_chiplet_partial_cavity_flags_overlap)
 {
-  // Create small INTERNAL_EXT regions that don't cover the full overlap
+  // The INTERNAL_EXT cavity only excuses overlap within its footprint. A cavity
+  // far smaller than the actual overlap leaves a real collision that must still
+  // be flagged.
   auto r1_int = dbChipRegion::create(
       chip1_, "r1_int_small", dbChipRegion::Side::INTERNAL_EXT, nullptr);
   r1_int->setBox(Rect(0, 0, 50, 50));
@@ -229,10 +232,9 @@ TEST_F(CheckerFixture, test_overlap_partially_covered_by_connection)
   inst1->setOrient(dbOrientType3D(dbOrientType::R0, false));
 
   auto inst2 = dbChipInst::create(top_chip_, chip2_, "inst2");
-  inst2->setLoc(Point3D(0, 0, 0));  // Full overlap of chip2 inside chip1
+  inst2->setLoc(Point3D(0, 0, 0));  // Overlap far exceeds the 50x50 cavity
   inst2->setOrient(dbOrientType3D(dbOrientType::R0, false));
 
-  // Connect them with small regions
   auto* ri1 = inst1->findChipRegionInst("r1_int_small");
   auto* ri2 = inst2->findChipRegionInst("r2_int_small");
   auto* conn = dbChipConn::create("c1", top_chip_, {inst1}, ri1, {inst2}, ri2);

--- a/src/odb/test/cpp/Test3DBloxCheckerFixture.h
+++ b/src/odb/test/cpp/Test3DBloxCheckerFixture.h
@@ -21,13 +21,17 @@ class CheckerFixture : public tst::DbFixture
     top_chip_
         = dbChip::create(db_.get(), nullptr, "TopChip", dbChip::ChipType::HIER);
 
-    // Create master chips
-    chip1_ = dbChip::create(db_.get(), tech_, "Chip1", dbChip::ChipType::DIE);
+    // Create master chips. They are SUBSTRATE (rather than DIE) so that the
+    // internal_ext region tests can legally attach INTERNAL_EXT regions, which
+    // dbChipRegion::create only allows on RDL/SUBSTRATE chips.
+    chip1_ = dbChip::create(
+        db_.get(), tech_, "Chip1", dbChip::ChipType::SUBSTRATE);
     chip1_->setWidth(2000);
     chip1_->setHeight(2000);
     chip1_->setThickness(500);
 
-    chip2_ = dbChip::create(db_.get(), tech_, "Chip2", dbChip::ChipType::DIE);
+    chip2_ = dbChip::create(
+        db_.get(), tech_, "Chip2", dbChip::ChipType::SUBSTRATE);
     chip2_->setWidth(1500);
     chip2_->setHeight(1500);
     chip2_->setThickness(500);

--- a/src/odb/test/cpp/TestChips.cpp
+++ b/src/odb/test/cpp/TestChips.cpp
@@ -56,9 +56,7 @@ struct ChipHierarchyFixture : public SimpleDbFixture
     memory_chip_region_r1 = dbChipRegion::create(
         memory_chip, "R1", dbChipRegion::Side::FRONT, layer_l1);
     memory_chip_region_r2 = dbChipRegion::create(
-        memory_chip, "R2", dbChipRegion::Side::BACK, layer_l1);
-    memory_chip_region_r3 = dbChipRegion::create(
-        memory_chip, "R3", dbChipRegion::Side::INTERNAL, nullptr);
+        memory_chip, "R2", dbChipRegion::Side::BACK, nullptr);
     io_chip_region_r1 = dbChipRegion::create(
         io_chip, "R1", dbChipRegion::Side::FRONT, layer_M1);
     dbChipRegion::create(cache_chip, "R1", dbChipRegion::Side::BACK, nullptr);
@@ -103,7 +101,6 @@ struct ChipHierarchyFixture : public SimpleDbFixture
   dbChipInst* cache_inst;
   dbChipRegion* memory_chip_region_r1;
   dbChipRegion* memory_chip_region_r2;
-  dbChipRegion* memory_chip_region_r3;
   dbChipRegion* io_chip_region_r1;
   dbChipBump* io_bump;
 };
@@ -260,24 +257,21 @@ TEST_F(ChipHierarchyFixture, test_chip_regions)
   EXPECT_EQ(memory_chip_region_r1->getSide(), dbChipRegion::Side::FRONT);
   EXPECT_EQ(memory_chip_region_r1->getLayer(), layer_l1);
   EXPECT_EQ(memory_chip_region_r1->getChip(), memory_chip);
-  EXPECT_EQ(memory_chip_region_r3->getSide(), dbChipRegion::Side::INTERNAL);
-  EXPECT_EQ(memory_chip_region_r3->getLayer(), nullptr);
+  EXPECT_EQ(memory_chip_region_r2->getSide(), dbChipRegion::Side::BACK);
+  EXPECT_EQ(memory_chip_region_r2->getLayer(), nullptr);
   // Test dbChip::findChipRegion
   EXPECT_EQ(memory_chip->findChipRegion("R1"), memory_chip_region_r1);
   EXPECT_EQ(memory_chip->findChipRegion("R2"), memory_chip_region_r2);
-  EXPECT_EQ(memory_chip->findChipRegion("R3"), memory_chip_region_r3);
-  EXPECT_EQ(memory_chip->findChipRegion("R4"), nullptr);
+  EXPECT_EQ(memory_chip->findChipRegion("R3"), nullptr);
   // Test dbChipInst::findChipRegionInst
   EXPECT_EQ(memory_inst->findChipRegionInst("R1")->getChipRegion(),
             memory_chip_region_r1);
   EXPECT_EQ(memory_inst->findChipRegionInst("R2")->getChipRegion(),
             memory_chip_region_r2);
-  EXPECT_EQ(memory_inst->findChipRegionInst("R3")->getChipRegion(),
-            memory_chip_region_r3);
-  EXPECT_EQ(memory_inst->findChipRegionInst("R4"), nullptr);
+  EXPECT_EQ(memory_inst->findChipRegionInst("R3"), nullptr);
 
-  iterateChipRegions(memory_chip, {"R1", "R2", "R3"});
-  iterateChipRegionInsts(memory_inst, {"R1", "R2", "R3"});
+  iterateChipRegions(memory_chip, {"R1", "R2"});
+  iterateChipRegionInsts(memory_inst, {"R1", "R2"});
   iterateChipRegions(io_chip, {"R1"});
 
   EXPECT_THROW(


### PR DESCRIPTION
## Summary
- Restrict `INTERNAL`/`INTERNAL_EXT` region sides to RDL and SUBSTRATE chiplets; error otherwise during 3DBV parsing.
- Skip the overlapping-chips check for chip pairs connected through an `INTERNAL_EXT` region, so a legitimately embedded chiplet is not reported as an overlap violation.

## Type of Change
- New feature

## Impact
- 3DBV designs with embedded chiplets no longer emit spurious overlap markers.
- Invalid internal-side regions on non-RDL/SUBSTRATE chiplets now fail fast with ODB-0564.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**