### PR TITLE
odb: temporary fix for wire ordering of input bump nets

### DIFF
--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -1305,14 +1305,23 @@ int tmg_conn::getStartNode()
     }
   }
 
-  // The starting point of an input bump net is the bump iterm. Note that
-  // bump nets have a bterm that represents the logical connectivity of the
-  // bump, but it has no physical geometry and is invisible to the graph.
-  if (bt_drv && bt_drv->getBPins().empty()
-      && dbProperty::find(net_, "BUMP_ASSIGNMENT")) {
-    for (const tmg_rcterm& rc_term : termV_) {
-      if (rc_term.iterm && rc_term.iterm->isSpecial() && rc_term.pt) {
-        return (rc_term.pt - ptV_.data());
+  // On a 3D-IC design, the starting point of an input bump net is the bump
+  // iterm even though such a net does have a bterm. The bterm has no geometry
+  // and only serves to represent the logical connectivity. The following code
+  // will NOT work if a die with such a net is loaded independently as a 2D
+  // design. This will need to be revisited.
+  if (bt_drv && bt_drv->getBPins().empty()) {
+    dbChipBump* chip_bump = bt_drv->getChipBump();
+
+    if (chip_bump) {
+      dbInst* bump = chip_bump->getInst();
+
+      for (const tmg_rcterm& rc_term : termV_) {
+        dbITerm* iterm = rc_term.iterm;
+
+        if (iterm && (iterm->getInst() == bump) && rc_term.pt) {
+          return (rc_term.pt - ptV_.data());
+        }
       }
     }
   }

--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -1305,15 +1305,14 @@ int tmg_conn::getStartNode()
     }
   }
 
-  // A driver bterm with no pin geometry cannot anchor the walk.  On nets
-  // the router tied to a bump (BUMP_ASSIGNMENT net property), the signal
-  // physically enters through the bump pad, connected as a special iterm;
-  // root the tree there.
+  // The starting point of an input bump net is the bump iterm. Note that
+  // bump nets have a bterm that represents the logical connectivity of the
+  // bump, but it has no physical geometry and is invisible to the graph.
   if (bt_drv && bt_drv->getBPins().empty()
       && dbProperty::find(net_, "BUMP_ASSIGNMENT")) {
-    for (const tmg_rcterm& x : termV_) {
-      if (x.iterm && x.iterm->isSpecial() && x.pt) {
-        return (x.pt - ptV_.data());
+    for (const tmg_rcterm& rc_term : termV_) {
+      if (rc_term.iterm && rc_term.iterm->isSpecial() && rc_term.pt) {
+        return (rc_term.pt - ptV_.data());
       }
     }
   }

--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -1298,11 +1298,26 @@ int tmg_conn::getStartNode()
   for (const tmg_rcterm& x : termV_) {
     if (x.iterm == it_drv && x.bterm == bt_drv) {
       if (!x.pt) {
-        return 0;
+        break;
       }
+
       return (x.pt - ptV_.data());
     }
   }
+
+  // A driver bterm with no pin geometry cannot anchor the walk.  On nets
+  // the router tied to a bump (BUMP_ASSIGNMENT net property), the signal
+  // physically enters through the bump pad, connected as a special iterm;
+  // root the tree there.
+  if (bt_drv && bt_drv->getBPins().empty()
+      && dbProperty::find(net_, "BUMP_ASSIGNMENT")) {
+    for (const tmg_rcterm& x : termV_) {
+      if (x.iterm && x.iterm->isSpecial() && x.pt) {
+        return (x.pt - ptV_.data());
+      }
+    }
+  }
+
   return 0;
 }
 

--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -1479,8 +1479,13 @@ void tmg_conn::treeReorder(const bool no_convert)
   }
   dfsClear();
   if (!dfsStart(jstart)) {
-    logger_->warn(ODB, 395, "cannot order {}", net_->getConstName());
-    return;
+    logger_->error(ODB,
+                   395,
+                   "Could not order wires of net {}. No wire segment is "
+                   "reachable from the start point ({} {}).",
+                   net_->getConstName(),
+                   ptV_[jstart].x,
+                   ptV_[jstart].y);
   }
   int last_term_index = 0;
   while (true) {
@@ -1561,8 +1566,13 @@ void tmg_conn::treeReorder(const bool no_convert)
     }
     jstart = pt - ptV_.data();
     if (!dfsStart(jstart)) {
-      logger_->warn(ODB, 396, "cannot order {}", net_->getConstName());
-      return;
+      logger_->error(ODB,
+                     396,
+                     "Could not order wires of net {}. No wire segment is "
+                     "reachable from the branch start point ({} {}).",
+                     net_->getConstName(),
+                     ptV_[jstart].x,
+                     ptV_[jstart].y);
     }
   }
 

