### PR TITLE
Fix integer truncation bug in RepairDesign::repairNetWire

### DIFF
--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -1614,7 +1614,7 @@ void RepairDesign::repairNetWire(
       // the new repeater's input pin cap does not shrink the load the
       // driver sees). Two such iterations in a row terminate the loop.
       const double prev_ref_cap = ref_cap;
-      const bool zero_advance = (buf_dist <= 0.0);
+      const bool zero_advance = (buf_dist < 1.0);
       double dx = from_x - to_x;
       double dy = from_y - to_y;
       double d = (length == 0) ? 0.0 : buf_dist / length;


### PR DESCRIPTION
When buf_dist evaluates to a fractional value strictly between 0.0 and 1.0 (in DBU), integer truncation causes length -= buf_dist to remain unchanged. Previously, the zero_advance detection only caught buf_dist <= 0.0. This fix broadens the condition to buf_dist < 1.0 to correctly detect lack of progress caused by integer truncation, preventing an infinite loop and subsequent stack overflow.

Signed-off-by: oyvind.harboe@zylin.com