### PR TITLE
The ui_* includes are used without prefix, so add an `includes=[]`

### DIFF
--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -156,6 +156,9 @@ cc_library(
         ":ui/ui_highlightGroupDlg.h",
         ":ui/ui_selectedWidget.h",
     ],
+    includes = [
+        "ui",
+    ],
 )
 
 qt6_resource_library(


### PR DESCRIPTION
The source codes that include these headers don't add the path prefix where the headers are to be found. So add the include path to the library that they are legitimately available.