--- a/src/odb/test/cpp/BUILD
+++ b/src/odb/test/cpp/BUILD
@@ -208,6 +208,7 @@ cc_test(
         "TestDbNet.cpp",
         "TestDbWire.cc",
         "TestDesignIsRouted.cpp",
+        "TestOrderWires.cpp",
         "TestPolygonalFloorplan.cc",
     ],
     args = [],

--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ set(GTEST_LIBS
         GTest::gtest_main
 )
 
-add_executable(OdbGTests TestDbWire.cc TestDbNet.cpp TestDesignIsRouted.cpp TestAbstractLef.cc TestPolygonalFloorplan.cc)
+add_executable(OdbGTests TestDbWire.cc TestDbNet.cpp TestDesignIsRouted.cpp TestAbstractLef.cc TestPolygonalFloorplan.cc TestOrderWires.cpp)
 add_executable(TestCallBacks TestCallBacks.cpp)
 add_executable(TestGeom TestGeom.cpp)
 add_executable(TestModule TestModule.cpp)

--- a/src/odb/test/cpp/TestOrderWires.cpp
+++ b/src/odb/test/cpp/TestOrderWires.cpp
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include "gtest/gtest.h"
+#include "odb/db.h"
+#include "odb/dbWireCodec.h"
+#include "odb/wOrder.h"
+#include "tst/fixture.h"
+
+namespace odb {
+
+class TestOrderWires : public tst::Fixture
+{
+ protected:
+  void SetUp() override
+  {
+    loadTechAndLib(
+        "tech", "Nangate45.lef", "_main/test/Nangate45/Nangate45.lef");
+    dbChip* chip = dbChip::create(db_.get(), db_->getTech());
+    block_ = dbBlock::create(chip, "top");
+  }
+
+  // A face-to-face style net: a receiver instance pin, a bump pad iterm
+  // (special, as a SPECIALNETS connection reads in), and an unplaced
+  // driver bterm carrying no geometry.  The BUMP_ASSIGNMENT net property
+  // marks the net as tied to the bump.
+  void buildBumpNet()
+  {
+    dbMaster* inv = db_->findMaster("INV_X1");
+
+    dbInst* recv = makeInst(block_,
+                            inv,
+                            "recv",
+                            {.location = {10000, 10000},
+                             .status = dbPlacementStatus::PLACED,
+                             .iterms = {{"n1", "A"}}});
+    dbInst* bump = makeInst(block_,
+                            inv,
+                            "bump",
+                            {.location = {50000, 10000},
+                             .status = dbPlacementStatus::PLACED,
+                             .iterms = {{"n1", "A"}}});
+
+    makeBTerm(block_, "n1", {.io_type = dbIoType::INPUT, .bpins = {}});
+
+    net_ = block_->findNet("n1");
+    recv_iterm_ = recv->findITerm("A");
+    bump_iterm_ = bump->findITerm("A");
+    bump_iterm_->setSpecial();
+    dbStringProperty::create(net_, "BUMP_ASSIGNMENT", "ASSIGNED");
+
+    ASSERT_TRUE(recv_iterm_->getAvgXY(&recv_x_, &recv_y_));
+    ASSERT_TRUE(bump_iterm_->getAvgXY(&bump_x_, &bump_y_));
+    ASSERT_EQ(recv_y_, bump_y_);
+  }
+
+  bool wireHasITerm(dbWire* wire, dbITerm* iterm)
+  {
+    dbWireDecoder decoder;
+    decoder.begin(wire);
+    for (dbWireDecoder::OpCode op = decoder.next();
+         op != dbWireDecoder::END_DECODE;
+         op = decoder.next()) {
+      if (op == dbWireDecoder::ITERM && decoder.getITerm() == iterm) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  dbBlock* block_;
+  dbNet* net_;
+  dbITerm* recv_iterm_;
+  dbITerm* bump_iterm_;
+  int recv_x_;
+  int recv_y_;
+  int bump_x_;
+  int bump_y_;
+};
+
+// A net driven by an unplaced bterm gives the tree walk no driver anchor,
+// making it start at the wire's first point.  If the first path holds only
+// a patch RECT that point has no graph edges, and the walk used to abort
+// (ODB-0395) without stamping any terminal markers into the wire, leaving
+// extraction with no terminal connections.  On a bump-assigned net the
+// walk must anchor at the bump pad iterm instead and stamp the reachable
+// terms.
+TEST_F(TestOrderWires, RectFirstBumpNetWithUnplacedDriverPin)
+{
+  buildBumpNet();
+  dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
+
+  dbWire* wire = dbWire::create(net_);
+  dbWireEncoder encoder;
+  encoder.begin(wire);
+  // First path: a lone patch RECT, making a wire point without edges.
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(bump_x_, bump_y_);
+  encoder.addRect(-70, -70, 70, 70);
+  // Second path: a real segment from the receiver pin to the bump pad.
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(recv_x_, recv_y_);
+  encoder.addPoint(bump_x_, bump_y_);
+  encoder.end();
+
+  const int warnings_before = logger_.getWarningCount();
+  orderWires(&logger_, block_);
+
+  EXPECT_TRUE(net_->isWireOrdered());
+  EXPECT_EQ(logger_.getWarningCount(), warnings_before);
+  EXPECT_TRUE(wireHasITerm(net_->getWire(), recv_iterm_));
+  EXPECT_TRUE(wireHasITerm(net_->getWire(), bump_iterm_));
+}
+
+// On a bump-assigned net whose driver is a bterm with no pin geometry,
+// the walk must be rooted at the bump pad iterm: the signal physically
+// enters the die there.
+TEST_F(TestOrderWires, BumpAssignedNetRootsTreeAtBumpIterm)
+{
+  buildBumpNet();
+  dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
+
+  dbWire* wire = dbWire::create(net_);
+  dbWireEncoder encoder;
+  encoder.begin(wire);
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(recv_x_, recv_y_);
+  encoder.addPoint(bump_x_, bump_y_);
+  encoder.end();
+
+  orderWires(&logger_, block_);
+
+  // The rewritten wire must begin at the bump pin, marker included.
+  dbWireDecoder decoder;
+  decoder.begin(net_->getWire());
+  EXPECT_EQ(decoder.next(), dbWireDecoder::PATH);
+  EXPECT_EQ(decoder.next(), dbWireDecoder::POINT);
+  int x, y;
+  decoder.getPoint(x, y);
+  EXPECT_EQ(x, bump_x_);
+  EXPECT_EQ(y, bump_y_);
+  EXPECT_EQ(decoder.next(), dbWireDecoder::ITERM);
+  EXPECT_EQ(decoder.getITerm(), bump_iterm_);
+}
+
+}  // namespace odb

--- a/src/odb/test/cpp/TestOrderWires.cpp
+++ b/src/odb/test/cpp/TestOrderWires.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <stdexcept>
+
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "odb/dbWireCodec.h"
@@ -141,6 +143,44 @@ TEST_F(TestOrderWires, BumpAssignedNetRootsTreeAtBumpIterm)
   EXPECT_EQ(y, bump_y_);
   EXPECT_EQ(decoder.next(), dbWireDecoder::ITERM);
   EXPECT_EQ(decoder.getITerm(), bump_iterm_);
+}
+
+// Without a bump assignment nothing anchors the walk of a net driven by a
+// bterm with no geometry, and a wire whose first path holds only a patch
+// RECT makes it start at a point with no reachable segment.  Ordering
+// must fail loudly (ODB-0395) and must not leave the net marked as
+// ordered.
+TEST_F(TestOrderWires, UnanchoredNetWithUnreachableStartPointFailsLoudly)
+{
+  dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
+  dbMaster* inv = db_->findMaster("INV_X1");
+
+  dbInst* recv = makeInst(block_,
+                          inv,
+                          "recv",
+                          {.location = {10000, 10000},
+                           .status = dbPlacementStatus::PLACED,
+                           .iterms = {{"n1", "A"}}});
+
+  makeBTerm(block_, "n1", {.io_type = dbIoType::INPUT, .bpins = {}});
+
+  dbNet* net = block_->findNet("n1");
+  int recv_x, recv_y;
+  ASSERT_TRUE(recv->findITerm("A")->getAvgXY(&recv_x, &recv_y));
+
+  dbWire* wire = dbWire::create(net);
+  dbWireEncoder encoder;
+  encoder.begin(wire);
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(recv_x, recv_y + 2000);
+  encoder.addRect(-70, -70, 70, 70);
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(recv_x, recv_y);
+  encoder.addPoint(recv_x, recv_y + 2000);
+  encoder.end();
+
+  EXPECT_THROW(orderWires(&logger_, block_), std::runtime_error);
+  EXPECT_FALSE(net->isWireOrdered());
 }
 
 }  // namespace odb

