### PR TITLE
odb, rcx: move extraction rules file path ownership from odb to rcx

### DIFF
--- a/src/odb/README.md
+++ b/src/odb/README.md
@@ -511,25 +511,6 @@ add_3dblox_alignment_marker_rule
 | `-tolerance` | Maximum allowed center-to-center misalignment in microns. Must be positive. Defaults to 0 (exact alignment required). |
 | `-relative_orientations` | Optional Tcl list of allowed orientations of master_b relative to master_a (e.g. `{R0 MY}`). When omitted, orientations are not constrained. |
 
-### Set Extraction Rules File
-
-Sets the path to the parasitics extraction rules file. For a design in which
-multiple technologies are used, the user must specify the technology for which
-they want to set the rules path.
-
-```tcl
-set_extraction_rules_file
-    [-tech tech_name]
-    rules_file
-```
-
-#### Options
-
-| Switch Name | Description |
-| ----- | ----- |
-| `-tech` | Technology for which to set the extraction rules path. |
-| `rules_file` | Path to the extraction rules file. |
-
 ## Regression tests
 
 There are a set of regression tests in `./test`. For more information, refer to this [section](../../README.md#regression-tests). 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -5910,10 +5910,6 @@ class dbTech : public dbObject
   ///
   std::string getName();
 
-  void setExtractionRulesFile(const std::string& path);
-
-  std::string getExtractionRulesFile();
-
   ///
   /// Get the Database units per micron.
   ///
@@ -7702,8 +7698,6 @@ class dbDatabase : public dbObject
 
   void setHierarchy(bool value);
   bool hasHierarchy() const;
-
-  bool hasHierarchicalChip() const;
 
   void setTopChip(dbChip* chip);
   ///

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -923,17 +923,6 @@ bool dbDatabase::hasHierarchy() const
   return db->hierarchy_;
 }
 
-bool dbDatabase::hasHierarchicalChip() const
-{
-  for (dbChip* chip : getChips()) {
-    if (chip->getChipType() == dbChip::ChipType::HIER) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 void dbDatabase::read(std::istream& file)
 {
   _dbDatabase* db = (_dbDatabase*) this;

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 138;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 139;  // Current revision number
+
+// Revision where dbTech::extraction_rules_file_ was removed
+inline constexpr uint32_t kSchemaRemoveTechExtractionRulesFile = 139;
 
 // Revision where _dbBox::min_spacing_ was added
 inline constexpr uint32_t kSchemaDbBoxMinSpacing = 138;

--- a/src/odb/src/db/dbTech.cpp
+++ b/src/odb/src/db/dbTech.cpp
@@ -86,10 +86,6 @@ bool _dbTech::operator==(const _dbTech& rhs) const
     return false;
   }
 
-  if (extraction_rules_file_ != rhs.extraction_rules_file_) {
-    return false;
-  }
-
   if (via_cnt_ != rhs.via_cnt_) {
     return false;
   }
@@ -334,7 +330,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTech& tech)
   stream << NamedTable("cell_edge_spacing_tbl_", tech.cell_edge_spacing_tbl_);
   stream << *tech.name_cache_;
   stream << tech.via_hash_;
-  stream << tech.extraction_rules_file_;
   return stream;
 }
 
@@ -386,8 +381,10 @@ dbIStream& operator>>(dbIStream& stream, _dbTech& tech)
   }
   stream >> *tech.name_cache_;
   stream >> tech.via_hash_;
