### PR TITLE
odb: add ability to specify the assembly extraction rules file path for a 3D design

### DIFF
--- a/src/odb/README.md
+++ b/src/odb/README.md
@@ -513,13 +513,15 @@ add_3dblox_alignment_marker_rule
 
 ### Set Extraction Rules File
 
-Sets the path to the parasitics extraction rules file. For a design in which
+Sets the path to the parasitics extraction rules file. For a 3D design in which
 multiple technologies are used, the user must specify the technology for which
-they want to set the rules path.
+they want to set the rules path as well as the assembly design kit extraction
+rules for the inter-chip parasitics with `-assembly`.
 
 ```tcl
 set_extraction_rules_file
     [-tech tech_name]
+    [-assembly]
     rules_file
 ```
 
@@ -528,6 +530,7 @@ set_extraction_rules_file
 | Switch Name | Description |
 | ----- | ----- |
 | `-tech` | Technology for which to set the extraction rules path. |
+| `-assembly` | Set the inter-chip extraction rules. |
 | `rules_file` | Path to the extraction rules file. |
 
 ## Regression tests

--- a/src/odb/README.md
+++ b/src/odb/README.md
@@ -516,7 +516,8 @@ add_3dblox_alignment_marker_rule
 Sets the path to the parasitics extraction rules file. For a 3D design in which
 multiple technologies are used, the user must specify the technology for which
 they want to set the rules path as well as the assembly design kit extraction
