### PR TITLE
psm: report the average IR drop under the drop__average metric

### DIFF
--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -1455,8 +1455,10 @@ void IRSolver::report(sta::Scene* corner) const
 
   logger_->metric(getMetricKey("design_powergrid__voltage__worst", corner),
                   results.worst_voltage);
-  logger_->metric(getMetricKey("design_powergrid__drop__average", corner),
+  logger_->metric(getMetricKey("design_powergrid__voltage__average", corner),
                   results.avg_voltage);
+  logger_->metric(getMetricKey("design_powergrid__drop__average", corner),
+                  results.avg_ir_drop);
   logger_->metric(getMetricKey("design_powergrid__drop__worst", corner),
                   results.worst_ir_drop);
 }


### PR DESCRIPTION
Fixes #11096, with both changes @gadfort asked for.

`design_powergrid__drop__average` passed `results.avg_voltage`, so on a power net it reported the supply voltage instead of the drop. `avg_ir_drop` was already computed in `getSolution()` and used correctly in the text report two lines earlier — it just never reached the metric.

It stayed hidden because on a **ground** net `net_voltage == 0`, so `getSolution()` sets `avg_ir_drop = avg_voltage` and the metric is accidentally right. Every run reports both a power and a ground net, so half the numbers always looked correct. On a 1.8 V power net the metric read `1.79999` where the average drop was `6.41e-06`.

## Changes

- `design_powergrid__drop__average` now carries `results.avg_ir_drop`.
- Adds `design_powergrid__voltage__average` carrying `results.avg_voltage`, so the value the old metric held is still published and named for what it is — and sits alongside the existing `design_powergrid__voltage__worst`.

## Notes

- No test goldens or docs reference these metric names, so nothing else needed updating — the two names are used only here.
- The text report is unchanged; it was already correct.
- Consumers keying on `drop__average` for power nets will see the value change (to the drop it was always named for); ground-net values are unaffected.