-  if (db->isSchema(kSchemaTechExtractionRulesFile)) {
-    stream >> tech.extraction_rules_file_;
+  if (db->isSchema(kSchemaTechExtractionRulesFile)
+      && db->isLessThanSchema(kSchemaRemoveTechExtractionRulesFile)) {
+    std::string obsolete_extraction_rules_file;
+    stream >> obsolete_extraction_rules_file;
   }
 
   return stream;
@@ -397,18 +394,6 @@ std::string dbTech::getName()
 {
   auto tech = (_dbTech*) this;
   return tech->name_;
-}
-
-void dbTech::setExtractionRulesFile(const std::string& path)
-{
-  _dbTech* tech = (_dbTech*) this;
-  tech->extraction_rules_file_ = path;
-}
-
-std::string dbTech::getExtractionRulesFile()
-{
-  _dbTech* tech = (_dbTech*) this;
-  return tech->extraction_rules_file_;
 }
 
 double _dbTech::getLefVersion() const

--- a/src/odb/src/db/dbTech.h
+++ b/src/odb/src/db/dbTech.h
@@ -73,7 +73,6 @@ class _dbTech : public _dbObject
  public:
   // PERSISTANT-MEMBERS
   std::string name_;
-  std::string extraction_rules_file_;
   int via_cnt_;
   int layer_cnt_;
   int rlayer_cnt_;

--- a/src/odb/src/swig/tcl/odb.tcl
+++ b/src/odb/src/swig/tcl/odb.tcl
@@ -1243,32 +1243,6 @@ proc add_3dblox_alignment_marker_rule { args } {
   }
 }
 
