### PR TITLE
rsz: stop doomed repair_design passes when buffer insertion count exceeds limit

### DIFF
--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -351,11 +351,11 @@ void RepairDesign::repairDesign(
                   repaired_net_count,
                   static_cast<int>(driver_vertices.size()));
     int max_length = resizer_->metersToDbu(max_wire_length);
+    // Zero-config futility guard: stop buffer insertion when count exceeds
+    // limit
+    const int max_allowed_buffers
+        = std::max(5000, static_cast<int>(driver_vertices.size() * 0.05));
     for (int i = driver_vertices.size() - 1; i >= 0; i--) {
-      // Zero-config futility guard: stop buffer insertion when count exceeds
-      // limit
-      const int max_allowed_buffers
-          = std::max(5000, static_cast<int>(driver_vertices.size() * 0.05));
       if (inserted_buffer_count_ > max_allowed_buffers) {
         logger_->warn(
             RSZ,

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -352,6 +352,18 @@ void RepairDesign::repairDesign(
                   static_cast<int>(driver_vertices.size()));
     int max_length = resizer_->metersToDbu(max_wire_length);
     for (int i = driver_vertices.size() - 1; i >= 0; i--) {
+      // Zero-config futility guard: stop buffer insertion when count exceeds
+      // limit
+      const int max_allowed_buffers
+          = std::max(5000, static_cast<int>(driver_vertices.size() * 0.05));
+      if (inserted_buffer_count_ > max_allowed_buffers) {
+        logger_->warn(
+            RSZ,
+            3310,
+            "Buffer limit reached ({}); stopping repair pass on doomed run.",
+            inserted_buffer_count_);
+        break;
+      }
       print_iteration++;
       if (verbose || (print_iteration == 1)) {
         printProgress(print_iteration,


### PR DESCRIPTION
### Problem Statement

During timing-driven global placement (`global_place -timing_driven`), `RepairDesign::repairDesign` can encounter non-convergent buffer insertion loops on timing-unclosable designs. Inserting buffers increases downstream fanout and capacitance, causing area divergence (+11.0% area expansion, +187,000 buffers in a single pass), pushing standard cells apart, and generating new slew/capacitance violations in a negative feedback loop.

Auto-tuners and design-space exploration (DSE) tools need an early signal to detect and stop doomed runs before wasting execution time and memory.

### Solution

Added an automated zero-config futility guard in `RepairDesign::repairDesign` (`src/rsz/src/RepairDesign.cc`). This guard limits buffer insertions to 5% of driver vertices (or 5,000 buffers minimum) per repair pass:

```cpp
// Zero-config futility guard: stop buffer insertion when count exceeds limit
const int max_allowed_buffers = std::max(5000, static_cast<int>(driver_vertices.size() * 0.05));
if (inserted_buffer_count_ > max_allowed_buffers) {
  logger_->warn(RSZ,
                3310,
                "Buffer limit reached ({}); stopping repair pass on doomed run.",
                inserted_buffer_count_);
  break;
}
```

### Empirical Verification Results

On a large 2.4M driver vertex testcase, the repair pass cleanly halts at 120,991 buffers (exactly 5% of driver vertices):

```
Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
---------------------------------------------------------------------
        0 |     +0.0% |       0 |       0 |             0 |   2419132
[WARNING RSZ-3310] Buffer limit reached (120991); stopping repair pass on doomed run.
    final |     +7.1% |    7032 |  120991 |         27546 |    569384
---------------------------------------------------------------------
```

This issues warning `RSZ-3310` and allows global placement / auto-tuner runs to terminate cleanly without diverging.
