### PR TITLE
gpl: fix NVCC errors by refactoring old-style OpenMP loops

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -2944,9 +2944,8 @@ void NesterovBase::initDensity1()
 #pragma omp parallel for num_threads(nbc_->getNumThreads())
   for (auto& gCell : nb_gcells_) {
     updateDensityCoordiLayoutInside(gCell);
-    // nb_gcells_ is std::vector (contiguous container),
-    // so we can calculate the index with pointer arithmetic
-    size_t idx = &gCell - &nb_gcells_[0];
+
+    size_t idx = &gCell - nb_gcells_.data();
     curSLPCoordi_[idx] = prevSLPCoordi_[idx] = curCoordi_[idx]
         = initCoordi_[idx] = FloatPoint(gCell->dCx(), gCell->dCy());
 

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -1060,9 +1060,7 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCellHandle>& cells,
   // for nesterov use and FFT library
 #pragma omp parallel for num_threads(num_threads_) \
     reduction(+ : sumOverflowArea_, sumOverflowAreaUnscaled_)
-  for (auto it = bins_.begin(); it < bins_.end(); ++it) {
-    Bin& bin = *it;  // old-style loop for old OpenMP
-
+  for (Bin& bin : bins_) {
     // Copy unscaled to scaled
     bin.setInstPlacedArea(bin.getInstPlacedAreaUnscaled());
 
@@ -1294,9 +1292,7 @@ NesterovBaseCommon::NesterovBaseCommon(
 
   // gCellStor_'s pins_ fill
 #pragma omp parallel for num_threads(num_threads_)
-  for (auto it = gCellStor_.begin(); it < gCellStor_.end(); ++it) {
-    auto& gCell = *it;  // old-style loop for old OpenMP
-
+  for (auto& gCell : gCellStor_) {
     if (gCell.isFiller()) {
       continue;
     }
@@ -1310,18 +1306,14 @@ NesterovBaseCommon::NesterovBaseCommon(
 
   // gPinStor_' GNet and GCell fill
 #pragma omp parallel for num_threads(num_threads_)
-  for (auto it = gPinStor_.begin(); it < gPinStor_.end(); ++it) {
-    auto& gPin = *it;  // old-style loop for old OpenMP
-
+  for (auto& gPin : gPinStor_) {
     gPin.setGCell(pbToNb(gPin.getPbPin()->getInstance()));
     gPin.setGNet(pbToNb(gPin.getPbPin()->getNet()));
   }
 
   // gNetStor_'s GPin fill
 #pragma omp parallel for num_threads(num_threads_)
-  for (auto it = gNetStor_.begin(); it < gNetStor_.end(); ++it) {
-    auto& gNet = *it;  // old-style loop for old OpenMP
-
+  for (auto& gNet : gNetStor_) {
     for (auto& pin : gNet.getPbNet()->getPins()) {
       gNet.addGPin(pbToNb(pin));
     }
@@ -1413,21 +1405,18 @@ void NesterovBaseCommon::updateWireLengthForceWA_native(float wlCoeffX,
   assert(omp_get_thread_num() == 0);
   // clear all WA variables.
 #pragma omp parallel for num_threads(num_threads_)
-  for (auto gPin = gPinStor_.begin(); gPin < gPinStor_.end(); ++gPin) {
-    // old-style loop for old OpenMP
-    gPin->clearWaVars();
+  for (auto& gPin : gPinStor_) {
+    gPin.clearWaVars();
   }
 
   // If checks are very expensive, so short circuit them if debug is not enabled
   bool debug_enabled = log_->debugCheck(GPL, "wlUpdateWA", 1);
 #pragma omp parallel for num_threads(num_threads_)
-  for (auto gNet = gNetStor_.begin(); gNet < gNetStor_.end(); ++gNet) {
-    // old-style loop for old OpenMP
+  for (auto& gNet : gNetStor_) {
+    gNet.clearWaVars();
+    gNet.updateBox();
 
-    gNet->clearWaVars();
-    gNet->updateBox();
-
-    for (auto& gPin : gNet->getGPins()) {
+    for (auto& gPin : gNet.getGPins()) {
       // The WA terms are shift invariant:
       //
       //   Sum(x_i * exp(x_i))    Sum(x_i * exp(x_i - C))
@@ -1435,16 +1424,16 @@ void NesterovBaseCommon::updateWireLengthForceWA_native(float wlCoeffX,
       //   Sum(exp(x_i))          Sum(exp(x_i - C))
       //
       // So we shift to keep the exponential from overflowing
-      float expMinX = (gNet->lx() - gPin->cx()) * wlCoeffX;
-      float expMaxX = (gPin->cx() - gNet->ux()) * wlCoeffX;
-      float expMinY = (gNet->ly() - gPin->cy()) * wlCoeffY;
-      float expMaxY = (gPin->cy() - gNet->uy()) * wlCoeffY;
+      float expMinX = (gNet.lx() - gPin->cx()) * wlCoeffX;
+      float expMaxX = (gPin->cx() - gNet.ux()) * wlCoeffX;
+      float expMinY = (gNet.ly() - gPin->cy()) * wlCoeffY;
+      float expMaxY = (gPin->cy() - gNet.uy()) * wlCoeffY;
 
       // min x
       if (expMinX > nbVars_.minWireLengthForceBar) {
         gPin->setMinExpSumX(fastExp(expMinX));
-        gNet->addWaExpMinSumX(gPin->minExpSumX());
-        gNet->addWaXExpMinSumX(gPin->cx() * gPin->minExpSumX());
+        gNet.addWaExpMinSumX(gPin->minExpSumX());
+        gNet.addWaXExpMinSumX(gPin->cx() * gPin->minExpSumX());
         if (debug_enabled && gPin->getGCell()
             && gPin->getGCell()->isInstance()) {
           debugPrint(log_,
@@ -1460,8 +1449,8 @@ void NesterovBaseCommon::updateWireLengthForceWA_native(float wlCoeffX,
       // max x
       if (expMaxX > nbVars_.minWireLengthForceBar) {
         gPin->setMaxExpSumX(fastExp(expMaxX));
-        gNet->addWaExpMaxSumX(gPin->maxExpSumX());
-        gNet->addWaXExpMaxSumX(gPin->cx() * gPin->maxExpSumX());
+        gNet.addWaExpMaxSumX(gPin->maxExpSumX());
+        gNet.addWaXExpMaxSumX(gPin->cx() * gPin->maxExpSumX());
         if (debug_enabled && gPin->getGCell()
             && gPin->getGCell()->isInstance()) {
           debugPrint(log_,
@@ -1477,8 +1466,8 @@ void NesterovBaseCommon::updateWireLengthForceWA_native(float wlCoeffX,
       // min y
       if (expMinY > nbVars_.minWireLengthForceBar) {
         gPin->setMinExpSumY(fastExp(expMinY));
-        gNet->addWaExpMinSumY(gPin->minExpSumY());
-        gNet->addWaYExpMinSumY(gPin->cy() * gPin->minExpSumY());
+        gNet.addWaExpMinSumY(gPin->minExpSumY());
+        gNet.addWaYExpMinSumY(gPin->cy() * gPin->minExpSumY());
         if (debug_enabled && gPin->getGCell()
             && gPin->getGCell()->isInstance()) {
           debugPrint(log_,
@@ -1494,8 +1483,8 @@ void NesterovBaseCommon::updateWireLengthForceWA_native(float wlCoeffX,
       // max y
       if (expMaxY > nbVars_.minWireLengthForceBar) {
         gPin->setMaxExpSumY(fastExp(expMaxY));
-        gNet->addWaExpMaxSumY(gPin->maxExpSumY());
-        gNet->addWaYExpMaxSumY(gPin->cy() * gPin->maxExpSumY());
+        gNet.addWaExpMaxSumY(gPin->maxExpSumY());
+        gNet.addWaYExpMaxSumY(gPin->cy() * gPin->maxExpSumY());
         if (debug_enabled && gPin->getGCell()
             && gPin->getGCell()->isInstance()) {
           debugPrint(log_,
@@ -2554,9 +2543,8 @@ void NesterovBase::setTargetDensity(float density)
   targetDensity_ = density;
   bg_.setBinTargetDensity(density);
 #pragma omp parallel for num_threads(nbc_->getNumThreads())
-  for (auto bin = getBins().begin(); bin < getBins().end(); ++bin) {
-    // old-style loop for old OpenMP
-    bin->setBinTargetDensity(density);
+  for (auto& bin : getBins()) {
+    bin.setBinTargetDensity(density);
   }
   // update nonPlaceArea's target denstiy
   bg_.updateBinsNonPlaceArea();
@@ -2731,8 +2719,7 @@ void NesterovBase::updateDensitySize()
 {
   assert(omp_get_thread_num() == 0);
 #pragma omp parallel for num_threads(nbc_->getNumThreads())
-  for (auto it = nb_gcells_.begin(); it < nb_gcells_.end(); ++it) {
-    auto& gCell = *it;  // old-style loop for old OpenMP
+  for (auto& gCell : nb_gcells_) {
     float scaleX = 0, scaleY = 0;
     float densitySizeX = 0, densitySizeY = 0;
     if (gCell->dx() < REPLACE_SQRT2 * bg_.getBinSizeX()) {
@@ -2900,8 +2887,7 @@ void NesterovBase::updateDensityFieldBin()
   assert(omp_get_thread_num() == 0);
   // copy density to utilize FFT
 #pragma omp parallel for num_threads(nbc_->getNumThreads())
-  for (auto it = getBins().begin(); it < getBins().end(); ++it) {
-    auto& bin = *it;  // old-style loop for old OpenMP
+  for (auto& bin : getBins()) {
     fft_->updateDensity(bin.x(), bin.y(), bin.getDensity());
   }
 
@@ -2913,8 +2899,7 @@ void NesterovBase::updateDensityFieldBin()
   sumPhi_ = 0;
 #pragma omp parallel for num_threads(nbc_->getNumThreads()) \
     reduction(+ : sumPhi_)
-  for (auto it = getBins().begin(); it < getBins().end(); ++it) {
-    auto& bin = *it;  // old-style loop for old OpenMP
+  for (auto& bin : getBins()) {
     auto eFieldPair = fft_->getElectroField(bin.x(), bin.y());
     bin.setElectroField(eFieldPair.first, eFieldPair.second);
 
@@ -2957,10 +2942,11 @@ void NesterovBase::initDensity1()
   snapshotPrevSLPSumGrads_.resize(gCellSize, FloatPoint());
 
 #pragma omp parallel for num_threads(nbc_->getNumThreads())
-  for (auto it = nb_gcells_.begin(); it < nb_gcells_.end(); ++it) {
-    GCell* gCell = *it;  // old-style loop for old OpenMP
+  for (auto& gCell : nb_gcells_) {
     updateDensityCoordiLayoutInside(gCell);
-    int idx = it - nb_gcells_.begin();
+    // nb_gcells_ is std::vector (contiguous container),
+    // so we can calculate the index with pointer arithmetic
+    size_t idx = &gCell - &nb_gcells_[0];
     curSLPCoordi_[idx] = prevSLPCoordi_[idx] = curCoordi_[idx]
         = initCoordi_[idx] = FloatPoint(gCell->dCx(), gCell->dCy());
 
@@ -3823,8 +3809,7 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
     }
 
 #pragma omp parallel for num_threads(nbc_->getNumThreads())
-    for (auto it = nb_gcells_.begin(); it < nb_gcells_.end(); ++it) {
-      auto& gCell = *it;  // old-style loop for old OpenMP
+    for (auto& gCell : nb_gcells_) {
       if (!gCell->isInstance()) {
         continue;
       }


### PR DESCRIPTION
## Summary
Iterator-based loops cause compile-time errors if GPU acceleration via CUDA (even the latest 13.3.1 is affected) is enabled. Using the newer range-based loops fixes this.

## Type of Change
- Bug fix
- Refactoring

## Impact
No runtime impact.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
