### PR TITLE
gpl: add separate Bazel targets for long-running regression tests

### DIFF
--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -102,7 +102,7 @@ filegroup(
         ["**/*"],
         exclude = [
             test + "." + ext
-            for test in TESTS
+            for test in ALL_TESTS + LARGE_TESTS
             for ext in [
                 "tcl",
                 "py",

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -55,6 +55,23 @@ PASSFAIL_TESTS = [
     "incremental02",
 ]
 
+# Longer-running regression tests (see regression_tests_large.tcl). These are
+# tagged "manual" so they are excluded from the default `bazel test //...`
+# wildcard and must be requested explicitly, e.g. via the :large_tests suite.
+LARGE_TESTS = [
+    "macro01",
+    "macro02",
+    "macro03",
+    "medium01",
+    "medium02",
+    "medium03",
+    "medium04",
+    "medium05",
+    "medium06",
+    "large01",
+    "large02",
+]
+
 ALL_TESTS = TESTS + PASSFAIL_TESTS
 
 py_library(
@@ -100,6 +117,21 @@ filegroup(
     check_passfail = True if test_name in PASSFAIL_TESTS else False,
     data = [":test_resources"],
 ) for test_name in ALL_TESTS]
+
+[regression_test(
+    name = test_name,
+    size = "enormous",
+    data = [":test_resources"],
+    tags = ["manual"],
+) for test_name in LARGE_TESTS]
+
+# Convenience suite to run all long-running tests explicitly:
+#   bazel test //src/gpl/test:large_tests
+test_suite(
+    name = "large_tests",
+    tags = ["manual"],
+    tests = [":" + test_name + "-tcl_test" for test_name in LARGE_TESTS],
+)
 
 PY_TESTS = [
     "ar01",

--- a/src/gpl/test/large01.ok
+++ b/src/gpl/test/large01.ok
@@ -12,6 +12,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 939.170 936.600 ) um
+[INFO GPL-0016] Core area:                  879626.622 um^2
 [INFO GPL-0036] Movable instances area:     524710.802 um^2
 [INFO GPL-0037] Total instances area:       524710.802 um^2
 [INFO GPL-0035] Pin density area adjust:     55011.532 um^2
@@ -22,9 +23,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                 290354
 [INFO GPL-0011] Number of pins:                1022106
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 939.170 936.600 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 939.170 936.600 ) um
-[INFO GPL-0016] Core area:                  879626.622 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 939.170 936.600 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 939.170 936.600 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                879626.622 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/large02.ok
+++ b/src/gpl/test/large02.ok
@@ -15,6 +15,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 1136.200 1135.400 ) um
+[INFO GPL-0016] Core area:                  1290041.480 um^2
 [INFO GPL-0036] Movable instances area:     755282.794 um^2
 [INFO GPL-0037] Total instances area:       755282.794 um^2
 [INFO GPL-0035] Pin density area adjust:     65202.937 um^2
@@ -25,9 +26,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                 406912
 [INFO GPL-0011] Number of pins:                1400119
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1136.200 1135.400 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 1136.200 1135.400 ) um
-[INFO GPL-0016] Core area:                  1290041.480 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1136.200 1135.400 ) um
+[INFO GPL-0013] Placement BBox: (  0.000  0.000 ) ( 1136.200 1135.400 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                1290041.480 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/macro01.ok
+++ b/src/gpl/test/macro01.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
+[INFO GPL-0016] Core area:                  2022140.512 um^2
 [INFO GPL-0036] Movable instances area:     237553.162 um^2
 [INFO GPL-0037] Total instances area:       237553.162 um^2
 [INFO GPL-0035] Pin density area adjust:     10192.638 um^2
@@ -18,9 +19,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  86445
 [INFO GPL-0011] Number of pins:                 254533
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1550.020 1342.600 ) um
-[INFO GPL-0013] Core BBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
-[INFO GPL-0016] Core area:                  2022140.512 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1550.020 1342.600 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                2022140.512 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/macro02.ok
+++ b/src/gpl/test/macro02.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070  9.800 ) ( 989.900 789.600 ) um
+[INFO GPL-0016] Core area:                  764071.434 um^2
 [INFO GPL-0036] Movable instances area:     195764.030 um^2
 [INFO GPL-0037] Total instances area:       195764.030 um^2
 [INFO GPL-0035] Pin density area adjust:      5417.603 um^2
