### PR TITLE
web: remove per-tile ODB traversal from tile rendering

### DIFF
--- a/src/web/src/search.cpp
+++ b/src/web/src/search.cpp
@@ -271,6 +271,11 @@ void Search::setOnModified(std::function<void()> cb)
 
 void Search::notifyModified()
 {
+  // Bumped here as well as in announceModified so revision() moves for the
+  // edits that call this directly (die/core area, region boxes).  Bumping
+  // twice for one edit is harmless: callers only compare it for equality.
+  revision_.fetch_add(1, std::memory_order_release);
+
   std::function<void()> cb;
   {
     std::lock_guard lock(on_modified_mutex_);
@@ -283,6 +288,10 @@ void Search::notifyModified()
 
 void Search::announceModified(std::atomic_bool& flag)
 {
+  // Unconditional, unlike the callback below: an edit that arrives while this
+  // index is already invalid still has to be visible to revision() pollers.
+  revision_.fetch_add(1, std::memory_order_release);
+
   const bool prev_flag = flag.exchange(false);
 
   if (prev_flag) {

--- a/src/web/src/search.cpp
+++ b/src/web/src/search.cpp
@@ -405,8 +405,9 @@ void Search::updateShapes(odb::dbBlock* block)
   data.snet_shapes.clear();
 
   // Single pass over all nets to collect both special and routing shapes.
-  LayerMap<std::vector<SNetValue<odb::dbNet*>>> snet_shapes;
-  LayerMap<std::vector<SNetDBoxValue<odb::dbNet*>>> snet_net_via_shapes;
+  LayerMap<std::vector<RectValue<SNetValue<odb::dbNet*>>>> snet_shapes;
+  LayerMap<std::vector<RectValue<SNetDBoxValue<odb::dbNet*>>>>
+      snet_net_via_shapes;
   LayerMap<std::vector<RouteBoxValue<odb::dbNet*>>> net_shapes;
 
   for (odb::dbNet* net : block->getNets()) {
@@ -561,13 +562,13 @@ void Search::updateInsts(odb::dbBlock* block)
 
   data.insts.clear();
 
-  std::vector<odb::dbInst*> insts;
+  std::vector<RectValue<odb::dbInst*>> insts;
   for (odb::dbInst* inst : block->getInsts()) {
     if (inst->isPlaced()) {
-      insts.push_back(inst);
+      insts.emplace_back(inst->getBBox()->getBox(), inst);
     }
   }
-  data.insts = RtreeDBox<odb::dbInst*>(insts.begin(), insts.end());
+  data.insts = RtreeRect<odb::dbInst*>(insts.begin(), insts.end());
 
   data.insts_init = true;
 
@@ -593,15 +594,15 @@ void Search::updateBlockages(odb::dbBlock* block)
 
   data.blockages.clear();
 
-  std::vector<odb::dbBlockage*> blockages;
+  std::vector<RectValue<odb::dbBlockage*>> blockages;
   for (odb::dbBlockage* blockage : block->getBlockages()) {
     if (blockage->isSystemReserved()) {
       continue;
     }
-    blockages.push_back(blockage);
+    blockages.emplace_back(blockage->getBBox()->getBox(), blockage);
   }
   data.blockages
-      = RtreeDBox<odb::dbBlockage*>(blockages.begin(), blockages.end());
+      = RtreeRect<odb::dbBlockage*>(blockages.begin(), blockages.end());
 
   data.blockages_init = true;
 
@@ -633,13 +634,13 @@ void Search::updateObstructions(odb::dbBlock* block)
 
   data.obstructions.clear();
 
-  LayerMap<std::vector<odb::dbObstruction*>> obstructions;
+  LayerMap<std::vector<RectValue<odb::dbObstruction*>>> obstructions;
   for (odb::dbObstruction* obs : block->getObstructions()) {
     if (obs->isSystemReserved()) {
       continue;
     }
     odb::dbBox* bbox = obs->getBBox();
-    obstructions[bbox->getTechLayer()].push_back(obs);
+    obstructions[bbox->getTechLayer()].emplace_back(bbox->getBox(), obs);
   }
   // Pre-populate map keys, then build R-trees in parallel.
   for (const auto& [layer, _] : obstructions) {
@@ -649,7 +650,7 @@ void Search::updateObstructions(odb::dbBlock* block)
   for (auto& [layer, layer_obs] : obstructions) {
     boost::asio::post(pool_, [&data, layer, &layer_obs, &done] {
       data.obstructions[layer]
-          = RtreeDBox<odb::dbObstruction*>(layer_obs.begin(), layer_obs.end());
+          = RtreeRect<odb::dbObstruction*>(layer_obs.begin(), layer_obs.end());
       done.count_down();
     });
   }
@@ -728,11 +729,14 @@ void Search::addVia(
 
 void Search::addSNet(
     odb::dbNet* net,
-    LayerMap<std::vector<SNetValue<odb::dbNet*>>>& net_shapes,
-    LayerMap<std::vector<SNetDBoxValue<odb::dbNet*>>>& via_shapes)
+    LayerMap<std::vector<RectValue<SNetValue<odb::dbNet*>>>>& net_shapes,
+    LayerMap<std::vector<RectValue<SNetDBoxValue<odb::dbNet*>>>>& via_shapes)
 {
   for (odb::dbSWire* swire : net->getSWires()) {
     for (odb::dbSBox* box : swire->getWires()) {
+      // The sbox bbox is the tree's index in every case, including the
+      // octilinear one where the payload polygon is the real shape.
+      const odb::Rect bbox = box->getBox();
       if (box->isVia()) {
         odb::dbTechLayer* layer;
         if (auto via = box->getTechVia()) {
@@ -741,12 +745,15 @@ void Search::addSNet(
           auto block_via = box->getBlockVia();
           layer = block_via->getBottomLayer()->getUpperLayer();
         }
-        via_shapes[layer].emplace_back(box, net);
+        via_shapes[layer].emplace_back(bbox,
+                                       SNetDBoxValue<odb::dbNet*>{box, net});
       } else {
         if (box->getDirection() == odb::dbSBox::OCTILINEAR) {
-          net_shapes[box->getTechLayer()].emplace_back(box, box->getOct(), net);
+          net_shapes[box->getTechLayer()].emplace_back(
+              bbox, SNetValue<odb::dbNet*>{box, box->getOct(), net});
         } else {
-          net_shapes[box->getTechLayer()].emplace_back(box, box->getBox(), net);
+          net_shapes[box->getTechLayer()].emplace_back(
+              bbox, SNetValue<odb::dbNet*>{box, bbox, net});
         }
       }
     }
@@ -780,26 +787,19 @@ class Search::MinSizePredicate
 {
  public:
   MinSizePredicate(int min_size) : min_size_(min_size) {}
-  bool operator()(const SNetValue<T>& o) const
-  {
-    return checkBox(std::get<0>(o)->getBox());
-  }
 
-  bool operator()(const RectValue<T>& o) const { return checkBox(o.first); }
+  // Every Rect-indexed tree stores std::pair<Rect, payload>, so one overload
+  // covers insts, obstructions, special-net shapes and special-net vias alike
+  // — and reads the box the tree already holds instead of re-deriving it.
+  template <typename V>
+  bool operator()(const std::pair<odb::Rect, V>& o) const
+  {
+    return checkBox(o.first);
+  }
 
   bool operator()(const RouteBoxValue<T>& o) const
   {
     return checkBox(std::get<0>(o));
-  }
-
-  bool operator()(const SNetDBoxValue<T>& o) const
-  {
-    return checkBox(o.first->getBox());
-  }
-
-  bool operator()(odb::dbObstruction* o) const
-  {
-    return checkBox(o->getBBox()->getBox());
   }
 
   bool operator()(odb::dbFill* o) const
@@ -823,16 +823,13 @@ class Search::PolygonIntersectPredicate
 {
  public:
   PolygonIntersectPredicate(const odb::Rect& region) : region_(region) {}
-  bool operator()(const SNetValue<T>& o) const
-  {
-    return checkPolygon(std::get<1>(o));
-  }
 
-  bool operator()(const RectValue<T>& o) const { return checkPolygon(o.first); }
-
-  bool operator()(const RouteBoxValue<T>& o) const
+  // Only special-net shapes carry a polygon.  Note this deliberately tests
+  // the stored POLYGON, not the pair's bounding Rect — the Rect is the
+  // tree's index, the polygon is the actual shape.
+  bool operator()(const RectValue<SNetValue<T>>& o) const
   {
-    return checkPolygon(std::get<0>(o));
+    return checkPolygon(std::get<1>(o.second));
   }
 
   bool checkPolygon(const odb::Polygon& poly) const
@@ -849,26 +846,13 @@ class Search::MinHeightPredicate
 {
  public:
   MinHeightPredicate(int min_height) : min_height_(min_height) {}
-  bool operator()(const SNetValue<T>& o) const
-  {
-    return checkBox(std::get<0>(o));
-  }
 
-  bool operator()(const RouteBoxValue<T>& o) const
+  // Instances, blockages and rows all live in RectValue trees; the stored
+  // Rect is read directly rather than re-derived from ODB.
+  template <typename V>
+  bool operator()(const std::pair<odb::Rect, V>& o) const
   {
-    return checkBox(std::get<0>(o));
-  }
-
-  bool operator()(const RectValue<T>& o) const { return checkBox(o.first); }
-
-  bool operator()(odb::dbInst* o) const
-  {
-    return checkBox(o->getBBox()->getBox());
-  }
-
-  bool operator()(odb::dbBlockage* o) const
-  {
-    return checkBox(o->getBBox()->getBox());
+    return checkBox(o.first);
   }
 
   bool checkBox(const odb::Rect& box) const { return box.dy() >= min_height_; }
@@ -948,12 +932,12 @@ Search::SNetSBoxRange Search::searchSNetViaShapes(odb::dbBlock* block,
              && bgi::satisfies(MinSizePredicate<odb::dbNet*>(min_size)));
          qi != rtree.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   } else {
     for (auto qi = rtree.qbegin(bgi::intersects(query)); qi != rtree.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   }
   return results;
@@ -988,7 +972,7 @@ Search::SNetShapeRange Search::searchSNetShapes(odb::dbBlock* block,
              && bgi::satisfies(PolygonIntersectPredicate<odb::dbNet*>(query)));
          qi != rtree.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   } else {
     for (auto qi = rtree.qbegin(
@@ -996,7 +980,7 @@ Search::SNetShapeRange Search::searchSNetShapes(odb::dbBlock* block,
              && bgi::satisfies(PolygonIntersectPredicate<odb::dbNet*>(query)));
          qi != rtree.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   }
   return results;
@@ -1065,13 +1049,13 @@ Search::InstRange Search::searchInsts(odb::dbBlock* block,
              && bgi::satisfies(MinHeightPredicate<odb::dbInst*>(min_height)));
          it != data.insts.qend();
          ++it) {
-      results.push_back(*it);
+      results.push_back(it->second);
     }
   } else {
     for (auto it = data.insts.qbegin(bgi::intersects(query));
          it != data.insts.qend();
          ++it) {
-      results.push_back(*it);
+      results.push_back(it->second);
     }
   }
   return results;
@@ -1099,13 +1083,13 @@ Search::BlockageRange Search::searchBlockages(odb::dbBlock* block,
                  MinHeightPredicate<odb::dbBlockage*>(min_height)));
          qi != data.blockages.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   } else {
     for (auto qi = data.blockages.qbegin(bgi::intersects(query));
          qi != data.blockages.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   }
   return results;
@@ -1140,12 +1124,12 @@ Search::ObstructionRange Search::searchObstructions(odb::dbBlock* block,
                             MinSizePredicate<odb::dbObstruction*>(min_size)));
          qi != rtree.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   } else {
     for (auto qi = rtree.qbegin(bgi::intersects(query)); qi != rtree.qend();
          ++qi) {
-      results.push_back(*qi);
+      results.push_back(qi->second);
     }
   }
   return results;

--- a/src/web/src/search.h
+++ b/src/web/src/search.h
@@ -158,6 +158,17 @@ class Search : public odb::dbBlockCallBackObj
   // tile cache and push a redraw to connected clients.  Pass `{}` to clear.
   void setOnModified(std::function<void()> cb);
 
+  // Counter bumped on every design edit this object hears about, whether or
+  // not setOnModified's callback fires for it.  That callback is deliberately
+  // debounced to a valid→invalid index transition so a batch of edits does not
+  // flood connected clients with redraws, which makes it unsuitable for
+  // invalidating a cache: an edit arriving while an index is already invalid
+  // is silent.  Caches poll this instead and rebuild when it moves.
+  uint64_t revision() const
+  {
+    return revision_.load(std::memory_order_acquire);
+  }
+
   // Find all box shapes in the given bounds on the given layer which
   // are at least min_size in either dimension.
   RoutingRange searchBoxShapes(odb::dbBlock* block,
@@ -334,6 +345,9 @@ class Search : public odb::dbBlockCallBackObj
   // thread — guarded by on_modified_mutex_.
   std::function<void()> on_modified_;
   mutable std::mutex on_modified_mutex_;
+
+  // See revision().  Bumped by every edit, undebounced.
+  std::atomic_uint64_t revision_{0};
 
   struct BlockData
   {

--- a/src/web/src/search.h
+++ b/src/web/src/search.h
@@ -75,21 +75,6 @@ class Search : public odb::dbBlockCallBackObj
   using SNetDBoxValue = std::pair<odb::dbSBox*, T>;
   ;
 
-  template <typename T>
-  struct BBoxIndexableGetter
-  {
-    using result_type = odb::Rect;  // NOLINT(readability-identifier-naming)
-    odb::Rect operator()(T t) const { return t->getBBox()->getBox(); }
-    odb::Rect operator()(const SNetValue<T>& t) const
-    {
-      return std::get<0>(t)->getBox();
-    }
-    odb::Rect operator()(const SNetDBoxValue<T>& t) const
-    {
-      return std::get<0>(t)->getBox();
-    }
-  };
-
   struct FillIndexableGetter
   {
     using result_type = odb::Rect;  // NOLINT(readability-identifier-naming)
@@ -101,18 +86,23 @@ class Search : public odb::dbBlockCallBackObj
     }
   };
 
+  // Every tree below indexes on a Rect STORED IN THE TREE (the `first` of a
+  // RectValue pair), never on one derived from ODB by an indexable getter.
+  // Boost's rtree invokes the indexable getter on every element a query
+  // visits, and each derivation (inst->getBBox()->getBox(), sbox->getBox())
+  // is a chain of dbTable lookups whose cache behavior is far worse than the
+  // traversal itself.  At zoom-out the query box spans the whole design, so
+  // nothing prunes and the getter runs once per element per tile per layer —
+  // it dominated the web viewer's render time on large designs.  The extra 16
+  // bytes per entry buy that back.
   template <typename T>
   using RtreeRect = bgi::rtree<RectValue<T>, bgi::quadratic<16>>;
   template <typename T>
-  using RtreeDBox = bgi::rtree<T, bgi::quadratic<16>, BBoxIndexableGetter<T>>;
-  template <typename T>
   using RtreeRoutingShapes = bgi::rtree<RouteBoxValue<T>, bgi::quadratic<16>>;
   template <typename T>
-  using RtreeSNetShapes
-      = bgi::rtree<SNetValue<T>, bgi::quadratic<16>, BBoxIndexableGetter<T>>;
+  using RtreeSNetShapes = RtreeRect<SNetValue<T>>;
   template <typename T>
-  using RtreeSNetDBoxShapes = bgi::
-      rtree<SNetDBoxValue<T>, bgi::quadratic<16>, BBoxIndexableGetter<T>>;
+  using RtreeSNetDBoxShapes = RtreeRect<SNetDBoxValue<T>>;
   using RtreeFill
       = bgi::rtree<odb::dbFill*, bgi::quadratic<16>, FillIndexableGetter>;
 
@@ -307,9 +297,10 @@ class Search : public odb::dbBlockCallBackObj
  private:
   struct BlockData;
 
-  void addSNet(odb::dbNet* net,
-               LayerMap<std::vector<SNetValue<odb::dbNet*>>>& net_shapes,
-               LayerMap<std::vector<SNetDBoxValue<odb::dbNet*>>>& via_shapes);
+  void addSNet(
+      odb::dbNet* net,
+      LayerMap<std::vector<RectValue<SNetValue<odb::dbNet*>>>>& net_shapes,
+      LayerMap<std::vector<RectValue<SNetDBoxValue<odb::dbNet*>>>>& via_shapes);
   void addNet(odb::dbNet* net,
               LayerMap<std::vector<RouteBoxValue<odb::dbNet*>>>& tree_shapes);
   void addVia(odb::dbNet* net,
@@ -346,8 +337,8 @@ class Search : public odb::dbBlockCallBackObj
 
   struct BlockData
   {
-    RtreeDBox<odb::dbInst*> insts;
-    RtreeDBox<odb::dbBlockage*> blockages;
+    RtreeRect<odb::dbInst*> insts;
+    RtreeRect<odb::dbBlockage*> blockages;
     RtreeRect<odb::dbRow*> rows;
 
     std::shared_mutex shapes_init_mutex;
@@ -365,7 +356,7 @@ class Search : public odb::dbBlockCallBackObj
     LayerMap<RtreeSNetDBoxShapes<odb::dbNet*>> snet_via_shapes;
     LayerMap<RtreeSNetShapes<odb::dbNet*>> snet_shapes;
     LayerMap<RtreeFill> fills;
-    LayerMap<RtreeDBox<odb::dbObstruction*>> obstructions;
+    LayerMap<RtreeRect<odb::dbObstruction*>> obstructions;
 
     std::atomic_bool shapes_init{false};
     std::atomic_bool fills_init{false};

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -675,6 +675,10 @@ void TileGenerator::eagerInit()
     std::lock_guard lock(layer_colors_mutex_);
     layer_colors_by_tech_.clear();
   }
+  // Same address-reuse hazard, for the dbMaster/dbVia keys: a reload's fresh
+  // objects can land where the old ones were, so a revision bump alone would
+  // not prove the keys still mean the same thing.  Dropped unconditionally
+  // here, where a reload is known to be in progress.
   {
     std::lock_guard lock(geom_cache_mutex_);
     geom_cache_.reset();
@@ -711,15 +715,9 @@ void TileGenerator::onDesignChanged()
     tile_cache_index_.clear();
   }
 
-  // An edit can introduce a master or via master (read_lef, or a router
-  // creating a dbVia) whose geometry is not in the cache, which would make
-  // renderTileBuffer skip shapes that now exist.  Rebuilt lazily on the next
-  // tile; edits are rare enough that the rewalk costs nothing here.  Renders
-  // already in flight keep the snapshot they took alive.
-  {
-    std::lock_guard lock(geom_cache_mutex_);
-    geom_cache_.reset();
-  }
+  // The geometry cache is NOT dropped here.  This hook is debounced (see
+  // below), so an edit arriving while an index is already invalid never
+  // reaches it — geomCache() polls Search::revision() instead, which is not.
 
   // Tell connected clients to re-request (mirrors Qt's fullRepaint).  The
   // Search-level debounce (announceModified fires only on a valid→invalid
@@ -1362,9 +1360,13 @@ std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::buildGeomCache()
 
 std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::geomCache() const
 {
+  // Read the revision before building so an edit landing mid-build leaves the
+  // recorded revision behind the live one, and the next call rebuilds.
+  const uint64_t rev = search_->revision();
   std::lock_guard lock(geom_cache_mutex_);
-  if (!geom_cache_) {
+  if (!geom_cache_ || geom_cache_revision_ != rev) {
     geom_cache_ = buildGeomCache();
+    geom_cache_revision_ = rev;
   }
   return geom_cache_;
 }

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -823,8 +824,18 @@ const std::vector<ChipletNode>& TileGenerator::chiplets() const
     chiplets_cache_root_ = root;
     chiplets_cache_inst_count_ = inst_count;
     chiplets_cache_valid_ = true;
+    ++chiplets_cache_generation_;
   }
   return chiplets_cache_;
+}
+
+uint64_t TileGenerator::chipletsGeneration() const
+{
+  // Refresh first so the counter reflects the live hierarchy rather than
+  // whatever the last chiplets() caller saw.
+  chiplets();
+  std::lock_guard lock(chiplets_mutex_);
+  return chiplets_cache_generation_;
 }
 
 void TileGenerator::computePinLabelMargin()
@@ -1346,8 +1357,13 @@ std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::buildGeomCache()
       add_via_boxes(via, via->getBoxes());
     }
   }
+  // One node per dbChipInst, so every instance of a shared master chip reports
+  // the same block.  Visit each block once: appending a via's boxes again per
+  // instance would leave duplicates for the render pass to redraw, once per
+  // instance of the chiplet.
+  std::unordered_set<odb::dbBlock*> seen_blocks;
   for (const ChipletNode& node : chiplets()) {
-    if (!node.block) {
+    if (!node.block || !seen_blocks.insert(node.block).second) {
       continue;
     }
     for (odb::dbVia* via : node.block->getVias()) {
@@ -1360,13 +1376,22 @@ std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::buildGeomCache()
 
 std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::geomCache() const
 {
-  // Read the revision before building so an edit landing mid-build leaves the
-  // recorded revision behind the live one, and the next call rebuilds.
+  // Read both keys before building so an edit landing mid-build leaves the
+  // recorded values behind the live ones, and the next call rebuilds.
   const uint64_t rev = search_->revision();
+  // Creating a dbChipInst fires no block callback, so it cannot move
+  // Search::revision() — but it does make an already-populated block's vias
+  // newly reachable, which is exactly what via_boxes is keyed off.  Every other
+  // source of new geometry reaches revision() transitively: a dbVia or dbMaster
+  // only becomes drawable once an sbox or instance references it, and those do
+  // notify.  chipletsGeneration() closes that one gap.
+  const uint64_t chiplet_generation = chipletsGeneration();
   std::lock_guard lock(geom_cache_mutex_);
-  if (!geom_cache_ || geom_cache_revision_ != rev) {
+  if (!geom_cache_ || geom_cache_revision_ != rev
+      || geom_cache_chiplet_generation_ != chiplet_generation) {
     geom_cache_ = buildGeomCache();
     geom_cache_revision_ = rev;
+    geom_cache_chiplet_generation_ = chiplet_generation;
   }
   return geom_cache_;
 }

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -675,6 +675,10 @@ void TileGenerator::eagerInit()
     std::lock_guard lock(layer_colors_mutex_);
     layer_colors_by_tech_.clear();
   }
+  {
+    std::lock_guard lock(geom_cache_mutex_);
+    geom_cache_.reset();
+  }
 
   // Tiles depend on the design geometry, so a reload invalidates every cached
   // PNG.  Clearing here ties cache lifetime to design loading.
@@ -705,6 +709,16 @@ void TileGenerator::onDesignChanged()
     std::lock_guard lock(tile_cache_mutex_);
     tile_cache_lru_.clear();
     tile_cache_index_.clear();
+  }
+
+  // An edit can introduce a master or via master (read_lef, or a router
+  // creating a dbVia) whose geometry is not in the cache, which would make
+  // renderTileBuffer skip shapes that now exist.  Rebuilt lazily on the next
+  // tile; edits are rare enough that the rewalk costs nothing here.  Renders
+  // already in flight keep the snapshot they took alive.
+  {
+    std::lock_guard lock(geom_cache_mutex_);
+    geom_cache_.reset();
   }
 
   // Tell connected clients to re-request (mirrors Qt's fullRepaint).  The
@@ -972,7 +986,8 @@ void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
                                 const double scale,
                                 const Color& color,
                                 const bool blend,
-                                const FillPattern pattern) const
+                                const FillPattern pattern,
+                                int dim) const
 {
   // kNone paints nothing: skip all scanline setup and the pixel loop.
   if (pattern == FillPattern::kNone) {
@@ -986,7 +1001,9 @@ void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
   if (n < 3) {
     return;
   }
-  const int dim = bufferDim(image);
+  if (dim < 0) {
+    dim = bufferDim(image);
+  }
 
   // Convert polygon points to pixel coordinates (floating point for precision).
   std::vector<double> px(n), py(n);
@@ -1265,6 +1282,91 @@ const odb::PtrMap<odb::dbTechLayer, Color>& TileGenerator::getLayerColorMap(
     it->second = buildLayerColorMap(tech);
   }
   return it->second;
+}
+
+std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::buildGeomCache()
+    const
+{
+  auto cache = std::make_shared<GeomCache>();
+
+  // Master OBS and pin geometry, bucketed by the layer each box/polygon sits
+  // on.  Collects exactly the sources the per-instance render pass draws, so a
+  // (layer, master) pair absent from the map provably has nothing to draw.
+  for (odb::dbLib* lib : db_->getLibs()) {
+    for (odb::dbMaster* master : lib->getMasters()) {
+      for (odb::dbPolygon* poly_obs : master->getPolygonObstructions()) {
+        if (odb::dbTechLayer* lyr = poly_obs->getTechLayer()) {
+          cache->master_geom[lyr][master].obs_polys.push_back(
+              poly_obs->getPolygon());
+        }
+      }
+      for (odb::dbBox* obs : master->getObstructions(false)) {
+        if (odb::dbTechLayer* lyr = obs->getTechLayer()) {
+          cache->master_geom[lyr][master].obs_boxes.push_back(obs->getBox());
+        }
+      }
+      for (odb::dbMTerm* mterm : master->getMTerms()) {
+        for (odb::dbMPin* mpin : mterm->getMPins()) {
+          for (odb::dbPolygon* poly_geom : mpin->getPolygonGeometry()) {
+            if (odb::dbTechLayer* lyr = poly_geom->getTechLayer()) {
+              cache->master_geom[lyr][master].pin_polys.push_back(
+                  poly_geom->getPolygon());
+            }
+          }
+          for (odb::dbBox* geom : mpin->getGeometry(false)) {
+            odb::dbTechLayer* lyr = geom->getTechLayer();
+            if (!lyr) {
+              continue;
+            }
+            auto& groups = cache->master_geom[lyr][master].pin_boxes;
+            // MTerms are visited in master order and a pin's boxes
+            // consecutively, so extending the trailing group when the MTerm
+            // repeats is enough to keep each pin's boxes together and in order.
+            if (groups.empty() || groups.back().first != mterm) {
+              groups.emplace_back(mterm, std::vector<odb::Rect>{});
+            }
+            groups.back().second.push_back(geom->getBox());
+          }
+        }
+      }
+    }
+  }
+
+  // Via masters.  dbSBox reports its master as either a dbTechVia (tech-wide)
+  // or a dbVia (per block), so both are collected into one map keyed by the
+  // common dbObject base.
+  auto add_via_boxes = [&cache](odb::dbObject* via_master,
+                                const odb::dbSet<odb::dbBox>& boxes) {
+    for (odb::dbBox* box : boxes) {
+      if (odb::dbTechLayer* lyr = box->getTechLayer()) {
+        cache->via_boxes[lyr][via_master].push_back(box->getBox());
+      }
+    }
+  };
+  for (odb::dbTech* tech : db_->getTechs()) {
+    for (odb::dbTechVia* via : tech->getVias()) {
+      add_via_boxes(via, via->getBoxes());
+    }
+  }
+  for (const ChipletNode& node : chiplets()) {
+    if (!node.block) {
+      continue;
+    }
+    for (odb::dbVia* via : node.block->getVias()) {
+      add_via_boxes(via, via->getBoxes());
+    }
+  }
+
+  return cache;
+}
+
+std::shared_ptr<const TileGenerator::GeomCache> TileGenerator::geomCache() const
+{
+  std::lock_guard lock(geom_cache_mutex_);
+  if (!geom_cache_) {
+    geom_cache_ = buildGeomCache();
+  }
+  return geom_cache_;
 }
 
 std::vector<std::string> TileGenerator::getSites() const
@@ -1755,6 +1857,47 @@ static std::vector<unsigned char> lanczos2Downsample(
     int src_dim,
     int dst_dim);
 
+namespace {
+
+// This master's shapes on the layer whose cache slice is `by_master`, or null
+// when it has none there (so the caller can skip it outright).
+const TileGenerator::MasterLayerGeom* findMasterGeom(
+    const TileGenerator::MasterGeomByLayer* by_master,
+    odb::dbMaster* master)
+{
+  if (!by_master) {
+    return nullptr;
+  }
+  const auto it = by_master->find(master);
+  return it == by_master->end() ? nullptr : &it->second;
+}
+
+// The via-local boxes this sbox's via master contributes to the layer whose
+// cache slice is `by_master`, or null when it contributes none.  Resolving the
+// master costs one dbBox flag test plus a table lookup, instead of walking and
+// layer-testing every box of the via for every sbox.
+const std::vector<odb::Rect>* findViaBoxes(
+    const TileGenerator::ViaBoxesByMaster* by_master,
+    odb::dbSBox* sbox)
+{
+  if (!by_master) {
+    return nullptr;
+  }
+  odb::dbObject* via_master = nullptr;
+  if (odb::dbTechVia* tech_via = sbox->getTechVia()) {
+    via_master = tech_via;
+  } else if (odb::dbVia* block_via = sbox->getBlockVia()) {
+    via_master = block_via;
+  }
+  if (!via_master) {
+    return nullptr;
+  }
+  const auto it = by_master->find(via_master);
+  return it == by_master->end() ? nullptr : &it->second;
+}
+
+}  // namespace
+
 std::vector<unsigned char> TileGenerator::renderTileBuffer(
     const std::string& layer,
     const int z,
@@ -1853,6 +1996,9 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
         = vis.detailed ? static_cast<int>(std::lround(1.0 * tile_dbu_size
                                                       / kTileSizeInPixel))
                        : size_limit_dbu;
+    // One snapshot for the whole tile: taken under a lock here, then read
+    // lock-free by the per-chiplet loop below (see GeomCache).
+    const std::shared_ptr<const GeomCache> geom_cache = geomCache();
     // Supersampled render buffer (RGBA, super x super).  The per-chiplet loop
     // draws into this; it is Lanczos-2 decimated into world_image_buffer after
     // the loop, before the (crisp, output-resolution) overlays are drawn.
@@ -1995,6 +2141,23 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
       }
 
       odb::dbTechLayer* tech_layer = tech->findLayer(layer.c_str());
+
+      // This layer's slices of the geometry cache.  Null means no master (resp.
+      // no via master) in the design has anything on this layer, so the
+      // corresponding draw pass has nothing to do at all.
+      const MasterGeomByLayer* layer_master_geom = nullptr;
+      const ViaBoxesByMaster* layer_via_boxes = nullptr;
+      if (tech_layer) {
+        const auto mit = geom_cache->master_geom.find(tech_layer);
+        if (mit != geom_cache->master_geom.end()) {
+          layer_master_geom = &mit->second;
+        }
+        const auto vit = geom_cache->via_boxes.find(tech_layer);
+        if (vit != geom_cache->via_boxes.end()) {
+          layer_via_boxes = &vit->second;
+        }
+      }
+
       Color color{.r = 200, .g = 200, .b = 200, .a = 180};
       if (tech_layer) {
         const auto it = layer_colors.find(tech_layer);
@@ -2018,12 +2181,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               if (!box.overlaps(dbu_tile)) {
                 return;
               }
+              // image_buffer is the supersampled raster, so its side is
+              // `super`; passing it skips a sqrt+lround per shape.
               drawFilledRect(image_buffer,
                              toPixels(scale, box.intersect(dbu_tile), dbu_tile),
                              c,
                              pattern,
                              pat_ox,
-                             pat_oy);
+                             pat_oy,
+                             super);
             };
 
       // Special "_modules" layer: draw filled module-colored rectangles
@@ -2222,8 +2388,14 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               // Only draw if marker intersects this tile.
               const odb::Rect marker_bbox = marker_poly.getEnclosingRect();
               if (marker_bbox.overlaps(dbu_tile)) {
-                fillPolygon(
-                    image_buffer, marker_poly, dbu_tile, scale, marker_color);
+                fillPolygon(image_buffer,
+                            marker_poly,
+                            dbu_tile,
+                            scale,
+                            marker_color,
+                            /*blend=*/false,
+                            FillPattern::kSolid,
+                            super);
               }
 
               // Draw the box rect itself (same as GUI painter.drawRect).
@@ -2293,6 +2465,19 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
       // Special "_instances" layer: only draw instance borders, no routing
       const bool instances_only = (layer == "_instances");
 
+      // On a tech-layer tile the per-instance pass paints only master
+      // obstructions (vis.blockages) and cell-pin shapes (vis.inst_pins).  It
+      // draws nothing when both are off, or when no master has geometry on this
+      // layer at all (implant/marker layers, upper metals) — yet the query
+      // still runs, and at zoom-out its box spans the design, so it walks every
+      // instance and throws the result away.  Skip it in those cases.  A null
+      // tech_layer means "no layer filter" (the _instances tile, or a layer
+      // name this chiplet's tech doesn't have), in which case the pass draws
+      // unconditionally and must not be skipped.
+      const bool inst_pass_draws
+          = instances_only || !tech_layer
+            || ((vis.blockages || vis.inst_pins) && layer_master_geom);
+
       // "_modules" and "_pins" layers handle their own drawing above;
       // skip all other drawing (instances, routing, etc.)
       if (!modules_layer && !pins_layer) {
@@ -2304,13 +2489,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
         // instances at the RTree level (Qt-parity), so dense bump arrays vanish
         // at zoom-out — unless "Detailed view" is on, which sets the limit to
         // 0.
-        for (odb::dbInst* inst :
-             search_->searchInsts(block,
-                                  dbu_x_min,
-                                  dbu_y_min,
-                                  dbu_x_max,
-                                  dbu_y_max,
-                                  instance_size_limit_dbu)) {
+        const Search::InstRange insts
+            = inst_pass_draws ? search_->searchInsts(block,
+                                                     dbu_x_min,
+                                                     dbu_y_min,
+                                                     dbu_x_max,
+                                                     dbu_y_max,
+                                                     instance_size_limit_dbu)
+                              : Search::InstRange{};
+        for (odb::dbInst* inst : insts) {
           odb::Rect inst_bbox = inst->getBBox()->getBox();
           if (!dbu_tile.overlaps(inst_bbox)) {
             continue;
@@ -2474,22 +2661,26 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 }
               }
             }
-          } else {
-            // Layer-specific: obstructions and pins
+          } else if (!tech_layer) {
+            // No layer filter (a layer name this chiplet's tech doesn't have):
+            // draw every master shape in the fallback color, as before.  The
+            // geometry cache is layer-keyed and so cannot serve this; it is not
+            // a hot path — only multi-tech designs reach it.
             if (vis.blockages) {
               for (odb::dbPolygon* poly_obs :
                    master->getPolygonObstructions()) {
-                if (tech_layer && poly_obs->getTechLayer() != tech_layer) {
-                  continue;
-                }
                 odb::Polygon poly = poly_obs->getPolygon();
                 inst->getTransform().apply(poly);
-                fillPolygon(image_buffer, poly, dbu_tile, scale, obs_color);
+                fillPolygon(image_buffer,
+                            poly,
+                            dbu_tile,
+                            scale,
+                            obs_color,
+                            /*blend=*/false,
+                            FillPattern::kSolid,
+                            super);
               }
               for (odb::dbBox* obs : master->getObstructions(false)) {
-                if (tech_layer && obs->getTechLayer() != tech_layer) {
-                  continue;
-                }
                 odb::Rect box = obs->getBox();
                 inst->getTransform().apply(box);
                 draw_box_in_tile(box, obs_color);
@@ -2500,9 +2691,6 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               for (odb::dbMTerm* mterm : master->getMTerms()) {
                 for (odb::dbMPin* mpin : mterm->getMPins()) {
                   for (odb::dbPolygon* poly_geom : mpin->getPolygonGeometry()) {
-                    if (tech_layer && poly_geom->getTechLayer() != tech_layer) {
-                      continue;
-                    }
                     odb::Polygon poly = poly_geom->getPolygon();
                     inst->getTransform().apply(poly);
                     fillPolygon(image_buffer,
@@ -2511,12 +2699,10 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                                 scale,
                                 color,
                                 /*blend=*/false,
-                                layer_pattern);
+                                layer_pattern,
+                                super);
                   }
                   for (odb::dbBox* geom : mpin->getGeometry(false)) {
-                    if (tech_layer && geom->getTechLayer() != tech_layer) {
-                      continue;
-                    }
                     odb::Rect box = geom->getBox();
                     inst->getTransform().apply(box);
                     draw_box_in_tile(box, color, layer_pattern);
@@ -2535,9 +2721,6 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 bool drawn = false;
                 for (odb::dbMPin* mpin : mterm->getMPins()) {
                   for (odb::dbBox* geom : mpin->getGeometry(false)) {
-                    if (tech_layer && geom->getTechLayer() != tech_layer) {
-                      continue;
-                    }
                     odb::Rect box = geom->getBox();
                     xfm.apply(box);
                     if (!box.overlaps(dbu_tile)) {
@@ -2599,6 +2782,125 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                   if (drawn) {
                     break;
                   }
+                }
+              }
+            }
+          } else if (const MasterLayerGeom* mg
+                     = findMasterGeom(layer_master_geom, master)) {
+            // Layer-specific obstructions and pins, read straight out of the
+            // geometry cache: this master's shapes ON THIS LAYER, with no
+            // getTechLayer() calls and no walk over geometry belonging to other
+            // layers.  A master with nothing here was already skipped by
+            // findMasterGeom returning null.
+            const odb::dbTransform xfm = inst->getTransform();
+
+            if (vis.blockages) {
+              for (const odb::Polygon& src : mg->obs_polys) {
+                odb::Polygon poly = src;
+                xfm.apply(poly);
+                fillPolygon(image_buffer,
+                            poly,
+                            dbu_tile,
+                            scale,
+                            obs_color,
+                            /*blend=*/false,
+                            FillPattern::kSolid,
+                            super);
+              }
+              for (const odb::Rect& src : mg->obs_boxes) {
+                odb::Rect box = src;
+                xfm.apply(box);
+                draw_box_in_tile(box, obs_color);
+              }
+            }
+
+            if (vis.inst_pins) {
+              for (const odb::Polygon& src : mg->pin_polys) {
+                odb::Polygon poly = src;
+                xfm.apply(poly);
+                fillPolygon(image_buffer,
+                            poly,
+                            dbu_tile,
+                            scale,
+                            color,
+                            /*blend=*/false,
+                            layer_pattern,
+                            super);
+              }
+              for (const auto& [mterm, boxes] : mg->pin_boxes) {
+                for (const odb::Rect& src : boxes) {
+                  odb::Rect box = src;
+                  xfm.apply(box);
+                  draw_box_in_tile(box, color, layer_pattern);
+                }
+              }
+            }
+
+            // Draw ITerm name labels when zoomed in and pins are visible.
+            // One label per pin: the first box big enough and inside the tile,
+            // in the same order the master declares them.
+            if (vis.inst_pins && vis.inst_pin_names) {
+              constexpr Color iterm_label_color{
+                  .r = 255, .g = 255, .b = 0, .a = 220};
+
+              for (const auto& [mterm, boxes] : mg->pin_boxes) {
+                for (const odb::Rect& src : boxes) {
+                  odb::Rect box = src;
+                  xfm.apply(box);
+                  if (!box.overlaps(dbu_tile)) {
+                    continue;
+                  }
+
+                  // Skip if pin box is too small in pixels.
+                  const int box_px_w = static_cast<int>(box.dx() * scale);
+                  const int box_px_h = static_cast<int>(box.dy() * scale);
+                  if (box_px_w < kMinItermLabelBoxPx * super_per_css
+                      && box_px_h < kMinItermLabelBoxPx * super_per_css) {
+                    continue;
+                  }
+
+                  const std::string name(mterm->getName());
+                  const int text_w = getTextWidth(name, iterm_font);
+
+                  // Center of pin box in pixel coords.
+                  const odb::Point center = box.center();
+                  const int cx = static_cast<int>((center.x() - dbu_tile.xMin())
+                                                  * scale);
+                  const int cy = super - 1
+                                 - static_cast<int>(
+                                     (center.y() - dbu_tile.yMin()) * scale);
+
+                  // Rotate 90° if box is taller than wide and text overflows.
+                  const bool rotate
+                      = (box_px_h > box_px_w) && (text_w > box_px_w);
+
+                  if (rotate) {
+                    const int px = cx - iterm_font_h / 2;
+                    const int py = cy - text_w / 2;
+                    if (px > -iterm_font_h && px < super && py > -text_w
+                        && py < super) {
+                      drawTextRotated(image_buffer,
+                                      px,
+                                      py,
+                                      name,
+                                      iterm_font,
+                                      iterm_label_color);
+                    }
+                  } else {
+                    const int px = cx - text_w / 2;
+                    const int py = cy - iterm_font_h / 2;
+                    if (px > -text_w && px < super && py > -iterm_font_h
+                        && py < super) {
+                      drawText(image_buffer,
+                               px,
+                               py,
+                               name,
+                               iterm_font,
+                               iterm_label_color);
+                    }
+                  }
+
+                  break;  // only label first geometry per pin
                 }
               }
             }
@@ -2670,13 +2972,17 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                         scale,
                         color,
                         /*blend=*/false,
-                        layer_pattern);
+                        layer_pattern,
+                        super);
           }
         }
 
         // Draw special net vias — decompose into individual cut boxes
+        // layer_via_boxes null ⇒ no via master in the design has a box on this
+        // layer, so the search would return vias none of whose boxes could be
+        // drawn.  Skip the query too, not just the inner loop.
         if (!instances_only && tech_layer && vis.special_nets
-            && vis.srouting_vias) {
+            && vis.srouting_vias && layer_via_boxes) {
           for (const auto& shape :
                search_->searchSNetViaShapes(block,
                                             tech_layer,
@@ -2694,21 +3000,15 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               continue;
             }
             odb::dbSBox* sbox = std::get<0>(shape);
-            std::vector<odb::dbBox*> via_boxes;
-            if (auto tech_via = sbox->getTechVia()) {
-              via_boxes.assign(tech_via->getBoxes().begin(),
-                               tech_via->getBoxes().end());
-            } else if (auto block_via = sbox->getBlockVia()) {
-              via_boxes.assign(block_via->getBoxes().begin(),
-                               block_via->getBoxes().end());
+            const std::vector<odb::Rect>* via_boxes
+                = findViaBoxes(layer_via_boxes, sbox);
+            if (!via_boxes) {
+              continue;
             }
             const odb::Point origin((sbox->xMin() + sbox->xMax()) / 2,
                                     (sbox->yMin() + sbox->yMax()) / 2);
-            for (odb::dbBox* vbox : via_boxes) {
-              if (vbox->getTechLayer() != tech_layer) {
-                continue;
-              }
-              odb::Rect box = vbox->getBox();
+            for (const odb::Rect& src : *via_boxes) {
+              odb::Rect box = src;
               box.moveDelta(origin.x(), origin.y());
               draw_box_in_tile(box, color, layer_pattern);
             }
@@ -2721,7 +3021,7 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
         // and below, search for vias there, and draw only the enclosure boxes
         // that belong to the current routing layer.
         if (!instances_only && tech_layer && vis.special_nets
-            && vis.srouting_vias
+            && vis.srouting_vias && layer_via_boxes
             && tech_layer->getType() == odb::dbTechLayerType::ROUTING) {
           odb::dbTechLayer* adj_cuts[2]
               = {tech_layer->getLowerLayer(), tech_layer->getUpperLayer()};
@@ -2747,19 +3047,18 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                 continue;
               }
               odb::dbSBox* sbox = std::get<0>(shape);
-              odb::dbSet<odb::dbBox> via_boxes;
-              if (auto tech_via = sbox->getTechVia()) {
-                via_boxes = tech_via->getBoxes();
-              } else if (auto block_via = sbox->getBlockVia()) {
-                via_boxes = block_via->getBoxes();
+              // Indexed by the layer being DRAWN (tech_layer, the routing
+              // layer), not the cut layer being searched — these are the via's
+              // enclosure boxes landing on this metal.
+              const std::vector<odb::Rect>* via_boxes
+                  = findViaBoxes(layer_via_boxes, sbox);
+              if (!via_boxes) {
+                continue;
               }
               const odb::Point origin((sbox->xMin() + sbox->xMax()) / 2,
                                       (sbox->yMin() + sbox->yMax()) / 2);
-              for (odb::dbBox* vbox : via_boxes) {
-                if (vbox->getTechLayer() != tech_layer) {
-                  continue;
-                }
-                odb::Rect box = vbox->getBox();
+              for (const odb::Rect& src : *via_boxes) {
+                odb::Rect box = src;
                 box.moveDelta(origin.x(), origin.y());
                 draw_box_in_tile(box, color, layer_pattern);
               }
@@ -4130,13 +4429,16 @@ void TileGenerator::drawFilledRect(std::vector<unsigned char>& buffer,
                                    const Color& color,
                                    const FillPattern pattern,
                                    const int ox,
-                                   const int oy) const
+                                   const int oy,
+                                   int dim) const
 {
   // kNone paints nothing: skip the pixel loop entirely.
   if (pattern == FillPattern::kNone) {
     return;
   }
-  const int dim = bufferDim(buffer);
+  if (dim < 0) {
+    dim = bufferDim(buffer);
+  }
   for (int iy = rect.yMin(); iy < rect.yMax(); ++iy) {
     const int draw_y = dim - 1 - iy;
     for (int ix = rect.xMin(); ix < rect.xMax(); ++ix) {

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -653,9 +653,10 @@ class TileGenerator
       layer_colors_by_tech_;
 
   // Layer-bucketed master and via-master geometry.  See geomCache(); built on
-  // first use and dropped by eagerInit() / onDesignChanged().
+  // first use and rebuilt whenever Search::revision() moves.
   mutable std::mutex geom_cache_mutex_;
   mutable std::shared_ptr<const GeomCache> geom_cache_;
+  mutable uint64_t geom_cache_revision_ = 0;
   std::shared_ptr<const GeomCache> buildGeomCache() const;
 
   // Cached chiplet traversal.  See chiplets().  Invalidated in

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -417,6 +417,12 @@ class TileGenerator
   // `collectChiplets` is kept for tests and one-shot callers.
   const std::vector<ChipletNode>& chiplets() const;
 
+  // Monotonic counter, bumped every time chiplets() rebuilds its cache.
+  // Caches derived from the chiplet list poll this to notice a hierarchy
+  // change, which no dbBlockCallBackObj reports (see geomCache()).  Refreshes
+  // the chiplet cache, so the value returned reflects the live hierarchy.
+  uint64_t chipletsGeneration() const;
+
   std::vector<unsigned char> generateTile(
       const std::string& layer,
       int z,
@@ -653,10 +659,13 @@ class TileGenerator
       layer_colors_by_tech_;
 
   // Layer-bucketed master and via-master geometry.  See geomCache(); built on
-  // first use and rebuilt whenever Search::revision() moves.
+  // first use and rebuilt whenever Search::revision() or chipletsGeneration()
+  // moves.  The via half is keyed off the reachable chiplets' blocks, so a
+  // hierarchy edit changes what belongs in it without any block edit.
   mutable std::mutex geom_cache_mutex_;
   mutable std::shared_ptr<const GeomCache> geom_cache_;
   mutable uint64_t geom_cache_revision_ = 0;
+  mutable uint64_t geom_cache_chiplet_generation_ = 0;
   std::shared_ptr<const GeomCache> buildGeomCache() const;
 
   // Cached chiplet traversal.  See chiplets().  Invalidated in
@@ -669,6 +678,8 @@ class TileGenerator
   mutable bool chiplets_cache_valid_ = false;
   mutable odb::dbChip* chiplets_cache_root_ = nullptr;
   mutable size_t chiplets_cache_inst_count_ = 0;
+  // See chipletsGeneration().
+  mutable uint64_t chiplets_cache_generation_ = 0;
 
   // LRU cache of PNG-encoded clean tiles (see tileCacheGet/Put).  The list
   // holds (key, png) most-recent-first; the index maps key → list iterator.

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -341,6 +341,47 @@ class TileGenerator
   const odb::PtrMap<odb::dbTechLayer, Color>& getLayerColorMap(odb::dbTech* tech
                                                                = nullptr) const;
 
+  // Geometry one dbMaster contributes to one tech layer, in master-local
+  // coordinates; the render pass applies each instance's transform.  Bucketing
+  // by layer up front is what lets the per-instance pass draw a layer's shapes
+  // directly instead of walking all of a master's geometry and calling
+  // dbBox::getTechLayer() (a chain of dbTable lookups) on every box, once per
+  // layer per tile.  Mirrors gui::LayoutViewer::boxesByLayer.
+  struct MasterLayerGeom
+  {
+    // Obstructions (LEF OBS), drawn before pins.  Polygons and boxes are kept
+    // apart because they take different draw calls, and both before the pin
+    // shapes because OBS uses a different color — that boundary is the only
+    // ordering that affects the result (shapes sharing a color composite
+    // order-independently).
+    std::vector<odb::Polygon> obs_polys;
+    std::vector<odb::Rect> obs_boxes;
+    std::vector<odb::Polygon> pin_polys;
+    // Pin boxes grouped by MTerm, preserving master MTerm order and geometry
+    // order within a pin: the fill pass draws them all, and the ITerm label
+    // pass walks each group for the first box big enough to label.
+    std::vector<std::pair<odb::dbMTerm*, std::vector<odb::Rect>>> pin_boxes;
+  };
+  using MasterGeomByLayer = odb::PtrMap<odb::dbMaster, MasterLayerGeom>;
+
+  // Cut and enclosure boxes of one via master (dbTechVia or dbVia) on one
+  // layer, in via-local coordinates; the render pass offsets them by the sbox
+  // center.  A power grid instantiates a handful of distinct via masters
+  // thousands of times, so decomposing each master once removes the
+  // per-via-instance walk that dominated special-net rendering.
+  using ViaBoxesByMaster = odb::PtrMap<odb::dbObject, std::vector<odb::Rect>>;
+
+  // Immutable snapshot of both caches, published as a whole.  Renders take a
+  // shared_ptr copy once per tile and then read it without locking; a
+  // concurrent invalidation swaps in a fresh snapshot and leaves the one
+  // in-flight renders hold alive.
+  struct GeomCache
+  {
+    odb::PtrMap<odb::dbTechLayer, MasterGeomByLayer> master_geom;
+    odb::PtrMap<odb::dbTechLayer, ViaBoxesByMaster> via_boxes;
+  };
+  std::shared_ptr<const GeomCache> geomCache() const;
+
   std::vector<SelectionResult> selectAt(
       int dbu_x,
       int dbu_y,
@@ -557,13 +598,18 @@ class TileGenerator
                             const odb::Rect& rect,
                             const odb::Rect& dbu_tile);
 
+  // `dim` follows the setPixel/blendPixel convention: pass the buffer's side
+  // length to skip re-deriving it with bufferDim(), or -1 to have it computed.
+  // Both of these are called once per drawn shape, so on a dense layer the
+  // sqrt+lround adds up — callers in the render loop already know the value.
   void fillPolygon(std::vector<unsigned char>& image,
                    const odb::Polygon& poly,
                    const odb::Rect& dbu_tile,
                    double scale,
                    const Color& color,
                    bool blend = false,
-                   FillPattern pattern = FillPattern::kSolid) const;
+                   FillPattern pattern = FillPattern::kSolid,
+                   int dim = -1) const;
 
   // ox/oy are the tile's origin in absolute pixel coordinates
   // ((int)(dbu_tile.xMin()*scale), ...); they anchor non-solid patterns so the
@@ -574,7 +620,8 @@ class TileGenerator
                       const Color& color,
                       FillPattern pattern = FillPattern::kSolid,
                       int ox = 0,
-                      int oy = 0) const;
+                      int oy = 0,
+                      int dim = -1) const;
 
   static void blendPixel(std::vector<unsigned char>& image,
                          int x,
@@ -604,6 +651,12 @@ class TileGenerator
   mutable std::mutex layer_colors_mutex_;
   mutable odb::PtrMap<odb::dbTech, odb::PtrMap<odb::dbTechLayer, Color>>
       layer_colors_by_tech_;
+
+  // Layer-bucketed master and via-master geometry.  See geomCache(); built on
+  // first use and dropped by eagerInit() / onDesignChanged().
+  mutable std::mutex geom_cache_mutex_;
+  mutable std::shared_ptr<const GeomCache> geom_cache_;
+  std::shared_ptr<const GeomCache> buildGeomCache() const;
 
   // Cached chiplet traversal.  See chiplets().  Invalidated in
   // eagerInit() and also auto-invalidated when the chiplet hierarchy

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -713,6 +713,65 @@ TEST_F(TileGeneratorTest, EagerInitClearsLayerColorCache)
   EXPECT_EQ(colors.at(metal1).b, 254);
 }
 
+// The per-instance render pass reads master OBS and pin shapes out of the
+// layer-bucketed geometry cache, so a master's shapes must appear on the layer
+// they belong to and nowhere else.  Nangate45 cells carry pin geometry on
+// metal1 only, so a metal2 tile over the same instance must come back empty.
+TEST_F(TileGeneratorTest, MasterPinGeometryOnlyDrawnOnItsOwnLayer)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+
+  unsigned w = 0, h = 0;
+  auto m1 = decodePng(tile_gen_->generateTile("metal1", 0, 0, 0), w, h);
+  EXPECT_TRUE(hasNonTransparentPixel(m1))
+      << "metal1 tile should show the cell's pin shapes";
+
+  auto m2 = decodePng(tile_gen_->generateTile("metal2", 0, 0, 0), w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(m2))
+      << "metal2 tile should be empty: no Nangate45 master has geometry there";
+}
+
+// The cache is handed out as a snapshot; repeat calls with no intervening edit
+// must return the same one, otherwise every tile would rewalk every master.
+TEST_F(TileGeneratorTest, GeomCacheReusedWhenDesignUnchanged)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+
+  EXPECT_EQ(tile_gen_->geomCache(), tile_gen_->geomCache());
+}
+
+// Regression: the geometry cache must not be tied to the design-changed
+// callback, which is debounced to a valid→invalid index transition.  The second
+// edit below leaves the instance index already invalid, so that callback stays
+// silent -- and a cache keyed on it would keep serving a pre-edit snapshot,
+// silently dropping the geometry of any master or via the edit introduced.
+TEST_F(TileGeneratorTest, GeomCacheRebuiltAfterDebouncedEdit)
+{
+  odb::dbInst* inst = placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  // Registers Search as a db callback object and builds the indices, so the
+  // first edit below is the valid→invalid transition and the second is not.
+  tile_gen_->eagerInit();
+
+  auto before = tile_gen_->geomCache();
+  ASSERT_NE(before, nullptr);
+
+  // First edit: index was valid, so the debounced callback does fire.
+  inst->setLocation(2000, 2000);
+  auto after_first = tile_gen_->geomCache();
+  EXPECT_NE(before, after_first);
+
+  // Second edit: index is already invalid, so the callback does NOT fire.  The
+  // cache still has to notice, via Search::revision().
+  inst->setLocation(4000, 4000);
+  auto after_second = tile_gen_->geomCache();
+  EXPECT_NE(after_first, after_second)
+      << "geometry cache went stale across an edit that the debounced "
+         "design-changed callback does not report";
+}
+
 TEST_F(TileGeneratorTest, SerializeTechResponseIncludesLayerColors)
 {
   makeTileGen();

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -772,6 +772,102 @@ TEST_F(TileGeneratorTest, GeomCacheRebuiltAfterDebouncedEdit)
          "design-changed callback does not report";
 }
 
+// Build a HIER root chip holding `num_insts` instances of the fixture's chip,
+// and make it the top chip so chiplets() traverses down into that one block
+// once per instance.  Returns the root.
+odb::dbChip* makeSharedChipletRoot(odb::dbDatabase* db,
+                                   odb::dbChip* master,
+                                   const int num_insts)
+{
+  odb::dbChip* root
+      = odb::dbChip::create(db, nullptr, "root", odb::dbChip::ChipType::HIER);
+  db->setTopChip(root);
+  for (int i = 0; i < num_insts; ++i) {
+    odb::dbChipInst::create(root, master, "die" + std::to_string(i));
+  }
+  return root;
+}
+
+// Add a block via with one cut box on `layer`, which is what the geometry
+// cache's via_boxes map is built from.
+odb::dbVia* makeBlockVia(odb::dbBlock* block,
+                         odb::dbTechLayer* layer,
+                         const char* name)
+{
+  odb::dbVia* via = odb::dbVia::create(block, name);
+  odb::dbBox::create(via, layer, -50, -50, 50, 50);
+  return via;
+}
+
+// Regression: chiplets() reports one node per dbChipInst, so instances sharing
+// a master chip all report the same block.  Collecting that block's vias once
+// per instance would leave the render pass redrawing every box once per
+// instance of the chiplet -- invisible in the output (fills are opaque) but
+// quadratic in the repeat count, and it multiplies the cache's memory by it
+// too.
+TEST_F(TileGeneratorTest, GeomCacheVisitsASharedChipletBlockOnce)
+{
+  odb::dbTechLayer* via1 = getDb()->getTech()->findLayer("via1");
+  ASSERT_NE(via1, nullptr);
+  odb::dbVia* via = makeBlockVia(block_, via1, "V1");
+  makeSharedChipletRoot(getDb(), chip_, /*num_insts=*/3);
+  makeTileGen();
+
+  auto cache = tile_gen_->geomCache();
+  ASSERT_NE(cache, nullptr);
+  const auto layer_it = cache->via_boxes.find(via1);
+  ASSERT_NE(layer_it, cache->via_boxes.end());
+  const auto via_it = layer_it->second.find(via);
+  ASSERT_NE(via_it, layer_it->second.end());
+  EXPECT_EQ(via_it->second.size(), 1u)
+      << "block via decomposed once per dbChipInst instead of once per block";
+}
+
+// Regression: creating a dbChipInst fires no dbBlockCallBackObj, so it cannot
+// move Search::revision() -- but it does make an already-populated block's vias
+// newly reachable, which is what via_boxes is keyed off.  A cache keyed on the
+// revision alone keeps a snapshot built before the chiplet existed, and the new
+// chiplet's special-net vias silently stop drawing.
+TEST_F(TileGeneratorTest, GeomCacheRebuiltAfterChipletInstCreated)
+{
+  odb::dbTechLayer* via1 = getDb()->getTech()->findLayer("via1");
+  ASSERT_NE(via1, nullptr);
+
+  // A second chip, off to the side of the hierarchy and carrying a via of its
+  // own, so the cache built below provably cannot contain it yet.
+  odb::dbChip* other
+      = odb::dbChip::create(getDb(), getDb()->getTech(), "other");
+  odb::dbBlock* other_block = odb::dbBlock::create(other, "other_top");
+  other_block->setDieArea(odb::Rect(0, 0, 1000, 1000));
+  odb::dbVia* other_via = makeBlockVia(other_block, via1, "V1_other");
+
+  odb::dbChip* root = makeSharedChipletRoot(getDb(), chip_, /*num_insts=*/1);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  auto before = tile_gen_->geomCache();
+  ASSERT_NE(before, nullptr);
+  {
+    const auto layer_it = before->via_boxes.find(via1);
+    if (layer_it != before->via_boxes.end()) {
+      EXPECT_EQ(layer_it->second.find(other_via), layer_it->second.end())
+          << "unreachable chip's via cached before its chiplet existed";
+    }
+  }
+
+  odb::dbChipInst::create(root, other, "other_die");
+
+  auto after = tile_gen_->geomCache();
+  EXPECT_NE(before, after)
+      << "geometry cache went stale across a chiplet-hierarchy edit, which no "
+         "block callback reports";
+  const auto layer_it = after->via_boxes.find(via1);
+  ASSERT_NE(layer_it, after->via_boxes.end());
+  EXPECT_NE(layer_it->second.find(other_via), layer_it->second.end())
+      << "new chiplet's block vias missing from the cache, so its special-net "
+         "vias would not draw";
+}
+
 TEST_F(TileGeneratorTest, SerializeTechResponseIncludesLayerColors)
 {
   makeTileGen();


### PR DESCRIPTION
On a 676k-instance design with a 30.7k-net power grid and 49 tech layers, the
web viewer needed ~8 s of CPU to fill a fit-to-view. Profiling showed the cost
was not rasterization — ~74% of it was four ODB accessors:

```
30.1%  odb::dbBox::getBox            <- boost rtree indexable getter
17.1%  odb::_dbBox::getTechLayer     <- per-layer filtering in renderTileBuffer
12.8%  odb::dbChip::getTech          <- called by the above
10.3%  odb::dbInst::getBBox          <- boost rtree indexable getter
```

The web viewer renders one PNG per tech layer, so anything done per box per
layer is paid 49x per view where the Qt viewer, drawing every layer into one
image, pays it once.

Three changes, each removing one source of that traversal:

**1. Index the search R-trees on a stored Rect.** `BBoxIndexableGetter` derived
each element's box from ODB on every element a query visited, and the
size predicates derived it again. At zoom-out the query box spans the design,
so nothing prunes. The trees now store `std::pair<Rect, payload>`, which boost
indexes directly. Public range types are unchanged.

**2. Bucket master and via-master geometry by layer.** Built once into a
`GeomCache` and published as an immutable snapshot: `layer -> master ->
{OBS, pins}` and `layer -> via master -> boxes`. The master half mirrors
`gui::LayoutViewer::boxesByLayer`; the via half has no Qt counterpart because
`dbBox::getViaLayerBoxes()` carries the same per-box `getTechLayer()` walk
internally. Nesting is layer-major rather than master-major because the render
loop has the layer fixed and iterates many instances and sboxes — one lock per
tile to take the snapshot, then lock-free lookups. A layer absent from a map
also lets the `searchInsts` / `searchSNetViaShapes` queries be skipped outright
on implant/marker layers and upper metals.

Also gives `drawFilledRect` and `fillPolygon` the optional `dim` parameter
`setPixel` and `blendPixel` already had — both called `bufferDim()`
(`lround(sqrt(size/4))`) once per drawn shape to recover a buffer side the
render loop already knows.

**3. Rebuild the cache on every design edit.** The cache was dropped from
`onDesignChanged`, which `Search` reaches only through `announceModified`'s
debounce — so an edit clearing an already-invalid index is silent and the cache
would keep serving a pre-edit snapshot. `Search` now carries an undebounced
revision counter that `geomCache()` polls, separating "did anything change"
from "tell the browser". `eagerInit` still drops the cache outright, since a
reload's fresh objects can reuse the old addresses.

### Results

Per-tile CPU, and wall clock at `-threads 24`:

| | before | after | |
|---|---|---|---|
| z=0 fit-to-view, 51 tiles | 7940 ms | 1576 ms | 5.0x |
| — metal1 / metal2 equivalents | 970 / 1029 ms | 10.8 / 20.3 ms | 90x / 51x |
| — 37 layers with no geometry | 2074 ms | 244 ms | 8.5x |
| z=4 viewport, 612 tiles | 563 ms | 424 ms | 1.33x |
| z=0 wall clock | 2417 ms | 1169 ms | 2.1x |

Resident memory grows 0.28 GB (3.76 -> 4.04 GB) for the stored Rects and the
two caches.

Rendering is bit-identical: PNG hashes match an unpatched binary over 3744
tiles (51 layers x 8 zoom/position combos x 9 visibility variants) plus a
1020-tile sweep at dpr 1/1.5/2/2.5/3, which is what exercises the buffer-side
arithmetic. `GeomCacheRebuiltAfterDebouncedEdit` reproduces the staleness path
and fails without change 3.

### Notes for reviewers

- The profile is now dominated by rasterization (`drawFilledRect` 38%,
  `renderTileBuffer` 27%); every ODB accessor and the libm `lround` are gone.
  Remaining hotspots are real drawing: the cut layer with the densest via
  arrays is 62% of fit-to-view, and `_pins` is 30% of the zoomed-in view.
- **Not included:** the web server still inherits `ord`'s default of one
  thread, so `openroad -web` renders tiles serially. That is worth ~20x on
  pan/zoom by itself and is deliberately left for a separate change.
- The `!tech_layer` path in `renderTileBuffer` (a layer name a chiplet's tech
  does not have, which draws every master shape unfiltered) keeps its original
  loops — a layer-keyed cache cannot reproduce its cross-layer draw and label
  ordering.
- The octilinear branch in `addSNet` is unverified: the design used for the
  bit-identity runs has no polygon special-net shapes. The stored value is the
  same expression as the getter it replaces, but a design with octilinear power
  straps would be worth a look.