--- a/src/odb/test/cpp/TestOrderWires.cpp
+++ b/src/odb/test/cpp/TestOrderWires.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
-#include <stdexcept>
-
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "odb/dbWireCodec.h"
@@ -14,6 +12,17 @@ namespace odb {
 class TestOrderWires : public tst::Fixture
 {
  protected:
+  struct InputBumpNet
+  {
+    dbNet* net;
+    dbITerm* receiver_iterm;
+    dbITerm* bump_iterm;
+    int receiver_x;
+    int receiver_y;
+    int bump_x;
+    int bump_y;
+  };
+
   void SetUp() override
   {
     loadTechAndLib(
@@ -22,165 +31,89 @@ class TestOrderWires : public tst::Fixture
     block_ = dbBlock::create(chip, "top");
   }
 
-  // A face-to-face style net: a receiver instance pin, a bump pad iterm
-  // (special, as a SPECIALNETS connection reads in), and an unplaced
-  // driver bterm carrying no geometry.  The BUMP_ASSIGNMENT net property
-  // marks the net as tied to the bump.
-  void buildBumpNet()
+  InputBumpNet buildInputBumpNet()
   {
-    dbMaster* inv = db_->findMaster("INV_X1");
+    InputBumpNet bump_net;
 
-    dbInst* recv = makeInst(block_,
-                            inv,
-                            "recv",
-                            {.location = {10000, 10000},
-                             .status = dbPlacementStatus::PLACED,
-                             .iterms = {{"n1", "A"}}});
     dbInst* bump = makeInst(block_,
-                            inv,
+                            db_->findMaster("INV_X1"),
                             "bump",
                             {.location = {50000, 10000},
                              .status = dbPlacementStatus::PLACED,
-                             .iterms = {{"n1", "A"}}});
+                             .iterms = {{"net", "A"}}});
 
-    makeBTerm(block_, "n1", {.io_type = dbIoType::INPUT, .bpins = {}});
+    // Note that here we could use any type of logical cell.
+    dbInst* receiver = makeInst(block_,
+                                db_->findMaster("INV_X1"),
+                                "receiver",
+                                {.location = {10000, 10000},
+                                 .status = dbPlacementStatus::PLACED,
+                                 .iterms = {{"net", "A"}}});
 
-    net_ = block_->findNet("n1");
-    recv_iterm_ = recv->findITerm("A");
-    bump_iterm_ = bump->findITerm("A");
-    bump_iterm_->setSpecial();
-    dbStringProperty::create(net_, "BUMP_ASSIGNMENT", "ASSIGNED");
+    // The bterm associated to the bump has no geometry.
+    makeBTerm(block_, "net", {.io_type = dbIoType::INPUT, .bpins = {}});
 
-    ASSERT_TRUE(recv_iterm_->getAvgXY(&recv_x_, &recv_y_));
-    ASSERT_TRUE(bump_iterm_->getAvgXY(&bump_x_, &bump_y_));
-    ASSERT_EQ(recv_y_, bump_y_);
-  }
+    bump_net.net = block_->findNet("net");
+    bump_net.receiver_iterm = receiver->findITerm("A");
+    bump_net.bump_iterm = bump->findITerm("A");
+    bump_net.bump_iterm->setSpecial();
+    dbStringProperty::create(bump_net.net, "BUMP_ASSIGNMENT", "ASSIGNED");
 
-  bool wireHasITerm(dbWire* wire, dbITerm* iterm)
-  {
-    dbWireDecoder decoder;
-    decoder.begin(wire);
-    for (dbWireDecoder::OpCode op = decoder.next();
-         op != dbWireDecoder::END_DECODE;
-         op = decoder.next()) {
-      if (op == dbWireDecoder::ITERM && decoder.getITerm() == iterm) {
-        return true;
-      }
-    }
-    return false;
+    bump_net.receiver_iterm->getAvgXY(&bump_net.receiver_x,
+                                      &bump_net.receiver_y);
+    bump_net.bump_iterm->getAvgXY(&bump_net.bump_x, &bump_net.bump_y);
+
+    return bump_net;
   }
 
   dbBlock* block_;
-  dbNet* net_;
-  dbITerm* recv_iterm_;
-  dbITerm* bump_iterm_;
-  int recv_x_;
-  int recv_y_;
-  int bump_x_;
-  int bump_y_;
 };
 
