### PR TITLE
grt: add -max_soft_ndr_resets switch to cap soft-NDR reset passes

### DIFF
--- a/src/grt/README.md
+++ b/src/grt/README.md
@@ -20,6 +20,7 @@ You may also choose to use incremental global routing using `-start_incremental`
 global_route 
     [-guide_file out_file]
     [-congestion_iterations iterations]
+    [-max_soft_ndr_resets resets]
     [-congestion_report_file file_name]
     [-congestion_report_iter_step steps]
     [-grid_origin {x y}]
@@ -42,6 +43,7 @@ global_route
 | ----- | ----- |
 | `-guide_file` | Set the output guides file name (e.g., `route.guide`). |
 | `-congestion_iterations` | Set the number of iterations made to remove the congestion of the routing. The default value is `50` for FastRoute and `5` when `-use_cugr` is set; the allowed values are integers `[0, MAX_INT]`. |
+| `-max_soft_ndr_resets` | Set the maximum number of restart passes allowed when demoting congested soft-NDR nets individually before demoting all remaining congested soft-NDR nets in a single batch. The default value is `4`; allowed values are non-negative integers `[0, MAX_INT]`. Setting `0` demotes all congested soft-NDR nets in a single batch on the first reset pass. |
 | `-congestion_report_file` | Set the file name to save the congestion report. The file generated can be read by the DRC viewer in the GUI (e.g., `report_file.rpt`). |
 | `-congestion_report_iter_step` | Set the number of iterations to report. The default value is `0`, and the allowed values are integers `[0, MAX_INT]`. |
 | `-grid_origin` | Set the (x, y) origin of the routing grid in DBU. For example, `-grid_origin {1 1}` corresponds to the die (0, 0) + 1 DBU in each x--, y- direction. |

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -149,7 +149,10 @@ class GlobalRouter
                            float reduction_percentage);
   void setVerbose(bool v);
   void setCongestionIterations(int iterations);
-  void setMaxSoftNdrResets(int resets) { max_soft_ndr_resets_ = std::max(0, resets); }
+  void setMaxSoftNdrResets(int resets)
+  {
+    max_soft_ndr_resets_ = std::max(0, resets);
+  }
   void setCongestionReportIterStep(int congestion_report_iter_step);
   void setCongestionReportFile(const char* file_name);
   void setGridOrigin(int x, int y);

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -149,6 +149,7 @@ class GlobalRouter
                            float reduction_percentage);
   void setVerbose(bool v);
   void setCongestionIterations(int iterations);
+  void setMaxSoftNdrResets(int resets) { max_soft_ndr_resets_ = resets; }
   void setCongestionReportIterStep(int congestion_report_iter_step);
   void setCongestionReportFile(const char* file_name);
   void setGridOrigin(int x, int y);
@@ -579,6 +580,7 @@ class GlobalRouter
   std::vector<RegionAdjustment> region_adjustments_;
 
   bool verbose_;
+  int max_soft_ndr_resets_ = 4;
 
   // variables for random grt
   int seed_;

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -149,7 +149,7 @@ class GlobalRouter
                            float reduction_percentage);
   void setVerbose(bool v);
   void setCongestionIterations(int iterations);
-  void setMaxSoftNdrResets(int resets) { max_soft_ndr_resets_ = resets; }
+  void setMaxSoftNdrResets(int resets) { max_soft_ndr_resets_ = std::max(0, resets); }
   void setCongestionReportIterStep(int congestion_report_iter_step);
   void setCongestionReportFile(const char* file_name);
   void setGridOrigin(int x, int y);

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1720,6 +1720,7 @@ void GlobalRouter::initNetlist(std::vector<Net*>& nets, bool incremental)
   int min_degree, max_degree;
   computeNetDegree(nets, min_degree, max_degree);
   fastroute_->setMaxNetDegree(max_degree);
+  fastroute_->setMaxSoftNDRResets(max_soft_ndr_resets_);
   reportNetDegree(nets);
 
   // Add resources for pin access in macro/pad pins after defining their on grid

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -82,6 +82,12 @@ set_congestion_iterations(int iterations)
 }
 
 void
