### PR TITLE
web: fix debug tiles to account for DPR

### DIFF
--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -998,14 +998,18 @@ export function populateDisplayControls(app, visibility, selectability,
         { key: 'scale_bar', label: 'Scale bar' },
     ]});
     visTree.add({ key: 'module_view', label: 'Module view' });
-    visTree.add({ key: 'debug', label: 'Debug tiles' });
-    // Debug graphics overlay: calls drawObjects() on registered renderers
-    // (e.g. gpl::GraphicsImpl when global_placement_debug is enabled).
-    visTree.add({ label: 'Debug Graphics', visKey: 'debug_renderers',
-        children: [
-            { key: 'debug_live', label: 'Live (don\'t require pause)' },
-        ],
-    });
+    // Developer overlays.  All three are plain leaves under a visKey-less
+    // group: giving the group `visKey: 'debug_renderers'` would tie the
+    // renderer overlay to the group's tri-state, so ticking the unrelated
+    // "Tiles" row would switch the renderers on via the indeterminate state.
+    visTree.add({ label: 'Debug Graphics', children: [
+        // Renderer overlay: calls drawObjects() on registered renderers
+        // (e.g. gpl::GraphicsImpl when global_placement_debug is enabled).
+        { key: 'debug_renderers', label: 'Renderers' },
+        { key: 'debug_live', label: 'Live (don\'t require pause)',
+          disabledBy: 'debug_renderers' },
+        { key: 'debug', label: 'Tiles' },
+    ]});
     visTree.render(app.displayControlsEl);
 
     if (!app.heatMapLayer) {

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -3401,7 +3401,11 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
 
     // Overlays draw at the OUTPUT resolution (crisp lines/text, not band-
     // limited), so they map DBU to pixels with the output-space scale.
-    const double scale_out = scale / super_per_css;
+    // `scale` is super-space (super px per DBU); the output buffer is tile_px
+    // = super / kCoverageSupersample on a side.  Dividing by super_per_css
+    // (= dpr * kCoverageSupersample) instead would land in CSS space and
+    // shrink every overlay to 1/dpr of the tile on HiDPI.
+    const double scale_out = scale / kCoverageSupersample;
 
     // Overlays render once in world space, on top of all chiplets.
     // Their geometry (timing paths, DRC rects, flight lines) is already
@@ -3456,7 +3460,7 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
       // out of tile_generator means test executables that link libweb
       // don't transitively need gui.a / ord.a.
       drawRendererOverlay(
-          world_image_buffer, dbu_tile_world, scale, vis.debug_live);
+          world_image_buffer, dbu_tile_world, scale_out, vis.debug_live);
     }
   }
 
@@ -4078,21 +4082,31 @@ void TileGenerator::drawDebugOverlay(std::vector<unsigned char>& image,
                                      const int y) const
 {
   const Color yellow{.r = 255, .g = 255, .b = 0, .a = 255};
-  const int last = kTileSizeInPixel - 1;
+  // The output buffer is tile_px = 256*dpr on a side, NOT kTileSizeInPixel.
+  // Recover the real dimension: hardcoding 256 boxed the whole overlay into
+  // the top-left 256x256 corner of a HiDPI tile, so the "tile" outline drew
+  // at 1/dpr of the tile it was supposed to trace.
+  const int dim = bufferDim(image);
+  const int last = dim - 1;
+  // Pixel-authored sizes (border inset, font height) are in CSS px; scale them
+  // to physical px so the overlay looks identical across dpr.
+  const double px_per_css = static_cast<double>(dim) / kTileSizeInPixel;
 
   // Draw 1-pixel yellow border
-  for (int i = 0; i < kTileSizeInPixel; ++i) {
-    setPixel(image, i, 0, yellow);
-    setPixel(image, i, last, yellow);
-    setPixel(image, 0, i, yellow);
-    setPixel(image, last, i, yellow);
+  for (int i = 0; i < dim; ++i) {
+    setPixel(image, i, 0, yellow, dim);
+    setPixel(image, i, last, yellow, dim);
+    setPixel(image, 0, i, yellow, dim);
+    setPixel(image, last, i, yellow, dim);
   }
 
   // Build the label string "z=<zoom> <x>/<y>"
   const std::string label = "z=" + std::to_string(z) + " " + std::to_string(x)
                             + "/" + std::to_string(y);
 
-  drawText(image, 4, 4, label, fontAtlasGetFont(20), yellow);
+  const int margin = static_cast<int>(std::lround(4 * px_per_css));
+  const int font_px = static_cast<int>(std::lround(20 * px_per_css));
+  drawText(image, margin, margin, label, fontAtlasGetFont(font_px), yellow);
 }
 
 namespace {
@@ -4124,10 +4138,12 @@ inline int toPxX(int dbu_x, const odb::Rect& tile, double scale)
   return static_cast<int>((dbu_x - tile.xMin()) * scale);
 }
 
-// Y is flipped: DBU grows up, pixel rows grow down.
-inline int toPxY(int dbu_y, const odb::Rect& tile, double scale)
+// Y is flipped: DBU grows up, pixel rows grow down.  `dim` is the buffer side
+// length (tile_px = 256*dpr), not a fixed 256 — a hardcoded flip anchors the
+// overlay 256 rows from the top instead of the tile bottom on HiDPI.
+inline int toPxY(int dbu_y, const odb::Rect& tile, double scale, int dim)
 {
-  return 255 - static_cast<int>((dbu_y - tile.yMin()) * scale);
+  return dim - 1 - static_cast<int>((dbu_y - tile.yMin()) * scale);
 }
 
 }  // namespace