-// A net driven by an unplaced bterm gives the tree walk no driver anchor,
-// making it start at the wire's first point.  If the first path holds only
-// a patch RECT that point has no graph edges, and the walk used to abort
-// (ODB-0395) without stamping any terminal markers into the wire, leaving
-// extraction with no terminal connections.  On a bump-assigned net the
-// walk must anchor at the bump pad iterm instead and stamp the reachable
-// terms.
-TEST_F(TestOrderWires, RectFirstBumpNetWithUnplacedDriverPin)
+TEST_F(TestOrderWires, InputBumpNetWithPatchAtTheBeginning)
 {
-  buildBumpNet();
+  const InputBumpNet bump_net = buildInputBumpNet();
   dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
+  dbWire* wire = dbWire::create(bump_net.net);
 
-  dbWire* wire = dbWire::create(net_);
   dbWireEncoder encoder;
   encoder.begin(wire);
+
   // First path: a lone patch RECT, making a wire point without edges.
   encoder.newPath(metal1, dbWireType::ROUTED);
-  encoder.addPoint(bump_x_, bump_y_);
+  encoder.addPoint(bump_net.bump_x, bump_net.bump_y);
   encoder.addRect(-70, -70, 70, 70);
+
   // Second path: a real segment from the receiver pin to the bump pad.
   encoder.newPath(metal1, dbWireType::ROUTED);
-  encoder.addPoint(recv_x_, recv_y_);
-  encoder.addPoint(bump_x_, bump_y_);
-  encoder.end();
-
-  const int warnings_before = logger_.getWarningCount();
-  orderWires(&logger_, block_);
-
-  EXPECT_TRUE(net_->isWireOrdered());
-  EXPECT_EQ(logger_.getWarningCount(), warnings_before);
-  EXPECT_TRUE(wireHasITerm(net_->getWire(), recv_iterm_));
-  EXPECT_TRUE(wireHasITerm(net_->getWire(), bump_iterm_));
-}
-
-// On a bump-assigned net whose driver is a bterm with no pin geometry,
-// the walk must be rooted at the bump pad iterm: the signal physically
-// enters the die there.
-TEST_F(TestOrderWires, BumpAssignedNetRootsTreeAtBumpIterm)
-{
-  buildBumpNet();
-  dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
-
-  dbWire* wire = dbWire::create(net_);
-  dbWireEncoder encoder;
-  encoder.begin(wire);
-  encoder.newPath(metal1, dbWireType::ROUTED);
-  encoder.addPoint(recv_x_, recv_y_);
-  encoder.addPoint(bump_x_, bump_y_);
+  encoder.addPoint(bump_net.receiver_x, bump_net.receiver_y);
+  encoder.addPoint(bump_net.bump_x, bump_net.bump_y);
   encoder.end();
 
   orderWires(&logger_, block_);
+  EXPECT_TRUE(bump_net.net->isWireOrdered());
 
-  // The rewritten wire must begin at the bump pin, marker included.
   dbWireDecoder decoder;
-  decoder.begin(net_->getWire());
+  decoder.begin(bump_net.net->getWire());
   EXPECT_EQ(decoder.next(), dbWireDecoder::PATH);
+
+  // Operation codes of the bump pin.
   EXPECT_EQ(decoder.next(), dbWireDecoder::POINT);
   int x, y;
   decoder.getPoint(x, y);
-  EXPECT_EQ(x, bump_x_);
-  EXPECT_EQ(y, bump_y_);
+  EXPECT_EQ(x, bump_net.bump_x);
+  EXPECT_EQ(y, bump_net.bump_y);
   EXPECT_EQ(decoder.next(), dbWireDecoder::ITERM);
-  EXPECT_EQ(decoder.getITerm(), bump_iterm_);
-}
+  EXPECT_EQ(decoder.getITerm(), bump_net.bump_iterm);
 
