### PR TITLE
gui: fix Unable to find visible display control at Timing Path/*

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -777,6 +777,12 @@ class Gui
   void registerRenderer(Renderer* renderer);
   void unregisterRenderer(Renderer* renderer);
 
+  // Adds/removes a renderer from the active paint set only, leaving any
+  // DisplayControls entries it owns in place. Used by widgets whose
+  // renderer's controls should stay scriptable (e.g. via
+  // gui::set_display_controls) even while the owning widget is hidden.
+  void setRendererPaintingEnabled(Renderer* renderer, bool enabled);
+
   // Make a Selected any object in the gui.  It should have a descriptor
   // registered for its exact type to be useful.
   Selected makeSelected(const std::any& object);

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -268,6 +268,16 @@ void Gui::unregisterRenderer(Renderer* renderer)
   redraw();
 }
 
+void Gui::setRendererPaintingEnabled(Renderer* renderer, bool enabled)
+{
+  if (enabled) {
+    renderers_.insert(renderer);
+  } else {
+    renderers_.erase(renderer);
+  }
+  redraw();
+}
+
 void Gui::redraw()
 {
   if (main_window != nullptr) {

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -446,6 +446,11 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
     settings.endGroup();
   }
 
+  // Register the timing path's DisplayControls entries once, up front, so
+  // "Timing Path/*" is always scriptable regardless of whether the Timing
+  // Report window is currently open (see TimingWidget::toggleRenderer).
+  controls_->registerRenderer(timing_widget_->getTimingRenderer());
+
   // load resources and set window icon
   loadQTResources();
   setWindowIcon(QIcon(":/icon.png"));

--- a/src/gui/src/timingWidget.cpp
+++ b/src/gui/src/timingWidget.cpp
@@ -868,12 +868,10 @@ void TimingWidget::toggleRenderer(bool visible)
     return;
   }
 
-  auto gui = Gui::get();
-  if (visible) {
-    gui->registerRenderer(path_renderer_.get());
-  } else {
-    gui->unregisterRenderer(path_renderer_.get());
-  }
+  // Only toggle painting; the "Timing Path" DisplayControls entries are
+  // registered once (see MainWindow's constructor) and stay in place while
+  // hidden so scripts can still reference them (e.g. "Timing Path/*").
+  Gui::get()->setRendererPaintingEnabled(path_renderer_.get(), visible);
 }
 
 void TimingWidget::setBlock(odb::dbBlock* block)


### PR DESCRIPTION
## Summary
Closes #9391

Add a new method to register a renderer, so it's possible to find even if its parent is not active.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
Now it's possible to use `gui::set_display_controls "Timing Path/*"` if the Timing report is closed.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [ ] I have included tests to prevent regressions.
- [x]  **I have signed my commits (DCO).**

## Related Issues
https://github.com/The-OpenROAD-Project/OpenROAD/issues/9391