### PR TITLE
web/gui: add an option for arrow keys scroll acceleration

### DIFF
--- a/src/gui/src/layoutTabs.cpp
+++ b/src/gui/src/layoutTabs.cpp
@@ -31,6 +31,7 @@ LayoutTabs::LayoutTabs(Options* options,
                        std::function<bool()> using_poly_decomp_view,
                        std::function<bool()> show_ruler_as_euclidian,
                        std::function<bool()> default_mouse_wheel_zoom,
+                       std::function<bool()> arrow_keys_scroll_accel,
                        std::function<int()> arrow_keys_scroll_step,
                        QWidget* parent)
     : QTabWidget(parent),
@@ -45,6 +46,7 @@ LayoutTabs::LayoutTabs(Options* options,
       using_poly_decomp_view_(std::move(using_poly_decomp_view)),
       show_ruler_as_euclidian_(std::move(show_ruler_as_euclidian)),
       default_mouse_wheel_zoom_(std::move(default_mouse_wheel_zoom)),
+      arrow_keys_scroll_accel_(std::move(arrow_keys_scroll_accel)),
       arrow_keys_scroll_step_(std::move(arrow_keys_scroll_step)),
       logger_(nullptr)
 {
@@ -99,7 +101,8 @@ void LayoutTabs::chipLoaded(odb::dbChip* chip)
     viewer->commandAboutToExecute();
   }
   auto scroll = new LayoutScroll(
-      viewer, default_mouse_wheel_zoom_, arrow_keys_scroll_step_, this);
+      viewer, default_mouse_wheel_zoom_, arrow_keys_scroll_accel_,
+      arrow_keys_scroll_step_, this);
   viewer->chipLoaded(chip);
 
   auto tech = chip->getTech();

--- a/src/gui/src/layoutTabs.h
+++ b/src/gui/src/layoutTabs.h
@@ -44,6 +44,7 @@ class LayoutTabs : public QTabWidget
              std::function<bool()> using_poly_decomp_view,
              std::function<bool()> show_ruler_as_euclidian,
              std::function<bool()> default_mouse_wheel_zoom,
+             std::function<bool()> arrow_keys_scroll_accel,
              std::function<int()> arrow_keys_scroll_step,
              QWidget* parent = nullptr);
 
@@ -135,6 +136,7 @@ class LayoutTabs : public QTabWidget
   std::function<bool()> using_poly_decomp_view_;
   std::function<bool()> show_ruler_as_euclidian_;
   std::function<bool()> default_mouse_wheel_zoom_;
+  std::function<bool()> arrow_keys_scroll_accel_;
   std::function<int()> arrow_keys_scroll_step_;
   utl::Logger* logger_;
   bool command_executing_ = false;

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2759,7 +2759,7 @@ void LayoutScroll::keyPressEvent(QKeyEvent* event)
     if (accelCounter < accelCounterMax) {
       accelCounter++;
     }