-// Without a bump assignment nothing anchors the walk of a net driven by a
-// bterm with no geometry, and a wire whose first path holds only a patch
-// RECT makes it start at a point with no reachable segment.  Ordering
-// must fail loudly (ODB-0395) and must not leave the net marked as
-// ordered.
-TEST_F(TestOrderWires, UnanchoredNetWithUnreachableStartPointFailsLoudly)
-{
-  dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
-  dbMaster* inv = db_->findMaster("INV_X1");
+  // Operation codes of the receiver.
+  EXPECT_EQ(decoder.next(), dbWireDecoder::POINT);
+  decoder.getPoint(x, y);
+  EXPECT_EQ(x, bump_net.receiver_x);
+  EXPECT_EQ(y, bump_net.receiver_y);
+  EXPECT_EQ(decoder.next(), dbWireDecoder::ITERM);
+  EXPECT_EQ(decoder.getITerm(), bump_net.receiver_iterm);
 
-  dbInst* recv = makeInst(block_,
-                          inv,
-                          "recv",
-                          {.location = {10000, 10000},
-                           .status = dbPlacementStatus::PLACED,
-                           .iterms = {{"n1", "A"}}});
-
-  makeBTerm(block_, "n1", {.io_type = dbIoType::INPUT, .bpins = {}});
-
-  dbNet* net = block_->findNet("n1");
-  int recv_x, recv_y;
-  ASSERT_TRUE(recv->findITerm("A")->getAvgXY(&recv_x, &recv_y));
-
-  dbWire* wire = dbWire::create(net);
-  dbWireEncoder encoder;
-  encoder.begin(wire);
-  encoder.newPath(metal1, dbWireType::ROUTED);
-  encoder.addPoint(recv_x, recv_y + 2000);
-  encoder.addRect(-70, -70, 70, 70);
-  encoder.newPath(metal1, dbWireType::ROUTED);
-  encoder.addPoint(recv_x, recv_y);
-  encoder.addPoint(recv_x, recv_y + 2000);
-  encoder.end();
-
-  EXPECT_THROW(orderWires(&logger_, block_), std::runtime_error);
-  EXPECT_FALSE(net->isWireOrdered());
+  EXPECT_EQ(decoder.next(), dbWireDecoder::END_DECODE);
 }
 
 }  // namespace odb

