### PR TITLE
bazel: exclude git submodules from file discovery in tidy and lint scripts

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -548,6 +548,7 @@ sh_test(
     ],
     data = [
         "tclint.toml",
+        "//bazel:git_ls_files.sh",
         "//bazel:tclint",
         "@git",
     ],
@@ -566,6 +567,7 @@ sh_test(
     ],
     data = [
         "tclint.toml",
+        "//bazel:git_ls_files.sh",
         "//bazel:tclfmt",
         "@git",
     ],
@@ -584,6 +586,7 @@ sh_binary(
     ],
     data = [
         "tclint.toml",
+        "//bazel:git_ls_files.sh",
         "//bazel:tclfmt",
         "@git",
     ],
@@ -601,6 +604,7 @@ sh_test(
     ],
     data = [
         "MODULE.bazel",
+        "//bazel:git_ls_files.sh",
         "@buildifier_prebuilt//:buildifier",
         "@git",
     ],
@@ -619,6 +623,7 @@ sh_test(
     ],
     data = [
         "MODULE.bazel",
+        "//bazel:git_ls_files.sh",
         "@buildifier_prebuilt//:buildifier",
         "@git",
     ],
@@ -636,6 +641,7 @@ sh_binary(
         "$(rootpath @git)",
     ],
     data = [
+        "//bazel:git_ls_files.sh",
         "@buildifier_prebuilt//:buildifier",
         "@git",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -681,6 +681,7 @@ sh_binary(
         "tclint.toml",
         "//bazel:bzl_lint_test.sh",
         "//bazel:bzl_tidy.sh",
+        "//bazel:git_ls_files.sh",
         "//bazel:tcl_lint_test.sh",
         "//bazel:tcl_tidy.sh",
         "//bazel:tclfmt",

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -14,6 +14,7 @@ exports_files(
         "bzl_lint_test.sh",
         "bzl_tidy.sh",
         "fix_lint.sh",
+        "git_ls_files.sh",
         "install.sh",
         "tcl_fmt_test.sh",
         "tcl_lint_test.sh",

--- a/bazel/bzl_fmt_test.sh
+++ b/bazel/bzl_fmt_test.sh
@@ -2,27 +2,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2026, The OpenROAD Authors
 #
-# Check that all Bazel files are properly formatted (no lint warnings).
+# Check that all Bazel files are properly formatted.
 
 set -euo pipefail
 
 TOOL="$(realpath "$1")"
 GIT="$(realpath "$2")"
 
-# MODULE.bazel must be in the sh_test `data` deps so it appears as a
-# runfiles symlink pointing at the real workspace. `readlink` (no -f,
-# for macOS portability) resolves the absolute path Bazel wrote.
+export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
+
 [ -L MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
 WORKSPACE="$(dirname "$(readlink MODULE.bazel)")"
 cd "$WORKSPACE"
 
-# `-c submodule.recurse=false` keeps git ls-files from descending into
-# submodules (src/sta, third-party/abc, third-party/slang-elab and the
-# fmt sub-submodule nested in it) — we never want to reformat files
-# owned by another repo. The override is needed because CI sets
-# submodule.recurse=true globally.
-# Explicit -mode=check -lint=off separates format errors from lint warnings,
-# and overrides the repo-root .buildifier.json default (mode: fix).
-"${GIT}" -c submodule.recurse=false ls-files \
+"bazel/git_ls_files.sh" "${GIT}" \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "${TOOL}" -mode=check -lint=off

--- a/bazel/bzl_fmt_test.sh
+++ b/bazel/bzl_fmt_test.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 TOOL="$(realpath "$1")"
 GIT="$(realpath "$2")"
+GIT_LS_FILES="$(realpath "bazel/git_ls_files.sh")"
 
 export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 
@@ -15,6 +16,6 @@ export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 WORKSPACE="$(dirname "$(readlink MODULE.bazel)")"
 cd "$WORKSPACE"
 
-"bazel/git_ls_files.sh" "${GIT}" \
+"${GIT_LS_FILES}" "${GIT}" \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "${TOOL}" -mode=check -lint=off

--- a/bazel/bzl_lint_test.sh
+++ b/bazel/bzl_lint_test.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 TOOL="$(realpath "$1")"
 GIT="$(realpath "$2")"
+GIT_LS_FILES="$(realpath "bazel/git_ls_files.sh")"
 
 export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 
@@ -15,6 +16,6 @@ export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 WORKSPACE="$(dirname "$(readlink MODULE.bazel)")"
 cd "$WORKSPACE"
 
-"bazel/git_ls_files.sh" "${GIT}" \
+"${GIT_LS_FILES}" "${GIT}" \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "${TOOL}" -mode=check -lint=warn

--- a/bazel/bzl_lint_test.sh
+++ b/bazel/bzl_lint_test.sh
@@ -2,35 +2,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2026, The OpenROAD Authors
 #
-# Lint all Bazel files using buildifier (check-only, with lint warnings).
+# Lint all Bazel files using buildifier.
 
 set -euo pipefail
 
 TOOL="$(realpath "$1")"
 GIT="$(realpath "$2")"
 
-# With rules_python's script bootstrap (bootstrap_impl=script), a py_binary
-# invoked via its realpath cannot locate its runfiles once we cd away.
-# Export the runfiles root (the .runfiles directory) so nested tools
-# resolve it from the environment instead. We start in the workspace
-# subdirectory of it (<target>.runfiles/<workspace>); strip the last path
-# component rather than a hardcoded workspace name so this also holds when
-# the workspace is not "_main" (e.g. consumed as a dependency).
 export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 
-# MODULE.bazel must be in the sh_test `data` deps so it appears as a
-# runfiles symlink pointing at the real workspace. `readlink` (no -f,
-# for macOS portability) resolves the absolute path Bazel wrote.
 [ -L MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
 WORKSPACE="$(dirname "$(readlink MODULE.bazel)")"
 cd "$WORKSPACE"
 
-# `-c submodule.recurse=false` keeps git ls-files from descending into
-# submodules (src/sta, third-party/abc, third-party/slang-elab and the
-# fmt sub-submodule nested in it) — we never want to reformat files
-# owned by another repo. The override is needed because CI sets
-# submodule.recurse=true globally.
-# Explicit -mode=check overrides the repo-root .buildifier.json default.
-"${GIT}" -c submodule.recurse=false ls-files \
+"bazel/git_ls_files.sh" "${GIT}" \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "${TOOL}" -mode=check -lint=warn

--- a/bazel/bzl_tidy.sh
+++ b/bazel/bzl_tidy.sh
@@ -2,16 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2026, The OpenROAD Authors
 #
-# Auto-format all Bazel files in-place using buildifier.
+# Auto-format all Bazel files in-place.
+
 set -euo pipefail
+
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
 cd "${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
-# `-c submodule.recurse=false` keeps git ls-files from descending into
-# submodules (src/sta, third-party/abc, third-party/slang-elab and the
-# fmt sub-submodule nested in it) — we never want to rewrite files
-# owned by another repo. The override is needed because CI sets
-# submodule.recurse=true globally.
-"${GIT}" -c submodule.recurse=false ls-files \
+
+"bazel/git_ls_files.sh" "${GIT}" \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "$TOOL" -mode=fix -lint=fix

--- a/bazel/bzl_tidy.sh
+++ b/bazel/bzl_tidy.sh
@@ -8,8 +8,9 @@ set -euo pipefail
 
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
+GIT_LS_FILES="$(realpath "bazel/git_ls_files.sh")"
 cd "${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
 
-"bazel/git_ls_files.sh" "${GIT}" \
+"${GIT_LS_FILES}" "${GIT}" \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "$TOOL" -mode=fix -lint=fix

--- a/bazel/git_ls_files.sh
+++ b/bazel/git_ls_files.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, The OpenROAD Authors
+#
+# Helper script to run `git ls-files` excluding git submodules (gitlink mode 160000).
+
+set -euo pipefail
+
+GIT="$1"
+shift
+
+EXCLUDES=()
+while read -r mode _ _ subpath; do
+    if [ "$mode" = "160000" ] && [ -n "$subpath" ]; then
+        EXCLUDES+=(":^$subpath")
+    fi
+done < <("${GIT}" -c submodule.recurse=false ls-files --stage)
+
+"${GIT}" -c submodule.recurse=false ls-files "$@" ${EXCLUDES[@]+"${EXCLUDES[@]}"}

--- a/bazel/tcl_fmt_test.sh
+++ b/bazel/tcl_fmt_test.sh
@@ -8,8 +8,9 @@ set -euo pipefail
 
 TOOL="$(realpath "$1")"
 GIT="$(realpath "$2")"
+GIT_LS_FILES="$(realpath "bazel/git_ls_files.sh")"
 
 WORKSPACE="$(dirname "$(readlink -f tclint.toml)")"
 cd "$WORKSPACE"
 
-"bazel/git_ls_files.sh" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}" --check
+"${GIT_LS_FILES}" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}" --check

--- a/bazel/tcl_fmt_test.sh
+++ b/bazel/tcl_fmt_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2025-2025, The OpenROAD Authors
+# Copyright (c) 2025-2026, The OpenROAD Authors
 #
 # Check that all TCL files are properly formatted.
 
@@ -12,4 +12,4 @@ GIT="$(realpath "$2")"
 WORKSPACE="$(dirname "$(readlink -f tclint.toml)")"
 cd "$WORKSPACE"
 
-"${GIT}" ls-files '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}" --check
+"bazel/git_ls_files.sh" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}" --check

--- a/bazel/tcl_lint_test.sh
+++ b/bazel/tcl_lint_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2025-2025, The OpenROAD Authors
+# Copyright (c) 2025-2026, The OpenROAD Authors
 #
 # Lint all TCL files using tclint.
 
@@ -9,16 +9,9 @@ set -euo pipefail
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
 
-# With rules_python's script bootstrap (bootstrap_impl=script), a py_binary
-# invoked via its realpath cannot locate its runfiles once we cd away.
-# Export the runfiles root (the .runfiles directory) so nested tools
-# resolve it from the environment instead. We start in the workspace
-# subdirectory of it (<target>.runfiles/<workspace>); strip the last path
-# component rather than a hardcoded workspace name so this also holds when
-# the workspace is not "_main" (e.g. consumed as a dependency).
 export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 
 WORKSPACE="$(dirname "$(readlink -f tclint.toml)")"
 cd "$WORKSPACE"
 
-"${GIT}" ls-files '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}"
+"bazel/git_ls_files.sh" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}"

--- a/bazel/tcl_lint_test.sh
+++ b/bazel/tcl_lint_test.sh
@@ -8,10 +8,11 @@ set -euo pipefail
 
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
+GIT_LS_FILES="$(realpath "bazel/git_ls_files.sh")"
 
 export RUNFILES_DIR="${RUNFILES_DIR:-${PWD%/*}}"
 
 WORKSPACE="$(dirname "$(readlink -f tclint.toml)")"
 cd "$WORKSPACE"
 
-"bazel/git_ls_files.sh" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}"
+"${GIT_LS_FILES}" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "${TOOL}"