-    // Achieve gentle exponenrial scaling by dividing
+    // Achieve gentle exponential scaling by dividing
     // the exponent and using 1.25 as the base
     multiplier = std::pow(1.25, accelCounter / 2);
   }

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2750,18 +2750,19 @@ void LayoutScroll::keyPressEvent(QKeyEvent* event)
 
   if (!event->isAutoRepeat()) {
     // First press of a key
-    currentKey = key;
-    accelCounter = 0;
+    current_key_ = key;
+    accel_counter_ = 0;
   }
 
   int multiplier = 1;
   if (arrow_keys_scroll_accel_()) {
-    if (accelCounter < accelCounterMax) {
-      accelCounter++;
+    if (accel_counter_ < kAccelCounterMax) {
+      accel_counter_++;
     }
     // Achieve gentle exponential scaling by dividing
     // the exponent and using 1.25 as the base
-    multiplier = std::pow(1.25, accelCounter / 2);
+    multiplier = static_cast<int>(
+                   std::round(std::pow(1.15, accel_counter_ / 2.0)));
   }
 
   scrollByKey(key, multiplier);

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2654,10 +2654,12 @@ void LayoutViewer::resetCache()
 LayoutScroll::LayoutScroll(
     LayoutViewer* viewer,
     const std::function<bool()>& default_mouse_wheel_zoom,
+    const std::function<bool()>& arrow_keys_scroll_accel,
     const std::function<int()>& arrow_keys_scroll_step,
     QWidget* parent)
     : QScrollArea(parent),
       default_mouse_wheel_zoom_(default_mouse_wheel_zoom),
+      arrow_keys_scroll_accel_(arrow_keys_scroll_accel),
       arrow_keys_scroll_step_(arrow_keys_scroll_step),
       viewer_(viewer),
       scrolling_with_cursor_(false)
@@ -2738,25 +2740,59 @@ bool LayoutScroll::eventFilter(QObject* object, QEvent* event)
 
 void LayoutScroll::keyPressEvent(QKeyEvent* event)
 {
-  switch (event->key()) {
+  Qt::Key key = static_cast<Qt::Key>(event->key());
+
+  if (!isScrollKey(key)) {
+    QScrollArea::keyPressEvent(event);
+    return;
+  }
+
+
+  if (!event->isAutoRepeat()) {
+    // First press of a key
+    currentKey = key;
+    accelCounter = 0;
+  }
+
+  int multiplier = 1;
+  if (arrow_keys_scroll_accel_()) {
+    if (accelCounter < accelCounterMax) {
+      accelCounter++;
+    }
+    // Achieve gentle exponenrial scaling by dividing
+    // the exponent and using 1.25 as the base
+    multiplier = std::pow(1.25, accelCounter / 2);
+  }
+
+  scrollByKey(key, multiplier);
+  event->accept();
+}
+
+bool LayoutScroll::isScrollKey(Qt::Key key) const
+{
+  return key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left
+         || key == Qt::Key_Right;
+}
+
+void LayoutScroll::scrollByKey(Qt::Key key, int multiplier)
+{
+  int step = arrow_keys_scroll_step_() * multiplier;
+
+  switch (key) {
     case Qt::Key_Up:
-      verticalScrollBar()->setValue(verticalScrollBar()->value()
-                                    - arrow_keys_scroll_step_());
+      verticalScrollBar()->setValue(verticalScrollBar()->value() - step);
       break;
     case Qt::Key_Down:
-      verticalScrollBar()->setValue(verticalScrollBar()->value()
-                                    + arrow_keys_scroll_step_());
+      verticalScrollBar()->setValue(verticalScrollBar()->value() + step);
       break;
     case Qt::Key_Left:
-      horizontalScrollBar()->setValue(horizontalScrollBar()->value()
-                                      - arrow_keys_scroll_step_());
+      horizontalScrollBar()->setValue(horizontalScrollBar()->value() - step);
       break;
     case Qt::Key_Right:
-      horizontalScrollBar()->setValue(horizontalScrollBar()->value()
-                                      + arrow_keys_scroll_step_());
+      horizontalScrollBar()->setValue(horizontalScrollBar()->value() + step);
       break;
     default:
-      QScrollArea::keyPressEvent(event);
+      break;
   }
 }
 

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2738,14 +2738,13 @@ bool LayoutScroll::eventFilter(QObject* object, QEvent* event)
   return QScrollArea::eventFilter(object, event);
 }
 
-std::array<int, LayoutScroll::kAccelLutSize> LayoutScroll::accel_lut_
-    = []() {
-        std::array<int, kAccelLutSize> lut;
-        for (int i = 0; i < kAccelLutSize; ++i) {
-          lut[i] = static_cast<int>(std::round(std::pow(1.15, i / 2.0)));
-        }
-        return lut;
-      }();
+std::array<int, LayoutScroll::kAccelLutSize> LayoutScroll::accel_lut_ = []() {
+  std::array<int, kAccelLutSize> lut;
+  for (int i = 0; i < kAccelLutSize; ++i) {
+    lut[i] = static_cast<int>(std::round(std::pow(1.15, i / 2.0)));
+  }
+  return lut;
+}();
 
 void LayoutScroll::keyPressEvent(QKeyEvent* event)
 {

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2738,6 +2738,15 @@ bool LayoutScroll::eventFilter(QObject* object, QEvent* event)
   return QScrollArea::eventFilter(object, event);
 }
 
+std::array<int, LayoutScroll::kAccelLutSize> LayoutScroll::accel_lut_
+    = []() {
+        std::array<int, kAccelLutSize> lut;
+        for (int i = 0; i < kAccelLutSize; ++i) {
+          lut[i] = static_cast<int>(std::round(std::pow(1.15, i / 2.0)));
+        }
+        return lut;
+      }();
+
 void LayoutScroll::keyPressEvent(QKeyEvent* event)
 {
   Qt::Key key = static_cast<Qt::Key>(event->key());
@@ -2746,7 +2755,6 @@ void LayoutScroll::keyPressEvent(QKeyEvent* event)
     QScrollArea::keyPressEvent(event);
     return;
   }
-
 
   if (!event->isAutoRepeat()) {
     // First press of a key
@@ -2759,10 +2767,8 @@ void LayoutScroll::keyPressEvent(QKeyEvent* event)
     if (accel_counter_ < kAccelCounterMax) {
       accel_counter_++;
     }
-    // Achieve gentle exponential scaling by dividing
-    // the exponent and using 1.25 as the base
-    multiplier = static_cast<int>(
-                   std::round(std::pow(1.15, accel_counter_ / 2.0)));
+
+    multiplier = getScrollAcceleration();
   }
 
   scrollByKey(key, multiplier);

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -467,6 +467,7 @@ class LayoutScroll : public QScrollArea
  public:
   LayoutScroll(LayoutViewer* viewer,
                const std::function<bool()>& default_mouse_wheel_zoom,
+               const std::function<bool()>& arrow_keys_scroll_accel,
                const std::function<int()>& arrow_keys_scroll_step,
                QWidget* parent = nullptr);
   bool isScrollingWithCursor();
@@ -486,9 +487,16 @@ class LayoutScroll : public QScrollArea
   void keyPressEvent(QKeyEvent* event) override;
 
  private:
+  bool isScrollKey(Qt::Key key) const;
+  void scrollByKey(Qt::Key key, int multiplier);
   std::function<bool()> default_mouse_wheel_zoom_;
+  std::function<bool()> arrow_keys_scroll_accel_;
   std::function<int()> arrow_keys_scroll_step_;
   LayoutViewer* viewer_;
+
+  Qt::Key currentKey = Qt::Key_unknown;
+  int accelCounter = 0;
+  static constexpr int accelCounterMax = 20;
 
   bool scrolling_with_cursor_;
 };

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -494,9 +494,9 @@ class LayoutScroll : public QScrollArea
   std::function<int()> arrow_keys_scroll_step_;
   LayoutViewer* viewer_;
 