--- a/src/odb/test/cpp/TestOrderWires.cpp
+++ b/src/odb/test/cpp/TestOrderWires.cpp
@@ -51,13 +51,18 @@ class TestOrderWires : public tst::Fixture
                                  .iterms = {{"net", "A"}}});
 
     // The bterm associated to the bump has no geometry.
-    makeBTerm(block_, "net", {.io_type = dbIoType::INPUT, .bpins = {}});
+    dbBTerm* bterm
+        = makeBTerm(block_, "net", {.io_type = dbIoType::INPUT, .bpins = {}});
 
     bump_net.net = block_->findNet("net");
     bump_net.receiver_iterm = receiver->findITerm("A");
     bump_net.bump_iterm = bump->findITerm("A");
-    bump_net.bump_iterm->setSpecial();
-    dbStringProperty::create(bump_net.net, "BUMP_ASSIGNMENT", "ASSIGNED");
+
+    dbChipRegion* chip_region = dbChipRegion::create(
+        db_->getChip(), "R1", dbChipRegion::Side::FRONT, nullptr);
+    dbChipBump* chip_bump = dbChipBump::create(chip_region, bump);
+    chip_bump->setNet(bump_net.net);
+    chip_bump->setBTerm(bterm);
 
     bump_net.receiver_iterm->getAvgXY(&bump_net.receiver_x,
                                       &bump_net.receiver_y);


