### PR TITLE
Add FreeBSD support

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -1196,6 +1196,17 @@ EOF
 }
 
 # ------------------------------------------------------------------------------
+# FreeBSD
+# ------------------------------------------------------------------------------
+_install_freebsd_packages() {
+    log "Install FreeBSD base packages using pkg (-base or -all)"
+    _execute "Updating the repository..." pkg update
+    _execute "Installing base packages..." pkg install -y \
+        bison boost-libs cmake coin-or-lemon cudd eigen gmake groff googletest \
+        or-tools pcre2 qt5 spdlog swig tcl86 yaml-cpp
+}
+
+# ------------------------------------------------------------------------------
 # Debian
 # ------------------------------------------------------------------------------
 _install_debian_packages() {
@@ -1399,6 +1410,9 @@ main() {
             fi
             os="Darwin"
             ;;
+        "FreeBSD")
+            os="FreeBSD"
+            ;;
         *)
             error "${platform} is not supported. We only officially support Linux at the moment."
             ;;
@@ -1484,6 +1498,13 @@ main() {
 To install or run OpenROAD, update your path with:
     export PATH="\$(brew --prefix bison)/bin:\$(brew --prefix flex)/bin:\$(brew --prefix tcl-tk@8)/bin:\${PATH}"
     export CMAKE_PREFIX_PATH=\$(brew --prefix or-tools)
+EOF
+            ;;
+        "FreeBSD")
+            _install_freebsd_packages
+	    cat <<EOF
+FreeBSD installs \`tclsh\` binary as \`tclsh86\` and any python 3 version as \`python3.XX\`,
+not \`python3\`, you'll have to make symlinks to those programs yourself.
 EOF
             ;;
         "openSUSE Leap")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,8 +170,11 @@ add_compile_options(
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  # All FreeBSD libraries installed by the user are in /usr/local
+  # tests fail to link if this is not specified
   link_directories(/usr/local/lib)
-  include_directories(/usr/local/include /usr/local/include/tcl8.6)
+  # cmake can't find the tcl header, include manually
+  include_directories(/usr/local/include/tcl8.6)
 endif()
 
 if (ASAN)
@@ -311,6 +314,8 @@ target_compile_options(openroad
 
 # Needed for boost stacktrace
 if(APPLE OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  target_compile_definitions(openroad PUBLIC _GNU_SOURCE)
+  # Propagate the flag to other targets (PUBLIC is not enough)
   add_compile_definitions(_GNU_SOURCE)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,11 @@ add_compile_options(
   $<$<BOOL:${UBSAN}>:-fno-omit-frame-pointer>
 )
 
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  link_directories(/usr/local/lib)
+  include_directories(/usr/local/include /usr/local/include/tcl8.6)
+endif()
+
 if (ASAN)
   add_link_options(-fsanitize=address)
   message(STATUS "Address Sanitizer is enabled")
@@ -305,8 +310,8 @@ target_compile_options(openroad
 )
 
 # Needed for boost stacktrace
-if(APPLE)
-  target_compile_definitions(openroad PUBLIC "-D_GNU_SOURCE")
+if(APPLE OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  add_compile_definitions(_GNU_SOURCE)
 endif()
 
 


### PR DESCRIPTION
## Summary
FreeBSD has _all_ the dependencies available in the default `pkg` repository, requires only minor changes to the build system and runs absolutely fine, _BUT_ there are some concerns:
* `third-party/abc` has a `make` call hardcoded in `CmakeLists.txt` - logic to switch to `gmake` on FreeBSD is needed (otherwise the build fails).
* Bazel does not officially support FreeBSD. There's a community port, I haven't checked it out so Bazel might not work at all for FreeBSD.
* GPU acceleration is problematic, Kokkos also does not target FreeBSD. Though if it can compile, it should work, even with CUDA ([libc6-shim](https://github.com/shkhln/libc6-shim) helped me get CUDA working In the past, I see no reason why it wouldn't work here).
* `tclsh` and `python3` binaries are absent, FreeBSD uses a different naming scheme - either the user will have to make the symlinks (eg., from `python3.12` to `python3`) or the source files will have to be configured to use the proper names.
* scripts in `./etc/` use bash, which is not present on the base system. IMHO, using bash for the dependency installer is superfluous, since most of the "bashisms" can be easily replaced with POSIX alternatives without affecting code readability. Or users can simply be told to install bash.
