### PR TITLE
rcx: fix the diff_spef test helper

### DIFF
--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -127,6 +127,12 @@ cc_test(
 )
 
 py_test(
+    name = "rcx_aux_test",
+    srcs = ["rcx_aux_test.py"],
+    data = ["rcx_aux.py"],
+)
+
+py_test(
     name = "rcx_man_tcl_check",
     srcs = ["rcx_man_tcl_check.py"],
     data = ["//src/rcx:doc_files"],

--- a/src/rcx/test/rcx_aux.py
+++ b/src/rcx/test/rcx_aux.py
@@ -110,7 +110,7 @@ def diff_spef(
     design, *, filename="", r_conn=False, r_res=False, r_cap=False, r_cc_cap=False
 ):
     opts = rcx.DiffOptions()
-    opts.file = file
+    opts.file = filename
     opts.r_res = r_res
     opts.r_cap = r_cap
     opts.r_cc_cap = r_cc_cap

--- a/src/rcx/test/rcx_aux_test.py
+++ b/src/rcx/test/rcx_aux_test.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class DiffSpefTest(unittest.TestCase):
+    def test_filename_is_forwarded_to_diff_options(self):
+        fake_rcx = types.ModuleType("rcx")
+        fake_rcx.DiffOptions = type("DiffOptions", (), {})
+        sys.modules["rcx"] = fake_rcx
+        sys.modules["utl"] = types.ModuleType("utl")
+
+        source = Path(__file__).with_name("rcx_aux.py")
+        spec = importlib.util.spec_from_file_location("rcx_aux", source)
+        rcx_aux = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(rcx_aux)
+
+        class FakeOpenRCX:
+            def diff_spef(self, options):
+                self.options = options
+
+        class FakeDesign:
+            def __init__(self):
+                self.open_rcx = FakeOpenRCX()
+
+            def getOpenRCX(self):
+                return self.open_rcx
+
+        design = FakeDesign()
+        rcx_aux.diff_spef(
+            design,
+            filename="roundtrip.spef",
+            r_conn=True,
+            r_res=True,
+            r_cap=False,
+            r_cc_cap=True,
+        )
+
+        options = design.open_rcx.options
+        self.assertEqual(options.file, "roundtrip.spef")
+        self.assertTrue(options.r_conn)
+        self.assertTrue(options.r_res)
+        self.assertFalse(options.r_cap)
+        self.assertTrue(options.r_cc_cap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the broken test helper reported in #11050.

The helper accepts a filename but was passing an undefined variable into DiffOptions. This patch changes only diff_spef to use the filename argument and leaves write_spef unchanged.

This PR covers the helper bug only. It does not claim to fix the separate diff_spef output and calibration issues from the report.

Tested on the VM:
bazel test //src/rcx/test:rcx_aux_test --test_output=errors