### PR TITLE
fix syn compile issue in dbg mode

### DIFF
--- a/src/syn/src/flow/acd.cc
+++ b/src/syn/src/flow/acd.cc
@@ -727,7 +727,7 @@ Search::Search(utl::Logger* logger,
   // is assumed by the symmetry class processing below and by initilization
   // of `next_var_`.
   for (int i = 0; i < problem_.numInputs(); i++) {
-    assert(problem_.function.variable(i) == i);
+    assert(problem_.getFunction().variable(i) == i);
   }
 
   if (timing_) {

--- a/src/syn/src/flow/acd_timing.cc
+++ b/src/syn/src/flow/acd_timing.cc
@@ -150,7 +150,7 @@ float networkSlack(utl::Logger* logger,
                    const sta::Scene* corner,
                    const float fixed_slew[2])
 {
-  assert(net.outs.size() == problem.outputs.size());
+  assert(net.outs.size() == problem.numOutputs());
 
   std::vector<float> load(net.nodes.size(), 0.0f);
 
@@ -313,7 +313,7 @@ void populateCutTiming(sta::dbNetwork* network,
   };
 
   std::unordered_map<sta::Vertex*, int> vertex_po_index;
-  assert(roots.size() == problem.outputs.size());
+  assert(roots.size() == problem.numOutputs());
   for (int i = 0; i < problem.numOutputs(); i++) {
     sta::PinSet* pin_set = network->drivers(roots[i]);
     if (pin_set->size() != 1) {
@@ -339,7 +339,7 @@ void populateCutTiming(sta::dbNetwork* network,
     problem.output(i).external_load = load;
   }
 
-  assert(leaves.size() == problem.inputs.size());
+  assert(leaves.size() == problem.numInputs());
   for (size_t li = 0; li < problem.numInputs(); li++) {
     sta::PinSet* pin_set = network->drivers(leaves[li]);
     if (pin_set->size() != 1) {


### PR DESCRIPTION
## Summary
 c70e60d ("syn: make SynthesisProblem into a class with encapsulation") made
  `function` / `inputs` / `outputs` private but missed four `assert()` bodies
  still referencing them. `NDEBUG` deletes those expressions before parsing, so
  release CI and Bazel never saw it; debug builds fail to compile.

  Switch to the public accessors:

  - `acd_timing.cc:153,316` — `problem.outputs.size()` → `problem.numOutputs()`
  - `acd_timing.cc:342` — `problem.inputs.size()` → `problem.numInputs()`
  - `acd.cc:730` — `problem_.function.variable(i)` → `problem_.getFunction().variable(i)`

  No functional change; asserts are compiled out of release builds.

  Tested: re-ran each file's compile command with `-UNDEBUG -fsyntax-only` to
  reproduce, then swept all 46 `src/syn/` translation units — zero errors.

## Type of Change
- Bug fix


## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
