### PR TITLE
odb: add ability to specify the extraction rules for the assembly kit

### DIFF
--- a/src/odb/README.md
+++ b/src/odb/README.md
@@ -513,13 +513,15 @@ add_3dblox_alignment_marker_rule
 
 ### Set Extraction Rules File
 
-Sets the path to the parasitics extraction rules file. For a design in which
+Sets the path to the parasitics extraction rules file. For a 3D design in which
 multiple technologies are used, the user must specify the technology for which
-they want to set the rules path.
+they want to set the rules path as well as the assembly design kit extraction
+rules for the inter-chip parasitics with `-assembly`.
 
 ```tcl
 set_extraction_rules_file
     [-tech tech_name]
+    [-assembly]
     rules_file
 ```
 
@@ -528,6 +530,7 @@ set_extraction_rules_file
 | Switch Name | Description |
 | ----- | ----- |
 | `-tech` | Technology for which to set the extraction rules path. |
+| `-assembly` | Set the inter-chip extraction rules. Cannot be combined with `-tech`. |
 | `rules_file` | Path to the extraction rules file. |
 
 ## Regression tests

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7699,7 +7699,9 @@ class dbDatabase : public dbObject
   void setHierarchy(bool value);
   bool hasHierarchy() const;
 
-  bool hasHierarchicalChip() const;
+  const std::string& getAssemblyExtractionRulesFile() const;
+
+  void setAssemblyExtractionRulesFile(const std::string& rules_file_path);
 
   void setTopChip(dbChip* chip);
   ///

--- a/src/odb/src/codeGenerator/schema/dbDatabase.json
+++ b/src/odb/src/codeGenerator/schema/dbDatabase.json
@@ -39,6 +39,11 @@
       "type": "uint32_t",
       "default": 0,
       "flags": ["no-serial"]
+    },
+    {
+      "name": "assembly_extraction_rules_file_",
+      "type": "std::string",
+      "flags": ["private", "no-serial"]
     }
   ]
 }

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -5,6 +5,7 @@
 #include "dbDatabase.h"
 
 #include <cstdint>
+#include <string>
 
 #include "dbAlignmentMarkerRule.h"
 #include "dbChip.h"
@@ -100,6 +101,9 @@ bool _dbDatabase::operator==(const _dbDatabase& rhs) const
     return false;
   }
   if (dbu_per_micron_ != rhs.dbu_per_micron_) {
+    return false;
+  }
+  if (assembly_extraction_rules_file_ != rhs.assembly_extraction_rules_file_) {
     return false;
   }
   if (*alignment_marker_rule_tbl_ != *rhs.alignment_marker_rule_tbl_) {
@@ -371,6 +375,9 @@ dbIStream& operator>>(dbIStream& stream, _dbDatabase& obj)
   } else {
     obj.hierarchy_ = false;
   }
+  if (obj.isSchema(kSchemaAssemblyExtractionRulesFile)) {
+    stream >> obj.assembly_extraction_rules_file_;
+  }
   // Set the _tech on the block & libs now they are loaded
   if (!obj.isSchema(kSchemaBlockTech)) {
     if (obj.chip_) {
@@ -484,6 +491,7 @@ dbOStream& operator<<(dbOStream& stream, const _dbDatabase& obj)
   stream << *obj.alignment_marker_rule_tbl_;
   stream << obj.dbu_per_micron_;
   stream << obj.hierarchy_;
+  stream << obj.assembly_extraction_rules_file_;
   // User Code End <<
   return stream;
 }
@@ -537,6 +545,8 @@ void _dbDatabase::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["assembly_extraction_rules_file"].add(
+      assembly_extraction_rules_file_);
   alignment_marker_rule_tbl_->collectMemInfo(
       info.children["alignment_marker_rule_tbl_"]);
   chip_tbl_->collectMemInfo(info.children["chip_tbl_"]);
@@ -923,15 +933,35 @@ bool dbDatabase::hasHierarchy() const
   return db->hierarchy_;
 }
 
