### PR TITLE
Make private headers visible to cts unittest

### DIFF
--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -27,7 +27,7 @@ cc_library(
     includes = [
         "src",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//src/cts/test:__pkg__"],
     deps = [
         # TODO: we use headers provided by :cts, but that reveals cyclic dep
         #":cts",

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -239,9 +239,9 @@ filegroup(
 cc_test(
     name = "cts_unittest",
     srcs = ["cts_unittest.cc"],
-    features = ["-layering_check"],  # TODO: accesses private headers
     deps = [
         "//src/cts",
+        "//src/cts:private_hdrs",
         "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",


### PR DESCRIPTION
so that we can enable the layering check.
