### PR TITLE
mbff: dont count Enable input pin as data input

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -6193,7 +6193,6 @@ bool dbNetwork::isDPin(odb::dbITerm* iterm) const
 
 int dbNetwork::getNumD(odb::dbInst* inst) const
 {
-  int cnt_d = 0;
   const Cell* cell = dbToSta(inst->getMaster());
   const LibertyCell* lib_cell = testCell(cell);
   if (lib_cell == nullptr) {

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -6200,20 +6200,10 @@ int dbNetwork::getNumD(odb::dbInst* inst) const
     return 0;
   }
 
+  int cnt_d = 0;
   for (const Sequential& seq : lib_cell->sequentials()) {
-    const FuncExpr* data = seq.data();
-    if (data) {
-      for (auto port : data->ports()) {
-        odb::dbMTerm* mterm = staToDb(port);
-        if (mterm == nullptr) {
-          continue;
-        }
-        odb::dbITerm* iterm = inst->getITerm(mterm);
-        if (iterm == nullptr) {
-          continue;
-        }
-        cnt_d += !(isScanIn(iterm) || isScanEnable(iterm));
-      }
+    if (seq.isRegister() || seq.isLatch()) {
+      cnt_d++;
     }
   }
 


### PR DESCRIPTION
## Summary
The current `getNumD()` implementation counts the Enable pin on our Enable flops as a D pin.

## Type of Change
- Bug fix

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
