### PR TITLE
rcx: add ability to specify the extraction rules for the assembly kit

### DIFF
--- a/src/rcx/README.md
+++ b/src/rcx/README.md
@@ -46,11 +46,13 @@ define_process_corner
 
 Sets the path to the parasitics extraction rules file. For a 3D design in
 which multiple technologies are used, the user must specify the technology
-for which they want to set the rules path.
+for which they want to set the rules path as well as the assembly design kit
+extraction rules for the inter-chip parasitics with `-assembly`.
 
 ```tcl
 set_extraction_rules_file
     [-tech tech_name]
+    [-assembly]
     rules_file
 ```
 
@@ -59,6 +61,7 @@ set_extraction_rules_file
 | Switch Name | Description |
 | ----- | ----- |
 | `-tech` | Technology for which to set the extraction rules path. |
+| `-assembly` | Set the inter-chip extraction rules. Cannot be combined with `-tech`. |
 | `rules_file` | Path to the extraction rules file. |
 
 ### Extract Parasitics

--- a/src/rcx/include/rcx/ext.h
+++ b/src/rcx/include/rcx/ext.h
@@ -78,6 +78,8 @@ class Ext
   void setExtractionRulesFile(const std::string& rules_file);
   void setExtractionRulesFile(const std::string& rules_file,
                               const std::string& tech_name);
+  void setAssemblyExtractionRulesFile(
+      const std::string& assembly_extraction_rules_file);
 
   void define_process_corner(int ext_model_index, const std::string& name);
   void define_derived_corner(const std::string& name,

--- a/src/rcx/include/rcx/multiChipExtractor.h
+++ b/src/rcx/include/rcx/multiChipExtractor.h
@@ -21,12 +21,15 @@ class MultiChipExtractor
 
   void setExtractionRulesFile(odb::dbTech* tech,
                               const std::string& extraction_rules_file);
+  void setAssemblyExtractionRulesFile(
+      const std::string& assembly_extraction_rules_file);
 
  private:
   odb::dbDatabase* db_{nullptr};
   utl::Logger* logger_{nullptr};
 
   odb::PtrMap<odb::dbTech, std::string> extraction_rules_files_;
+  std::string assembly_extraction_rules_file_;
 };
 
 }  // namespace rcx

--- a/src/rcx/src/OpenRCX.tcl
+++ b/src/rcx/src/OpenRCX.tcl
@@ -21,16 +21,27 @@ proc define_process_corner { args } {
 }
 
 sta::define_cmd_args "set_extraction_rules_file" {
-    [-tech tech_name] rules_file
+    [-tech tech_name] [-assembly] rules_file
 }
 
 proc set_extraction_rules_file { args } {
   sta::parse_key_args "set_extraction_rules_file" args \
-    keys {-tech} flags {}
+    keys {-tech} flags {-assembly}
   sta::check_argc_eq1 "set_extraction_rules_file" $args
 
   if { ![ord::db_has_tech] } {
     utl::error RCX 520 "No LEF technology has been read."
+  }
+
+  set rules_file [file nativename [lindex $args 0]]
+
+  if { [info exists flags(-assembly)] } {
+    if { [info exists keys(-tech)] } {
+      utl::error RCX 526 "-assembly cannot be used with -tech."
+    }
+
+    rcx::set_assembly_extraction_rules_file $rules_file
+    return
   }
 
   set tech_name ""
@@ -40,8 +51,6 @@ proc set_extraction_rules_file { args } {
       utl::error RCX 519 "Technology $tech_name not found."
     }
   }
-
-  set rules_file [file nativename [lindex $args 0]]
 
   rcx::set_extraction_rules_file $rules_file $tech_name
 }

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -241,6 +241,13 @@ void Ext::setExtractionRulesFile(const std::string& rules_file,
   multi_chip_extractor_->setExtractionRulesFile(tech, rules_file);
 }
 
+void Ext::setAssemblyExtractionRulesFile(
+    const std::string& assembly_extraction_rules_file)
+{
+  multi_chip_extractor_->setAssemblyExtractionRulesFile(
+      assembly_extraction_rules_file);
+}
+
 void Ext::extract(ExtractOptions options)
 {
   _ext->setBlockFromChip(_db->getChip());

--- a/src/rcx/src/ext.i
+++ b/src/rcx/src/ext.i
@@ -61,6 +61,27 @@ set_extraction_rules_file(const std::string& rules_file,
 }
 
 void
+set_assembly_extraction_rules_file(const std::string& rules_file)
+{
+  Ext* ext = getOpenRCX();
+  utl::Logger* logger = getLogger();
+  odb::dbChip* top_chip = ord::getOpenRoad()->getDb()->getChip();
+
+  if (!top_chip) {
+    logger->error(utl::RCX, 524, "No design is loaded.");
+  }
+
+  if (top_chip->getChipType() != odb::dbChip::ChipType::HIER) {
+    logger->error(utl::RCX,
+                  525,
+                  "Could not set assembly extraction rules file. Design is "
+                  "not 3D.");
+  }
+
+  ext->setAssemblyExtractionRulesFile(rules_file);
+}
+
+void
 extract(const char* ext_model_file,
         int corner_cnt,
         double max_res,

--- a/src/rcx/src/multiChipExtractor.cpp
+++ b/src/rcx/src/multiChipExtractor.cpp
@@ -22,4 +22,10 @@ void MultiChipExtractor::setExtractionRulesFile(
   extraction_rules_files_[tech] = extraction_rules_file;
 }
 
+void MultiChipExtractor::setAssemblyExtractionRulesFile(
+    const std::string& assembly_extraction_rules_file)
+{
+  assembly_extraction_rules_file_ = assembly_extraction_rules_file;
+}
+
 }  // namespace rcx


### PR DESCRIPTION
## Type of Change
- New feature
- Documentation update

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
#11005.
