### PR TITLE
dpl: ensure site exists for one site gap check

### DIFF
--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -406,15 +406,15 @@ Node* Opendp::checkOneSiteGaps(Node& cell) const
           case Direction2D::South:
             return;
         }
-        // check the abutting pixel
         const Pixel* abut_pixel = grid_->gridPixel(x + abut_x, y);
-        const bool abuttment_exists = (abut_pixel && abut_pixel->cell);
-        if (!abuttment_exists) {
-          // check the 1 site gap pixel
-          const Pixel* gap_pixel = grid_->gridPixel(x + GridX{2 * abut_x.v}, y);
-          if (gap_pixel) {
-            gap_cell = gap_pixel->cell;
-          }
+        if (abut_pixel == nullptr || !abut_pixel->is_valid
+            || abut_pixel->cell) {
+          return;
+        }
+        // check the 1 site gap pixel
+        const Pixel* gap_pixel = grid_->gridPixel(x + GridX{2 * abut_x.v}, y);
+        if (gap_pixel) {
+          gap_cell = gap_pixel->cell;
         }
       });
   return gap_cell;

--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -406,15 +406,16 @@ Node* Opendp::checkOneSiteGaps(Node& cell) const
           case Direction2D::South:
             return;
         }
+        // check the abutting pixel
         const Pixel* abut_pixel = grid_->gridPixel(x + abut_x, y);
-        if (abut_pixel == nullptr || !abut_pixel->is_valid
-            || abut_pixel->cell) {
-          return;
-        }
-        // check the 1 site gap pixel
-        const Pixel* gap_pixel = grid_->gridPixel(x + GridX{2 * abut_x.v}, y);
-        if (gap_pixel) {
-          gap_cell = gap_pixel->cell;
+        const bool site_exists = (abut_pixel && abut_pixel->is_valid);
+        const bool abuttment_exists = (abut_pixel && abut_pixel->cell);
+        if (site_exists && !abuttment_exists) {
+          // check the 1 site gap pixel
+          const Pixel* gap_pixel = grid_->gridPixel(x + GridX{2 * abut_x.v}, y);
+          if (gap_pixel) {
+            gap_cell = gap_pixel->cell;
+          }
         }
       });
   return gap_cell;


### PR DESCRIPTION
## Summary
Only checking if `abut_pixel != nullptr` does not guarantee a site is present, it must also be a valid site. Include this check to avoid false positive one site gap check for a macro on a private design.

## Type of Change
- Bug fix

## Impact
no-op, fixes a corner case.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [ ] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Replaced PR https://github.com/The-OpenROAD-Project/OpenROAD/pull/11036, which would solve the issue by disregarding macros on one site gap. The present PR is better and more complete, making sure a site actually exists.