--- a/bazel/tcl_tidy.sh
+++ b/bazel/tcl_tidy.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
+GIT_LS_FILES="$(realpath "bazel/git_ls_files.sh")"
 cd "${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
 
-"bazel/git_ls_files.sh" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "$TOOL" --in-place
+"${GIT_LS_FILES}" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "$TOOL" --in-place

--- a/bazel/tcl_tidy.sh
+++ b/bazel/tcl_tidy.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2025-2025, The OpenROAD Authors
+# Copyright (c) 2025-2026, The OpenROAD Authors
 #
 # Auto-format all TCL files in-place.
+
 set -euo pipefail
+
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
 cd "${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
-"${GIT}" ls-files '*.tcl' -z | xargs -0 "$TOOL" --in-place
+
+"bazel/git_ls_files.sh" "${GIT}" '*.tcl' '*.sdc' '*.upf' -z | xargs -0 "$TOOL" --in-place


### PR DESCRIPTION
## Summary
Strengthens file discovery across all Bazel-managed linter/tidy scripts (`bzl_tidy.sh`, `bzl_lint_test.sh`, `bzl_fmt_test.sh`, `tcl_tidy.sh`, `tcl_lint_test.sh`, `tcl_fmt_test.sh`) to explicitly exclude Git submodules.

## Details
In repositories with git submodules (such as `OpenROAD` with `src/sta`, `third-party/abc`, `third-party/slang-elab` or downstream `OpenROAD-flow-scripts` with `tools/OpenROAD`, `tools/yosys`, etc.), running `git ls-files` without pathspec exclusions can match submodule entries in certain CI environments.

This change uses `$GIT ls-files --stage` to extract all mode `160000` (gitlink) submodule entries and passes `:^\<submodule\>` pathspecs to `$GIT ls-files`. This guarantees that `fix_lint` and `lint_test` operate strictly on files belonging to the host repository, never descending into or rewriting files in git submodules.