@@ -18,9 +19,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  51437
 [INFO GPL-0011] Number of pins:                 151266
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 999.970 799.400 ) um
-[INFO GPL-0013] Core BBox: ( 10.070  9.800 ) ( 989.900 789.600 ) um
-[INFO GPL-0016] Core area:                  764071.434 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 999.970 799.400 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070  9.800 ) ( 989.900 789.600 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                764071.434 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/macro03.ok
+++ b/src/gpl/test/macro03.ok
@@ -10,6 +10,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
+[INFO GPL-0016] Core area:                  2022140.512 um^2
 [INFO GPL-0036] Movable instances area:     528230.514 um^2
 [INFO GPL-0037] Total instances area:       528230.514 um^2
 [INFO GPL-0035] Pin density area adjust:     20095.625 um^2
@@ -20,9 +21,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                 143973
 [INFO GPL-0011] Number of pins:                 463771
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1550.020 1342.600 ) um
-[INFO GPL-0013] Core BBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
-[INFO GPL-0016] Core area:                  2022140.512 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1550.020 1342.600 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                2022140.512 um^2
 [INFO GPL-0017] Fixed instances area:            0.000 um^2

--- a/src/gpl/test/medium01.ok
+++ b/src/gpl/test/medium01.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070 11.200 ) ( 440.230 439.600 ) um
+[INFO GPL-0016] Core area:                  184280.544 um^2
 [INFO GPL-0036] Movable instances area:      29267.448 um^2
 [INFO GPL-0037] Total instances area:        29553.132 um^2
 [INFO GPL-0035] Pin density area adjust:      1876.602 um^2
@@ -18,9 +19,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  19320
 [INFO GPL-0011] Number of pins:                  54012
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 450.170 450.000 ) um
-[INFO GPL-0013] Core BBox: ( 10.070 11.200 ) ( 440.230 439.600 ) um
-[INFO GPL-0016] Core area:                  184280.544 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 450.170 450.000 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070 11.200 ) ( 440.230 439.600 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                184280.544 um^2
 [INFO GPL-0017] Fixed instances area:          285.684 um^2

--- a/src/gpl/test/medium02.ok
+++ b/src/gpl/test/medium02.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070 11.200 ) ( 589.950 589.400 ) um
+[INFO GPL-0016] Core area:                  335286.616 um^2
 [INFO GPL-0036] Movable instances area:      56546.014 um^2
 [INFO GPL-0037] Total instances area:        56986.510 um^2
 [INFO GPL-0035] Pin density area adjust:      4805.857 um^2
@@ -18,9 +19,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  39218
 [INFO GPL-0011] Number of pins:                 118496
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 600.080 599.800 ) um
-[INFO GPL-0013] Core BBox: ( 10.070 11.200 ) ( 589.950 589.400 ) um
-[INFO GPL-0016] Core area:                  335286.616 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 600.080 599.800 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070 11.200 ) ( 589.950 589.400 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                335286.616 um^2
 [INFO GPL-0017] Fixed instances area:          440.496 um^2

--- a/src/gpl/test/medium03.ok
+++ b/src/gpl/test/medium03.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070  9.800 ) ( 1189.970 1190.000 ) um
+[INFO GPL-0016] Core area:                  1392517.980 um^2
 [INFO GPL-0036] Movable instances area:     128253.230 um^2
 [INFO GPL-0037] Total instances area:       129713.304 um^2
 [INFO GPL-0035] Pin density area adjust:      8802.450 um^2