@@ -4169,6 +4185,9 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
                                            const double scale) const
 {
   {
+    // Buffer side length (tile_px = 256*dpr) — every Y flip below is relative
+    // to it, not to a fixed 256.
+    const int dim = bufferDim(image);
     for (const DrawOp& op : ops) {
       if (const auto* r = std::get_if<DrawRectOp>(&op)) {
         const odb::Rect px = toPixels(scale, r->rect, dbu_tile);
@@ -4178,7 +4197,7 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
           const Color fill = toTileColor(r->brush.color);
           for (int iy = px.yMin(); iy < px.yMax(); ++iy) {
             for (int ix = px.xMin(); ix < px.xMax(); ++ix) {
-              blendPixel(image, ix, 255 - iy, fill);
+              blendPixel(image, ix, dim - 1 - iy, fill, dim);
             }
           }
         }
@@ -4187,8 +4206,8 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
           const int w = penWidthPx(r->pen, scale);
           const int x0 = px.xMin();
           const int x1 = px.xMax() - 1;
-          const int y0 = 255 - px.yMin();
-          const int y1 = 255 - (px.yMax() - 1);
+          const int y0 = dim - 1 - px.yMin();
+          const int y1 = dim - 1 - (px.yMax() - 1);
           drawLine(image, x0, y0, x1, y0, pen, w);
           drawLine(image, x1, y0, x1, y1, pen, w);
           drawLine(image, x1, y1, x0, y1, pen, w);
@@ -4199,9 +4218,9 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
           continue;
         }
         const int x0 = toPxX(l->p1.x(), dbu_tile, scale);
-        const int y0 = toPxY(l->p1.y(), dbu_tile, scale);
+        const int y0 = toPxY(l->p1.y(), dbu_tile, scale, dim);
         const int x1 = toPxX(l->p2.x(), dbu_tile, scale);
-        const int y1 = toPxY(l->p2.y(), dbu_tile, scale);
+        const int y1 = toPxY(l->p2.y(), dbu_tile, scale, dim);
         drawLine(image,
                  x0,
                  y0,
@@ -4212,7 +4231,7 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
       } else if (const auto* c = std::get_if<DrawCircleOp>(&op)) {
         // Simple midpoint circle (outline only).
         const int cx = toPxX(c->cx, dbu_tile, scale);
-        const int cy = toPxY(c->cy, dbu_tile, scale);
+        const int cy = toPxY(c->cy, dbu_tile, scale, dim);
         const int pr = std::max(1, static_cast<int>(c->r * scale));
         if (c->pen.color.a == 0) {
           continue;
@@ -4243,7 +4262,7 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
           continue;
         }
         const int cx = toPxX(xop->cx, dbu_tile, scale);
-        const int cy = toPxY(xop->cy, dbu_tile, scale);
+        const int cy = toPxY(xop->cy, dbu_tile, scale, dim);
         const int half = std::max(1, static_cast<int>(xop->size * scale / 2));
         const Color pen = toTileColor(xop->pen.color);
         const int w = penWidthPx(xop->pen, scale);
@@ -4270,9 +4289,9 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
             const odb::Point& b = p->points[(i + 1) % n];
             drawLine(image,
                      toPxX(a.x(), dbu_tile, scale),
-                     toPxY(a.y(), dbu_tile, scale),
+                     toPxY(a.y(), dbu_tile, scale, dim),
                      toPxX(b.x(), dbu_tile, scale),
-                     toPxY(b.y(), dbu_tile, scale),
+                     toPxY(b.y(), dbu_tile, scale, dim),
                      pen,
                      w);
           }
@@ -4285,7 +4304,7 @@ void TileGenerator::rasterizeWebPainterOps(std::vector<unsigned char>& image,
         const int tw = getTextWidth(s->text, str_font);
         const int th = getTextHeight(str_font);
         int ax = toPxX(s->x, dbu_tile, scale);
-        int ay = toPxY(s->y, dbu_tile, scale);
+        int ay = toPxY(s->y, dbu_tile, scale, dim);
         // Adjust anchor: text renders with top-left at (ax, ay).
         switch (s->anchor) {
           case gui::Painter::kBottomLeft:

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -106,7 +106,7 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
   struct BoolField
   {
     const char* key;
-    bool TileVisibility::*field;
+    bool TileVisibility::* field;
     bool default_val;
   };
 
@@ -4105,7 +4105,11 @@ void TileGenerator::drawDebugOverlay(std::vector<unsigned char>& image,
                             + "/" + std::to_string(y);
 
   const int margin = static_cast<int>(std::lround(4 * px_per_css));
-  const int font_px = static_cast<int>(std::lround(20 * px_per_css));
+  // Floor at 10px, matching rasterizeWebPainterOps: a dpr < 0.5 (browser zoom
+  // out) would otherwise round the height toward 0 and hand fontAtlasGetFont a
+  // degenerate size.
+  const int font_px
+      = std::max(10, static_cast<int>(std::lround(20 * px_per_css)));
   drawText(image, margin, margin, label, fontAtlasGetFont(font_px), yellow);
 }
 

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -106,7 +106,7 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
   struct BoolField
   {
     const char* key;
-    bool TileVisibility::* field;
+    bool TileVisibility::*field;
     bool default_val;
   };
 

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -1281,6 +1281,53 @@ TEST_F(TileGeneratorTest, DebugModeDrawsBorder)
   EXPECT_EQ(pixels[last + 3], 255);  // A
 }
 
+TEST_F(TileGeneratorTest, DebugBorderTracesFullHiDpiTile)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+
+  TileVisibility vis;
+  vis.debug = true;
+
+  // dpr=2 → a 512px tile.  The border must trace the 512px edges: drawing it
+  // at a hardcoded 256 boxed the outline into the top-left quadrant, so the
+  // debug "tile" was only 1/dpr of the tile it claimed to outline.
+  auto png = tile_gen_->generateTile("_instances",
+                                     0,
+                                     0,
+                                     0,
+                                     vis,
+                                     /*highlight_rects=*/{},
+                                     /*highlight_polys=*/{},
+                                     /*colored_rects=*/{},
+                                     /*flight_lines=*/{},
+                                     /*module_colors=*/nullptr,
+                                     /*focus_net_ids=*/nullptr,
+                                     /*route_guide_net_ids=*/nullptr,
+                                     /*dpr=*/2.0);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  ASSERT_EQ(w, 512u);
+  ASSERT_EQ(h, 512u);
+
+  const auto is_yellow = [&pixels, w](const unsigned px, const unsigned py) {
+    const size_t i = (static_cast<size_t>(py) * w + px) * 4;
+    return pixels[i] == 255 && pixels[i + 1] == 255 && pixels[i + 2] == 0
+           && pixels[i + 3] == 255;
+  };
+
+  // All four true corners of the 512px tile.
+  EXPECT_TRUE(is_yellow(0, 0));
+  EXPECT_TRUE(is_yellow(w - 1, 0));
+  EXPECT_TRUE(is_yellow(0, h - 1));
+  EXPECT_TRUE(is_yellow(w - 1, h - 1));
+
+  // Midpoints of the right and bottom edges, which the 256px border missed
+  // entirely.
+  EXPECT_TRUE(is_yellow(w - 1, h / 2));
+  EXPECT_TRUE(is_yellow(w / 2, h - 1));
+}
+
 TEST_F(TileGeneratorTest, DebugDefaultOff)
 {
   TileVisibility vis;


### PR DESCRIPTION
## Summary
I noticed that the debug tiles were incorrect on displays with DPR != 1. This ensures we account for them and moves the `Debug Tiles` under debug graphics.
<img width="756" height="1248" alt="debugtiles_wrong" src="https://github.com/user-attachments/assets/e4064548-0ff0-41d6-998b-cf511defda4d" />

## Type of Change
- Bug fix

## Impact
N/A

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]
