### PR TITLE
bazel: silence pip warnings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -335,6 +335,7 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "openroad-pip",
     python_version = "3.13",
+    quiet = True,
     requirements_lock = "//bazel:requirements_lock_3_13.txt",
 )
 use_repo(pip, "openroad-pip")


### PR DESCRIPTION
## Summary
Silence bazel warning that we're not going to fix.
