### PR TITLE
web: cleanup inspector, honor use DBU, format strings, add tables

### DIFF
--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -415,48 +415,124 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
         }, 1100);
     }
 
-    function renderProperty(prop, data) {
-        // Group with children (PropertyList or SelectionSet)
-        if (prop.children) {
-            const group = document.createElement('div');
-            group.className = 'inspector-group';
+    // Build the collapsible shell (header row + body) shared by the group and
+    // table property renderers.  `count` is the parenthesised badge after the
+    // name; pass null to omit it.
+    function makeCollapsibleGroup(name, count, collapsed) {
+        const group = document.createElement('div');
+        group.className = 'inspector-group';
 
-            const header = document.createElement('div');
-            header.className = 'inspector-group-header';
-            const arrow = document.createElement('span');
-            arrow.className = 'vis-arrow';
-            arrow.textContent = '▶';
-            const nameSpan = document.createElement('span');
-            nameSpan.className = 'inspector-prop-name';
-            nameSpan.textContent = prop.name;
+        const header = document.createElement('div');
+        header.className = 'inspector-group-header';
+        const arrow = document.createElement('span');
+        arrow.className = 'vis-arrow';
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'inspector-prop-name';
+        nameSpan.textContent = name;
+        nameSpan.title = name;
+        header.appendChild(arrow);
+        header.appendChild(nameSpan);
+        if (count !== null) {
             const countSpan = document.createElement('span');
             countSpan.className = 'inspector-count';
-            countSpan.textContent = `(${prop.children.length})`;
-            header.appendChild(arrow);
-            header.appendChild(nameSpan);
+            countSpan.textContent = `(${count})`;
             header.appendChild(countSpan);
-            group.appendChild(header);
+        }
+        group.appendChild(header);
 
-            const kids = document.createElement('div');
-            const autoExpand = prop.children.length < 10;
-            kids.className = 'inspector-group-children' + (autoExpand ? '' : ' collapsed');
-            arrow.textContent = autoExpand ? '▼' : '▶';
-            for (const child of prop.children) {
-                kids.appendChild(renderProperty(child, data));
+        const body = document.createElement('div');
+        body.className = 'inspector-group-children'
+            + (collapsed ? ' collapsed' : '');
+        arrow.textContent = collapsed ? '▶' : '▼';
+        group.appendChild(body);
+
+        const toggle = () => {
+            body.classList.toggle('collapsed');
+            arrow.textContent = body.classList.contains('collapsed')
+                ? '▶' : '▼';
+        };
+        // Two listeners: the arrow's click also bubbles to the header, so
+        // clicking the arrow toggles twice and leaves the group as it was.
+        // That is fixed on the web-display-controls branch by dropping this
+        // arrow listener; kept as-is here so the two branches don't fix the
+        // same line twice.
+        arrow.addEventListener('click', toggle);
+        header.addEventListener('click', toggle);
+
+        return { group, header, arrow, body };
+    }
+
+    // Render a PropertyTable (e.g. a layer's two-widths spacing table) as a
+    // grid, matching the Qt inspector.  Row and column headers are optional:
+    // a table that has none is drawn as a bare grid rather than with a blank
+    // header row/column.
+    function renderTable(table) {
+        const columns = table.column_headers || [];
+        const rowHeaders = table.row_headers || [];
+        const data = table.data || [];
+        const hasColumnHeaders = columns.some(h => h !== '');
+        const hasRowHeaders = rowHeaders.some(h => h !== '');
+
+        const el = document.createElement('table');
+        el.className = 'inspector-table';
+
+        if (hasColumnHeaders) {
+            const head = document.createElement('thead');
+            const tr = document.createElement('tr');
+            if (hasRowHeaders) {
+                // Empty corner cell above the row-header column.
+                tr.appendChild(document.createElement('th'));
             }
-            group.appendChild(kids);
+            for (const header of columns) {
+                const th = document.createElement('th');
+                th.textContent = header;
+                tr.appendChild(th);
+            }
+            head.appendChild(tr);
+            el.appendChild(head);
+        }
 
-            arrow.addEventListener('click', () => {
-                kids.classList.toggle('collapsed');
-                arrow.textContent = kids.classList.contains('collapsed')
-                    ? '▶' : '▼';
-            });
-            header.addEventListener('click', () => {
-                kids.classList.toggle('collapsed');
-                arrow.textContent = kids.classList.contains('collapsed')
-                    ? '▶' : '▼';
-            });
+        const body = document.createElement('tbody');
+        data.forEach((row, i) => {
+            const tr = document.createElement('tr');
+            if (hasRowHeaders) {
+                const th = document.createElement('th');
+                th.textContent = rowHeaders[i] || '';
+                tr.appendChild(th);
+            }
+            for (const cell of row) {
+                const td = document.createElement('td');
+                td.textContent = cell;
+                tr.appendChild(td);
+            }
+            body.appendChild(tr);
+        });
+        el.appendChild(body);
 
+        return el;
+    }
+
+    function renderProperty(prop, data) {
+        // Table-valued property (PropertyTable)
+        if (prop.table) {
+            const rows = (prop.table.data || []).length;
+            const { group, body } = makeCollapsibleGroup(
+                prop.name, rows, /*collapsed=*/rows >= 10);
+            const scroller = document.createElement('div');
+            scroller.className = 'inspector-table-scroll';
+            scroller.appendChild(renderTable(prop.table));
+            body.appendChild(scroller);
+            return group;
+        }
+
+        // Group with children (PropertyList, SelectionSet or value list)
+        if (prop.children) {
+            const autoExpand = prop.children.length < 10;
+            const { group, body } = makeCollapsibleGroup(
+                prop.name, prop.children.length, /*collapsed=*/!autoExpand);
+            for (const child of prop.children) {
+                body.appendChild(renderProperty(child, data));
+            }
             return group;
         }
 
@@ -466,6 +542,8 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
         const nameEl = document.createElement('span');
         nameEl.className = 'inspector-prop-name';
         nameEl.textContent = prop.name || '';
+        // The column clips long names, so keep the full text reachable.
+        nameEl.title = prop.name || '';
         const valEl = document.createElement('span');
         valEl.className = 'inspector-prop-value';
         valEl.textContent = prop.value || '';
@@ -501,6 +579,52 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
         }
 
         return row;
+    }
+
+    // Width of the property-name column, in pixels.  Held here rather than in
+    // the DOM because updateInspector() rebuilds the panel from scratch on
+    // every selection, which would otherwise reset a width the user set.
+    const kDefaultNameWidth = 140;
+    const kMinNameWidth = 60;
+    const kMaxNameWidth = 500;
+    let nameColumnWidth = kDefaultNameWidth;
+
+    function applyNameColumnWidth() {
+        if (!app.inspectorEl) return;
+        app.inspectorEl.style.setProperty(
+            '--inspector-name-w', nameColumnWidth + 'px');
+    }
+
+    // Divider between the name and value columns; drag to widen the name
+    // column when a property name is clipped.
+    function makeColumnResizer() {
+        const grip = document.createElement('div');
+        grip.className = 'inspector-col-resizer';
+        grip.title = 'Drag to resize the name column';
+
+        grip.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            const startX = e.clientX;
+            const startWidth = nameColumnWidth;
+            grip.classList.add('dragging');
+
+            const onMove = (ev) => {
+                nameColumnWidth = Math.max(
+                    kMinNameWidth,
+                    Math.min(kMaxNameWidth,
+                             startWidth + ev.clientX - startX));
+                applyNameColumnWidth();
+            };
+            const onUp = () => {
+                grip.classList.remove('dragging');
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            };
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
+
+        return grip;
     }
 
     function zoomToBBox(bbox) {
@@ -612,9 +736,14 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             app.inspectorEl.appendChild(nav);
         }
 
+        const rows = document.createElement('div');
+        rows.className = 'inspector-rows';
         for (const prop of data.properties) {
-            app.inspectorEl.appendChild(renderProperty(prop, data));
+            rows.appendChild(renderProperty(prop, data));
         }
+        rows.appendChild(makeColumnResizer());
+        app.inspectorEl.appendChild(rows);
+        applyNameColumnWidth();
     }
 
     function createInspector(container) {

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -133,6 +133,28 @@ void writePayload(WebSocketResponse& resp, const boost::json::value& v)
 
 }  // namespace
 
+// The design's database units per micron.  Preferred from the top block, but
+// falls back to the tech: db->getChip() is null until a chip is the designated
+// top, and a null block used to silently disable micron formatting for the
+// whole request — which shows up as "Show DBU" appearing to be stuck on, since
+// every property comes back in raw DBU no matter what the client asked for.
+// Returns 0 when neither is loaded, i.e. there is nothing to convert against.
+static double dbuPerMicron(odb::dbDatabase* db)
+{
+  if (db == nullptr) {
+    return 0;
+  }
+  if (odb::dbChip* chip = db->getChip()) {
+    if (odb::dbBlock* block = chip->getBlock()) {
+      return block->getDbUnitsPerMicron();
+    }
+  }
+  if (odb::dbTech* tech = db->getTech()) {
+    return tech->getDbUnitsPerMicron();
+  }
+  return 0;
+}
+
 // RAII helper: temporarily sets Descriptor::Property::convert_dbu to a
 // micron-aware formatter (matching the Qt GUI's default) for the lifetime
 // of the scope.  When `use_dbu` is true the default identity formatter is
@@ -141,13 +163,13 @@ void writePayload(WebSocketResponse& resp, const boost::json::value& v)
 class [[nodiscard]] ScopedDbuFormat
 {
  public:
-  ScopedDbuFormat(odb::dbBlock* block, bool use_dbu)
+  ScopedDbuFormat(odb::dbDatabase* db, bool use_dbu)
       : saved_(gui::Descriptor::Property::convert_dbu)
   {
-    if (use_dbu || !block) {
+    const double dbu_per_micron = dbuPerMicron(db);
+    if (use_dbu || dbu_per_micron <= 0) {
       return;  // keep default (raw DBU)
     }
-    const double dbu_per_micron = block->getDbUnitsPerMicron();
     const int precision
         = static_cast<int>(std::ceil(std::log10(dbu_per_micron)));
     gui::Descriptor::Property::convert_dbu
@@ -242,6 +264,61 @@ static void serializeAnyValue(boost::json::object& out,
   out[field_name] = gui::Descriptor::Property::toString(value);
 }
 
+// Serialize an ordered list of unkeyed values (Property values held as a
+// std::vector/std::set of std::any) as inspector children.  Mirrors the Qt
+// inspector's makeList(): entries have no name of their own, so they are
+// numbered 1..N and the value carries the content.
+template <typename Iterator>
+static boost::json::array serializeAnyList(
+    Iterator begin,
+    Iterator end,
+    std::vector<gui::Selected>& selectables)
+{
+  boost::json::array children;
+  int index = 0;
+  for (Iterator itr = begin; itr != end; ++itr) {
+    boost::json::object child;
+    child["name"] = std::to_string(++index);
+    serializeAnyValue(child, "value", *itr, selectables);
+    children.emplace_back(std::move(child));
+  }
+  return children;
+}
+
+// Serialize a PropertyTable as a row/column grid.  The Qt inspector renders
+// these as an HTML table; the client does the same from this data rather than
+// from server-generated markup.  Headers are kept separate from the cells so
+// the client can drop the header row or column when a table has none.
+static boost::json::object serializePropertyTable(
+    const gui::PropertyTable& table)
+{
+  boost::json::object out;
+
+  boost::json::array columns;
+  for (const auto& header : table.getColumnHeaders()) {
+    columns.emplace_back(header);
+  }
+  out["column_headers"] = std::move(columns);
+
+  boost::json::array rows;
+  for (const auto& header : table.getRowHeaders()) {
+    rows.emplace_back(header);
+  }
+  out["row_headers"] = std::move(rows);
+
+  boost::json::array data;
+  for (const auto& row : table.getData()) {
+    boost::json::array cells;
+    for (const auto& cell : row) {
+      cells.emplace_back(cell);
+    }
+    data.emplace_back(std::move(cells));
+  }
+  out["data"] = std::move(data);
+
+  return out;
+}
+
 static boost::json::object serializeProperty(
     const gui::Descriptor::Property& prop,
     std::vector<gui::Selected>& selectables)
@@ -270,6 +347,12 @@ static boost::json::object serializeProperty(
       children.emplace_back(std::move(child));
     }
     o["children"] = std::move(children);
+  } else if (auto* table = std::any_cast<gui::PropertyTable>(&prop.value)) {
+    o["table"] = serializePropertyTable(*table);
+  } else if (auto* vec = std::any_cast<std::vector<std::any>>(&prop.value)) {
+    o["children"] = serializeAnyList(vec->begin(), vec->end(), selectables);
+  } else if (auto* set = std::any_cast<std::set<std::any>>(&prop.value)) {
+    o["children"] = serializeAnyList(set->begin(), set->end(), selectables);
   } else if (auto* sel = std::any_cast<gui::Selected>(&prop.value)) {
     if (*sel) {
       int id = storeSelectable(selectables, *sel);
@@ -632,7 +715,7 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
     // serialize with other STA callers (timing, clock tree, tcl eval).
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
     const bool use_dbu = jsonOr(req.json, "use_dbu", false);
-    ScopedDbuFormat dbu_fmt(gen_->getBlock(), use_dbu);
+    ScopedDbuFormat dbu_fmt(gen_->getDb(), use_dbu);
 
     resp.type = WebSocketResponse::kJson;
     boost::json::object root;
@@ -749,7 +832,7 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
     // serialize with other STA callers (timing, clock tree, tcl eval).
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
     const bool use_dbu = jsonOr(req.json, "use_dbu", false);
-    ScopedDbuFormat dbu_fmt(gen_->getBlock(), use_dbu);
+    ScopedDbuFormat dbu_fmt(gen_->getDb(), use_dbu);
 
     bool can_navigate_back = false;
     int sel_count = 0;
@@ -808,7 +891,7 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
 
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
     const bool use_dbu = jsonOr(req.json, "use_dbu", false);
-    ScopedDbuFormat dbu_fmt(gen_->getBlock(), use_dbu);
+    ScopedDbuFormat dbu_fmt(gen_->getDb(), use_dbu);
     int sel_count = 0;
     int sel_index = -1;
     {
@@ -859,7 +942,7 @@ static WebSocketResponse handleSelectionCycle(
     SessionState& state,
     const int direction,
     std::shared_ptr<TclEvaluator>& tcl_eval,
-    odb::dbBlock* block)
+    odb::dbDatabase* db)
 {
   WebSocketResponse resp;
   resp.id = req.id;
@@ -868,7 +951,7 @@ static WebSocketResponse handleSelectionCycle(
 
     std::lock_guard<std::mutex> sta_lock(tcl_eval->mutex);
     const bool use_dbu = jsonOr(req.json, "use_dbu", false);
-    ScopedDbuFormat dbu_fmt(block, use_dbu);
+    ScopedDbuFormat dbu_fmt(db, use_dbu);
     int sel_count = 0;
     int sel_index = -1;
     {
@@ -924,13 +1007,13 @@ static WebSocketResponse handleSelectionCycle(
 WebSocketResponse SelectHandler::handleSelectNext(const WebSocketRequest& req,
                                                   SessionState& state)
 {
-  return handleSelectionCycle(req, state, +1, tcl_eval_, gen_->getBlock());
+  return handleSelectionCycle(req, state, +1, tcl_eval_, gen_->getDb());
 }
 
 WebSocketResponse SelectHandler::handleSelectPrev(const WebSocketRequest& req,
                                                   SessionState& state)
 {
-  return handleSelectionCycle(req, state, -1, tcl_eval_, gen_->getBlock());
+  return handleSelectionCycle(req, state, -1, tcl_eval_, gen_->getDb());
 }
 
 WebSocketResponse SelectHandler::handleHover(const WebSocketRequest& req,
@@ -1049,7 +1132,7 @@ WebSocketResponse SelectHandler::handleSelectFanoutBin(
     // serialize the entire net walk and inspection with the shared STA lock.
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
     const bool use_dbu = jsonOr(req.json, "use_dbu", false);
-    ScopedDbuFormat dbu_fmt(block, use_dbu);
+    ScopedDbuFormat dbu_fmt(gen_->getDb(), use_dbu);
 
     std::vector<odb::dbNet*> matched;
     for (odb::dbNet* net : block->getNets()) {
@@ -1825,7 +1908,7 @@ WebSocketResponse SelectHandler::handleSchematicInspect(
     // serialize with other STA callers (timing, clock tree, tcl eval).
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
     const bool use_dbu = jsonOr(req.json, "use_dbu", false);
-    ScopedDbuFormat dbu_fmt(block, use_dbu);
+    ScopedDbuFormat dbu_fmt(gen_->getDb(), use_dbu);
 
     {
       std::lock_guard<std::mutex> lock(state.selection_mutex);

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -866,15 +866,49 @@ html, body {
     padding: 2px 0;
     border-bottom: 1px solid var(--bg-context);
 }
+/* The name column is a fixed width so every value starts at the same x.
+ * Letting it size to its content (the old min-width) made one long name such
+ * as "Wrong way minimum width" shove that row's value out past all the
+ * others, which reads as a broken table.  Names too long for the column are
+ * clipped with an ellipsis and carry the full text as a tooltip; the width
+ * itself is draggable via .inspector-col-resizer. */
 .inspector-prop-name {
     color: var(--accent-text);
-    min-width: 120px;
+    box-sizing: border-box;
+    flex: 0 0 var(--inspector-name-w, 140px);
     padding-right: 8px;
-    word-break: break-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
+/* `pre`, not the default `normal`, for two reasons.  LEF58 rules arrive from
+ * odb as multi-line strings (e.g. "SPACING 0.018 ENDOFLINE ...\nPARALLELEDGE
+ * ...") and collapsing those newlines to spaces runs the clauses together,
+ * when the rule is meant to be read line by line.  And a long line must stay
+ * one line: wrapping it to the panel width meant the only way to read it as a
+ * line was to widen the whole inspector.  Instead each value scrolls sideways
+ * inside its own cell, so a long value costs one thin scrollbar on that row
+ * rather than a horizontal scroll of the whole panel.  min-width:0 is what
+ * lets the cell shrink to the row instead of stretching it. */
 .inspector-prop-value {
     color: var(--fg-primary);
-    word-break: break-all;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-x: auto;
+    white-space: pre;
+}
+.inspector-prop-value,
+.inspector-table-scroll {
+    scrollbar-width: thin;
+}
+.inspector-prop-value::-webkit-scrollbar,
+.inspector-table-scroll::-webkit-scrollbar {
+    height: 6px;
+}
+.inspector-prop-value::-webkit-scrollbar-thumb,
+.inspector-table-scroll::-webkit-scrollbar-thumb {
+    background: var(--border-strong);
+    border-radius: 3px;
 }
 .inspector-editable {
     cursor: text;
@@ -885,6 +919,26 @@ html, body {
     outline: none;
     border-bottom: 1px solid var(--fg-primary);
     background: var(--bg-input);
+}
+/* Holds the property rows so the column divider can be absolutely positioned
+ * over their full height. */
+.inspector-rows {
+    position: relative;
+}
+.inspector-col-resizer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--inspector-name-w, 140px);
+    width: 7px;
+    margin-left: -4px;
+    cursor: col-resize;
+    z-index: 2;
+}
+.inspector-col-resizer:hover,
+.inspector-col-resizer.dragging {
+    background: var(--accent-text);
+    opacity: 0.35;
 }
 .inspector-group {
     margin: 1px 0;
@@ -917,6 +971,34 @@ html, body {
 }
 .inspector-group-children.collapsed {
     display: none;
+}
+/* Property tables (e.g. a layer's two-widths spacing table) can be far wider
+ * than the docked panel, so the grid scrolls inside its own box rather than
+ * forcing the whole inspector to scroll sideways. */
+.inspector-table-scroll {
+    overflow-x: auto;
+    padding: 2px 0 4px;
+}
+.inspector-table {
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.inspector-table th,
+.inspector-table td {
+    border: 1px solid var(--border-strong);
+    padding: 2px 6px;
+    text-align: center;
+    vertical-align: middle;
+    /* Headers carry embedded newlines (width above, PRL below). */
+    white-space: pre-line;
+}
+.inspector-table th {
+    color: var(--accent-text);
+    background: var(--bg-context);
+    font-weight: normal;
+}
+.inspector-table td {
+    color: var(--fg-primary);
 }
 .inspector-link {
     color: var(--accent-link);

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -32,6 +32,7 @@ struct FakeInspectable
   std::string name;
   std::string type;
   odb::Rect bbox;
+  gui::Descriptor::Properties properties;
 };
 
 class FakeDescriptor : public gui::Descriptor
@@ -60,7 +61,10 @@ class FakeDescriptor : public gui::Descriptor
   {
   }
 
-  Properties getProperties(const std::any&) const override { return {}; }
+  Properties getProperties(const std::any& object) const override
+  {
+    return std::any_cast<FakeInspectable*>(object)->properties;
+  }
 
   gui::Selected makeSelected(const std::any& object) const override
   {
@@ -544,11 +548,14 @@ class SelectHandlerTest : public tst::Nangate45Fixture
     block_->setDieArea(odb::Rect(0, 0, 100000, 100000));
     block_->setCoreArea(odb::Rect(0, 0, 100000, 100000));
     placeInst("BUF_X16", "buf1", 0, 0);
-    fake_current_
-        = {.name = "current", .type = "FakeCurrent", .bbox = {0, 0, 100, 100}};
+    fake_current_ = {.name = "current",
+                     .type = "FakeCurrent",
+                     .bbox = {0, 0, 100, 100},
+                     .properties = {}};
     fake_previous_ = {.name = "previous",
                       .type = "FakePrevious",
-                      .bbox = {100, 100, 200, 200}};
+                      .bbox = {100, 100, 200, 200},
+                      .properties = {}};
     gen_ = std::make_shared<TileGenerator>(
         getDb(), /*sta=*/nullptr, getLogger());
     tcl_eval_ = std::make_shared<TclEvaluator>(/*interp=*/nullptr, getLogger());
@@ -837,6 +844,120 @@ TEST_F(SelectHandlerTest, InspectRespectsDbuToggle)
   std::string json_um = payloadStr(resp_um);
   EXPECT_NE(json_um.find("\"value\":\"(1, 2), (3, 4)\""), std::string::npos)
       << json_um;
+}
+
+// Micron formatting must not depend on a top block existing.  Before, a null
+// block quietly disabled the conversion and every property came back in raw
+// DBU whatever the client asked for, which reads as "Show DBU" being stuck on.
+class TechOnlySelectHandlerTest : public tst::Fixture
+{
+ protected:
+  void SetUp() override
+  {
+    loadTechAndLib("ng45", "ng45", "_main/test/Nangate45/Nangate45.lef");
+    fake_ = {.name = "current",
+             .type = "FakeCurrent",
+             .bbox = {2000, 4000, 6000, 8000},
+             .properties = {}};
+    gen_ = std::make_shared<TileGenerator>(
+        getDb(), /*sta=*/nullptr, getLogger());
+    tcl_eval_ = std::make_shared<TclEvaluator>(/*interp=*/nullptr, getLogger());
+    handler_ = std::make_unique<SelectHandler>(gen_, tcl_eval_);
+  }
+
+  std::shared_ptr<TileGenerator> gen_;
+  std::shared_ptr<TclEvaluator> tcl_eval_;
+  std::unique_ptr<SelectHandler> handler_;
+  SessionState state_;
+  FakeDescriptor fake_descriptor_;
+  FakeInspectable fake_;
+};
+
+TEST_F(TechOnlySelectHandlerTest, InspectUsesTechDbuWhenNoBlock)
+{
+  ASSERT_EQ(getDb()->getChip(), nullptr);
+
+  {
+    std::lock_guard<std::mutex> lock(state_.selectables_mutex);
+    state_.selectables = {gui::Selected(&fake_, &fake_descriptor_)};
+  }
+
+  WebSocketRequest req;
+  req.id = 40;
+  req.type = WebSocketRequest::kInspect;
+  req.json = parseObj(R"({"select_id":0,"use_dbu":false})");
+
+  const std::string json = payloadStr(handler_->handleInspect(req, state_));
+  EXPECT_NE(json.find("\"value\":\"(1, 2), (3, 4)\""), std::string::npos)
+      << json;
+}
+
+// A PropertyTable (e.g. a layer's two-widths spacing table) is serialized as a
+// grid the client draws as a table, not flattened to Property::toString()'s
+// "<unknown>".
+TEST_F(SelectHandlerTest, InspectSerializesPropertyTable)
+{
+  gui::PropertyTable table(/*rows=*/2, /*columns=*/2);
+  table.setColumnHeader(0, "0 \xC2\xB5m");
+  table.setColumnHeader(1, "0.2 \xC2\xB5m\nPRL 0.1 \xC2\xB5m");
+  table.setRowHeader(0, "0 \xC2\xB5m");
+  table.setRowHeader(1, "0.2 \xC2\xB5m\nPRL 0.1 \xC2\xB5m");
+  table.setData(0, 0, "0.065 \xC2\xB5m");
+  table.setData(0, 1, "0.1 \xC2\xB5m");
+  table.setData(1, 0, "0.1 \xC2\xB5m");
+  table.setData(1, 1, "0.2 \xC2\xB5m");
+  fake_current_.properties = {{"Two width spacing rules", table}};
+
+  {
+    std::lock_guard<std::mutex> lock(state_.selectables_mutex);
+    state_.selectables = {makeFakeSelected(&fake_current_)};
+  }
+
+  WebSocketRequest req;
+  req.id = 30;
+  req.type = WebSocketRequest::kInspect;
+  req.json = parseObj(R"({"select_id":0,"use_dbu":true})");
+
+  const std::string json = payloadStr(handler_->handleInspect(req, state_));
+  EXPECT_EQ(json.find("<unknown>"), std::string::npos) << json;
+  EXPECT_NE(json.find("\"table\""), std::string::npos) << json;
+  EXPECT_NE(json.find("\"column_headers\""), std::string::npos) << json;
+  EXPECT_NE(json.find("\"row_headers\""), std::string::npos) << json;
+  // Newlines inside a header survive as real newlines for the client to
+  // render as separate lines.
+  EXPECT_NE(json.find("0.2 \xC2\xB5m\\nPRL 0.1 \xC2\xB5m"), std::string::npos)
+      << json;
+  EXPECT_NE(json.find("[[\"0.065 \xC2\xB5m\",\"0.1 \xC2\xB5m\"],"
+                      "[\"0.1 \xC2\xB5m\",\"0.2 \xC2\xB5m\"]]"),
+            std::string::npos)
+      << json;
+}
+
+// An unkeyed list value (a layer's width table) becomes numbered children,
+// mirroring the Qt inspector's indexed list rows.
+TEST_F(SelectHandlerTest, InspectSerializesValueList)
+{
+  const std::vector<std::any> widths
+      = {std::string("0.018 \xC2\xB5m"), std::string("0.09 \xC2\xB5m")};
+  fake_current_.properties = {{"Width table", widths}};
+
+  {
+    std::lock_guard<std::mutex> lock(state_.selectables_mutex);
+    state_.selectables = {makeFakeSelected(&fake_current_)};
+  }
+
+  WebSocketRequest req;
+  req.id = 31;
+  req.type = WebSocketRequest::kInspect;
+  req.json = parseObj(R"({"select_id":0,"use_dbu":true})");
+
+  const std::string json = payloadStr(handler_->handleInspect(req, state_));
+  EXPECT_EQ(json.find("<unknown>"), std::string::npos) << json;
+  EXPECT_NE(json.find("\"children\":[{\"name\":\"1\","
+                      "\"value\":\"0.018 \xC2\xB5m\"},"
+                      "{\"name\":\"2\",\"value\":\"0.09 \xC2\xB5m\"}]"),
+            std::string::npos)
+      << json;
 }
 
 //------------------------------------------------------------------------------

--- a/src/web/test/js/test-inspector.js
+++ b/src/web/test/js/test-inspector.js
@@ -313,5 +313,137 @@ describe('Inspector focus nets', () => {
             const kids = groups[0].querySelector('.inspector-group-children');
             assert.equal(kids.children.length, 2);
         });
+
+        it('keeps the full property name as a tooltip', () => {
+            panel.updateInspector({
+                type: 'Tech layer',
+                name: 'metal1',
+                properties: [
+                    { name: 'Wrong way minimum width', value: '0.07 um' },
+                ],
+            });
+            const nameEl = app.inspectorEl.querySelector('.inspector-prop-name');
+            assert.equal(nameEl.title, 'Wrong way minimum width');
+        });
+    });
+
+    describe('table properties', () => {
+        const tableData = {
+            type: 'Tech layer',
+            name: 'metal1',
+            properties: [{
+                name: 'Two width spacing rules',
+                table: {
+                    column_headers: ['0 um', '0.2 um\nPRL 0.1 um'],
+                    row_headers: ['0 um', '0.2 um\nPRL 0.1 um'],
+                    data: [['0.065 um', '0.1 um'], ['0.1 um', '0.2 um']],
+                },
+            }],
+        };
+
+        it('renders a grid with header row and header column', () => {
+            panel.updateInspector(tableData);
+            const table = app.inspectorEl.querySelector('.inspector-table');
+            assert.ok(table, 'table should be rendered');
+            // Header row: empty corner cell + one cell per column.
+            const headRow = table.querySelectorAll('thead tr th');
+            assert.equal(headRow.length, 3);
+            assert.equal(headRow[0].textContent, '');
+            assert.equal(headRow[1].textContent, '0 um');
+            assert.equal(headRow[2].textContent, '0.2 um\nPRL 0.1 um');
+            // Body rows: row header + one cell per column.
+            const bodyRows = table.querySelectorAll('tbody tr');
+            assert.equal(bodyRows.length, 2);
+            assert.equal(bodyRows[0].children[0].tagName, 'TH');
+            assert.equal(bodyRows[0].children[0].textContent, '0 um');
+            assert.equal(bodyRows[0].children[1].textContent, '0.065 um');
+            assert.equal(bodyRows[1].children[2].textContent, '0.2 um');
+        });
+
+        it('omits the header column when a table has no row headers', () => {
+            panel.updateInspector({
+                type: 'Tech layer',
+                name: 'metal1',
+                properties: [{
+                    name: 'Grid',
+                    table: {
+                        column_headers: ['a', 'b'],
+                        row_headers: ['', ''],
+                        data: [['1', '2'], ['3', '4']],
+                    },
+                }],
+            });
+            const table = app.inspectorEl.querySelector('.inspector-table');
+            assert.equal(table.querySelectorAll('thead tr th').length, 2);
+            assert.equal(table.querySelectorAll('tbody tr')[0].children.length, 2);
+        });
+
+        it('puts the table in a collapsible group with a row count', () => {
+            panel.updateInspector(tableData);
+            const group = app.inspectorEl.querySelector('.inspector-group');
+            assert.ok(group, 'table should live in a group');
+            assert.equal(
+                group.querySelector('.inspector-count').textContent, '(2)');
+            const body = group.querySelector('.inspector-group-children');
+            assert.equal(body.classList.contains('collapsed'), false);
+            group.querySelector('.inspector-group-header').dispatchEvent(
+                new dom.window.MouseEvent('click', { bubbles: true }));
+            assert.equal(body.classList.contains('collapsed'), true);
+        });
+    });
+
+    describe('name column width', () => {
+        function render() {
+            panel.updateInspector({
+                type: 'Net',
+                name: 'sig',
+                properties: [{ name: 'Name', value: 'sig' }],
+            });
+        }
+
+        it('adds a resizer to the property rows', () => {
+            render();
+            const grip = app.inspectorEl.querySelector('.inspector-col-resizer');
+            assert.ok(grip, 'resizer should be present');
+            assert.equal(grip.parentElement.className, 'inspector-rows');
+        });
+
+        it('drags the column wider and keeps the width across re-renders', () => {
+            render();
+            const grip = app.inspectorEl.querySelector('.inspector-col-resizer');
+            const before = app.inspectorEl.style.getPropertyValue(
+                '--inspector-name-w');
+            assert.equal(before, '140px');
+
+            grip.dispatchEvent(new dom.window.MouseEvent(
+                'mousedown', { clientX: 140, bubbles: true }));
+            document.dispatchEvent(new dom.window.MouseEvent(
+                'mousemove', { clientX: 200, bubbles: true }));
+            document.dispatchEvent(new dom.window.MouseEvent(
+                'mouseup', { bubbles: true }));
+            assert.equal(
+                app.inspectorEl.style.getPropertyValue('--inspector-name-w'),
+                '200px');
+
+            // A new selection rebuilds the panel; the width must survive.
+            render();
+            assert.equal(
+                app.inspectorEl.style.getPropertyValue('--inspector-name-w'),
+                '200px');
+        });
+
+        it('clamps the dragged width to the allowed range', () => {
+            render();
+            const grip = app.inspectorEl.querySelector('.inspector-col-resizer');
+            grip.dispatchEvent(new dom.window.MouseEvent(
+                'mousedown', { clientX: 140, bubbles: true }));
+            document.dispatchEvent(new dom.window.MouseEvent(
+                'mousemove', { clientX: -500, bubbles: true }));
+            document.dispatchEvent(new dom.window.MouseEvent(
+                'mouseup', { bubbles: true }));
+            assert.equal(
+                app.inspectorEl.style.getPropertyValue('--inspector-name-w'),
+                '60px');
+        });
     });
 });


### PR DESCRIPTION
## Summary
Aligns inspector in web to GUI a little more, by adding table support, DBU support, and literal string formatting

## Type of Change
- New feature

## Impact

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**
