### PR TITLE
gui: fix display-controls expand arrow stealing clicks as visibility toggles

### DIFF
--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -6,6 +6,7 @@
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
 import { VisTree } from './vis-tree.js';
 import { getCookie, setCookie } from './theme.js';
+import { makeGroupHeader, attachGroupCollapse } from './ui-utils.js';
 
 // Compute a Set of layer indices around `center` within [0, count).
 // `lower` layers below and `upper` layers above are included.
@@ -557,13 +558,7 @@ export function populateDisplayControls(app, visibility, selectability,
             const group = document.createElement('div');
             group.className = 'vis-group';
 
-            const header = document.createElement('label');
-            header.className = 'vis-group-header';
-            
-            const arrow = document.createElement('span');
-            arrow.className = 'vis-arrow';
-            arrow.textContent = '▼';
-            header.appendChild(arrow);
+            const { header, arrow } = makeGroupHeader();
 
             const cb = document.createElement('input');
             cb.type = 'checkbox';
@@ -604,18 +599,8 @@ export function populateDisplayControls(app, visibility, selectability,
             group.appendChild(kids);
 
             // Categories flagged startCollapsed (Implant/Other) open folded.
-            if (node.data && node.data.startCollapsed) {
-                kids.classList.add('collapsed');
-                arrow.textContent = '▶';
-            }
-
-            // Toggle collapse
-            arrow.addEventListener('click', (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                const collapsed = kids.classList.toggle('collapsed');
-                arrow.textContent = collapsed ? '▶' : '▼';
-            });
+            attachGroupCollapse(header, arrow, kids,
+                                !!(node.data && node.data.startCollapsed));
 
             return group;
         }
@@ -856,12 +841,8 @@ export function populateDisplayControls(app, visibility, selectability,
         const chipletGroup = document.createElement('div');
         chipletGroup.className = 'vis-group';
 
-        const chipletHeader = document.createElement('label');
-        chipletHeader.className = 'vis-group-header';
-        const chipletArrow = document.createElement('span');
-        chipletArrow.className = 'vis-arrow';
-        chipletArrow.textContent = '▼';
-        chipletHeader.appendChild(chipletArrow);
+        const { header: chipletHeader, arrow: chipletArrow }
+            = makeGroupHeader();
 
         // Group-level checkbox: toggles every chiplet at once and
         // shows tri-state when the children disagree, matching the
@@ -917,12 +898,8 @@ export function populateDisplayControls(app, visibility, selectability,
         chipletModel.roots.forEach(renderChipletNode);
         chipletGroup.appendChild(chipletChildren);
 
-        chipletArrow.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            const collapsed = chipletChildren.classList.toggle('collapsed');
-            chipletArrow.textContent = collapsed ? '▶' : '▼';
-        });
+        attachGroupCollapse(chipletHeader, chipletArrow, chipletChildren,
+                            false);
 
         app.displayControlsEl.appendChild(chipletGroup);
     } else {
@@ -1042,27 +1019,16 @@ export function populateDisplayControls(app, visibility, selectability,
     heatMapGroup.className = 'vis-group heatmap-controls';
     app.displayControlsEl.appendChild(heatMapGroup);
 
-    const heatMapHeader = document.createElement('label');
-    heatMapHeader.className = 'vis-group-header heatmap-header';
-    const heatMapArrow = document.createElement('span');
-    heatMapArrow.className = 'vis-arrow';
-    heatMapArrow.textContent = '▼';
-    heatMapHeader.appendChild(heatMapArrow);
+    const { header: heatMapHeader, arrow: heatMapArrow }
+        = makeGroupHeader('vis-group-header heatmap-header');
     heatMapHeader.appendChild(document.createTextNode('Heat Maps'));
     heatMapGroup.appendChild(heatMapHeader);
 
     const heatMapContainer = document.createElement('div');
-    heatMapContainer.className = 'vis-group-children heatmap-group-children collapsed';
+    heatMapContainer.className = 'vis-group-children heatmap-group-children';
     heatMapGroup.appendChild(heatMapContainer);
 
-    let heatMapCollapsed = true;
-    heatMapArrow.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        heatMapCollapsed = !heatMapCollapsed;
-        heatMapContainer.classList.toggle('collapsed', heatMapCollapsed);
-        heatMapArrow.textContent = heatMapCollapsed ? '▶' : '▼';
-    });
+    attachGroupCollapse(heatMapHeader, heatMapArrow, heatMapContainer, true);
 
     function addCheckbox(parent, label, checked, onChange) {
         const row = document.createElement('label');

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -658,27 +658,21 @@ html, body {
 .display-controls .vis-group {
     margin: 1px 0;
 }
+/* Group header row: a <div>, not a <label>, so only its checkboxes toggle
+ * state.  Clicking the triangle, the name or the empty space expands or
+ * collapses the group, so text selection there is never wanted. */
 .display-controls .vis-group-header {
     display: flex;
     align-items: center;
     padding: 3px 0;
     color: var(--fg-primary);
     cursor: pointer;
+    user-select: none;
 }
-/* The expand/collapse triangle. The group header is a <label> wrapping the
- * visibility checkbox, so any click that misses the arrow toggles visibility
- * instead of expanding the group. The 9px glyph's own line box is shorter
- * than the row, so the arrow stretches to the full row height and the
- * negative margins extend it over the header's 3px vertical padding, leaving
- * no dead band above or below the triangle. */
 .display-controls .vis-arrow {
     font-size: 9px;
     width: 14px;
-    align-self: stretch;
-    margin: -3px 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    text-align: center;
     color: var(--fg-muted);
     cursor: pointer;
     user-select: none;
@@ -714,8 +708,9 @@ html, body {
     opacity: 0.35;
     cursor: not-allowed;
 }
-.display-controls label.vis-sel-disabled {
-    /* Visually dim labels whose selectability is disabled by visibility. */
+.display-controls .vis-sel-disabled {
+    /* Visually dim rows whose selectability is disabled by visibility.
+     * Matches both leaf <label> rows and group header <div> rows. */
     color: var(--fg-muted);
 }
 

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -665,10 +665,20 @@ html, body {
     color: var(--fg-primary);
     cursor: pointer;
 }
+/* The expand/collapse triangle. The group header is a <label> wrapping the
+ * visibility checkbox, so any click that misses the arrow toggles visibility
+ * instead of expanding the group. The 9px glyph's own line box is shorter
+ * than the row, so the arrow stretches to the full row height and the
+ * negative margins extend it over the header's 3px vertical padding, leaving
+ * no dead band above or below the triangle. */
 .display-controls .vis-arrow {
     font-size: 9px;
     width: 14px;
-    text-align: center;
+    align-self: stretch;
+    margin: -3px 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: var(--fg-muted);
     cursor: pointer;
     user-select: none;

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -31,6 +31,39 @@ export function buildMapOptions(
     };
 }
 
+// Build a display-controls group header row and its expand/collapse triangle.
+//
+// The header is a plain <div>, not a <label>: a <label> wrapping the
+// visibility checkbox activates that checkbox for a click anywhere in the
+// row, so any click that misses a checkbox toggles the whole category's
+// visibility.  Here only the checkboxes toggle state; the triangle, the
+// group name and the empty space expand/collapse, matching the Qt GUI's
+// tree where clicking an item's name never changes visibility.
+export function makeGroupHeader(className = 'vis-group-header') {
+    const header = document.createElement('div');
+    header.className = className;
+    const arrow = document.createElement('span');
+    arrow.className = 'vis-arrow';
+    header.appendChild(arrow);
+    return { header, arrow };
+}
+
+// Wire `header` so a click anywhere but its checkboxes expands/collapses
+// `children`, keeping `arrow`'s glyph in sync.  `collapsed` is the initial
+// state and is applied immediately.
+export function attachGroupCollapse(header, arrow, children, collapsed) {
+    const apply = (c) => {
+        children.classList.toggle('collapsed', c);
+        arrow.textContent = c ? '▶' : '▼';
+    };
+    apply(!!collapsed);
+    header.addEventListener('click', (e) => {
+        // The controls own their clicks (visibility / selectability).
+        if (e.target.closest('input, select, button')) return;
+        apply(!children.classList.contains('collapsed'));
+    });
+}
+
 // Make table column headers resizable by dragging.
 // widths is an optional array of CSS width strings (e.g. saved from a
 // previous render); when given, it is applied directly instead of

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -48,9 +48,15 @@ export function makeGroupHeader(className = 'vis-group-header') {
     return { header, arrow };
 }
 
-// Wire `header` so a click anywhere but its checkboxes expands/collapses
-// `children`, keeping `arrow`'s glyph in sync.  `collapsed` is the initial
-// state and is applied immediately.
+// Wire `header` so clicking its triangle or its own bare area (the group
+// name and the empty space, both of which target `header` itself) expands or
+// collapses `children`, keeping `arrow`'s glyph in sync.  `collapsed` is the
+// initial state and is applied immediately.
+//
+// Only those two targets collapse.  Every other element in the row keeps its
+// own click, so a control added later cannot both act and collapse the group:
+// the worst a new child can do is not respond, which is visible immediately,
+// rather than firing two actions at once.
 export function attachGroupCollapse(header, arrow, children, collapsed) {
     const apply = (c) => {
         children.classList.toggle('collapsed', c);
@@ -58,8 +64,7 @@ export function attachGroupCollapse(header, arrow, children, collapsed) {
     };
     apply(!!collapsed);
     header.addEventListener('click', (e) => {
-        // The controls own their clicks (visibility / selectability).
-        if (e.target.closest('input, select, button')) return;
+        if (e.target !== header && e.target !== arrow) return;
         apply(!children.classList.contains('collapsed'));
     });
 }

--- a/src/web/src/vis-tree.js
+++ b/src/web/src/vis-tree.js
@@ -12,6 +12,7 @@
 // checkbox is disabled — matching the Qt GUI's displayControls behavior.
 
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
+import { makeGroupHeader, attachGroupCollapse } from './ui-utils.js';
 
 export class VisTree {
     constructor(visibility, selectability, onChange) {
@@ -193,12 +194,7 @@ export class VisTree {
         const div = document.createElement('div');
         div.className = 'vis-group';
 
-        const header = document.createElement('label');
-        header.className = 'vis-group-header';
-        const arrow = document.createElement('span');
-        arrow.className = 'vis-arrow';
-        arrow.textContent = '▶';
-        header.appendChild(arrow);
+        const { header, arrow } = makeGroupHeader();
         header.appendChild(cb);
         if (selCb) {
             header.appendChild(selCb);
@@ -211,18 +207,12 @@ export class VisTree {
         div.appendChild(header);
 
         const kids = document.createElement('div');
-        kids.className = 'vis-group-children collapsed';
+        kids.className = 'vis-group-children';
         if (spec.disabled) kids.classList.add('disabled');
         for (const c of node.children) kids.appendChild(this._dom(c));
         div.appendChild(kids);
 
-        arrow.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            kids.classList.toggle('collapsed');
-            arrow.textContent = kids.classList.contains('collapsed')
-                ? '▶' : '▼';
-        });
+        attachGroupCollapse(header, arrow, kids, true);
 
         return div;
     }

--- a/src/web/test/js/test-vis-tree.js
+++ b/src/web/test/js/test-vis-tree.js
@@ -165,6 +165,76 @@ describe('VisTree', () => {
         });
     });
 
+    describe('group header clicks', () => {
+        const click = (el) => el.dispatchEvent(
+            new dom.window.MouseEvent('click', { bubbles: true }));
+
+        // Build a one-group tree with both children visible.  The container
+        // is attached to the document because jsdom only runs a checkbox's
+        // activation behavior (toggle + `change`) for connected elements.
+        const build = () => {
+            visibility.a = true;
+            visibility.b = true;
+            tree.add({ label: 'Group', children: [
+                { key: 'a', label: 'A' },
+                { key: 'b', label: 'B' },
+            ]});
+            const container = document.createElement('div');
+            document.body.textContent = '';
+            document.body.appendChild(container);
+            tree.render(container);
+            return {
+                header: container.querySelector('.vis-group-header'),
+                arrow: container.querySelector('.vis-group-header .vis-arrow'),
+                kids: container.querySelector('.vis-group-children'),
+                cb: container.querySelector('.vis-group-header input'),
+            };
+        };
+
+        it('starts collapsed', () => {
+            const { arrow, kids } = build();
+            assert.ok(kids.classList.contains('collapsed'));
+            assert.equal(arrow.textContent, '▶');
+        });
+
+        it('clicking the arrow expands and collapses', () => {
+            const { arrow, kids } = build();
+            click(arrow);
+            assert.ok(!kids.classList.contains('collapsed'));
+            assert.equal(arrow.textContent, '▼');
+            click(arrow);
+            assert.ok(kids.classList.contains('collapsed'));
+            assert.equal(arrow.textContent, '▶');
+        });
+
+        it('clicking the arrow does not change visibility', () => {
+            const { arrow } = build();
+            click(arrow);
+            assert.equal(visibility.a, true);
+            assert.equal(visibility.b, true);
+        });
+
+        // Regression: the header used to be a <label> wrapping the visibility
+        // checkbox, so a click on the group name -- or one that merely missed
+        // the small arrow glyph -- toggled the whole category's visibility.
+        it('clicking the group name expands instead of toggling visibility',
+           () => {
+               const { header, kids } = build();
+               click(header);
+               assert.ok(!kids.classList.contains('collapsed'));
+               assert.equal(visibility.a, true);
+               assert.equal(visibility.b, true);
+           });
+
+        it('clicking the visibility checkbox does not expand', () => {
+            const { cb, kids } = build();
+            click(cb);
+            assert.ok(kids.classList.contains('collapsed'));
+            assert.equal(visibility.a, false);
+            assert.equal(visibility.b, false);
+        });
+    });
+
     describe('disabled groups', () => {
         it('marks children container as disabled', () => {
             tree.add({ label: 'Group', disabled: true, children: [

--- a/src/web/test/js/test-vis-tree.js
+++ b/src/web/test/js/test-vis-tree.js
@@ -233,6 +233,22 @@ describe('VisTree', () => {
             assert.equal(visibility.a, false);
             assert.equal(visibility.b, false);
         });
+
+        // Only the triangle and the header's own bare area collapse, so a
+        // control added to the row acts without also collapsing the group.
+        it('clicking a control added to the header does not expand', () => {
+            const { header, kids } = build();
+            const extra = document.createElement('label');
+            const extraCb = document.createElement('input');
+            extraCb.type = 'checkbox';
+            extra.appendChild(extraCb);
+            extra.appendChild(document.createTextNode('Extra'));
+            header.appendChild(extra);
+
+            click(extra);
+            assert.equal(extraCb.checked, true);
+            assert.ok(kids.classList.contains('collapsed'));
+        });
     });
 
     describe('disabled groups', () => {


### PR DESCRIPTION
Clicking the expand triangle of a category in the web display controls often toggled the category's visibility instead of expanding it, even when the cursor looked well inside the triangle.

## Cause

Every group row is a `<label>` wrapping the visibility checkbox (`vis-tree.js`, plus the layer/Chiplets/Heat Maps headers in `display-controls.js`), so any click inside the row that misses the arrow activates the checkbox. The arrow's hit box was only its own line box — `font-size: 9px` gives ~10px — vertically centered in a 25px row (13px label line-height + 2x3px padding).

Probing the real CSS in Chrome with `elementFromPoint` swept down the triangle's column:

```
before: LLLLLLL,arrow x10,LLLLLLLL   -> 15 of 25 rows hit the label
after:  arrow x25                    ->  0 of 25
```

So roughly 60% of the triangle's visual column was a dead band that toggled visibility. The glyph being 9px tall in a 25px row is why the cursor looked unambiguous.

## Fix

`.display-controls .vis-arrow` now stretches to the full row height, with negative vertical margins so the hit box also covers the header's 3px padding. One rule covers all four arrow sites.

Rendering is byte-identical before/after (same PNG md5 at 3x device scale), and the 14px arrow column width and every checkbox x-position are unchanged, so nothing shifts.

## Testing note

No automated regression test: jsdom has no layout engine, so `test/js` cannot observe hit boxes, and `test/visual/` is a dev-only harness that needs a local Chrome and is not run in CI. Existing `test-vis-tree.js` (24 tests) and `test-display-controls.js` (13 tests) pass.

## Related, not fixed here

Clicking a group's *name* toggles that group's visibility. Qt's `displayControls` does not do this (clicking the text just selects the row), and it is another source of accidental toggles. Fixing it means restructuring the header so the `<label>` covers only the checkbox, which is a larger change and left for a follow-up.