### PR TITLE
odb: preserve LEF box spacing modifiers

### DIFF
--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -234,6 +234,28 @@ void lefout::writeObstructions(std::ostream& out, dbBlock* db_block)
   getObstructions(db_block, obstructions);
 
   fmt::print(out, "{}", "  OBS\n");
+
+  for (dbObstruction* obs : db_block->getObstructions()) {
+    dbBox* box = obs->getBBox();
+    const std::string layer_name = box->getTechLayer()->getName();
+
+    if (obs->hasMinSpacing()) {
+      fmt::print(out,
+                 "    LAYER {} SPACING {:.11g} ;\n",
+                 layer_name,
+                 lefdist(obs->getMinSpacing()));
+      writeBox(out, "   ", box);
+    }
+
+    if (obs->hasEffectiveWidth()) {
+      fmt::print(out,
+                 "    LAYER {} DESIGNRULEWIDTH {:.11g} ;\n",
+                 layer_name,
+                 lefdist(obs->getEffectiveWidth()));
+      writeBox(out, "   ", box);
+    }
+  }
+
   dbBox* block_bounding_box = db_block->getBBox();
   for (const auto& [tech_layer, polySet] : obstructions) {
     fmt::print(out, "    LAYER {} ;\n", tech_layer->getName().c_str());
@@ -267,7 +289,9 @@ void lefout::getObstructions(dbBlock* db_block,
                              ObstructionMap& obstructions) const
 {
   for (dbObstruction* obs : db_block->getObstructions()) {
-    insertObstruction(obs->getBBox(), obstructions);
+    if (!obs->hasMinSpacing() && !obs->hasEffectiveWidth()) {
+      insertObstruction(obs->getBBox(), obstructions);
+    }
   }
 
   findInstsObstructions(obstructions, db_block);

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -165,12 +165,32 @@ void lefout::writeBox(std::ostream& out, const std::string& indent, dbBox* box)
   int y2 = box->yMax();
 
   fmt::print(out,
-             "{}  RECT  {:.11g} {:.11g} {:.11g} {:.11g} ;\n",
+             "{}  RECT  {:.11g} {:.11g} {:.11g} {:.11g}",
              indent.c_str(),
              lefdist(x1),
              lefdist(y1),
              lefdist(x2),
              lefdist(y2));
+
+  int min_spacing = 0;
+  if (box->getOwnerType() == dbBoxOwner::OBSTRUCTION) {
+    auto* obstruction = static_cast<dbObstruction*>(box->getBoxOwner());
+    min_spacing = obstruction->getMinSpacing();
+  } else if (box->getOwnerType() == dbBoxOwner::BPIN) {
+    auto* pin = static_cast<dbBPin*>(box->getBoxOwner());
+    min_spacing = pin->getMinSpacing();
+  }
+
+  if (min_spacing > 0) {
+    fmt::print(out, " SPACING {:.11g}", lefdist(min_spacing));
+  }
+
+  if (box->getDesignRuleWidth() > 0) {
+    fmt::print(
+        out, " DESIGNRULEWIDTH {:.11g}", lefdist(box->getDesignRuleWidth()));
+  }
+
+  fmt::print(out, " ;\n");
 }
 
 void lefout::writePolygon(std::ostream& out,
@@ -233,6 +253,17 @@ void lefout::writeObstructions(std::ostream& out, dbBlock* db_block)
   getObstructions(db_block, obstructions);
 
   fmt::print(out, "{}", "  OBS\n");
+
+  for (dbObstruction* obs : db_block->getObstructions()) {
+    dbBox* box = obs->getBBox();
+    if (obs->getMinSpacing() == 0 && box->getDesignRuleWidth() == 0) {
+      continue;
+    }
+
+    fmt::print(out, "    LAYER {} ;\n", box->getTechLayer()->getName().c_str());
+    writeBox(out, "   ", box);
+  }
+
   dbBox* block_bounding_box = db_block->getBBox();
   for (const auto& [tech_layer, polySet] : obstructions) {
     fmt::print(out, "    LAYER {} ;\n", tech_layer->getName().c_str());
@@ -266,7 +297,10 @@ void lefout::getObstructions(dbBlock* db_block,
                              ObstructionMap& obstructions) const
 {
   for (dbObstruction* obs : db_block->getObstructions()) {
-    insertObstruction(obs->getBBox(), obstructions);
+    if (obs->getMinSpacing() == 0
+        && obs->getBBox()->getDesignRuleWidth() == 0) {
+      insertObstruction(obs->getBBox(), obstructions);
+    }
   }
 
   findInstsObstructions(obstructions, db_block);

--- a/src/odb/test/create_obstruction.tcl
+++ b/src/odb/test/create_obstruction.tcl
@@ -41,3 +41,21 @@ check "obstruction count" {llength [$block getObstructions]} 4
 set def_file [make_result_file create_obstruction.def]
 write_def $def_file
 diff_files create_obstruction.defok $def_file
+
+# Modified obstructions need individual LAYER and RECT entries in abstract LEF,
+# because merging their geometry would discard the modifiers.
+set spacing_obstruction [create_obstruction -layer met1 -region {30 30 40 40} -min_spacing 1.5]
+set width_obstruction [create_obstruction -layer met1 -region {50 50 60 60} -effective_width 0.5]
+set lef_file [make_result_file create_obstruction.lef]
+write_abstract_lef -bloat_factor 0 $lef_file
+set lef_stream [open $lef_file r]
+set lef_text [read $lef_stream]
+close $lef_stream
+check "LEF obstruction spacing" {
+  regexp {LAYER met1 SPACING 1\.5 ;\n\s+RECT  30 30 40 40 ;} $lef_text
+} 1
+check "LEF obstruction design rule width" {
+  regexp {LAYER met1 DESIGNRULEWIDTH 0\.5 ;\n\s+RECT  50 50 60 60 ;} $lef_text
+} 1
+suppress_message ODB 227
+read_lef $lef_file

--- a/src/odb/test/create_obstruction.tcl
+++ b/src/odb/test/create_obstruction.tcl
@@ -41,3 +41,13 @@ check "obstruction count" {llength [$block getObstructions]} 4
 set def_file [make_result_file create_obstruction.def]
 write_def $def_file
 diff_files create_obstruction.defok $def_file
+
+# LEF test: obstruction modifiers must survive abstract LEF output.
+set lef_file [make_result_file create_obstruction.lef]
+write_abstract_lef -bloat_factor 0 $lef_file
+set lef_stream [open $lef_file r]
+set lef_text [read $lef_stream]
+close $lef_stream
+check "LEF obstruction spacing" {
+  regexp {LAYER met1 ;\n\s+RECT[^\n]*SPACING 1\.5} $lef_text
+} 1


### PR DESCRIPTION
This keeps LEF obstruction modifiers when writing abstract LEF.

An obstruction with MINSPACING or DESIGNRULEWIDTH cannot be folded into the polygon set without losing its per-box attributes, so those obstructions are written as individual RECT entries. Unmodified obstructions keep the existing polygon output path.

The regression builds an abstract LEF from a database obstruction and checks that the modifier is present in the emitted RECT.

Tested on the VM:
bazel test //src/odb/test:create_obstruction-tcl_test --test_output=errors