### PR TITLE
Revert "est: skip parasitic estimation for timing-irrelevant nets; key wire RC by tech"

### DIFF
--- a/src/est/include/est/EstimateParasitics.h
+++ b/src/est/include/est/EstimateParasitics.h
@@ -235,8 +235,8 @@ class EstimateParasitics : public sta::dbStaState, public ParasiticsService
   template <typename T>
   const std::vector<T>& resolveWireRC(std::vector<T> WireRC::*category) const;
   void ensureParasitics();
-  bool isSkipPin(const sta::Pin* pin) const;
-  bool isSkipNet(const sta::Net* net) const;
+  bool isIdealClockPin(const sta::Pin* pin) const;
+  bool isIdealClockNet(const sta::Net* net) const;
   void estimateWireParasiticSteiner(const sta::Pin* drvr_pin,
                                     const sta::Net* net,
                                     sta::SpefWriter* spef_writer);

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -34,7 +34,6 @@
 #include "sta/ArcDelayCalc.hh"
 #include "sta/Liberty.hh"
 #include "sta/MinMax.hh"
-#include "sta/Mode.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/Parasitics.hh"
@@ -498,7 +497,7 @@ void EstimateParasitics::updateParasitics()
   switch (parasitics_src_) {
     case ParasiticsSrc::kPlacement:
       for (const sta::Net* net : parasitics_invalid_) {
-        if (isSkipNet(net)) {
+        if (isIdealClockNet(net)) {
           continue;
         }
         //
@@ -527,7 +526,7 @@ void EstimateParasitics::updateParasitics()
       // TODO: update detailed route for modified nets
       incr_groute_->updateRoutes();
       for (const sta::Net* net : parasitics_invalid_) {
-        if (isSkipNet(net)) {
+        if (isIdealClockNet(net)) {
           continue;
         }
         debugPrint(logger_,
@@ -551,7 +550,7 @@ void EstimateParasitics::updateParasitics()
   // groute call.
   if (parasitics_src_ != ParasiticsSrc::kNone) {
     for (const sta::Net* net : parasitics_invalid_) {
-      if (isSkipNet(net)) {
+      if (isIdealClockNet(net)) {
         continue;
       }
       debugPrint(logger_,
@@ -808,131 +807,130 @@ void EstimateParasitics::estimateWireParasiticSteiner(
     const sta::Net* net,
     sta::SpefWriter* spef_writer)
 {
-  if (isSkipPin(drvr_pin)) {
-    return;
-  }
-  SteinerTree* tree = makeSteinerTree(drvr_pin);
-  if (tree) {
-    debugPrint(logger_,
-               EST,
-               "estimate_parasitics",
-               1,
-               "estimate wire {}",
-               sdc_network_->pathName(net));
-    for (sta::Scene* corner : sta_->scenes()) {
-      if (sta_->isIdealClock(drvr_pin, corner->mode())) {
-        continue;
-      }
-      std::set<const Pin*> connected_pins;
-      Parasitics* parasitics = corner->parasitics(max_);
-      Parasitic* parasitic = parasitics->makeParasiticNetwork(net, false);
-      bool is_clk = global_router_->isNonLeafClock(db_network_->staToDb(net));
-      double wire_cap = 0.0;
-      double wire_res = 0.0;
-      const int branch_count = tree->branchCount();
-      int max_node_index = tree->getMaxIndex();
-      size_t resistor_id = 1;
-      for (int i = 0; i < branch_count; i++) {
-        odb::Point pt1, pt2;
-        SteinerPt steiner_pt1, steiner_pt2;
-        int wire_length_dbu;
-        tree->branch(i, pt1, steiner_pt1, pt2, steiner_pt2, wire_length_dbu);
-        if (wire_length_dbu) {
-          double dx = dbuToMeters(abs(pt1.x() - pt2.x()))
-                      / dbuToMeters(wire_length_dbu);
-          double dy = dbuToMeters(abs(pt1.y() - pt2.y()))
-                      / dbuToMeters(wire_length_dbu);
+  if (!isIdealClockPin(drvr_pin)) {
+    SteinerTree* tree = makeSteinerTree(drvr_pin);
+    if (tree) {
+      debugPrint(logger_,
+                 EST,
+                 "estimate_parasitics",
+                 1,
+                 "estimate wire {}",
+                 sdc_network_->pathName(net));
+      for (sta::Scene* corner : sta_->scenes()) {
+        if (sta_->isIdealClock(drvr_pin, corner->mode())) {
+          continue;
+        }
+        std::set<const Pin*> connected_pins;
+        Parasitics* parasitics = corner->parasitics(max_);
+        Parasitic* parasitic = parasitics->makeParasiticNetwork(net, false);
+        bool is_clk = global_router_->isNonLeafClock(db_network_->staToDb(net));
+        double wire_cap = 0.0;
+        double wire_res = 0.0;
+        const int branch_count = tree->branchCount();
+        int max_node_index = tree->getMaxIndex();
+        size_t resistor_id = 1;
+        for (int i = 0; i < branch_count; i++) {
+          odb::Point pt1, pt2;
+          SteinerPt steiner_pt1, steiner_pt2;
+          int wire_length_dbu;
+          tree->branch(i, pt1, steiner_pt1, pt2, steiner_pt2, wire_length_dbu);
+          if (wire_length_dbu) {
+            double dx = dbuToMeters(abs(pt1.x() - pt2.x()))
+                        / dbuToMeters(wire_length_dbu);
+            double dy = dbuToMeters(abs(pt1.y() - pt2.y()))
+                        / dbuToMeters(wire_length_dbu);
 
-          if (is_clk) {
-            wire_cap = dx * wireClkHCapacitance(corner)
-                       + dy * wireClkVCapacitance(corner);
-            wire_res = dx * wireClkHResistance(corner)
-                       + dy * wireClkVResistance(corner);
+            if (is_clk) {
+              wire_cap = dx * wireClkHCapacitance(corner)
+                         + dy * wireClkVCapacitance(corner);
+              wire_res = dx * wireClkHResistance(corner)
+                         + dy * wireClkVResistance(corner);
+            } else {
+              wire_cap = dx * wireSignalHCapacitance(corner)
+                         + dy * wireSignalVCapacitance(corner);
+              wire_res = dx * wireSignalHResistance(corner)
+                         + dy * wireSignalVResistance(corner);
+            }
           } else {
-            wire_cap = dx * wireSignalHCapacitance(corner)
-                       + dy * wireSignalVCapacitance(corner);
-            wire_res = dx * wireSignalHResistance(corner)
-                       + dy * wireSignalVResistance(corner);
+            wire_cap = is_clk ? wireClkCapacitance(corner)
+                              : wireSignalCapacitance(corner);
+            wire_res = is_clk ? wireClkResistance(corner)
+                              : wireSignalResistance(corner);
           }
-        } else {
-          wire_cap = is_clk ? wireClkCapacitance(corner)
-                            : wireSignalCapacitance(corner);
-          wire_res = is_clk ? wireClkResistance(corner)
-                            : wireSignalResistance(corner);
-        }
-        sta::ParasiticNode* n1 = parasitics->ensureParasiticNode(
-            parasitic, net, steiner_pt1, network_);
-        sta::ParasiticNode* n2 = parasitics->ensureParasiticNode(
-            parasitic, net, steiner_pt2, network_);
-        if (wire_length_dbu == 0) {
-          // Use a small resistor to keep the connectivity intact.
-          parasitics->makeResistor(parasitic, resistor_id++, 1.0e-3, n1, n2);
-        } else {
-          double length = dbuToMeters(wire_length_dbu);
-          double cap = length * wire_cap;
-          double res = length * wire_res;
+          sta::ParasiticNode* n1 = parasitics->ensureParasiticNode(
+              parasitic, net, steiner_pt1, network_);
+          sta::ParasiticNode* n2 = parasitics->ensureParasiticNode(
+              parasitic, net, steiner_pt2, network_);
+          if (wire_length_dbu == 0) {
+            // Use a small resistor to keep the connectivity intact.
+            parasitics->makeResistor(parasitic, resistor_id++, 1.0e-3, n1, n2);
+          } else {
+            double length = dbuToMeters(wire_length_dbu);
+            double cap = length * wire_cap;
+            double res = length * wire_res;
 
-          // Reduce resistance if the net has NDR with increased width
-          odb::dbTechNonDefaultRule* ndr
-              = db_network_->staToDb(net)->getNonDefaultRule();
-          if (ndr) {
-            std::vector<odb::dbTechLayerRule*> layer_rules;
-            ndr->getLayerRules(layer_rules);
-            float ratio = (float) layer_rules.at(0)->getWidth()
-                          / layer_rules.at(0)->getLayer()->getWidth();
-            res /= ratio;
+            // Reduce resistance if the net has NDR with increased width
+            odb::dbTechNonDefaultRule* ndr
+                = db_network_->staToDb(net)->getNonDefaultRule();
+            if (ndr) {
+              std::vector<odb::dbTechLayerRule*> layer_rules;
+              ndr->getLayerRules(layer_rules);
+              float ratio = (float) layer_rules.at(0)->getWidth()
+                            / layer_rules.at(0)->getLayer()->getWidth();
+              res /= ratio;
+            }
+
+            // Make pi model for the wire.
+            debugPrint(logger_,
+                       EST,
+                       "estimate_parasitics",
+                       2,
+                       " pi {} l={} c2={} rpi={} c1={} {}",
+                       parasitics->name(n1),
+                       units_->distanceUnit()->asString(length),
+                       units_->capacitanceUnit()->asString(cap / 2.0),
+                       units_->resistanceUnit()->asString(res),
+                       units_->capacitanceUnit()->asString(cap / 2.0),
+                       parasitics->name(n2));
+            parasitics->incrCap(n1, cap / 2.0);
+            parasitics->makeResistor(parasitic, resistor_id++, res, n1, n2);
+            parasitics->incrCap(n2, cap / 2.0);
           }
-
-          // Make pi model for the wire.
-          debugPrint(logger_,
-                     EST,
-                     "estimate_parasitics",
-                     2,
-                     " pi {} l={} c2={} rpi={} c1={} {}",
-                     parasitics->name(n1),
-                     units_->distanceUnit()->asString(length),
-                     units_->capacitanceUnit()->asString(cap / 2.0),
-                     units_->resistanceUnit()->asString(res),
-                     units_->capacitanceUnit()->asString(cap / 2.0),
-                     parasitics->name(n2));
-          parasitics->incrCap(n1, cap / 2.0);
-          parasitics->makeResistor(parasitic, resistor_id++, res, n1, n2);
-          parasitics->incrCap(n2, cap / 2.0);
+          parasiticNodeConnectPins(parasitics,
+                                   parasitic,
+                                   n1,
+                                   tree,
+                                   steiner_pt1,
+                                   resistor_id,
+                                   corner,
+                                   connected_pins,
+                                   net,
+                                   max_node_index,
+                                   is_clk);
+          parasiticNodeConnectPins(parasitics,
+                                   parasitic,
+                                   n2,
+                                   tree,
+                                   steiner_pt2,
+                                   resistor_id,
+                                   corner,
+                                   connected_pins,
+                                   net,
+                                   max_node_index,
+                                   is_clk);
         }
-        parasiticNodeConnectPins(parasitics,
-                                 parasitic,
-                                 n1,
-                                 tree,
-                                 steiner_pt1,
-                                 resistor_id,
-                                 corner,
-                                 connected_pins,
-                                 net,
-                                 max_node_index,
-                                 is_clk);
-        parasiticNodeConnectPins(parasitics,
-                                 parasitic,
-                                 n2,
-                                 tree,
-                                 steiner_pt2,
-                                 resistor_id,
-                                 corner,
-                                 connected_pins,
-                                 net,
-                                 max_node_index,
-                                 is_clk);
-      }
-      if (spef_writer) {
-        spef_writer->writeNet(corner, net, parasitic, parasitics);
-      }
+        if (spef_writer) {
+          spef_writer->writeNet(corner, net, parasitic, parasitics);
+        }
 
-      if (arc_delay_calc_->reduceSupported()) {
-        arc_delay_calc_->reduceParasitic(
-            parasitic, net, corner, sta::MinMaxAll::all());
-        parasitics->deleteParasiticNetwork(net);
+        if (arc_delay_calc_->reduceSupported()) {
+          arc_delay_calc_->reduceParasitic(
+              parasitic, net, corner, sta::MinMaxAll::all());
+          parasitics->deleteParasiticNetwork(net);
+        }
       }
+      delete tree;
     }
-    delete tree;
   }
 }
 
@@ -1232,50 +1230,27 @@ bool EstimateParasitics::isPad(const sta::Instance* inst) const
   return false;
 }
 
-bool EstimateParasitics::isSkipPin(const sta::Pin* pin) const
+bool EstimateParasitics::isIdealClockPin(const sta::Pin* pin) const
 {
-  // A pin can be skipped when its parasitics never affect timing in any mode.
-  // The clock reason spans modes: a pin is an ideal clock if it is a clock in
-  // at least one mode and ideal in every mode where it is a clock (non-clock
-  // modes are ignored, e.g. a scan clock absent from function mode). The
-  // remaining reasons are combined per mode: a pin is skippable when it is
-  // timing-irrelevant in every mode, even if the reason differs across modes
-  // (e.g. constant in one mode and disabled in another).
+  // An ideal clock pin carries fixed arrivals that do not depend on
+  // parasitics, so its parasitics never need re-estimation.
   bool is_clock = false;
-  bool ideal_clock = true;
-  bool irrelevant_in_all_modes = true;
   for (sta::Mode* mode : sta_->modes()) {
     // In multi-mode designs, a pin may be an ideal clock only in a subset of
     // modes. Ignore modes where the pin is not a clock at all.
     // e.g., scan clock pin may not be defined as clock in function mode.
-    if (sta_->isClock(pin, mode)) {
-      is_clock = true;
-      if (!sta_->isIdealClock(pin, mode)) {
-        ideal_clock = false;
-      }
+    if (!sta_->isClock(pin, mode)) {
+      continue;
     }
-    // A constant or disabled pin carries no parasitic-dependent timing in this
-    // mode.
-    if (!sta_->isConstant(pin, mode)
-        && !mode->sdc()->isDisabledConstraint(pin)) {
-      irrelevant_in_all_modes = false;
+    is_clock = true;
+    if (!sta_->isIdealClock(pin, mode)) {
+      return false;
     }
   }
-
-  // An ideal clock pin carries fixed arrivals that do not depend on parasitics.
-  if (is_clock && ideal_clock) {
-    return true;
-  }
-
-  // The pin is constant or disabled in every mode.
-  if (irrelevant_in_all_modes) {
-    return true;
-  }
-
-  return false;
+  return is_clock;
 }
 
-bool EstimateParasitics::isSkipNet(const sta::Net* net) const
+bool EstimateParasitics::isIdealClockNet(const sta::Net* net) const
 {
   odb::dbNet* db_net = db_network_->staToDb(net);
   if (db_net == nullptr) {
@@ -1288,7 +1263,7 @@ bool EstimateParasitics::isSkipNet(const sta::Net* net) const
   }
 
   const Pin* drvr_pin = *drivers->begin();
-  return isSkipPin(drvr_pin);
+  return isIdealClockPin(drvr_pin);
 }
 
 void EstimateParasitics::parasiticsInvalid(const sta::Net* net)

--- a/src/est/test/cpp/TestEstimateParasitics.cc
+++ b/src/est/test/cpp/TestEstimateParasitics.cc
@@ -7,15 +7,11 @@
 #include "odb/db.h"
 #include "rsz/Resizer.hh"
 #include "sta/Liberty.hh"
-#include "sta/MinMax.hh"
 #include "sta/Mode.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
-#include "sta/Parasitics.hh"
-#include "sta/Scene.hh"
 #include "sta/SdcClass.hh"
 #include "sta/Search.hh"
-#include "sta/Transition.hh"
 #include "sta/Units.hh"
 #include "tst/IntegratedFixture.h"
 
@@ -100,171 +96,7 @@ class TestEstimateParasitics : public tst::IntegratedFixture
     ASSERT_NE(dff_x2, nullptr);
     ASSERT_TRUE(resizer_.replaceCell(inst, dff_x2));
   }
-
-  // Give every instance and top port a legal location so that
-  // estimateWireParasitics() can build Steiner trees (it skips unplaced nets).
-  void placeDesign()
-  {
-    odb::dbTechLayer* layer = block_->getTech()->findRoutingLayer(1);
-    ASSERT_NE(layer, nullptr);
-
-    int x = 100;
-    for (odb::dbInst* inst : block_->getInsts()) {
-      inst->setLocation(x, x);
-      inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
-      x += 100;
-    }
-
-    int y = 50;
-    for (odb::dbBTerm* bterm : block_->getBTerms()) {
-      odb::dbBPin* bpin = odb::dbBPin::create(bterm);
-      odb::dbBox::create(bpin, layer, y, y, y + 10, y + 10);
-      bpin->setPlacementStatus(odb::dbPlacementStatus::PLACED);
-      y += 100;
-    }
-  }
-
-  // True if the net's driver has a reduced (pi-Elmore) parasitic, i.e. wire
-  // parasitics were actually estimated for it.
-  bool hasPi(sta::Net* net) const
-  {
-    sta::PinSet* drivers = db_network_->drivers(net);
-    if (drivers == nullptr || drivers->empty()) {
-      return false;
-    }
-    const sta::Pin* drvr = *drivers->begin();
-    sta::Parasitics* par
-        = sta_->scenes().front()->parasitics(sta::MinMax::max());
-    return par->findPiElmore(drvr, sta::RiseFall::rise(), sta::MinMax::max())
-           != nullptr;
-  }
 };
-
-// Verifies that a net whose driver pin is held at a logic constant is skipped
-// by updateParasitics(): its wire parasitics are not re-estimated, while an
-// ordinary net in the same invalidation set is. A pin that is constant in every
-// mode carries no parasitic-dependent timing.
-TEST_F(TestEstimateParasitics, ConstantNetSkipsParasiticEstimation)
-{
-  readVerilogAndSetup("TestEstimateParasitics.v");
-  placeDesign();
-  ep_.estimateWireParasitics();
-
-  // Hold the top data port at a constant in the only mode.
-  sta::Pin* d_pin = findTopPin("d");
-  ASSERT_NE(d_pin, nullptr);
-  sta_->setCaseAnalysis(d_pin, sta::LogicValue::zero, sta_->cmdMode());
-  ASSERT_TRUE(sta_->isConstant(d_pin, sta_->cmdMode()));
-
-  sta::Net* d_net = flatNet(d_pin);
-  sta::Net* q0_net = flatNet(findTopPin("q0"));
-  ASSERT_NE(d_net, nullptr);
-  ASSERT_NE(q0_net, nullptr);
-
-  // Start from a clean slate so re-estimation is observable per net.
-  sta_->scenes().front()->parasitics(sta::MinMax::max())->deleteParasitics();
-  ASSERT_FALSE(hasPi(d_net));
-  ASSERT_FALSE(hasPi(q0_net));
-
-  ep_.setParasiticsSrc(ParasiticsSrc::kPlacement);
-  ep_.setIncrementalParasiticsEnabled(true);
-  ep_.parasiticsInvalid(d_net);
-  ep_.parasiticsInvalid(q0_net);
-  ep_.updateParasitics();
-
-  // The ordinary net is re-estimated; the constant net is skipped.
-  EXPECT_TRUE(hasPi(q0_net));
-  EXPECT_FALSE(hasPi(d_net));
-  ep_.setIncrementalParasiticsEnabled(false);
-}
-
-// Verifies that a net whose driver pin has a set_disable_timing constraint is
-// skipped by updateParasitics(): its wire parasitics are not re-estimated,
-// while an ordinary net in the same invalidation set is.
-TEST_F(TestEstimateParasitics, DisabledConstraintNetSkipsParasiticEstimation)
-{
-  readVerilogAndSetup("TestEstimateParasitics.v");
-  placeDesign();
-  ep_.estimateWireParasitics();
-
-  // Disable timing on the top data port so its net is a skip candidate.
-  sta::Pin* d_pin = findTopPin("d");
-  ASSERT_NE(d_pin, nullptr);
-  sta_->disable(d_pin, sta_->cmdSdc());
-
-  sta::Net* d_net = flatNet(d_pin);
-  sta::Net* q0_net = flatNet(findTopPin("q0"));
-  ASSERT_NE(d_net, nullptr);
-  ASSERT_NE(q0_net, nullptr);
-
-  // Start from a clean slate so re-estimation is observable per net.
-  sta_->scenes().front()->parasitics(sta::MinMax::max())->deleteParasitics();
-  ASSERT_FALSE(hasPi(d_net));
-  ASSERT_FALSE(hasPi(q0_net));
-
-  ep_.setParasiticsSrc(ParasiticsSrc::kPlacement);
-  ep_.setIncrementalParasiticsEnabled(true);
-  ep_.parasiticsInvalid(d_net);
-  ep_.parasiticsInvalid(q0_net);
-  ep_.updateParasitics();
-
-  // The ordinary net is re-estimated; the disabled net is skipped.
-  EXPECT_TRUE(hasPi(q0_net));
-  EXPECT_FALSE(hasPi(d_net));
-  ep_.setIncrementalParasiticsEnabled(false);
-}
-
-// Verifies that skippability is combined per mode: a pin that is timing
-// irrelevant in every mode is skipped even when the reason differs across
-// modes. Here d is constant in function mode and disabled in test mode; it is
-// irrelevant in both, so its net must be skipped. A per-reason (all_constant ||
-// all_disabled) check would wrongly re-estimate it.
-TEST_F(TestEstimateParasitics, MixedConstantDisabledNetSkipsParasiticEstimation)
-{
-  readVerilogAndSetup("TestEstimateParasitics.v", false);
-
-  // Two modes: d is constant only in function mode, disabled only in test mode.
-  sta_->setCmdMode("function");
-  sta::Mode* function_mode = sta_->cmdMode();
-  sta_->setCmdMode("test");
-  sta::Mode* test_mode = sta_->cmdMode();
-
-  // Build the graph before adding constraints: disable() invalidates delays
-  // through the delay calculator, which requires an existing graph.
-  sta_->ensureGraph();
-  sta_->ensureLevelized();
-  resizer_.initBlock();
-  placeDesign();
-
-  sta::Pin* d_pin = findTopPin("d");
-  ASSERT_NE(d_pin, nullptr);
-  sta_->setCaseAnalysis(d_pin, sta::LogicValue::zero, function_mode);
-  sta_->disable(d_pin, test_mode->sdc());
-  ep_.estimateWireParasitics();
-  ASSERT_TRUE(sta_->isConstant(d_pin, function_mode));
-  ASSERT_FALSE(sta_->isConstant(d_pin, test_mode));
-
-  sta::Net* d_net = flatNet(d_pin);
-  sta::Net* q0_net = flatNet(findTopPin("q0"));
-  ASSERT_NE(d_net, nullptr);
-  ASSERT_NE(q0_net, nullptr);
-
-  // Start from a clean slate so re-estimation is observable per net.
-  sta_->scenes().front()->parasitics(sta::MinMax::max())->deleteParasitics();
-  ASSERT_FALSE(hasPi(d_net));
-  ASSERT_FALSE(hasPi(q0_net));
-
-  ep_.setParasiticsSrc(ParasiticsSrc::kPlacement);
-  ep_.setIncrementalParasiticsEnabled(true);
-  ep_.parasiticsInvalid(d_net);
-  ep_.parasiticsInvalid(q0_net);
-  ep_.updateParasitics();
-
-  // The ordinary net is re-estimated; the mixed-reason net is skipped.
-  EXPECT_TRUE(hasPi(q0_net));
-  EXPECT_FALSE(hasPi(d_net));
-  ep_.setIncrementalParasiticsEnabled(false);
-}
 
 // Verifies that an ideal clock net can be present in the incremental
 // parasitic invalidation set without forcing STA delay invalidation.


### PR DESCRIPTION
Temporary until an STA bug can be resolved (constant net slews are being propagated in slew merging).