+set_max_soft_ndr_resets(int resets)
+{
+  getGlobalRouter()->setMaxSoftNdrResets(resets);
+}
+
+void
 set_congestion_report_iter_step(int congestion_report_iter_step)
 {
   getGlobalRouter()->setCongestionReportIterStep(congestion_report_iter_step);

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -219,7 +219,7 @@ proc global_route { args } {
 
   if { [info exists keys(-max_soft_ndr_resets)] } {
     set resets $keys(-max_soft_ndr_resets)
-    sta::check_integer "-max_soft_ndr_resets" $resets
+    sta::check_positive_integer "-max_soft_ndr_resets" $resets
     grt::set_max_soft_ndr_resets $resets
   } else {
     grt::set_max_soft_ndr_resets 4

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -142,6 +142,7 @@ proc set_global_routing_random { args } {
 
 sta::define_cmd_args "global_route" {[-guide_file out_file] \
                                   [-congestion_iterations iterations] \
+                                  [-max_soft_ndr_resets resets] \
                                   [-congestion_report_file file_name] \
                                   [-congestion_report_iter_step steps] \
                                   [-grid_origin origin] \
@@ -160,7 +161,8 @@ sta::define_cmd_args "global_route" {[-guide_file out_file] \
 
 proc global_route { args } {
   sta::parse_key_args "global_route" args \
-    keys {-guide_file -congestion_iterations -congestion_report_file \
+    keys {-guide_file -congestion_iterations -max_soft_ndr_resets \
+          -congestion_report_file \
           -grid_origin -critical_nets_percentage -res_aware_nets_percentage \
           -congestion_report_iter_step \
           -skip_large_fanout_nets -snapshot_batched_width
@@ -213,6 +215,14 @@ proc global_route { args } {
     grt::set_congestion_iterations 5
   } else {
     grt::set_congestion_iterations 50
+  }
+
+  if { [info exists keys(-max_soft_ndr_resets)] } {
+    set resets $keys(-max_soft_ndr_resets)
+    sta::check_integer "-max_soft_ndr_resets" $resets
+    grt::set_max_soft_ndr_resets $resets
+  } else {
+    grt::set_max_soft_ndr_resets 4
   }
 
   if { [info exists keys(-congestion_report_file)] } {

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -127,7 +127,7 @@ class FastRouteCore
   void init3DEdges();
   void initLowerBoundCapacities();
   void setEdgeCapacity(int x1, int y1, int x2, int y2, int layer, int capacity);
-  void setMaxSoftNDRResets(int resets) { max_soft_ndr_resets_ = resets; }
+  void setMaxSoftNDRResets(int resets) { max_soft_ndr_resets_ = std::max(0, resets); }
   int getMaxSoftNDRResets() const { return max_soft_ndr_resets_; }
   int getDbNetLayerEdgeCost(odb::dbNet* db_net, int layer);
   void initEdgesCapacityPerLayer();

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -127,7 +127,10 @@ class FastRouteCore
   void init3DEdges();
   void initLowerBoundCapacities();
   void setEdgeCapacity(int x1, int y1, int x2, int y2, int layer, int capacity);
-  void setMaxSoftNDRResets(int resets) { max_soft_ndr_resets_ = std::max(0, resets); }
+  void setMaxSoftNDRResets(int resets)
+  {
+    max_soft_ndr_resets_ = std::max(0, resets);
+  }
   int getMaxSoftNDRResets() const { return max_soft_ndr_resets_; }
   int getDbNetLayerEdgeCost(odb::dbNet* db_net, int layer);
   void initEdgesCapacityPerLayer();

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -127,6 +127,8 @@ class FastRouteCore
   void init3DEdges();
   void initLowerBoundCapacities();
   void setEdgeCapacity(int x1, int y1, int x2, int y2, int layer, int capacity);
+  void setMaxSoftNDRResets(int resets) { max_soft_ndr_resets_ = resets; }
+  int getMaxSoftNDRResets() const { return max_soft_ndr_resets_; }
   int getDbNetLayerEdgeCost(odb::dbNet* db_net, int layer);
   void initEdgesCapacityPerLayer();
   void setNumAdjustments(int nAdjustments);
@@ -877,6 +879,7 @@ class FastRouteCore
   multi_array<int, 3> path_len_3D_;
   double snapshot_batch_sync_time_ = 0.0;
   double snapshot_batch_route_time_ = 0.0;
+
   double snapshot_batch_apply_time_ = 0.0;
   int snapshot_batch_count_ = 0;
   int snapshot_batch_net_count_ = 0;
@@ -884,6 +887,7 @@ class FastRouteCore
   bool snapshot_batch_disabled_for_run_ = false;
   bool snapshot_cleanup_active_ = false;
   bool has_non_soft_ndr_nets_ = false;
+  int max_soft_ndr_resets_ = 4;
   int detour_penalty_;
 };
 

--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -2148,7 +2148,6 @@ NetRouteMap FastRouteCore::run()
   // number of restarts; once exceeded we disable every remaining congested
   // NDR net in a single batch instead of one-per-restart.
   int soft_ndr_resets = 0;
-  constexpr int max_soft_ndr_resets = 4;
   float overflow_reduction_percent = -1;
   // Minimum overflow stagnation
   int minofl_stagnant = 0;
@@ -2399,7 +2398,7 @@ NetRouteMap FastRouteCore::run()
 
         std::vector<int> net_ids;
 
-        if (soft_ndr_resets >= max_soft_ndr_resets) {
+        if (soft_ndr_resets >= max_soft_ndr_resets_) {
           // We have already restarted the overflow loop many times, disabling
           // NDR nets one (or a few) at a time. Disabling nets individually with
           // a full loop reset per restart is O(N) full overflow loops, which


### PR DESCRIPTION
In congested designs with soft Non-Default Rules (NDRs), FastRoute can repeatedly restart routing when demoting soft-NDR nets one at a time. The restart loop cap was previously hardcoded as a `constexpr int` (4).

### Use Case
In large or highly congested designs, these one-net-at-a-time reset passes can take **hours** before producing an initial global routing result for inspection. For fast clock period estimation loops and early physical exploration, waiting hours for an initial routing iteration is impractical.

Exposing the `-max_soft_ndr_resets` switch in `global_route` (defaulting to 4) allows fast estimation scripts to pass `-max_soft_ndr_resets 0` to demote all congested soft-NDR nets in a single batch pass, obtaining immediate routing feedback and clock period estimates in minutes instead of hours while maintaining existing default behavior for standard production runs.

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>