@@ -18,9 +19,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  98214
 [INFO GPL-0011] Number of pins:                 283188
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1200.040 1199.800 ) um
-[INFO GPL-0013] Core BBox: ( 10.070  9.800 ) ( 1189.970 1190.000 ) um
-[INFO GPL-0016] Core area:                  1392517.980 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1200.040 1199.800 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070  9.800 ) ( 1189.970 1190.000 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                1392517.980 um^2
 [INFO GPL-0017] Fixed instances area:         1460.074 um^2

--- a/src/gpl/test/medium04.ok
+++ b/src/gpl/test/medium04.ok
@@ -10,6 +10,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
+[INFO GPL-0016] Core area:                  2022140.512 um^2
 [INFO GPL-0036] Movable instances area:     200167.660 um^2
 [INFO GPL-0037] Total instances area:       202179.684 um^2
 [INFO GPL-0035] Pin density area adjust:     20514.791 um^2
@@ -20,9 +21,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                 139550
 [INFO GPL-0011] Number of pins:                 449016
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1550.020 1342.600 ) um
-[INFO GPL-0013] Core BBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
-[INFO GPL-0016] Core area:                  2022140.512 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 1550.020 1342.600 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070 11.200 ) ( 1540.140 1332.800 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                2022140.512 um^2
 [INFO GPL-0017] Fixed instances area:         2012.024 um^2

--- a/src/gpl/test/medium05.ok
+++ b/src/gpl/test/medium05.ok
@@ -9,6 +9,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070  9.800 ) ( 914.850 789.600 ) um
+[INFO GPL-0016] Core area:                  705547.444 um^2
 [INFO GPL-0036] Movable instances area:      60979.170 um^2
 [INFO GPL-0037] Total instances area:        63998.802 um^2
 [INFO GPL-0035] Pin density area adjust:      4610.158 um^2
@@ -19,9 +20,8 @@
 [INFO GPL-0009] Dummy instances:                   168
 [INFO GPL-0010] Number of nets:                  43429
 [INFO GPL-0011] Number of pins:                 128113
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 924.920 799.400 ) um
-[INFO GPL-0013] Core BBox: ( 10.070  9.800 ) ( 914.850 789.600 ) um
-[INFO GPL-0016] Core area:                  705547.444 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 924.920 799.400 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070  9.800 ) ( 914.850 789.600 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                705547.444 um^2
 [INFO GPL-0017] Fixed instances area:         3738.896 um^2

--- a/src/gpl/test/medium06.ok
+++ b/src/gpl/test/medium06.ok
@@ -8,6 +8,7 @@
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: ( 10.070 11.200 ) ( 610.090 610.400 ) um
+[INFO GPL-0016] Core area:                  359531.984 um^2
 [INFO GPL-0036] Movable instances area:      25503.814 um^2
 [INFO GPL-0037] Total instances area:        25960.270 um^2
 [INFO GPL-0035] Pin density area adjust:      2922.998 um^2
@@ -18,9 +19,8 @@
 [INFO GPL-0009] Dummy instances:                     0
 [INFO GPL-0010] Number of nets:                  18575
 [INFO GPL-0011] Number of pins:                  61936
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 620.150 620.600 ) um
-[INFO GPL-0013] Core BBox: ( 10.070 11.200 ) ( 610.090 610.400 ) um
-[INFO GPL-0016] Core area:                  359531.984 um^2
+[INFO GPL-0012] Die BBox:       (  0.000  0.000 ) ( 620.150 620.600 ) um
+[INFO GPL-0013] Placement BBox: ( 10.070 11.200 ) ( 610.090 610.400 ) um
 [INFO GPL-0014] Region name: top-level.
 [INFO GPL-0015] Region area:                359531.984 um^2
 [INFO GPL-0017] Fixed instances area:          456.456 um^2


### PR DESCRIPTION
### Summary
Registers the tests from `src/gpl/test/regression_tests_large.tcl` (`macro01-03`, `medium01-06`, `large01-02`) as Bazel `regression_test` targets. Previously these long-running tests were only wired into the legacy CTest/shell harness (`regression-large`) and had no Bazel targets.

### Details
- New `LARGE_TESTS` list in `src/gpl/test/BUILD`, registered via the existing `regression_test` macro with `size = "enormous"`.
- Tagged `manual` so they are **excluded** from the default `bazel test //...` wildcard and must be requested explicitly.
- Added a `:large_tests` `test_suite` for convenience.
- Updated the stale golden `.ok` files to match current GPL log output (message reordering/relabeling, e.g. `Core BBox` -> `Placement BBox`).

### Test
```
bazel test //src/gpl/test:large_tests
```