### PR TITLE
Fix Qt related dependency visibility

### DIFF
--- a/.bant-macros
+++ b/.bant-macros
@@ -48,6 +48,8 @@ tcl_encode_sta = genrule(
 )
 
 # gist extracted from @qt-bazel//:build_defs.bzl
+qt_internal_library = bant_forward_args(cc_library())
+
 qt6_library = (
     [
         genrule(
@@ -65,7 +67,12 @@ qt6_library = (
             for uisrc in uic_srcs
         ],
         includes = includes,
-        deps = deps,
+        deps = deps + [
+            "@qt-bazel//qt_source:core",
+            "@qt-bazel//qt_source:widgets",
+            "@qt-bazel//qt_source:charts",
+            "@qt-bazel//qt_source:gui",
+        ],
     ),
 )
 

--- a/etc/bazel-make-compilation-db.sh
+++ b/etc/bazel-make-compilation-db.sh
@@ -35,17 +35,6 @@ BAZEL_OPTS="${BAZEL_OPTS:--c opt ${BAZEL_REMOTE_MATERIALIZE}}"
 
 "${BANT}" compile-flags -o compile_flags.txt
 
-# The QT headers are not properly picked up; add them manually.
-for f in bazel-out/../../../external/qt-bazel*/qt_source/qtbase*/build/include \
-  bazel-out/../../../external/qt-bazel*/qt_source/qtbase*/build/include/Q* \
-  bazel-out/../../../external/qt-bazel*/qt_source/qtcharts*/include/QtCharts
-do
-  echo "-I$f"
-  # There is a bug in clangd that does not properly follow symbolic links.
-  # So expand them here as well for interactive use.
-  echo "-I$(realpath $f)"
-done >> compile_flags.txt
-
 # Qt include files check for this
 echo '-fPIC' >> compile_flags.txt
 

--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -159,6 +159,10 @@ cc_library(
     includes = [
         "ui",
     ],
+    deps = [
+        "@qt-bazel//qt_source:core",
+        "@qt-bazel//qt_source:widgets",
+    ],
 )
 
 qt6_resource_library(


### PR DESCRIPTION
 * qt6_library: make dependencies better visible to tooling. Refine the bant macro that reflects how qt6_library() is to be handled w.r.t. dependencies. Fixes: #10993
 * Since we see qt libraries now, remove hack in compilation db to manually add the qt libraries. Bant can see them now and emit the correct compilation db
 * the library `//src/gui:uic_lib` with generated headers uses qt libs, so add the relevant dependencies.