-bool dbDatabase::hasHierarchicalChip() const
+const std::string& dbDatabase::getAssemblyExtractionRulesFile() const
 {
-  for (dbChip* chip : getChips()) {
-    if (chip->getChipType() == dbChip::ChipType::HIER) {
-      return true;
-    }
+  _dbDatabase* db = (_dbDatabase*) this;
+  return db->assembly_extraction_rules_file_;
+}
+
+void dbDatabase::setAssemblyExtractionRulesFile(
+    const std::string& rules_file_path)
+{
+  _dbDatabase* db = (_dbDatabase*) this;
+  utl::Logger* logger = db->getLogger();
+
+  dbChip* top_chip = getChip();
+
+  if (!top_chip) {
+    logger->error(utl::ODB,
+                  1219,
+                  "Could not set assembly extraction rules file. No design "
+                  "loaded.");
   }
 
-  return false;
+  if (top_chip->getChipType() != dbChip::ChipType::HIER) {
+    logger->error(utl::ODB,
+                  1220,
+                  "Could not set assembly extraction rules file. Design is "
+                  "not 3D.");
+  }
+
+  db->assembly_extraction_rules_file_ = rules_file_path;
 }
 
 void dbDatabase::read(std::istream& file)

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 #include "dbCore.h"
 #include "dbHashTable.h"
@@ -50,7 +51,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 137;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 138;  // Current revision number
+
+// Revision where dbDatabase::assembly_extraction_rules_file_ was added
+inline constexpr uint32_t kSchemaAssemblyExtractionRulesFile = 138;
 
 // Revision where dbChipCapNode/dbChipRSeg inter-chip parasitics were added
 inline constexpr uint32_t kSchemaChipParasitics = 137;
@@ -352,6 +356,7 @@ class _dbDatabase : public _dbObject
   uint32_t master_id_;
   dbId<_dbChip> chip_;
   uint32_t dbu_per_micron_;
+  std::string assembly_extraction_rules_file_;
   dbTable<_dbAlignmentMarkerRule>* alignment_marker_rule_tbl_;
   dbTable<_dbChip, 2>* chip_tbl_;
   dbHashTable<_dbChip, 2> chip_hash_;

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1244,20 +1244,31 @@ proc add_3dblox_alignment_marker_rule { args } {
 }
 
 sta::define_cmd_args "set_extraction_rules_file" {
-    [-tech tech_name] rules_file
+    [-tech tech_name] [-assembly] rules_file
 }
 
 proc set_extraction_rules_file { args } {
   sta::parse_key_args "set_extraction_rules_file" args \
-    keys {-tech} flags {}
+    keys {-tech} flags {-assembly}
   sta::check_argc_eq1 "set_extraction_rules_file" $args
 
   set db [ord::get_db]
+
+  if { [info exists flags(-assembly)] } {
+    if { [info exists keys(-tech)] } {
+      utl::error ODB 1221 "-assembly cannot be used with -tech."
+    }
+
+    $db setAssemblyExtractionRulesFile [lindex $args 0]
+    return
+  }
+
   if { [info exists keys(-tech)] } {
     set tech [$db findTech $keys(-tech)]
-  } elseif { [$db hasHierarchicalChip] } {
+  } elseif { [llength [$db getTechs]] > 1 } {
     utl::error ODB 478 "Could not set extraction rules file.\
-      Use -tech to specify a technology in a 3D design."
+      Use -tech to specify a technology in a design with multiple\
+      technologies."
   } else {
     set tech [$db getTech]
   }


### PR DESCRIPTION
## Summary
The idea is to specify the path for the assembly extraction rules and keep it in `dbDatabase` as for our current version there's single global assembly kit.

I'm also fixing the condition for multiple techs when running `set_extraction_rules_path -tech` as the odb API I added was not accurate.

## Type of Change
<!-- Delete items that do not apply -->
- New feature
- Documentation update

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
https://github.com/The-OpenROAD-Project/OpenROAD/issues/11005
