### PR TITLE
dbSta: add SWIG interface to allow dbNet -> sta::Net conversion

### DIFF
--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -192,6 +192,14 @@ sta_to_db_mod_net(Net *net)
   return db_mod_net;
 }
 
+Net *
+db_net_to_sta(odb::dbNet *db_net)
+{
+  ord::OpenRoad *openroad = ord::getOpenRoad();
+  sta::dbNetwork *db_network = openroad->getDbNetwork();
+  return db_network->dbToSta(db_net);
+}
+
 odb::dbMaster *
 sta_to_db_master(LibertyCell *cell)
 {


### PR DESCRIPTION
## Summary
Estimated parasitics are retrieved via `sta::Net*` as they're not stored in ODB. So, in order for us to iterate over `dbNet`s rather than sta nets on [write_rc_helper.tcl](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/03a6ea0831c0c0735ea94a4eb9820d65e42129e5/flow/util/write_rc_helper.tcl#L7) we need a way of retrieving the `sta::Net*` from the `dbNet*`.

_It's preferable to iterate the `dbNet`s as we don't have to deal module nets._

## Type of Change
- New feature

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/4383
