### PR TITLE
rsz: Keep input ModNet name when buffer removal creates a feedthrough

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2869,10 +2869,12 @@ bool Resizer::removeBuffer(sta::Instance* buffer)
   odb::dbModNet* input_modnet = db_network_->hierNet(input_pin);
   odb::dbModNet* survivor_modnet = input_modnet;
   odb::dbModNet* removed_modnet = output_modnet;
+  const bool creates_feedthrough
+      = bufferRemovalCreatesFeedthrough(input_modnet, output_modnet);
   // Preserve the input ModNet on feedthrough removal so write_verilog can
   // emit the assign between distinct port and net names.
-  if (!bufferRemovalCreatesFeedthrough(input_modnet, output_modnet)
-      && !db_network_->hasPort(input_net) && db_network_->hasPort(output_net)) {
+  if (!creates_feedthrough && !db_network_->hasPort(input_net)
+      && db_network_->hasPort(output_net)) {
     survivor = output_net;
     removed_net = input_net;
     survivor_modnet = output_modnet;
@@ -2895,7 +2897,12 @@ bool Resizer::removeBuffer(sta::Instance* buffer)
   std::optional<std::string> new_modnet_name;
   if (db_survivor->isDeeperThan(db_removed)) {
     new_net_name = db_removed->getName();
-    if (removed_modnet != nullptr) {
+    // The rename exists to keep the ModNet name in sync with the flat net
+    // name.  Feedthrough is the exception: removed_modnet is the output
+    // ModNet, so syncing would name the ModNet after the output port and
+    // write_verilog would then drop the assign statement.  On a feedthrough
+    // the ModNet name must always stay the input port name.
+    if (removed_modnet != nullptr && !creates_feedthrough) {
       new_modnet_name = removed_modnet->getName();
     }
   }

--- a/src/rsz/test/cpp/TestBufferRemoval3.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval3.cc
@@ -893,4 +893,106 @@ TEST_F(BufRemTest3, FeedthroughAssign)
   writeAndCompareVerilogOutputFile(test_name, test_name + "_post.v");
 }
 
+// Regression test for a feedthrough buffer whose two sides sit at different
+// hierarchy depths, where remove_buffers leaves a kept sub-module output port
+// without any driver.
+//
+// Design:
+//   top
+//   +- u_wrap (wrap_mod)
+//   |    +- u_blk (blk_mod)
+//   |         +- u_drv    (drv_mod)  NOR2_X1 g_drv drives drv_o
+//   |         +- u_ft_mod (ft_mod)   ft_i -> BUF_X1 u_ft -> ft_o
+//   +- u_sink (sink_mod)             sink_i -> OR2_X1 g_sink .A1
+//
+// Unlike FeedthroughAssign, the buffer output leaves ft_mod, blk_mod and
+// wrap_mod before it re-enters sink_mod, so the two flat nets around the
+// buffer end up at very different depths:
+//   input  side  u_wrap/u_blk/drv_to_ft
+//   output side  mid                      (top level)
+//
+// removeBuffer() correctly keeps the input ModNet as the survivor for the
+// feedthrough, but because the surviving flat net is the deeper one it then
+// renames the surviving ModNet to the removed one's name, i.e. to the output
+// port name "ft_o".  VerilogWriter now sees output port "ft_o" sitting on a
+// net also called "ft_o" and emits nothing, so the "assign ft_o = ft_i;"
+// bridge is lost and ft_mod comes out with an undriven output port.
+//
+// The flat dbNet merge itself is correct, which is why placement and routing
+// never notice the problem and only LEC or gate level simulation fails.
+//
+// NOTE: this test fails on current master by design.  The golden file holds
+// the netlist that a correct remove_buffers has to produce.
+TEST_F(BufRemTest3, HierFeedthroughAcrossLevels)
+{
+  std::string test_name = "TestBufferRemoval3_hier_feedthrough";
+  readVerilogAndSetup(test_name + ".v", /*init_default_sdc=*/false);
+
+  odb::dbModule* ft_mod = block_->findModule("ft_mod");
+  ASSERT_NE(ft_mod, nullptr);
+  ASSERT_NE(block_->findInst("u_wrap/u_blk/u_ft_mod/u_ft"), nullptr)
+      << "Feedthrough buffer u_ft not found";
+
+  // The leaf driver and the leaf load at the two ends of the whole path.
+  odb::dbInst* drv_inst = block_->findInst("u_wrap/u_blk/u_drv/g_drv");
+  odb::dbInst* sink_inst = block_->findInst("u_sink/g_sink");
+  ASSERT_NE(drv_inst, nullptr);
+  ASSERT_NE(sink_inst, nullptr);
+  odb::dbITerm* drv_iterm = drv_inst->findITerm("ZN");
+  odb::dbITerm* sink_iterm = sink_inst->findITerm("A1");
+  ASSERT_NE(drv_iterm, nullptr);
+  ASSERT_NE(sink_iterm, nullptr);
+
+  odb::dbModBTerm* bt_in = ft_mod->findModBTerm("ft_i");
+  odb::dbModBTerm* bt_out = ft_mod->findModBTerm("ft_o");
+  ASSERT_NE(bt_in, nullptr);
+  ASSERT_NE(bt_out, nullptr);
+
+  // Before removal the buffer separates the two flat nets as well as the two
+  // boundary ModNets of ft_mod.  The depth asymmetry is what triggers the
+  // survivor rename inside removeBuffer().
+  EXPECT_NE(drv_iterm->getNet(), sink_iterm->getNet());
+  EXPECT_NE(bt_in->getModNet(), bt_out->getModNet())
+      << "ModNets should be separate before remove_buffers";
+  EXPECT_EQ(drv_iterm->getNet()->getName(), "u_wrap/u_blk/drv_to_ft");
+  EXPECT_EQ(sink_iterm->getNet()->getName(), "mid");
+
+  if (debug_) {
+    std::cout << "pre  ft_i modnet: " << bt_in->getModNet()->getName() << "\n";
+    std::cout << "pre  ft_o modnet: " << bt_out->getModNet()->getName() << "\n";
+  }
+
+  resizer_.removeBuffers({});
+
+  EXPECT_EQ(block_->findInst("u_wrap/u_blk/u_ft_mod/u_ft"), nullptr)
+      << "Feedthrough buffer should be removed";
+
+  // Flat view: the merge is correct, the leaf driver and the leaf load share
+  // one dbNet.  This part already works today.
+  EXPECT_EQ(drv_iterm->getNet(), sink_iterm->getNet())
+      << "flat dbNets should be merged after buffer removal";
+
+  // Hierarchical view: both boundary terminals stay bound to one ModNet, so
+  // the database itself is consistent.  What breaks is the name that ModNet
+  // is given, because VerilogWriter can only express the feedthrough when the
+  // net name differs from the output port name.
+  odb::dbModNet* in_modnet = bt_in->getModNet();
+  odb::dbModNet* out_modnet = bt_out->getModNet();
+  ASSERT_NE(in_modnet, nullptr) << "ft_i lost its dbModNet";
+  ASSERT_NE(out_modnet, nullptr) << "ft_o lost its dbModNet";
+  EXPECT_EQ(in_modnet, out_modnet)
+      << "ft_mod boundary ModNets should be merged after buffer removal";
+  if (debug_) {
+    std::cout << "post ft_i modnet: " << in_modnet->getName() << "\n";
+    std::cout << "post ft_o modnet: " << out_modnet->getName() << "\n";
+  }
+  EXPECT_NE(in_modnet->getName(), std::string("ft_o"))
+      << "surviving ModNet must not take the output port name, otherwise "
+         "write_verilog drops the feedthrough assign";
+
+  // The emitted netlist must keep ft_mod's output port driven, which requires
+  // "assign ft_o = ft_i;" inside ft_mod.
+  writeAndCompareVerilogOutputFile(test_name, test_name + "_post.v");
+}
+
 }  // namespace rsz

--- a/src/rsz/test/cpp/TestBufferRemoval3_hier_feedthrough.v
+++ b/src/rsz/test/cpp/TestBufferRemoval3_hier_feedthrough.v
@@ -1,0 +1,76 @@
+module top (a,
+    b,
+    out);
+ input a;
+ input b;
+ output out;
+
+ wire mid;
+
+ sink_mod u_sink (.sink_i(mid),
+    .sink_b(b),
+    .sink_o(out));
+ wrap_mod u_wrap (.wrap_a(a),
+    .wrap_b(b),
+    .wrap_o(mid));
+endmodule
+module blk_mod (blk_a,
+    blk_b,
+    blk_o);
+ input blk_a;
+ input blk_b;
+ output blk_o;
+
+ wire drv_to_ft;
+
+ drv_mod u_drv (.drv_a(blk_a),
+    .drv_b(blk_b),
+    .drv_o(drv_to_ft));
+ ft_mod u_ft_mod (.ft_i(drv_to_ft),
+    .ft_o(blk_o));
+endmodule
+module drv_mod (drv_a,
+    drv_b,
+    drv_o);
+ input drv_a;
+ input drv_b;
+ output drv_o;
+
+
+ NOR2_X1 g_drv (.A1(drv_a),
+    .A2(drv_b),
+    .ZN(drv_o));
+endmodule
+module ft_mod (ft_i,
+    ft_o);
+ input ft_i;
+ output ft_o;
+
+
+ BUF_X1 u_ft (.A(ft_i),
+    .Z(ft_o));
+endmodule
+module sink_mod (sink_i,
+    sink_b,
+    sink_o);
+ input sink_i;
+ input sink_b;
+ output sink_o;
+
+
+ OR2_X1 g_sink (.A1(sink_i),
+    .A2(sink_b),
+    .ZN(sink_o));
+endmodule
+module wrap_mod (wrap_a,
+    wrap_b,
+    wrap_o);
+ input wrap_a;
+ input wrap_b;
+ output wrap_o;
+
+
+ blk_mod u_blk (.blk_a(wrap_a),
+    .blk_b(wrap_b),
+    .blk_o(wrap_o));
+endmodule

--- a/src/rsz/test/cpp/TestBufferRemoval3_hier_feedthrough_post.v
+++ b/src/rsz/test/cpp/TestBufferRemoval3_hier_feedthrough_post.v
@@ -1,0 +1,75 @@
+module top (a,
+    b,
+    out);
+ input a;
+ input b;
+ output out;
+
+ wire mid;
+
+ sink_mod u_sink (.sink_i(mid),
+    .sink_b(b),
+    .sink_o(out));
+ wrap_mod u_wrap (.wrap_a(a),
+    .wrap_b(b),
+    .wrap_o(mid));
+endmodule
+module blk_mod (blk_a,
+    blk_b,
+    blk_o);
+ input blk_a;
+ input blk_b;
+ output blk_o;
+
+ wire drv_to_ft;
+
+ drv_mod u_drv (.drv_a(blk_a),
+    .drv_b(blk_b),
+    .drv_o(drv_to_ft));
+ ft_mod u_ft_mod (.ft_i(drv_to_ft),
+    .ft_o(blk_o));
+endmodule
+module drv_mod (drv_a,
+    drv_b,
+    drv_o);
+ input drv_a;
+ input drv_b;
+ output drv_o;
+
+
+ NOR2_X1 g_drv (.A1(drv_a),
+    .A2(drv_b),
+    .ZN(drv_o));
+endmodule
+module ft_mod (ft_i,
+    ft_o);
+ input ft_i;
+ output ft_o;
+
+
+ assign ft_o = ft_i;
+endmodule
+module sink_mod (sink_i,
+    sink_b,
+    sink_o);
+ input sink_i;
+ input sink_b;
+ output sink_o;
+
+
+ OR2_X1 g_sink (.A1(sink_i),
+    .A2(sink_b),
+    .ZN(sink_o));
+endmodule
+module wrap_mod (wrap_a,
+    wrap_b,
+    wrap_o);
+ input wrap_a;
+ input wrap_b;
+ output wrap_o;
+
+
+ blk_mod u_blk (.blk_a(wrap_a),
+    .blk_b(wrap_b),
+    .blk_o(wrap_o));
+endmodule


### PR DESCRIPTION
## Summary

- `remove_buffers` drops the `write_verilog` assign statement that carries a feedthrough through a kept sub-module, leaving that sub-module's output port undriven in the hierarchical netlist.
- The `dbModNet` merge itself is correct. The defect is the name given to the surviving `dbModNet`.
- New regression `TEST_F(BufRemTest3, HierFeedthroughAcrossLevels)`
<img width="892" height="234" alt="image" src="https://github.com/user-attachments/assets/089505e0-5ba6-4460-9a1e-87108427a230" />


**Fail sequence:**

1. `removeBuffer()` keeps the input `dbModNet` as the survivor, which is what a feedthrough needs.
2. The surviving flat net happens to be the deeper of the two, so the rename step reserves the removed `dbModNet` name, and on a feedthrough that is the output port name.
3. The rename hands the surviving `dbModNet` the output port name, undoing step 1.
4. `writeAssigns()` sees the output port name equal to its net name, skips the alias, and the sub-module output port ends up with no driver.

<img width="1058" height="618" alt="image" src="https://github.com/user-attachments/assets/d26f4af2-0d9b-40e1-8fa9-e893e3a07c44" />


## Problem

`removeBuffer()` already keeps the input `dbModNet` as the survivor when dropping the buffer turns a kept sub-module into a feedthrough, because `VerilogWriter::writeAssigns()` can only express that feedthrough as an alias of the output port onto a net with a different name. The survivor rename that follows undid this.

The path through `Resizer::removeBuffer()`, annotated with the values measured on the new test case:

```cpp
  // Survivor selection.  The input ModNet is kept on a feedthrough.
  odb::dbModNet* survivor_modnet = input_modnet;                     // ft_i
  odb::dbModNet* removed_modnet = output_modnet;                     // ft_o
  if (!bufferRemovalCreatesFeedthrough(input_modnet, output_modnet)
      && !db_network_->hasPort(input_net)
      && db_network_->hasPort(output_net)) {   // false, so no swap happens
    survivor_modnet = output_modnet;
    removed_modnet = input_modnet;
  }

  // Rename reservation.  db_survivor is u_wrap/u_blk/drv_to_ft with two
  // hierarchy delimiters, db_removed is the top level net mid with none.
  if (db_survivor->isDeeperThan(db_removed)) {                       // true
    new_net_name = db_removed->getName();                            // "mid"
    if (removed_modnet != nullptr) {
      new_modnet_name = removed_modnet->getName();   // "ft_o", the output port
    }
  }

  // The rename undoes the survivor selection above.
  if (survivor_modnet != nullptr && new_modnet_name.has_value()) {
    survivor_modnet->rename(new_modnet_name->c_str());         // ft_i -> ft_o
  }
```

Renaming to the shallower and more canonical name is correct for the flat net. For the `dbModNet` it hands the survivor the output port name, and `writeAssigns()` only aliases a port when both of these hold:

```cpp
network_->direction(port)->isAnyOutput()
    && network_->name(port) != network_->name(net)
```

With the surviving `dbModNet` named after the output port, neither boundary terminal produces an alias:

| port | direction | net | isAnyOutput | name differs | alias |
|---|---|---|---|---|---|
| `ft_i` | input | `ft_o` | no | yes | not emitted |
| `ft_o` | output | `ft_o` | yes | no | not emitted |

Input ports are never aliased, so nothing bridges the two boundary terminals and the sub-module comes out empty:

```verilog
module ft_mod (ft_i, ft_o);
 input ft_i;
 output ft_o;


endmodule
```

`dbNet::isDeeperThan()` compares the count of hierarchy delimiters in the net names, so the trigger is a depth asymmetry between the two flat nets around the buffer.

The flat `dbNet` merge stays correct, so placement, CTS and routing see a properly driven net and report nothing. Only LEC and gate level simulation fail.

## Solution

- `src/rsz/src/Resizer.cc`: skip the `dbModNet` rename when the removal creates a feedthrough. The flat net rename is unaffected.
- Hoist `bufferRemovalCreatesFeedthrough()` into a local so the survivor selection and the rename share one result. Short circuit evaluation already called it unconditionally, so the call count is unchanged.

```cpp
  if (db_survivor->isDeeperThan(db_removed)) {
    new_net_name = db_removed->getName();
    if (removed_modnet != nullptr && !creates_feedthrough) {
      new_modnet_name = removed_modnet->getName();
    }
  }
```

- `src/rsz/test/cpp/TestBufferRemoval3.cc`: add `BufRemTest3.HierFeedthroughAcrossLevels`. The existing `FeedthroughAssign` test does not catch this because both of its flat nets sit at top level, so `isDeeperThan()` is false and no rename happens.

The new test asserts the whole chain so a future failure points at the right stage:

| assertion | before the fix |
|---|---|
| flat `dbNet`s merged | passed |
| boundary `dbModNet`s merged | passed |
| surviving `dbModNet` name is not the output port name | failed |
| golden holds `assign ft_o = ft_i;` | failed |

The input netlist is written in `write_verilog` output style, so a diff against the golden shows only the buffer to assign change.

## Impact

- No QoR impact. The change only affects the name assigned to the surviving `dbModNet`, never the decision to remove a buffer, so buffer counts, area and timing are unaffected. This differs from blocking the removal outright, which would preserve every boundary buffer.
- Behavior changes only when `bufferRemovalCreatesFeedthrough()` is true and the surviving flat net is the deeper one. All other paths are untouched.
- No API or database schema change.
