### PR TITLE
cts: fix infinite loop in HTree bisection when sink count reaches 1

### DIFF
--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -1268,6 +1268,14 @@ void HTreeBuilder::run()
 
     computeLevelTopology(level, regionWidth, regionHeight);
 
+    if (numSinksPerSubRegion <= 1) {
+      logger_->info(CTS,
+                    136,
+                    " Stop criterion found. Sink region has {} sink(s).",
+                    numSinksPerSubRegion);
+      break;
+    }
+
     if (isNumberOfSinksTooSmall(numSinksPerSubRegion)) {
       if (options_->getMaxWl()) {
         double maxHPWL = topologyForEachLevel_.back().getLargestSinkRegionHPWL(

--- a/src/cts/test/array.ok
+++ b/src/cts/test/array.ok
@@ -66,7 +66,7 @@
     Sinks per sub-region: 1
     Sub-region size: 41.2500 X 79.5345
 [INFO CTS-0034]     Segment length (rounded): 20.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 120.
 [INFO CTS-0201] 225 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/array_ins_delay.ok
+++ b/src/cts/test/array_ins_delay.ok
@@ -66,7 +66,7 @@
     Sinks per sub-region: 1
     Sub-region size: 41.2500 X 79.5345
 [INFO CTS-0034]     Segment length (rounded): 20.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 120.
 [INFO CTS-0201] 225 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/array_max_wl.ok
+++ b/src/cts/test/array_max_wl.ok
@@ -396,7 +396,7 @@ TritonCTS forced slew degradation on these wires.
 [DEBUG CTS-tech char]     Key: 14 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 8 wl2fistyBuf: 8 lastWL: 8 delay: 0
 [DEBUG CTS-tech char] curr wl = 12
 [DEBUG CTS-tech char]     Key: 0 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 4 wl2fistyBuf: 4 lastWL: 4 delay: 0
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 120.
 [INFO CTS-0201] 225 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/array_no_blockages.ok
+++ b/src/cts/test/array_no_blockages.ok
@@ -65,7 +65,7 @@
     Sinks per sub-region: 1
     Sub-region size: 41.2500 X 79.5523
 [INFO CTS-0034]     Segment length (rounded): 20.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 120.
 [INFO CTS-0201] 225 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/array_repair_clock_nets.ok
+++ b/src/cts/test/array_repair_clock_nets.ok
@@ -66,7 +66,7 @@
     Sinks per sub-region: 1
     Sub-region size: 41.2500 X 79.5345
 [INFO CTS-0034]     Segment length (rounded): 20.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 120.
 [INFO CTS-0201] 225 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/colocated_sinks.ok
+++ b/src/cts/test/colocated_sinks.ok
@@ -31,7 +31,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 2.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/find_clock_pad.ok
+++ b/src/cts/test/find_clock_pad.ok
@@ -29,7 +29,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0714 X 0.0357
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 2.
 [INFO CTS-0018]     Created 3 clock buffers.
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 2.

--- a/src/cts/test/gated_clock1.ok
+++ b/src/cts/test/gated_clock1.ok
@@ -50,7 +50,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/gated_clock2.ok
+++ b/src/cts/test/gated_clock2.ok
@@ -33,7 +33,7 @@
     Sinks per sub-region: 1
     Sub-region size: 3.5489 X 0.6050
 [INFO CTS-0034]     Segment length (rounded): 2.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 2.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.
@@ -84,7 +84,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net gclk1_regs.

--- a/src/cts/test/gated_clock3.ok
+++ b/src/cts/test/gated_clock3.ok
@@ -131,7 +131,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net gclk4_regs.

--- a/src/cts/test/gated_clock4.ok
+++ b/src/cts/test/gated_clock4.ok
@@ -76,7 +76,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net gclk4_regs.

--- a/src/cts/test/gated_clock5.ok
+++ b/src/cts/test/gated_clock5.ok
@@ -31,7 +31,7 @@
     Sinks per sub-region: 1
     Sub-region size: 3.5902 X 6.0700
 [INFO CTS-0034]     Segment length (rounded): 2.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 2.
 [INFO CTS-0201] 1 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/hier_insertion_delay.ok
+++ b/src/cts/test/hier_insertion_delay.ok
@@ -31,7 +31,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 1 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/insertion_delay.ok
+++ b/src/cts/test/insertion_delay.ok
@@ -30,7 +30,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (692.813 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 1 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/inverters.ok
+++ b/src/cts/test/inverters.ok
@@ -31,7 +31,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 1 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/lvt_lib.ok
+++ b/src/cts/test/lvt_lib.ok
@@ -26,7 +26,7 @@
     Sinks per sub-region: 1
     Sub-region size: 0.0000 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 1.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.

--- a/src/cts/test/max_wl_two_sinks.ok
+++ b/src/cts/test/max_wl_two_sinks.ok
@@ -31,7 +31,7 @@
     Sinks per sub-region: 1
     Sub-region size: 642.1429 X 0.0000
 [INFO CTS-0034]     Segment length (rounded): 1.
-[INFO CTS-0054]  Stop criterion found. Sink region hpwl (900.000 um) did not improve and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 3.
 [INFO CTS-0018]     Created 43 clock buffers.
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 22.

--- a/src/cts/test/skip_nets.ok
+++ b/src/cts/test/skip_nets.ok
@@ -56,7 +56,7 @@ CTS config:
     Sinks per sub-region: 1
     Sub-region size: 3.5489 X 0.6050
 [INFO CTS-0034]     Segment length (rounded): 2.
-[INFO CTS-0038]  Stop criterion found. Sink region hpwl is smaller than max wirelength (530.044 um) and max number of sinks is 15.
+[INFO CTS-0136]  Stop criterion found. Sink region has 1 sink(s).
 [INFO CTS-0035]  Number of sinks covered: 2.
 [INFO CTS-0201] 0 blockages from hard placement blockages and placed macros will be used.
 [INFO CTS-0027] Generating H-Tree topology for net clk_regs.


### PR DESCRIPTION
With max_wl set, once sinks per sub-region reaches 1 the only remaining stop criteria were hpwl < max_wl (CTS-0038) or hpwl not improving (CTS-0054). If hpwl keeps improving asymptotically above max_wl, the loop bisects up to clock_tree_max_depth (100) with per-level cost doubling, i.e. a practical hang. Break once sinks <= 1: further bisection cannot reduce fanout.

Reviewer notes:
- All .ok diffs change only the stop-criterion message line; buffer counts and tree structure are unchanged, so no QoR change in the existing suite.
- Trade-off: under max_wl this stops even if hpwl is still improving toward max_wl; a long final wire is left to repair_clock_nets.
- Check is placed after computeLevelTopology, matching where the old criteria fired. CTS-0136 is a new message ID.

Reported in ascenium/issues/50; demonstrated by max_wl_two_sinks.

## Summary
[Describe your changes here]

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix
- New feature
- Breaking change
- Refactoring
- Documentation update

## Impact
[How does this change the tool's behavior?]

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ ] I have run the relevant tests and they pass.
- [ ] My code follows the repository's formatting guidelines.
<!-- Delete next item if this PR is not a bug fix or new feature -->
- [ ] I have included tests to prevent regressions.
- [ ] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]
