### PR TITLE
psm: error early when a report writer has no solution, and skip unpowered nodes

### DIFF
--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -1348,6 +1348,20 @@ bool IRSolver::hasSolution(sta::Scene* corner) const
   return false;
 }
 
+void IRSolver::ensureSolution(sta::Scene* corner) const
+{
+  if (hasSolution(corner)) {
+    return;
+  }
+
+  logger_->error(utl::PSM,
+                 92,
+                 "No solution available for {} on corner {}. Run "
+                 "analyze_power_grid first.",
+                 net_->getName(),
+                 corner != nullptr ? corner->name() : "default");
+}
+
 IRSolver::Results IRSolver::getSolution(sta::Scene* corner) const
 {
   Results results;
@@ -1505,6 +1519,8 @@ void IRSolver::writeInstanceVoltageFile(const std::string& voltage_file,
     return;
   }
 
+  ensureSolution(corner);
+
   std::ofstream report(voltage_file);
   if (!report) {
     logger_->error(utl::PSM,
@@ -1545,6 +1561,8 @@ void IRSolver::writeEMFile(const std::string& em_file, sta::Scene* corner) const
     return;
   }
 
+  ensureSolution(corner);
+
   std::ofstream report(em_file);
   if (!report) {
     logger_->error(utl::PSM, 91, "Unable to open {} to write EM file", em_file);
@@ -1576,6 +1594,8 @@ void IRSolver::writeSpiceFile(GeneratedSourceType source_type,
                               sta::Scene* corner,
                               const std::string& voltage_source_file) const
 {
+  ensureSolution(corner);
+
   std::ofstream spice(spice_file);
   if (!spice.is_open()) {
     logger_->error(
@@ -1606,7 +1626,13 @@ void IRSolver::writeSpiceFile(GeneratedSourceType source_type,
   const auto& currents = currents_.at(corner);
   std::size_t current_number = 0;
   for (const auto& node : network_->getITermNodes()) {
-    const auto current = currents.at(node.get());
+    // The current map only holds nodes of instances that draw power, so an
+    // instance with none -- a filler, tap or decap -- has no entry at all.
+    const auto find_current = currents.find(node.get());
+    if (find_current == currents.end()) {
+      continue;
+    }
+    const auto current = find_current->second;
     if (std::abs(current) < kSpiceFileMinCurrent) {
       continue;
     }

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -1348,12 +1348,8 @@ bool IRSolver::hasSolution(sta::Scene* corner) const
   return false;
 }
 
-void IRSolver::ensureSolution(sta::Scene* corner) const
+void IRSolver::reportNoSolution(sta::Scene* corner) const
 {
-  if (hasSolution(corner)) {
-    return;
-  }
-
   logger_->error(utl::PSM,
                  92,
                  "No solution available for {} on corner {}. Run "
@@ -1519,7 +1515,9 @@ void IRSolver::writeInstanceVoltageFile(const std::string& voltage_file,
     return;
   }
 
-  ensureSolution(corner);
+  if (voltages_.find(corner) == voltages_.end()) {
+    reportNoSolution(corner);
+  }
 
   std::ofstream report(voltage_file);
   if (!report) {
@@ -1561,7 +1559,11 @@ void IRSolver::writeEMFile(const std::string& em_file, sta::Scene* corner) const
     return;
   }
 
-  ensureSolution(corner);
+  // generateCurrentMap() below derives per-connection current from the node
+  // voltages, so voltages are what this writer requires.
+  if (voltages_.find(corner) == voltages_.end()) {
+    reportNoSolution(corner);
+  }
 
   std::ofstream report(em_file);
   if (!report) {
@@ -1594,7 +1596,9 @@ void IRSolver::writeSpiceFile(GeneratedSourceType source_type,
                               sta::Scene* corner,
                               const std::string& voltage_source_file) const
 {
-  ensureSolution(corner);
+  if (currents_.find(corner) == currents_.end()) {
+    reportNoSolution(corner);
+  }
 
   std::ofstream spice(spice_file);
   if (!spice.is_open()) {

--- a/src/psm/src/ir_solver.h
+++ b/src/psm/src/ir_solver.h
@@ -110,6 +110,9 @@ class IRSolver
 
   std::vector<sta::Scene*> getCorners() const;
   bool hasSolution(sta::Scene* corner) const;
+  // Error out if no solution exists for this corner, so a report derived from one
+  // fails with a usable message instead of an out-of-range map lookup.
+  void ensureSolution(sta::Scene* corner) const;
   Voltage getNetVoltage(sta::Scene* corner) const;
   std::optional<Voltage> getVoltage(sta::Scene* corner, Node* node) const;
 

--- a/src/psm/src/ir_solver.h
+++ b/src/psm/src/ir_solver.h
@@ -110,8 +110,8 @@ class IRSolver
 
   std::vector<sta::Scene*> getCorners() const;
   bool hasSolution(sta::Scene* corner) const;
-  // Error out if no solution exists for this corner, so a report derived from one
-  // fails with a usable message instead of an out-of-range map lookup.
+  // Error out if no solution exists for this corner, so a report derived from
+  // one fails with a usable message instead of an out-of-range map lookup.
   void ensureSolution(sta::Scene* corner) const;
   Voltage getNetVoltage(sta::Scene* corner) const;
   std::optional<Voltage> getVoltage(sta::Scene* corner, Node* node) const;

--- a/src/psm/src/ir_solver.h
+++ b/src/psm/src/ir_solver.h
@@ -110,9 +110,12 @@ class IRSolver
 
   std::vector<sta::Scene*> getCorners() const;
   bool hasSolution(sta::Scene* corner) const;
-  // Error out if no solution exists for this corner, so a report derived from
-  // one fails with a usable message instead of an out-of-range map lookup.
-  void ensureSolution(sta::Scene* corner) const;
+  // Report that no solve has produced data for this corner, and stop, so a
+  // report derived from one fails with a usable message instead of an
+  // out-of-range map lookup. Each writer tests the map it actually reads
+  // rather than hasSolution(): a grid solved with no powered instances has
+  // voltages and an empty current map, and voltages are still reportable.
+  void reportNoSolution(sta::Scene* corner) const;
   Voltage getNetVoltage(sta::Scene* corner) const;
   std::optional<Voltage> getVoltage(sta::Scene* corner, Node* node) const;
 

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -42,6 +42,7 @@ COMPULSORY_TESTS = [
     "insert_decap_with_padding1",
     "missing_resistance",
     "pad_connected_by_abutment",
+    "report_writers_require_solution",
     "switch_top_grid",
     "top_grid_settings",
     "zerosoc_pads",

--- a/src/psm/test/CMakeLists.txt
+++ b/src/psm/test/CMakeLists.txt
@@ -35,6 +35,7 @@ or_integration_tests(
     insert_decap_with_padding1
     missing_resistance
     pad_connected_by_abutment
+    report_writers_require_solution
     switch_top_grid
     top_grid_settings
     zerosoc_pads

--- a/src/psm/test/report_writers_require_solution.ok
+++ b/src/psm/test/report_writers_require_solution.ok
@@ -1,0 +1,33 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 624 components and 2752 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 1248 connections.
+[INFO ODB-0133]     Created 581 nets and 1504 connections.
+[ERROR PSM-0092] No solution available for VDD on corner default. Run analyze_power_grid first.
+PSM-0092
+spice file written before analysis: 0
+[INFO PSM-0040] All shapes on net VDD are connected.
+[INFO PSM-0015] Reading location of sources from: Vsrc_gcd_vdd.loc.
+########## IR report #################
+Net              : VDD
+Corner           : default
+Total power      : 1.38e-04 W
+Supply voltage   : 1.10e+00 V
+Worstcase voltage: 1.10e+00 V
+Average voltage  : 1.10e+00 V
+Average IR drop  : 3.13e-04 V
+Worstcase IR drop: 5.04e-04 V
+Percentage drop  : 0.05 %
+######################################
+########## EM analysis ###############
+Net                : VDD
+Corner             : default
+Maximum current    : 8.10e-05 A
+Average current    : 1.20e-06 A
+Number of resistors: 2503
+######################################
+[INFO PSM-0015] Reading location of sources from: Vsrc_gcd_vdd.loc.
+spice file written after analysis: 1
+voltage file written: 1
+em file written: 1

--- a/src/psm/test/report_writers_require_solution.tcl
+++ b/src/psm/test/report_writers_require_solution.tcl
@@ -1,0 +1,30 @@
+# The report writers derive their output from a solution, so each must say so when
+# there isn't one -- and must say it before creating a file.
+#
+# write_pg_spice called on its own used to throw a bare `map::at` from inside the
+# solver, after having already written the resistive network. That left a
+# syntactically valid spice deck with no sources and no sinks: a floating network a
+# simulator will solve to nonsense rather than reject.
+source helpers.tcl
+
+read_lef Nangate45/Nangate45.lef
+read_def Nangate45_data/gcd.def
+read_liberty Nangate45/Nangate45_typ.lib
+read_sdc Nangate45_data/gcd.sdc
+
+set spice_file [make_result_file report_writers_require_solution.sp]
+set voltage_file [make_result_file report_writers_require_solution-voltage.rpt]
+set em_file [make_result_file report_writers_require_solution-em.rpt]
+
+catch { write_pg_spice -net VDD -vsrc Vsrc_gcd_vdd.loc $spice_file } err
+puts $err
+puts "spice file written before analysis: [file exists $spice_file]"
+
+# and once a solution exists, all three writers work
+analyze_power_grid -net VDD -vsrc Vsrc_gcd_vdd.loc \
+  -voltage_file $voltage_file -enable_em -em_outfile $em_file
+write_pg_spice -net VDD -vsrc Vsrc_gcd_vdd.loc $spice_file
+
+puts "spice file written after analysis: [file exists $spice_file]"
+puts "voltage file written: [file exists $voltage_file]"
+puts "em file written: [file exists $em_file]"


### PR DESCRIPTION
Fixes #11098, doing the three things @gadfort asked for.

## Error before the file is created

`writeSpiceFile`, `writeInstanceVoltageFile` and `writeEMFile` all reach into `currents_`/`voltages_` with `at()`, so calling one before a solution exists threw a bare `std::out_of_range` with nothing to act on. Each now calls a small `ensureSolution()` first — before opening its stream — reporting the net and corner and naming `analyze_power_grid`:

```
[ERROR PSM-0092] No solution available for VDD on corner default. Run analyze_power_grid first.
```

This matters most for `write_pg_spice`, which threw *after* writing the resistive network: it left a syntactically valid deck with no sources and no sinks — a floating network a simulator solves to nonsense rather than rejects.

## `find()` for the sparse current map

`writeSpiceFile` looked up **every** `ITermNode` in the per-node current map with `at()`. That map is sparse by construction — `generateCurrentMap()` inserts only nodes of instances returned by `getInstancePower()`, so a filler, tap or decap has no entry. `solve()` reads the same map with `find()` and a zero default (`ir_solver.cpp:932-937`), twenty lines of context away, so the sparse case was already handled correctly there. The lookup now matches, and skips a node with no current the way the neighbouring `kSpiceFileMinCurrent` guard already skips a negligible one.

## Test

`report_writers_require_solution` covers `write_pg_spice` before a solution exists — asserting the error *and* that no file is left behind — then `analyze_power_grid -voltage_file -enable_em -em_outfile` followed by `write_pg_spice`, so all three writers are exercised on the success path too.

## Two things worth flagging

**I could not run the suite locally**, so the `.ok` was composed rather than captured: the ODB banner from `missing_resistance.ok`, the report block from `gcd_em_test_vdd.ok`, and `write_pg_spice`'s own `PSM-0015` line from `gcd_write_sp_test_vdd.ok` — all on the same design and invocation. It should be exact, but please have CI confirm it rather than taking my word.

**The sparse-map path is not covered by this test, and I would rather say so than imply it is.** Nangate45's `FILLCELL_X1` has no pins and appears in no net, so gcd creates no unpowered `ITermNode` and `at()` never throws there — which is why `gcd_write_sp_test_vdd` passes today. Reproducing it needs a design whose unpowered instances connect to the power net, as sky130-style flows do via `( * VPWR )`; I hit it on a 72k-instance sky130 block where 57,142 of the instances carry no power. If you would like that covered, `sky130hd_data/gcd_sky130hd_floorplan.def` looks like the right existing fixture and I am happy to add it in a follow-up.