### PR TITLE
//src/gui: Remove not-needed header that required Qt libs

### DIFF
--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -30,7 +30,6 @@ cc_library(
         "src/heatMapPlacementDensity.cpp",
         "src/heatMapPlacementDensity.h",
         "src/init_descriptors.cpp",
-        "src/insertBufferDialog.h",
         "src/staDescriptors.cpp",
         "src/staDescriptors.h",
         ":tcl",


### PR DESCRIPTION
The //src/gui should be agnostic of qt headers, yet it had one header that included Qt headers (but was not needed). Remove.

Fixes: #10997
