### PR TITLE
grt: fastroute: Improve GRT-0183 message

### DIFF
--- a/src/grt/src/fastroute/src/maze3D.cpp
+++ b/src/grt/src/fastroute/src/maze3D.cpp
@@ -1184,7 +1184,9 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
           if (src_heap_3D_.empty()) {
             logger_->error(GRT,
                            183,
-                           "Net {}: heap underflow during 3D maze routing.",
+                           "Net {}: the 3D maze router ran out of legal paths "
+                           "(heap underflow) - the net is boxed in by local "
+                           "congestion or blockages.",
                            nets_[netID]->getName());
           }
           // update ind1 for next loop


### PR DESCRIPTION
The GRT-0183 error message is - for normal OpenROAD users - very cryptic and includes almost no information what's wrong. Update the error message and include more the actualy issue.