-  Qt::Key currentKey = Qt::Key_unknown;
-  int accelCounter = 0;
-  static constexpr int accelCounterMax = 20;
+  Qt::Key current_key_ = Qt::Key_unknown;
+  int accel_counter_ = 0;
+  static constexpr int kAccelCounterMax = 20;
 
   bool scrolling_with_cursor_;
 };

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -496,7 +496,10 @@ class LayoutScroll : public QScrollArea
 
   Qt::Key current_key_ = Qt::Key_unknown;
   int accel_counter_ = 0;
-  static constexpr int kAccelCounterMax = 20;
+  static constexpr int kAccelLutSize = 20;
+  static constexpr int kAccelCounterMax = kAccelLutSize - 1;
+  static std::array<int, kAccelLutSize> accel_lut_;
+  int getScrollAcceleration() const { return accel_lut_[accel_counter_]; };
 
   bool scrolling_with_cursor_;
 };

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -96,6 +96,7 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
           [this]() -> bool { return show_poly_decomp_view_->isChecked(); },
           [this]() -> bool { return default_ruler_style_->isChecked(); },
           [this]() -> bool { return default_mouse_wheel_zoom_->isChecked(); },
+          [this]() -> bool { return arrow_keys_scroll_accel_->isChecked(); },
           [this]() -> int { return arrow_keys_scroll_step_; },
           this)),
       selection_browser_(
@@ -436,6 +437,11 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
         settings
             .value("mouse_wheel_zoom", default_mouse_wheel_zoom_->isChecked())
             .toBool());
+    arrow_keys_scroll_accel_->setChecked(
+        settings
+            .value("arrow_keys_scroll_accel",
+                   arrow_keys_scroll_accel_->isChecked())
+            .toBool());
     arrow_keys_scroll_step_
         = settings.value("arrow_keys_scroll_step", arrow_keys_scroll_step_)
               .toInt();
@@ -743,6 +749,11 @@ void MainWindow::createActions()
   default_mouse_wheel_zoom_->setCheckable(true);
   default_mouse_wheel_zoom_->setChecked(false);
 
+  arrow_keys_scroll_accel_
+      = new QAction("Arrow keys scroll acceleration", this);
+  arrow_keys_scroll_accel_->setCheckable(true);
+  arrow_keys_scroll_accel_->setChecked(false);
+
   arrow_keys_scroll_step_dialog_ = new QAction("Arrow keys scroll step", this);
   arrow_keys_scroll_step_ = 20;
 
@@ -895,6 +906,7 @@ void MainWindow::createMenus()
   option_menu->addAction(show_dbu_);
   option_menu->addAction(default_ruler_style_);
   option_menu->addAction(default_mouse_wheel_zoom_);
+  option_menu->addAction(arrow_keys_scroll_accel_);
   option_menu->addAction(arrow_keys_scroll_step_dialog_);
   option_menu->addAction(font_);
   option_menu->addAction(show_poly_decomp_view_);
@@ -1625,6 +1637,8 @@ void MainWindow::saveSettings()
   settings.setValue("use_dbu", show_dbu_->isChecked());
   settings.setValue("ruler_style", default_ruler_style_->isChecked());
   settings.setValue("mouse_wheel_zoom", default_mouse_wheel_zoom_->isChecked());
+  settings.setValue("arrow_keys_scroll_accel",
+                    arrow_keys_scroll_accel_->isChecked());
   settings.setValue("arrow_keys_scroll_step", arrow_keys_scroll_step_);
   script_->writeSettings(&settings);
   controls_->writeSettings(&settings);

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -375,6 +375,7 @@ class MainWindow : public QMainWindow, public odb::dbDatabaseObserver
   QAction* show_poly_decomp_view_;
   QAction* default_ruler_style_;
   QAction* default_mouse_wheel_zoom_;
+  QAction* arrow_keys_scroll_accel_;
   QAction* arrow_keys_scroll_step_dialog_;
   QAction* font_;
   QAction* global_connect_;


### PR DESCRIPTION
## Summary
Scrolling with the arrow keys is convenient, but the acceleration is controlled only by the system. Adding an option for acceleration does not overcomplicate the settings and makes arrow keys scrolling a bit more practical.
Testing with different key repeat settings did not reveal any problems related to different auto-repeat frequencies and delays.

## Type of Change
- New feature

## Impact
Adds a checkbox to the "Options" menu.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
