### PR TITLE
grt: use boolean grid map for fast congestion nets lookup

### DIFF
--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -369,10 +369,6 @@ class FastRouteCore
   int getOverflow2D(int* maxOverflow);
   int getOverflow2Dmaze(int* maxOverflow, int* tUsage);
   int getOverflow3D();
-  void findNetsNearPosition(odb::PtrSet<odb::dbNet>& congestion_nets,
-                            const odb::Point& position,
-                            bool is_horizontal,
-                            int& radius);
   void SaveLastRouteLen();
   void checkAndFixEmbeddedTree(int net_id);
   bool areEdgesOverlapping(int net_id,

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -2110,7 +2110,9 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
 
   // The radius around the congested zone is increased when no new nets are
   // obtained
-  for (int radius = 0; radius < 5 && old_size == congestion_nets.size();
+  static constexpr int kMaxSearchRadius = 5;
+  for (int radius = 0;
+       radius < kMaxSearchRadius && old_size == congestion_nets.size();
        radius++) {
     std::fill(congested_h.begin(), congested_h.end(), 0);
     std::fill(congested_v.begin(), congested_v.end(), 0);
@@ -2149,7 +2151,7 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
         const std::vector<GPoint3D>& grids = treeedge->route.grids;
         const int routeLen = treeedge->route.routelen;
 
-        if (routeLen <= 0 || grids.size() < static_cast<size_t>(routeLen + 1)) {
+        if (routeLen <= 0 || grids.size() <= static_cast<size_t>(routeLen)) {
           continue;
         }
 

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -1990,51 +1990,6 @@ void FastRouteCore::getCongestionGrid(
   }
 }
 
-void FastRouteCore::findNetsNearPosition(
-    odb::PtrSet<odb::dbNet>& congestion_nets,
-    const odb::Point& position,
-    bool is_horizontal,
-    int& radius)
-{
-  // get Nets with overflow
-  for (int netID = 0; netID < netCount(); netID++) {
-    if (nets_[netID] == nullptr || nets_[netID]->isClock()
-        || (congestion_nets.find(nets_[netID]->getDbNet())
-            != congestion_nets.end())) {
-      continue;
-    }
-
-    const auto& treeedges = sttrees_[netID].edges;
-    const int num_edges = sttrees_[netID].num_edges();
-
-    for (int edgeID = 0; edgeID < num_edges; edgeID++) {
-      const TreeEdge* treeedge = &(treeedges[edgeID]);
-      const std::vector<GPoint3D>& grids = treeedge->route.grids;
-      const int routeLen = treeedge->route.routelen;
-
-      for (int i = 0; i < routeLen; i++) {
-        if (grids[i].layer != grids[i + 1].layer) {
-          continue;
-        }
-        if (grids[i].x == grids[i + 1].x) {  // a vertical edge
-          const int ymin = std::min(grids[i].y, grids[i + 1].y);
-          if (abs(ymin - position.getY()) <= radius
-              && abs(grids[i].x - position.getX()) <= radius
-              && !is_horizontal) {
-            congestion_nets.insert(nets_[netID]->getDbNet());
-          }
-        } else if (grids[i].y == grids[i + 1].y) {  // a horizontal edge
-          const int xmin = std::min(grids[i].x, grids[i + 1].x);
-          if (abs(grids[i].y - position.getY()) <= radius
-              && abs(xmin - position.getX()) <= radius && is_horizontal) {
-            congestion_nets.insert(nets_[netID]->getDbNet());
-          }
-        }
-      }
-    }
-  }
-}
-
 // Get overflow positions
 void FastRouteCore::getOverflowPositions(
     std::vector<std::pair<odb::Point, bool>>& overflow_pos)
@@ -2136,8 +2091,11 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
   // Get overflow position -- [(x,y), is horizontal]
   std::vector<std::pair<odb::Point, bool>> overflow_positions;
   getOverflowPositions(overflow_positions);
+  if (overflow_positions.empty()) {
+    return;
+  }
 
-  int old_size = congestion_nets.size();
+  const size_t old_size = congestion_nets.size();
   std::vector<bool> already_added(netCount(), false);
   for (int netID = 0; netID < netCount(); netID++) {
     if (nets_[netID] != nullptr
@@ -2158,14 +2116,14 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
     std::fill(congested_v.begin(), congested_v.end(), 0);
 
     for (const auto& position : overflow_positions) {
-      int px = position.first.getX();
-      int py = position.first.getY();
-      bool is_horizontal = position.second;
+      const int px = position.first.getX();
+      const int py = position.first.getY();
+      const bool is_horizontal = position.second;
 
-      int y_start = std::max(0, py - radius);
-      int y_end = std::min(y_grid_ - 1, py + radius);
-      int x_start = std::max(0, px - radius);
-      int x_end = std::min(x_grid_ - 1, px + radius);
+      const int y_start = std::max(0, py - radius);
+      const int y_end = std::min(y_grid_ - 1, py + radius);
+      const int x_start = std::max(0, px - radius);
+      const int x_end = std::min(x_grid_ - 1, px + radius);
 
       auto& congested_grid = is_horizontal ? congested_h : congested_v;
       for (int y = y_start; y <= y_end; ++y) {

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -2138,15 +2138,92 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
   getOverflowPositions(overflow_positions);
 
   int old_size = congestion_nets.size();
+  std::vector<bool> already_added(netCount(), false);
+  for (int netID = 0; netID < netCount(); netID++) {
+    if (nets_[netID] != nullptr
+        && congestion_nets.find(nets_[netID]->getDbNet())
+               != congestion_nets.end()) {
+      already_added[netID] = true;
+    }
+  }
 
   // The radius around the congested zone is increased when no new nets are
   // obtained
   for (int radius = 0; radius < 5 && old_size == congestion_nets.size();
        radius++) {
-    // Find nets for each congestion ggrid
+    std::vector<std::vector<bool>> congested_h(
+        y_grid_, std::vector<bool>(x_grid_, false));
+    std::vector<std::vector<bool>> congested_v(
+        y_grid_, std::vector<bool>(x_grid_, false));
+
     for (const auto& position : overflow_positions) {
-      findNetsNearPosition(
-          congestion_nets, position.first, position.second, radius);
+      int px = position.first.getX();
+      int py = position.first.getY();
+      bool is_horizontal = position.second;
+
+      int y_start = std::max(0, py - radius);
+      int y_end = std::min(y_grid_ - 1, py + radius);
+      int x_start = std::max(0, px - radius);
+      int x_end = std::min(x_grid_ - 1, px + radius);
+
+      if (is_horizontal) {
+        for (int y = y_start; y <= y_end; ++y) {
+          for (int x = x_start; x <= x_end; ++x) {
+            congested_h[y][x] = true;
+          }
+        }
+      } else {
+        for (int y = y_start; y <= y_end; ++y) {
+          for (int x = x_start; x <= x_end; ++x) {
+            congested_v[y][x] = true;
+          }
+        }
+      }
+    }
+
+    // Find nets that overlap with any congested grid
+    for (int netID = 0; netID < netCount(); netID++) {
+      if (already_added[netID] || nets_[netID] == nullptr
+          || nets_[netID]->isClock()) {
+        continue;
+      }
+
+      const auto& treeedges = sttrees_[netID].edges;
+      const int num_edges = sttrees_[netID].num_edges();
+
+      bool found = false;
+      for (int edgeID = 0; edgeID < num_edges && !found; edgeID++) {
+        const TreeEdge* treeedge = &(treeedges[edgeID]);
+        const std::vector<GPoint3D>& grids = treeedge->route.grids;
+        const int routeLen = treeedge->route.routelen;
+
+        for (int i = 0; i < routeLen && !found; i++) {
+          if (grids[i].layer != grids[i + 1].layer) {
+            continue;
+          }
+          if (grids[i].x == grids[i + 1].x) {  // a vertical edge
+            const int ymin = std::min(grids[i].y, grids[i + 1].y);
+            if (grids[i].x >= 0 && grids[i].x < x_grid_ && ymin >= 0
+                && ymin < y_grid_) {
+              if (congested_v[ymin][grids[i].x]) {
+                congestion_nets.insert(nets_[netID]->getDbNet());
+                already_added[netID] = true;
+                found = true;
+              }
+            }
+          } else if (grids[i].y == grids[i + 1].y) {  // a horizontal edge
+            const int xmin = std::min(grids[i].x, grids[i + 1].x);
+            if (xmin >= 0 && xmin < x_grid_ && grids[i].y >= 0
+                && grids[i].y < y_grid_) {
+              if (congested_h[grids[i].y][xmin]) {
+                congestion_nets.insert(nets_[netID]->getDbNet());
+                already_added[netID] = true;
+                found = true;
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -2097,16 +2097,16 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
 
   const size_t old_size = congestion_nets.size();
   std::vector<bool> already_added(netCount(), false);
-  for (int netID = 0; netID < netCount(); netID++) {
-    if (nets_[netID] != nullptr
-        && congestion_nets.find(nets_[netID]->getDbNet())
-               != congestion_nets.end()) {
-      already_added[netID] = true;
+  for (odb::dbNet* db_net : congestion_nets) {
+    auto it = db_net_id_map_.find(db_net);
+    if (it != db_net_id_map_.end()) {
+      already_added[it->second] = true;
     }
   }
 
-  std::vector<char> congested_h(y_grid_ * x_grid_, 0);
-  std::vector<char> congested_v(y_grid_ * x_grid_, 0);
+  const size_t grid_size = static_cast<size_t>(y_grid_) * x_grid_;
+  std::vector<char> congested_h(grid_size, 0);
+  std::vector<char> congested_v(grid_size, 0);
 
   // The radius around the congested zone is increased when no new nets are
   // obtained
@@ -2128,7 +2128,7 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
       auto& congested_grid = is_horizontal ? congested_h : congested_v;
       for (int y = y_start; y <= y_end; ++y) {
         for (int x = x_start; x <= x_end; ++x) {
-          congested_grid[y * x_grid_ + x] = 1;
+          congested_grid[static_cast<size_t>(y) * x_grid_ + x] = 1;
         }
       }
     }
@@ -2161,7 +2161,8 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
             const int ymin = std::min(grids[i].y, grids[i + 1].y);
             if (grids[i].x >= 0 && grids[i].x < x_grid_ && ymin >= 0
                 && ymin < y_grid_) {
-              if (congested_v[ymin * x_grid_ + grids[i].x]) {
+              if (congested_v[static_cast<size_t>(ymin) * x_grid_
+                              + grids[i].x]) {
                 congestion_nets.insert(nets_[netID]->getDbNet());
                 already_added[netID] = true;
                 found = true;
@@ -2171,7 +2172,8 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
             const int xmin = std::min(grids[i].x, grids[i + 1].x);
             if (xmin >= 0 && xmin < x_grid_ && grids[i].y >= 0
                 && grids[i].y < y_grid_) {
-              if (congested_h[grids[i].y * x_grid_ + xmin]) {
+              if (congested_h[static_cast<size_t>(grids[i].y) * x_grid_
+                              + xmin]) {
                 congestion_nets.insert(nets_[netID]->getDbNet());
                 already_added[netID] = true;
                 found = true;

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -2147,14 +2147,15 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
     }
   }
 
+  std::vector<char> congested_h(y_grid_ * x_grid_, 0);
+  std::vector<char> congested_v(y_grid_ * x_grid_, 0);
+
   // The radius around the congested zone is increased when no new nets are
   // obtained
   for (int radius = 0; radius < 5 && old_size == congestion_nets.size();
        radius++) {
-    std::vector<std::vector<bool>> congested_h(
-        y_grid_, std::vector<bool>(x_grid_, false));
-    std::vector<std::vector<bool>> congested_v(
-        y_grid_, std::vector<bool>(x_grid_, false));
+    std::fill(congested_h.begin(), congested_h.end(), 0);
+    std::fill(congested_v.begin(), congested_v.end(), 0);
 
     for (const auto& position : overflow_positions) {
       int px = position.first.getX();
@@ -2169,7 +2170,7 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
       auto& congested_grid = is_horizontal ? congested_h : congested_v;
       for (int y = y_start; y <= y_end; ++y) {
         for (int x = x_start; x <= x_end; ++x) {
-          congested_grid[y][x] = true;
+          congested_grid[y * x_grid_ + x] = 1;
         }
       }
     }
@@ -2190,6 +2191,10 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
         const std::vector<GPoint3D>& grids = treeedge->route.grids;
         const int routeLen = treeedge->route.routelen;
 
+        if (routeLen <= 0 || grids.size() < static_cast<size_t>(routeLen + 1)) {
+          continue;
+        }
+
         for (int i = 0; i < routeLen && !found; i++) {
           if (grids[i].layer != grids[i + 1].layer) {
             continue;
@@ -2198,7 +2203,7 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
             const int ymin = std::min(grids[i].y, grids[i + 1].y);
             if (grids[i].x >= 0 && grids[i].x < x_grid_ && ymin >= 0
                 && ymin < y_grid_) {
-              if (congested_v[ymin][grids[i].x]) {
+              if (congested_v[ymin * x_grid_ + grids[i].x]) {
                 congestion_nets.insert(nets_[netID]->getDbNet());
                 already_added[netID] = true;
                 found = true;
@@ -2208,7 +2213,7 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
             const int xmin = std::min(grids[i].x, grids[i + 1].x);
             if (xmin >= 0 && xmin < x_grid_ && grids[i].y >= 0
                 && grids[i].y < y_grid_) {
-              if (congested_h[grids[i].y][xmin]) {
+              if (congested_h[grids[i].y * x_grid_ + xmin]) {
                 congestion_nets.insert(nets_[netID]->getDbNet());
                 already_added[netID] = true;
                 found = true;

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -2166,17 +2166,10 @@ void FastRouteCore::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
       int x_start = std::max(0, px - radius);
       int x_end = std::min(x_grid_ - 1, px + radius);
 
-      if (is_horizontal) {
-        for (int y = y_start; y <= y_end; ++y) {
-          for (int x = x_start; x <= x_end; ++x) {
-            congested_h[y][x] = true;
-          }
-        }
-      } else {
-        for (int y = y_start; y <= y_end; ++y) {
-          for (int x = x_start; x <= x_end; ++x) {
-            congested_v[y][x] = true;
-          }
+      auto& congested_grid = is_horizontal ? congested_h : congested_v;
+      for (int y = y_start; y <= y_end; ++y) {
+        for (int x = x_start; x <= x_end; ++x) {
+          congested_grid[y][x] = true;
         }
       }
     }

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_test")
 load("//test:regression.bzl", "doc_check_test", "regression_test")
 
@@ -209,6 +210,22 @@ regression_test(
     check_log = False,
     check_passfail = True,
     data = [":test_resources"],
+)
+
+cc_test(
+    name = "TestCongestionNets",
+    size = "small",
+    srcs = ["cpp/TestCongestionNets.cpp"],
+    deps = [
+        "//src/grt",
+        "//src/grt:fastroute",
+        "//src/odb/src/db",
+        "//src/stt",
+        "//src/tst:db_fixture",
+        "//src/utl",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
 )
 
 py_test(

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -140,3 +140,5 @@ or_integration_tests(
     snapshot_batched_smoke
     thread_count_reports
 )
+
+add_subdirectory(cpp)

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -141,4 +141,6 @@ or_integration_tests(
     thread_count_reports
 )
 
-add_subdirectory(cpp)
+if(ENABLE_TESTS)
+  add_subdirectory(cpp)
+endif()

--- a/src/grt/test/cpp/CMakeLists.txt
+++ b/src/grt/test/cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026-2026, The OpenROAD Authors
+
+add_executable(TestCongestionNets TestCongestionNets.cpp)
+
+target_link_libraries(TestCongestionNets
+    GTest::gtest
+    GTest::gtest_main
+    grt_lib
+    tst_base
+    stt_lib
+    utl_lib
+)
+
+gtest_discover_tests(TestCongestionNets
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+add_dependencies(build_and_test TestCongestionNets)

--- a/src/grt/test/cpp/TestCongestionNets.cpp
+++ b/src/grt/test/cpp/TestCongestionNets.cpp
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025-2026, The OpenROAD Authors
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "FastRoute.h"
+#include "gtest/gtest.h"
+#include "odb/PtrSetMap.h"
+#include "odb/db.h"
+#include "odb/geom.h"
+#include "stt/SteinerTreeBuilder.h"
+#include "tst/db_fixture.h"
+#include "utl/ServiceRegistry.h"
+
+namespace grt {
+namespace {
+
+// Exercises FastRouteCore::getCongestionNets on a small synthetic grid.
+//
+// The state getCongestionNets reads (routed tree edges and 2D edge usage)
+// is built entirely through the public API: addNet() registers a net and
+// its (empty) Steiner tree, addTreeEdge() appends a routed edge and bumps
+// graph2d_ usage, and updateEdge2DAnd3DUsage() adds raw usage to create
+// overflow at chosen cells without giving any scannable net a route there.
+class CongestionNetsTest : public tst::DbFixture
+{
+ protected:
+  static constexpr int kXGrid = 10;
+  static constexpr int kYGrid = 10;
+  static constexpr int kNumLayers = 2;
+  // Per-layer edge capacity; the 2D capacity of an edge is the sum over
+  // layers.  Routes added in tests use 1 unit per edge, so they never
+  // overflow on their own.
+  static constexpr int kEdgeCap = 10;
+  static constexpr int kOverflowUsage = kEdgeCap * kNumLayers + 5;
+
+  void SetUp() override
+  {
+    odb::dbTech* tech = odb::dbTech::create(db_.get(), "tech");
+    odb::dbTechLayer::create(tech, "L1", odb::dbTechLayerType::MASTERSLICE);
+    odb::dbChip* chip = odb::dbChip::create(db_.get(), tech);
+    block_ = odb::dbBlock::create(chip, "top");
+
+    fastroute_ = std::make_unique<FastRouteCore>(
+        db_.get(), &logger_, &registry_, &stt_builder_, /*sta=*/nullptr);
+    fastroute_->setLowerLeft(0, 0);
+    fastroute_->setTileSize(100);
+    fastroute_->setGridsAndLayers(kXGrid, kYGrid, kNumLayers);
+    fastroute_->initEdges();
+    for (int layer = 1; layer <= kNumLayers; layer++) {
+      for (int y = 0; y < kYGrid; y++) {
+        for (int x = 0; x < kXGrid - 1; x++) {
+          fastroute_->setEdgeCapacity(x, y, x + 1, y, layer, kEdgeCap);
+        }
+      }
+      for (int y = 0; y < kYGrid - 1; y++) {
+        for (int x = 0; x < kXGrid; x++) {
+          fastroute_->setEdgeCapacity(x, y, x, y + 1, layer, kEdgeCap);
+        }
+      }
+    }
+
+    // Carrier net for injecting overflow usage.  It is a clock net with no
+    // tree edges, so getCongestionNets never selects it.
+    overflow_net_ = makeFrNet("__overflow_carrier", /*is_clock=*/true);
+  }
+
+  odb::dbNet* makeFrNet(const char* name, const bool is_clock = false)
+  {
+    odb::dbNet* db_net = odb::dbNet::create(block_, name);
+    fastroute_->addNet(db_net,
+                       is_clock,
+                       /*is_local=*/false,
+                       /*driver_idx=*/0,
+                       /*cost=*/1,
+                       /*min_layer=*/0,
+                       /*max_layer=*/kNumLayers - 1,
+                       /*slack=*/0,
+                       /*edge_cost_per_layer=*/nullptr);
+    return db_net;
+  }
+
+  // Routes on layer 1; coordinates must be ascending.
+  void addRouteH(odb::dbNet* net, const int x1, const int x2, const int y)
+  {
+    fastroute_->addTreeEdge(x1, y, x2, y, /*layer=*/1, net);
+  }
+
+  void addRouteV(odb::dbNet* net, const int x, const int y1, const int y2)
+  {
+    fastroute_->addTreeEdge(x, y1, x, y2, /*layer=*/1, net);
+  }
+
+  void overflowH(const int x, const int y)
+  {
+    fastroute_->updateEdge2DAnd3DUsage(
+        x, y, x + 1, y, /*layer=*/1, kOverflowUsage, overflow_net_);
+  }
+
+  void overflowV(const int x, const int y)
+  {
+    fastroute_->updateEdge2DAnd3DUsage(
+        x, y, x, y + 1, /*layer=*/1, kOverflowUsage, overflow_net_);
+  }
+
+  odb::PtrSet<odb::dbNet> getCongestionNets()
+  {
+    odb::PtrSet<odb::dbNet> nets;
+    fastroute_->getCongestionNets(nets);
+    return nets;
+  }
+
+  size_t overflowPositionCount()
+  {
+    std::vector<std::pair<odb::Point, bool>> positions;
+    fastroute_->getOverflowPositions(positions);
+    return positions.size();
+  }
+
+  odb::dbBlock* block_ = nullptr;
+  utl::ServiceRegistry registry_{&logger_};
+  stt::SteinerTreeBuilder stt_builder_{&logger_};
+  std::unique_ptr<FastRouteCore> fastroute_;
+  odb::dbNet* overflow_net_ = nullptr;
+};
+
+TEST_F(CongestionNetsTest, FindsNetsCrossingOverflowAtRadiusZero)
+{
+  odb::dbNet* h_net = makeFrNet("h_net");
+  addRouteH(h_net, 2, 5, 3);
+  odb::dbNet* v_net = makeFrNet("v_net");
+  addRouteV(v_net, 7, 2, 5);
+
+  overflowH(3, 3);
+  overflowV(7, 3);
+  EXPECT_EQ(overflowPositionCount(), 2u);
+
+  const auto nets = getCongestionNets();
+  EXPECT_EQ(nets.size(), 2u);
+  EXPECT_EQ(nets.count(h_net), 1u);
+  EXPECT_EQ(nets.count(v_net), 1u);
+}
+
+TEST_F(CongestionNetsTest, HorizontalOverflowIgnoresVerticalOnlyNet)
+{
+  odb::dbNet* v_net = makeFrNet("v_net");
+  addRouteV(v_net, 5, 3, 7);
+
+  // Horizontal overflow on a cell the vertical route passes through.
+  overflowH(5, 5);
+
+  EXPECT_TRUE(getCongestionNets().empty());
+}
+
+TEST_F(CongestionNetsTest, VerticalOverflowIgnoresHorizontalOnlyNet)
+{
+  odb::dbNet* h_net = makeFrNet("h_net");
+  addRouteH(h_net, 3, 7, 5);
+
+  overflowV(5, 5);
+
+  EXPECT_TRUE(getCongestionNets().empty());
+}
+
+TEST_F(CongestionNetsTest, ClockNetsExcluded)
+{
+  odb::dbNet* clk_net = makeFrNet("clk", /*is_clock=*/true);
+  addRouteH(clk_net, 2, 6, 4);
+
+  overflowH(3, 4);
+
+  EXPECT_TRUE(getCongestionNets().empty());
+}
+
+TEST_F(CongestionNetsTest, NoOverflowFindsNothing)
+{
+  odb::dbNet* h_net = makeFrNet("h_net");
+  addRouteH(h_net, 2, 6, 4);
+
+  EXPECT_EQ(overflowPositionCount(), 0u);
+  EXPECT_TRUE(getCongestionNets().empty());
+}
+
+TEST_F(CongestionNetsTest, RadiusExpandsUntilNetFound)
+{
+  // Route at Chebyshev distance 2 from the overflow cell: only reachable
+  // once the search radius expands to 2.
+  odb::dbNet* net = makeFrNet("net");
+  addRouteH(net, 4, 7, 7);
+
+  overflowH(5, 5);
+
+  const auto nets = getCongestionNets();
+  EXPECT_EQ(nets.size(), 1u);
+  EXPECT_EQ(nets.count(net), 1u);
+}
+
+TEST_F(CongestionNetsTest, NetsBeyondMaxRadiusNotFound)
+{
+  // Chebyshev distance 6 exceeds the maximum search radius of 4.
+  odb::dbNet* far_net = makeFrNet("far_net");
+  addRouteH(far_net, 2, 6, 8);
+
+  overflowH(3, 2);
+
+  EXPECT_TRUE(getCongestionNets().empty());
+}
+
+TEST_F(CongestionNetsTest, RadiusStopsExpandingOnceNetsFound)
+{
+  odb::dbNet* near_net = makeFrNet("near_net");
+  addRouteH(near_net, 2, 6, 4);
+  odb::dbNet* next_net = makeFrNet("next_net");
+  addRouteH(next_net, 2, 6, 5);
+
+  overflowH(3, 4);
+
+  // near_net is found at radius 0, so the radius never grows to reach
+  // next_net one row away.
+  const auto nets = getCongestionNets();
+  EXPECT_EQ(nets.size(), 1u);
+  EXPECT_EQ(nets.count(near_net), 1u);
+}
+
+TEST_F(CongestionNetsTest, AlreadyAddedNetsDontStopRadiusExpansion)
+{
+  odb::dbNet* seeded_net = makeFrNet("seeded_net");
+  addRouteH(seeded_net, 2, 6, 4);
+  odb::dbNet* found_net = makeFrNet("found_net");
+  addRouteH(found_net, 2, 6, 7);
+
+  overflowH(3, 4);
+
+  // seeded_net crosses the overflow but is already in the set; the radius
+  // keeps expanding until found_net (distance 3) is picked up.
+  odb::PtrSet<odb::dbNet> nets;
+  nets.insert(seeded_net);
+  fastroute_->getCongestionNets(nets);
+  EXPECT_EQ(nets.size(), 2u);
+  EXPECT_EQ(nets.count(found_net), 1u);
+}
+
+TEST_F(CongestionNetsTest, AllNetsOnOverflowCellFound)
+{
+  odb::dbNet* net_a = makeFrNet("net_a");
+  addRouteH(net_a, 2, 6, 4);
+  odb::dbNet* net_b = makeFrNet("net_b");
+  addRouteH(net_b, 3, 7, 4);
+
+  overflowH(4, 4);
+
+  const auto nets = getCongestionNets();
+  EXPECT_EQ(nets.size(), 2u);
+  EXPECT_EQ(nets.count(net_a), 1u);
+  EXPECT_EQ(nets.count(net_b), 1u);
+}
+
+}  // namespace
+}  // namespace grt


### PR DESCRIPTION
FastRouteCore::getCongestionNets iterated over every overflow position and for each position, checked intersection with every net in the design. This created an O(P * N) bottleneck that caused the router to hang for hours on congested designs where P and N are both large.

Replace the pointer-chasing intersection checks with a boolean grid map. First, project all overflow positions onto 2D boolean arrays. Then, iterate over the nets once to check if any segments overlap with a congested grid cell. This reduces the complexity to O(P + N), eliminating the bottleneck.