### PR TITLE
rcx: handle track grids with tracks in only one direction

### DIFF
--- a/src/rcx/src/CMakeLists.txt
+++ b/src/rcx/src/CMakeLists.txt
@@ -100,6 +100,7 @@ if(ENABLE_TESTS)
   enable_testing()
 
   add_executable(rcxUnitTest
+    ${PROJECT_SOURCE_DIR}/test/TestExtractor.cpp
     ${PROJECT_SOURCE_DIR}/test/ext2dBoxTest.cpp
   )
 

--- a/src/rcx/src/extFlow.cpp
+++ b/src/rcx/src/extFlow.cpp
@@ -315,10 +315,14 @@ uint32_t extMain::initSearchForNets(int* X1,
 
     dbTrackGrid* tg = _block->findTrackGrid(layer);
     if (tg) {
+      // A layer may have tracks in only one direction; fall back to the block
+      // origin for the missing direction rather than indexing an empty grid.
       tg->getGridX(trackXY);
-      X1[n] = trackXY[0] - layer->getWidth() / 2;
+      X1[n] = trackXY.empty() ? maxRect.xMin()
+                              : trackXY[0] - layer->getWidth() / 2;
       tg->getGridY(trackXY);
-      Y1[n] = trackXY[0] - layer->getWidth() / 2;
+      Y1[n] = trackXY.empty() ? maxRect.yMin()
+                              : trackXY[0] - layer->getWidth() / 2;
     } else {
       X1[n] = maxRect.xMin();
       Y1[n] = maxRect.yMin();

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -120,9 +120,14 @@ test_suite(
 
 cc_test(
     name = "rcx_unittest",
-    srcs = ["ext2dBoxTest.cpp"],
+    srcs = [
+        "TestExtractor.cpp",
+        "ext2dBoxTest.cpp",
+    ],
     deps = [
+        "//src/odb/src/db",
         "//src/rcx",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/rcx/test/TestExtractor.cpp
+++ b/src/rcx/test/TestExtractor.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2019-2025, The OpenROAD Authors
+
+#include "gtest/gtest.h"
+#include "odb/db.h"
+#include "rcx/extRCap.h"
+#include "utl/Logger.h"
+
+namespace rcx {
+
+TEST(TestExtractor, InitSearchWithSingleDirectionTrackGrid)
+{
+  utl::Logger logger;
+  odb::dbDatabase* db = odb::dbDatabase::create();
+  db->setLogger(&logger);
+
+  odb::dbTech* tech = odb::dbTech::create(db, "tech");
+
+  odb::dbTechLayer* met1
+      = odb::dbTechLayer::create(tech, "met1", odb::dbTechLayerType::ROUTING);
+  met1->setWidth(100);
+  met1->setPitch(200);
+
+  odb::dbTechLayer* met2
+      = odb::dbTechLayer::create(tech, "met2", odb::dbTechLayerType::ROUTING);
+  met2->setWidth(100);
+  met2->setPitch(200);
+
+  odb::dbChip* chip = odb::dbChip::create(db, tech, "chip");
+  odb::dbBlock* block = odb::dbBlock::create(chip, "block");
+  block->setDieArea(odb::Rect(1000, 2000, 11000, 12000));
+
+  // met1 has tracks only in Y; met2 has tracks only in X.
+  odb::dbTrackGrid* met1_grid = odb::dbTrackGrid::create(block, met1);
+  met1_grid->addGridPatternY(2500, 10, 200);
+
+  odb::dbTrackGrid* met2_grid = odb::dbTrackGrid::create(block, met2);
+  met2_grid->addGridPatternX(1700, 10, 200);
+
+  extMain extractor;
+  extractor.init(db, &logger);
+  extractor.setBlockFromChip(chip);
+
+  constexpr int kTableSize = 8;
+  int x_origins[kTableSize] = {};
+  int y_origins[kTableSize] = {};
+  uint32_t pitch_table[kTableSize] = {};
+  uint32_t width_table[kTableSize] = {};
+  uint32_t dir_table[kTableSize] = {};
+  odb::Rect ext_rect(0, 0, 0, 0);
+
+  extractor.initSearchForNets(x_origins,
+                              y_origins,
+                              pitch_table,
+                              width_table,
+                              dir_table,
+                              ext_rect,
+                              false);
+
+  // A direction without tracks falls back to the die origin; a direction
+  // with tracks anchors at the first track minus half the layer width.
+  EXPECT_EQ(x_origins[1], 1000);
+  EXPECT_EQ(y_origins[1], 2500 - 100 / 2);
+
+  EXPECT_EQ(x_origins[2], 1700 - 100 / 2);
+  EXPECT_EQ(y_origins[2], 2000);
+}
+
+}  // namespace rcx


### PR DESCRIPTION
## Summary
Revealed during @dsengupta0628 tests of the 3D RCX implementation.

## Type of Change
- Bug fix

## Impact
Prevent a crash.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**