### PR DESCRIPTION
Resolve #11014.

It looks like, for 3D-IC, _a net bonding two dies with one terminal in each die_ requires a DEF port component on each side so that each one of those dies can be treated as a standalone design. Those ports exist only at the logical level and they are not actual physical top-level terminals. One consequence of that is: **at the input part of such a cross-die net**, i.e., the part that is receving the signal, ODB sees a net being driven by a bterm with no geometry.

When we run `orderWires`, before it can actually walk the wire and generate a new encoding, it needs to set up an initial point for that wire. Before the changes here, for a net with a driver bterm without geometry (such as the one described in the previous paragraph), `orderWires` would default the starting point as the first metal point that it registered for that wire. That could lead to two situations, and they're both bad:
1. If the wire did NOT have a patch at the beginning, **`orderWires` would assign an **arbitrary point** as the starting point and the wire would be ordered based on that** - nothing downstream would complain about it.
2. If the wire did have a patch at the beginning,`orderWires` would register the patch point as the starting point and it would try to perform a DFS from that patch point downstream. However, there would be no edge connecting that point to the rest of the wire. **The result would be that `orderWires` would early-return, keep the original encoding AND still assign the wire as ordered (`wireOrdered(true)`)**.

The item (2) is exactly the situation @dsengupta0628 stumbled into when she was testing 3D RCX. That's why we were getting a SPEF with empty *CONN entries.

All that said, this PR:
1. Ensure that for an input bump net, `orderWires` starting point is correctly assigned to the bump terminal.
2. Ensure that if DFS fails for whatever reason, `orderWires` errors.

**As the fix here relies on the existence of a `dbChipBump`, it won't work if a design with such a net is loaded independently via `read_def` as a standalone 2D design. This will need to be revisited.**

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
#11005.
