### PR TITLE
grt/cugr: skip zero length segments during buildNetRoute

### DIFF
--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -968,6 +968,11 @@ void CUGR::buildNetRoute(const GRNet* net, GRoute& route) const
       routing_tree, [&](const std::shared_ptr<GRTreeNode>& node) {
         for (const auto& child : node->getChildren()) {
           if (node->getLayerIdx() == child->getLayerIdx()) {
+            // Degenerate tree edges (same gcell and layer) would become
+            // zero-length segments, which segmentIsLine rejects.
+            if (node->x() == child->x() && node->y() == child->y()) {
+              continue;
+            }
             auto [min_x, max_x] = std::minmax({node->x(), child->x()});
             auto [min_y, max_y] = std::minmax({node->y(), child->y()});
 


### PR DESCRIPTION
## Summary

Fix GRT-0265 (`Segment N of net X is not a horizontal/vertical line or via`)
when running CUGR with timing repair.

`PatternRoute::constructDetours` (stage 3) can create a shifted detour node
that lands on the gcell of an existing node, producing a routing tree edge
whose endpoints share the same gcell and layer. `CUGR::buildNetRoute`
converted such edges into zero-length segments (dimensionality 0), which
`GlobalRouter::segmentIsLine` rejects. The error surfaced during incremental
routing when `repair_timing` removed a buffer and the post-merge
`isConnected` check swept the merged route.

The fix skips degenerate tree edges in `CUGR::buildNetRoute`, the single
conversion point from CUGR trees to `GRoute` segments. A zero-length segment
describes no wire and both endpoints coincide, so dropping it changes no
geometry, demand, or guides.

## Type of Change

- Bug fix

## Impact

`global_route -use_cugr` followed by `repair_timing` no longer fails with
GRT-0265 (reproduced on ORFS gf180/riscv32i). Routing results are unchanged:
initial-route wirelength/congestion are bit-identical on the reproducer, and
detailed routing converges to 0 violations.

## Verification

- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass (grt regression: 154/154).
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues

None