-rules for the inter-chip parasitics with `-assembly`.
+rules for the inter-chip parasitics with `-assembly`. The parasitics extractor
+only supports 3D designs with two chips and no RDL.
 
 ```tcl
 set_extraction_rules_file

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7366,6 +7366,10 @@ class dbChip : public dbObject
 
   dbTech* getTech() const;
 
+  std::string getAssemblyExtractionRulesFile() const;
+
+  void setAssemblyExtractionRulesFile(const std::string& rules_file_path);
+
   Rect getBBox() const;
 
   Cuboid getCuboid() const;
@@ -7700,6 +7704,8 @@ class dbDatabase : public dbObject
   bool hasHierarchy() const;
 
   bool hasHierarchicalChip() const;
+
+  dbChip* getHierarchicalChip() const;
 
   void setTopChip(dbChip* chip);
   ///

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7366,7 +7366,7 @@ class dbChip : public dbObject
 
   dbTech* getTech() const;
 
-  std::string getAssemblyExtractionRulesFile() const;
+  const std::string& getAssemblyExtractionRulesFile() const;
 
   void setAssemblyExtractionRulesFile(const std::string& rules_file_path);
 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7705,8 +7705,6 @@ class dbDatabase : public dbObject
 
   bool hasHierarchicalChip() const;
 
-  dbChip* getHierarchicalChip() const;
-
   void setTopChip(dbChip* chip);
   ///
   /// Return the libs contained in the database. A database can contain

--- a/src/odb/src/codeGenerator/schema/chip/dbChip.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbChip.json
@@ -188,6 +188,12 @@
       "schema": "kSchemaChipTech"
     },
     {
+      "name": "assembly_extraction_rules_file_",
+      "type": "std::string",
+      "flags": ["private"],
+      "schema": "kSchemaChipAssemblyExtractionRulesFile"
+    },
+    {
       "name": "marker_categories_map_",
       "type": "std::unordered_map<std::string, dbId<_dbMarkerCategory>>",
       "flags": ["private", "no-serial"]

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -115,6 +115,9 @@ bool _dbChip::operator==(const _dbChip& rhs) const
   if (tech_ != rhs.tech_) {
     return false;
   }
+  if (assembly_extraction_rules_file_ != rhs.assembly_extraction_rules_file_) {
+    return false;
+  }
   if (*prop_tbl_ != *rhs.prop_tbl_) {
     return false;
   }
@@ -273,6 +276,9 @@ dbIStream& operator>>(dbIStream& stream, _dbChip& obj)
   if (obj.getDatabase()->isSchema(kSchemaChipTech)) {
     stream >> obj.tech_;
   }
+  if (obj.getDatabase()->isSchema(kSchemaChipAssemblyExtractionRulesFile)) {
+    stream >> obj.assembly_extraction_rules_file_;
+  }
   if (obj.getDatabase()->isSchema(kSchemaChipRegion)) {
     stream >> *obj.chip_region_tbl_;
   }
@@ -335,6 +341,7 @@ dbOStream& operator<<(dbOStream& stream, const _dbChip& obj)
   stream << obj.conns_;
   stream << obj.nets_;
   stream << obj.tech_;
+  stream << obj.assembly_extraction_rules_file_;
   stream << *obj.chip_region_tbl_;
   stream << *obj.chip_cap_node_tbl_;
   stream << *obj.chip_r_seg_tbl_;
@@ -380,6 +387,8 @@ void _dbChip::collectMemInfo(MemInfo& info)
 
   info.children["chipinsts_map"].add(chipinsts_map_);
   info.children["chip_region_map"].add(chip_region_map_);
+  info.children["assembly_extraction_rules_file"].add(
+      assembly_extraction_rules_file_);
   info.children["marker_categories_map"].add(marker_categories_map_);
   prop_tbl_->collectMemInfo(info.children["prop_tbl_"]);
   chip_region_tbl_->collectMemInfo(info.children["chip_region_tbl_"]);
@@ -658,6 +667,34 @@ dbChip::ChipType dbChip::getChipType() const
 {
   _dbChip* obj = (_dbChip*) this;
   return (dbChip::ChipType) obj->type_;
+}
+
+std::string dbChip::getAssemblyExtractionRulesFile() const
+{
+  _dbChip* chip = (_dbChip*) this;
+
+  if (getChipType() != ChipType::HIER) {
+    chip->getLogger()->error(utl::ODB,
+                             1219,
+                             "The assembly extraction rules file is only "
+                             "available on a hierarchical chip.");
+  }
+
+  return chip->assembly_extraction_rules_file_;
+}
+
+void dbChip::setAssemblyExtractionRulesFile(const std::string& rules_file_path)
+{
+  _dbChip* chip = (_dbChip*) this;
+
+  if (getChipType() != ChipType::HIER) {
+    chip->getLogger()->error(utl::ODB,
+                             1220,
+                             "The assembly extraction rules file can only be "
+                             "set on a hierarchical chip.");
+  }
+
+  chip->assembly_extraction_rules_file_ = rules_file_path;
 }
 
 dbBlock* dbChip::getBlock()

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -686,12 +686,30 @@ const std::string& dbChip::getAssemblyExtractionRulesFile() const
 void dbChip::setAssemblyExtractionRulesFile(const std::string& rules_file_path)
 {
   _dbChip* chip = (_dbChip*) this;
+  utl::Logger* logger = chip->getLogger();
 
   if (getChipType() != ChipType::HIER) {
-    chip->getLogger()->error(utl::ODB,
-                             1220,
-                             "The assembly extraction rules file can only be "
-                             "set on a hierarchical chip.");
+    logger->error(utl::ODB,
+                  1220,
+                  "Could not set assembly extraction rules file. Design is "
+                  "not 3D.");
+  }
+
+  dbSet<dbChipInst> chip_insts = getChipInsts();
+
+  if (chip_insts.size() != 2) {
+    logger->error(utl::ODB,
+                  1223,
+                  "3D-IC extraction with more than 2 dies is not supported.");
+  }
+
+  for (dbChipInst* chip_inst : chip_insts) {
+    if (chip_inst->getMasterChip()->getChipType() == ChipType::HIER) {
+      logger->error(utl::ODB,
+                    1224,
+                    "3D-IC extraction with nested hierarchy is not "
+                    "supported.");
+    }
   }
 
   chip->assembly_extraction_rules_file_ = rules_file_path;

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -669,7 +669,7 @@ dbChip::ChipType dbChip::getChipType() const
   return (dbChip::ChipType) obj->type_;
 }
 
-std::string dbChip::getAssemblyExtractionRulesFile() const
+const std::string& dbChip::getAssemblyExtractionRulesFile() const
 {
   _dbChip* chip = (_dbChip*) this;
 

--- a/src/odb/src/db/dbChip.h
+++ b/src/odb/src/db/dbChip.h
@@ -83,6 +83,7 @@ class _dbChip : public _dbObject
   std::unordered_map<std::string, dbId<_dbChipInst>> chipinsts_map_;
   std::unordered_map<std::string, dbId<_dbChipRegion>> chip_region_map_;
   dbId<_dbTech> tech_;
+  std::string assembly_extraction_rules_file_;
   std::unordered_map<std::string, dbId<_dbMarkerCategory>>
       marker_categories_map_;
   dbTable<_dbProperty>* prop_tbl_;

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -925,13 +925,18 @@ bool dbDatabase::hasHierarchy() const
 
 bool dbDatabase::hasHierarchicalChip() const
 {
+  return getHierarchicalChip() != nullptr;
+}
+
+dbChip* dbDatabase::getHierarchicalChip() const
+{
   for (dbChip* chip : getChips()) {
     if (chip->getChipType() == dbChip::ChipType::HIER) {
-      return true;
+      return chip;
     }
   }
 
-  return false;
+  return nullptr;
 }
 
 void dbDatabase::read(std::istream& file)

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -925,18 +925,13 @@ bool dbDatabase::hasHierarchy() const
 
 bool dbDatabase::hasHierarchicalChip() const
 {
-  return getHierarchicalChip() != nullptr;
-}
-
-dbChip* dbDatabase::getHierarchicalChip() const
-{
   for (dbChip* chip : getChips()) {
     if (chip->getChipType() == dbChip::ChipType::HIER) {
-      return chip;
+      return true;
     }
   }
 
-  return nullptr;
+  return false;
 }
 
 void dbDatabase::read(std::istream& file)

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 137;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 138;  // Current revision number
+
+// Revision where dbChip::assembly_extraction_rules_file_ was added
+inline constexpr uint32_t kSchemaChipAssemblyExtractionRulesFile = 138;
 
 // Revision where dbChipCapNode/dbChipRSeg inter-chip parasitics were added
 inline constexpr uint32_t kSchemaChipParasitics = 137;

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1262,7 +1262,7 @@ proc set_extraction_rules_file { args } {
     set hier_chip [$db getHierarchicalChip]
 
     if { $hier_chip == "NULL" } {
-      utl::error ODB 481 "Could not set assembly extraction rules file.\
+      utl::error ODB 1222 "Could not set assembly extraction rules file.\
         No hierarchical chip found."
     }
 

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1244,15 +1244,32 @@ proc add_3dblox_alignment_marker_rule { args } {
 }
 
 sta::define_cmd_args "set_extraction_rules_file" {
-    [-tech tech_name] rules_file
+    [-tech tech_name] [-assembly] rules_file
 }
 
 proc set_extraction_rules_file { args } {
   sta::parse_key_args "set_extraction_rules_file" args \
-    keys {-tech} flags {}
+    keys {-tech} flags {-assembly}
   sta::check_argc_eq1 "set_extraction_rules_file" $args
 
   set db [ord::get_db]
+
+  if { [info exists flags(-assembly)] } {
+    if { [info exists keys(-tech)] } {
+      utl::error ODB 1221 "-assembly cannot be used with -tech."
+    }
+
+    set hier_chip [$db getHierarchicalChip]
+
+    if { $hier_chip == "NULL" } {
+      utl::error ODB 481 "Could not set assembly extraction rules file.\
+        No hierarchical chip found."
+    }
+
+    $hier_chip setAssemblyExtractionRulesFile [lindex $args 0]
+    return
+  }
+
   if { [info exists keys(-tech)] } {
     set tech [$db findTech $keys(-tech)]
   } elseif { [$db hasHierarchicalChip] } {

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1259,14 +1259,14 @@ proc set_extraction_rules_file { args } {
       utl::error ODB 1221 "-assembly cannot be used with -tech."
     }
 
-    set hier_chip [$db getHierarchicalChip]
+    set top_chip [$db getChip]
 
-    if { $hier_chip == "NULL" } {
+    if { $top_chip == "NULL" } {
       utl::error ODB 1222 "Could not set assembly extraction rules file.\
-        No hierarchical chip found."
+        No chip found."
     }
 
-    $hier_chip setAssemblyExtractionRulesFile [lindex $args 0]
+    $top_chip setAssemblyExtractionRulesFile [lindex $args 0]
     return
   }
 


### PR DESCRIPTION
## Summary
`dbChip` now has a string field for the ADK rules path. Only the top chip can have an assembly rules file as the initial 3D extractor will only handle 2 dies with no nested chiplet hierarchy.

## Type of Change
- New feature
- Documentation update

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
#11005.