-sta::define_cmd_args "set_extraction_rules_file" {
-    [-tech tech_name] rules_file
-}
-
-proc set_extraction_rules_file { args } {
-  sta::parse_key_args "set_extraction_rules_file" args \
-    keys {-tech} flags {}
-  sta::check_argc_eq1 "set_extraction_rules_file" $args
-
-  set db [ord::get_db]
-  if { [info exists keys(-tech)] } {
-    set tech [$db findTech $keys(-tech)]
-  } elseif { [$db hasHierarchicalChip] } {
-    utl::error ODB 478 "Could not set extraction rules file.\
-      Use -tech to specify a technology in a 3D design."
-  } else {
-    set tech [$db getTech]
-  }
-
-  if { $tech == "NULL" } {
-    utl::error ODB 477 "Could not set extraction rules file. Tech not found."
-  }
-
-  $tech setExtractionRulesFile [lindex $args 0]
-}
-
 namespace eval odb {
 proc resolve_master { cell { lib_name "" } } {
   set db [ord::get_db]

--- a/src/odb/test/odb_readme_msgs_check.ok
+++ b/src/odb/test/odb_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 24,        Desc: 24,        Syn: 24,        Options: 24,        Args: 24
+Names: 23,        Desc: 23,        Syn: 23,        Options: 23,        Args: 23
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.

--- a/src/rcx/README.md
+++ b/src/rcx/README.md
@@ -42,6 +42,25 @@ define_process_corner
 | `-ext_model_index` | Extraction model index. Expects 2 inputs (an index, and corner name). |
 | `filename` | Path to process corner file `rcx_patterns.rules`. |
 
+### Set Extraction Rules File
+
+Sets the path to the parasitics extraction rules file. For a 3D design in
+which multiple technologies are used, the user must specify the technology
+for which they want to set the rules path.
+
+```tcl
+set_extraction_rules_file
+    [-tech tech_name]
+    rules_file
+```
+
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-tech` | Technology for which to set the extraction rules path. |
+| `rules_file` | Path to the extraction rules file. |
+
 ### Extract Parasitics
 
 The `extract_parasitics` command performs parasitic extraction based on the

--- a/src/rcx/include/rcx/ext.h
+++ b/src/rcx/include/rcx/ext.h
@@ -75,6 +75,10 @@ class Ext
   void extract(ExtractOptions options);
   void extractMultiChip(const ExtractOptions& options);
 
+  void setExtractionRulesFile(const std::string& rules_file);
+  void setExtractionRulesFile(const std::string& rules_file,
+                              const std::string& tech_name);
+
   void define_process_corner(int ext_model_index, const std::string& name);
   void define_derived_corner(const std::string& name,
                              const std::string& process_corner_name,

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1831,6 +1831,15 @@ class extMain
                                bool v = false);
   bool modelExists();
 
+  void setExtractionRulesFile(const std::string& extraction_rules_file)
+  {
+    extraction_rules_file_ = extraction_rules_file;
+  }
+  const std::string& getExtractionRulesFile() const
+  {
+    return extraction_rules_file_;
+  }
+
   void addInstsGeometries(const Array1D<uint32_t>* instTable,
                           Array1D<uint32_t>* tmpInstIdTable,
                           uint32_t dir);
@@ -2661,6 +2670,8 @@ class extMain
  private:
   utl::Logger* logger_;
 
+  std::string extraction_rules_file_;
+
   bool _batchScaleExt = true;
   Array1D<extCorner*>* _processCornerTable = nullptr;
   Array1D<extCorner*>* _scaledCornerTable = nullptr;
@@ -2825,6 +2836,7 @@ class extMain
 
 std::unique_ptr<extRCModel> parseRules(
     odb::dbTech* tech,
+    const std::string& rules_file,
     const Array1D<extCorner*>* extractor_corner_table,
     bool is_v2,
     utl::Logger* logger);

--- a/src/rcx/include/rcx/multiChipExtractor.h
+++ b/src/rcx/include/rcx/multiChipExtractor.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <string>
+
+#include "odb/PtrSetMap.h"
 #include "odb/db.h"
 #include "rcx/ext_options.h"
 #include "utl/Logger.h"
@@ -16,9 +19,14 @@ class MultiChipExtractor
 
   void run(const ExtractOptions& options);
 
+  void setExtractionRulesFile(odb::dbTech* tech,
+                              const std::string& extraction_rules_file);
+
  private:
   odb::dbDatabase* db_{nullptr};
   utl::Logger* logger_{nullptr};
+
+  odb::PtrMap<odb::dbTech, std::string> extraction_rules_files_;
 };
 
 }  // namespace rcx

--- a/src/rcx/src/OpenRCX.tcl
+++ b/src/rcx/src/OpenRCX.tcl
@@ -20,6 +20,32 @@ proc define_process_corner { args } {
   rcx::define_process_corner $ext_model_index $filename
 }
 
+sta::define_cmd_args "set_extraction_rules_file" {
+    [-tech tech_name] rules_file
+}
+
+proc set_extraction_rules_file { args } {
+  sta::parse_key_args "set_extraction_rules_file" args \
+    keys {-tech} flags {}
+  sta::check_argc_eq1 "set_extraction_rules_file" $args
+
+  if { ![ord::db_has_tech] } {
+    utl::error RCX 520 "No LEF technology has been read."
+  }
+
+  set tech_name ""
+  if { [info exists keys(-tech)] } {
+    set tech_name $keys(-tech)
+    if { [[ord::get_db] findTech $tech_name] == "NULL" } {
+      utl::error RCX 519 "Technology $tech_name not found."
+    }
+  }
+
+  set rules_file [file nativename [lindex $args 0]]
+
+  rcx::set_extraction_rules_file $rules_file $tech_name
+}
+
 sta::define_cmd_args "define_rcx_corners" {
     [-corner_list cornerList]
 }

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -222,6 +222,25 @@ void Ext::extractMultiChip(const ExtractOptions& options)
   multi_chip_extractor_->run(options);
 }
 
+void Ext::setExtractionRulesFile(const std::string& rules_file)
+{
+  _ext->setExtractionRulesFile(rules_file);
+}
+
+void Ext::setExtractionRulesFile(const std::string& rules_file,
+                                 const std::string& tech_name)
+{
+  odb::dbTech* tech = _db->findTech(tech_name.c_str());
+  if (!tech) {
+    logger_->error(RCX,
+                   522,
+                   "Could not set extraction rules file. Tech {} not found.",
+                   tech_name);
+  }
+
+  multi_chip_extractor_->setExtractionRulesFile(tech, rules_file);
+}
+
 void Ext::extract(ExtractOptions options)
 {
   _ext->setBlockFromChip(_db->getChip());
@@ -229,17 +248,16 @@ void Ext::extract(ExtractOptions options)
 
   odb::orderWires(logger_, block);
 
-  odb::dbTech* tech = block->getTech();
   if (options.ext_model_file != nullptr && options.ext_model_file[0] != '\0') {
     logger_->warn(RCX,
                   514,
                   "The ext_model_file option is deprecated. Use "
                   "set_extraction_rules_file command instead.");
 
-    tech->setExtractionRulesFile(options.ext_model_file);
+    _ext->setExtractionRulesFile(options.ext_model_file);
   }
 
-  std::string rules_file = tech->getExtractionRulesFile();
+  const std::string& rules_file = _ext->getExtractionRulesFile();
   if (!rules_file.empty()) {
     options.ext_model_file = rules_file.c_str();
   }
@@ -261,8 +279,9 @@ void Ext::extract(ExtractOptions options)
     _ext->setExtractionOptions(options);
 
     if (_ext->modelExists()) {
-      std::unique_ptr<extRCModel> rules_model
-          = parseRules(tech, _ext->getProcessCornerTable(), _ext->_v2, logger_);
+      odb::dbTech* tech = block->getTech();
+      std::unique_ptr<extRCModel> rules_model = parseRules(
+          tech, rules_file, _ext->getProcessCornerTable(), _ext->_v2, logger_);
 
       _ext->registerRulesModel(rules_model.release());
       _ext->setCornerCount();

--- a/src/rcx/src/ext.i
+++ b/src/rcx/src/ext.i
@@ -23,6 +23,7 @@ using ord::getOpenRCX;
 using rcx::Ext;
 %}
 
+%include <std_string.i>
 %include "../../Exception.i"
 %inline %{
 
@@ -31,6 +32,32 @@ define_process_corner(int ext_model_index, const char* file)
 {
   Ext* ext = getOpenRCX();
   ext->define_process_corner(ext_model_index, file);
+}
+
+void
+set_extraction_rules_file(const std::string& rules_file,
+                          const std::string& tech_name)
+{
+  Ext* ext = getOpenRCX();
+  utl::Logger* logger = getLogger();
+  odb::dbChip* top_chip = ord::getOpenRoad()->getDb()->getChip();
+
+  if (!top_chip) {
+    logger->error(utl::RCX, 523, "No design is loaded.");
+  }
+
+  if (top_chip->getChipType() == odb::dbChip::ChipType::HIER) {
+    if (tech_name.empty()) {
+      logger->error(utl::RCX,
+                    521,
+                    "Could not set extraction rules file. Use -tech to "
+                    "specify a technology in a 3D design.");
+    }
+
+    ext->setExtractionRulesFile(rules_file, tech_name);
+  } else {
+    ext->setExtractionRulesFile(rules_file);
+  }
 }
 
 void

--- a/src/rcx/src/multiChipExtractor.cpp
+++ b/src/rcx/src/multiChipExtractor.cpp
@@ -15,4 +15,11 @@ void MultiChipExtractor::run(const ExtractOptions& /* options */)
   logger_->error(utl::RCX, 515, "3D extraction is not yet supported.");
 }
 
+void MultiChipExtractor::setExtractionRulesFile(
+    odb::dbTech* tech,
+    const std::string& extraction_rules_file)
+{
+  extraction_rules_files_[tech] = extraction_rules_file;
+}
+
 }  // namespace rcx

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1430,6 +1430,7 @@ void extMain::makeCornerNameMap()
 
 std::unique_ptr<extRCModel> parseRules(
     odb::dbTech* tech,
+    const std::string& rules_file,
     const Array1D<extCorner*>* extractor_corner_table,
     bool is_v2,
     utl::Logger* logger)
@@ -1456,7 +1457,6 @@ std::unique_ptr<extRCModel> parseRules(
     }
   }
 
-  const std::string rules_file = tech->getExtractionRulesFile();
   if (rules_file.empty()) {
     logger->error(RCX,
                   17,
@@ -1620,7 +1620,7 @@ void extMain::getPrevControl()
 bool extMain::modelExists()
 {
   if ((_prevControl->_ruleFileName.empty()) && (getRCmodel(0) == nullptr)
-      && (_block->getTech()->getExtractionRulesFile().empty())) {
+      && (extraction_rules_file_.empty())) {
     logger_->warn(RCX,
                   127,
                   "No RC model was read with command <load_model>, "

--- a/src/rcx/test/45_gcd.py
+++ b/src/rcx/test/45_gcd.py
@@ -17,8 +17,7 @@ via_45.set_resistance(tech)
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-db_tech = tech.getTech()
-db_tech.setExtractionRulesFile("45_patterns.rules")
+rcx_aux.set_extraction_rules_file(design, filename="45_patterns.rules")
 
 rcx_aux.extract_parasitics(design, max_res=0, coupling_threshold=0.1)
 

--- a/src/rcx/test/coordinates.py
+++ b/src/rcx/test/coordinates.py
@@ -17,8 +17,7 @@ via_45.set_resistance(tech)
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-db_tech = tech.getTech()
-db_tech.setExtractionRulesFile("45_patterns.rules")
+rcx_aux.set_extraction_rules_file(design, filename="45_patterns.rules")
 
 rcx_aux.extract_parasitics(design, max_res=0, coupling_threshold=0.1)
 

--- a/src/rcx/test/ext_pattern.py
+++ b/src/rcx/test/ext_pattern.py
@@ -11,8 +11,7 @@ design.readDef("generate_pattern.defok")
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-db_tech = tech.getTech()
-db_tech.setExtractionRulesFile("ext_pattern.rules")
+rcx_aux.set_extraction_rules_file(design, filename="ext_pattern.rules")
 
 rcx_aux.extract_parasitics(
     design,

--- a/src/rcx/test/gcd.py
+++ b/src/rcx/test/gcd.py
@@ -18,8 +18,7 @@ design.evalTclString("source sky130hs/sky130hs.rc")
 
 rcx_aux.define_process_corner(design, ext_model_index=0, filename="X")
 
-db_tech = tech.getTech()
-db_tech.setExtractionRulesFile("ext_pattern.rules")
+rcx_aux.set_extraction_rules_file(design, filename="ext_pattern.rules")
 
 rcx_aux.extract_parasitics(design, max_res=0, coupling_threshold=0.1)
 

--- a/src/rcx/test/rcx_aux.py
+++ b/src/rcx/test/rcx_aux.py
@@ -8,6 +8,10 @@ def define_process_corner(design, *, ext_model_index=0, filename=""):
     design.getOpenRCX().define_process_corner(ext_model_index, filename)
 
 
+def set_extraction_rules_file(design, *, filename=""):
+    design.getOpenRCX().setExtractionRulesFile(filename)
+
+
 def extract_parasitics(
     design,
     *,

--- a/src/rcx/test/rcx_readme_msgs_check.ok
+++ b/src/rcx/test/rcx_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 17,        Desc: 17,        Syn: 17,        Options: 17,        Args: 17
+Names: 18,        Desc: 18,        Syn: 18,        Options: 18,        Args: 18
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.


### PR DESCRIPTION
## Summary
The changes here are possible now that we have a place to store the rules for a multi-tech database.

The main argument for this PR is that the database should be **complete and work regardless of external paths**. Serializing and persisting a path was moving us to the opposite direction.

When the time comes and ODB has a proper representation of the rules, we'll be able to make that data persist.

Remembering that `set_extraction_rules_file` is for us to handle 3D extractions in which it will become painful to have an RCX argument that expresses what rules to use for each technology.

The main idea here is: if a design is single tech, we use the cache the rules path in the old engine `Ext::_ext` and if the design is 3D we cache them in the new engine `Ext::multi_chip_extractor_` in the form of a map.

I also removed an ODB API which we were using wrongly and now is dead.

## Type of Change
- Refactoring
- Documentation update

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
#11005.