### PR TITLE
web: add rudy heatmap view as save_image -web display option

### DIFF
--- a/src/web/README.md
+++ b/src/web/README.md
@@ -81,6 +81,7 @@ field and the value is `true` or `false`.
 | `net_clock` | true | Clock nets |
 | `rows` | false | Row outlines |
 | `tracks_pref` | false | Preferred-direction tracks |
+| `rudy` | false | Estimated congestion (RUDY) heatmap overlay |
 
 #### Examples
 
@@ -104,6 +105,9 @@ save_image -web -area {0 0 100 100} -width 2048 region.png
 save_image -web -display_option {routing false} \
                 -display_option {net_power false} \
                 layout.png
+
+# Save with RUDY congestion heatmap overlay
+save_image -web -display_option {rudy true} layout_rudy.png
 ```
 
 ### Save Report

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -233,6 +233,7 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
     {"regions",            &TileVisibility::regions,            true},
     {"mfg_grid",           &TileVisibility::mfg_grid,           false},
     {"gcell_grid",         &TileVisibility::gcell_grid,         false},
+    {"rudy",               &TileVisibility::rudy,               false},
     {"inst_names",         &TileVisibility::inst_names,         true},
     {"inst_pins",          &TileVisibility::inst_pins,          true},
     {"inst_pin_names",     &TileVisibility::inst_pin_names,     true},
@@ -1416,6 +1417,10 @@ static odb::PtrMap<odb::dbTechLayer, Color> buildLayerColorMap(
 
 void TileGenerator::clearOverlayCaches() const
 {
+  {
+    std::lock_guard lock(heatmap_mutex_);
+    heatmaps_.clear();
+  }
   std::lock_guard lock(overlay_cache_mutex_);
   dropOverlayCaches();
 }
@@ -2505,6 +2510,17 @@ void TileGenerator::drawGcellGridLayer(std::vector<unsigned char>& image,
   draw_h(die_area.yMax());
 }
 
+void TileGenerator::drawRudyLayer(std::vector<unsigned char>& image,
+                                  odb::dbBlock* /*block*/,
+                                  const TileFrame& frame,
+                                  const TileVisibility& /*vis*/) const
+{
+  auto rudy = getHeatMapSource("RUDY");
+  if (rudy) {
+    drawHeatMap(image, *rudy, frame);
+  }
+}
+
 /* static */
 std::vector<std::string> TileGenerator::saveImageLayerOrder(
     const TileVisibility& vis,
@@ -2546,14 +2562,14 @@ std::vector<std::string> TileGenerator::saveImageLayerOrder(
   return names;
 }
 
-const std::array<TileGenerator::PseudoLayerDef, 4>&
+const std::array<TileGenerator::PseudoLayerDef, 5>&
 TileGenerator::pseudoLayerDefs()
 {
   // z_index mirrors addPseudoLayer() in display-controls.js (see
   // saveImageLayerOrder); those values in turn follow the GUI's paint order
   // (renderThread.cpp:1201-1298), where the manufacturing grid goes down before
   // the routing layers and access points, regions and the gcell grid on top.
-  static const std::array<PseudoLayerDef, 4> defs = {{
+  static const std::array<PseudoLayerDef, 5> defs = {{
       {.name = "_access_points",
        .flag = &TileVisibility::access_points,
        .painter = &TileGenerator::drawAccessPointsLayer,
@@ -2570,6 +2586,10 @@ TileGenerator::pseudoLayerDefs()
        .flag = &TileVisibility::gcell_grid,
        .painter = &TileGenerator::drawGcellGridLayer,
        .z_index = 1002},
+      {.name = "_rudy",
+       .flag = &TileVisibility::rudy,
+       .painter = &TileGenerator::drawRudyLayer,
+       .z_index = 1003},
   }};
   return defs;
 }
@@ -4147,39 +4167,33 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
   return world_image_buffer;
 }
 
-std::vector<unsigned char> TileGenerator::generateHeatMapTile(
-    gui::HeatMapDataSource& source,
-    const int z,
-    const int x,
-    int y,
-    const double dpr,
-    const int requested_tile_px) const
+std::shared_ptr<gui::HeatMapDataSource> TileGenerator::getHeatMapSource(
+    const std::string& name) const
 {
-  // Same contract as the layer and overlay tiles: the client states the
-  // device-pixel square, so the heat map is as crisp as the layers under it
-  // instead of being a 256 px image stretched over them.  0 falls back to the
-  // historical 256*dpr.
-  const double effective_dpr = dpr > 0.0 ? dpr : 1.0;
-  const int dim
-      = requested_tile_px > 0
-            ? requested_tile_px
-            : static_cast<int>(std::lround(kTileSizeInPixel * effective_dpr));
-  std::vector<unsigned char> image_buffer(static_cast<size_t>(dim) * dim * 4,
-                                          0);
-
-  const double num_tiles_at_zoom = pow(2, z);
-  if (x < 0 || y < 0 || x >= num_tiles_at_zoom || y >= num_tiles_at_zoom) {
-    return {};
+  const std::lock_guard<std::mutex> lock(heatmap_mutex_);
+  const auto it = heatmaps_.find(name);
+  if (it != heatmaps_.end()) {
+    return it->second;
   }
+  const auto reg = gui::findRegisteredHeatMapSource(name);
+  if (!reg) {
+    return nullptr;
+  }
+  auto ptr = reg->createInstance();
+  if (ptr) {
+    ptr->setChip(db_->getChip());
+  }
+  heatmaps_[name] = ptr;
+  return ptr;
+}
 
-  y = num_tiles_at_zoom - 1 - y;
-  const odb::Rect hm_bounds = getBounds();
-  const double tile_dbu_size = hm_bounds.maxDXDY() / num_tiles_at_zoom;
-  const double scale = dim / tile_dbu_size;
-  // Same exact grid as the layer tiles this heat map is drawn over.
-  const TileFrame frame
-      = tileFrame(hm_bounds, x, y, tile_dbu_size, scale, effective_dpr);
+void TileGenerator::drawHeatMap(std::vector<unsigned char>& image_buffer,
+                                gui::HeatMapDataSource& source,
+                                const TileFrame& frame) const
+{
   const odb::Rect& dbu_tile = frame.cull;
+  const int dim = bufferDim(image_buffer);
+  const double scale = frame.scale;
   constexpr double kTextRectMargin = 0.8;
   // Authored in CSS px, so it scales with the display like every other
   // pixel-specified size; a fixed 14 would shrink as the ratio rises.
@@ -4249,9 +4263,45 @@ std::vector<unsigned char> TileGenerator::generateHeatMapTile(
     drawText(
         image_buffer, text_px_min, text_py_min, text, heatmap_font, text_color);
   }
+}
+
+std::vector<unsigned char> TileGenerator::generateHeatMapTile(
+    gui::HeatMapDataSource& source,
+    const int z,
+    const int x,
+    int y,
+    const double dpr,
+    const int requested_tile_px) const
+{
+  // Same contract as the layer and overlay tiles: the client states the
+  // device-pixel square, so the heat map is as crisp as the layers under it
+  // instead of being a 256 px image stretched over them.  0 falls back to the
+  // historical 256*dpr.
+  const double effective_dpr = dpr > 0.0 ? dpr : 1.0;
+  const int dim
+      = requested_tile_px > 0
+            ? requested_tile_px
+            : static_cast<int>(std::lround(kTileSizeInPixel * effective_dpr));
+  std::vector<unsigned char> image_buffer(static_cast<size_t>(dim) * dim * 4,
+                                          0);
+
+  const double num_tiles_at_zoom = pow(2, z);
+  if (x < 0 || y < 0 || x >= num_tiles_at_zoom || y >= num_tiles_at_zoom) {
+    return {};
+  }
+
+  y = num_tiles_at_zoom - 1 - y;
+  const odb::Rect hm_bounds = getBounds();
+  const double tile_dbu_size = hm_bounds.maxDXDY() / num_tiles_at_zoom;
+  const double scale = dim / tile_dbu_size;
+  // Same exact grid as the layer tiles this heat map is drawn over.
+  const TileFrame frame
+      = tileFrame(hm_bounds, x, y, tile_dbu_size, scale, effective_dpr);
+
+  drawHeatMap(image_buffer, source, frame);
 
   std::vector<unsigned char> png_data;
-  unsigned error = lodepng::encode(png_data, image_buffer, dim, dim);
+  const unsigned error = lodepng::encode(png_data, image_buffer, dim, dim);
   if (error) {
     logger_->report("PNG encoder error: {}", lodepng_error_text(error));
   }

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -243,6 +243,7 @@ struct TileVisibility
       = true;  // dbRegion boundaries overlay, on by default (Qt parity)
   bool mfg_grid = false;  // manufacturing-grid dots, off by default (Qt parity)
   bool gcell_grid = false;  // GCell grid lines, off by default (Qt parity)
+  bool rudy = false;        // RUDY congestion heatmap, off by default
 
   // Shapes — other per-layer geometry (not routing sub-types)
   bool blockages = true;  // master obstructions (LEF OBS)
@@ -834,6 +835,15 @@ class TileGenerator
                           odb::dbBlock* block,
                           const TileFrame& frame,
                           const TileVisibility& vis) const;
+  void drawRudyLayer(std::vector<unsigned char>& image,
+                     odb::dbBlock* block,
+                     const TileFrame& frame,
+                     const TileVisibility& vis) const;
+  void drawHeatMap(std::vector<unsigned char>& image,
+                   gui::HeatMapDataSource& source,
+                   const TileFrame& frame) const;
+  std::shared_ptr<gui::HeatMapDataSource> getHeatMapSource(
+      const std::string& name) const;
 
   // Registry of the self-painting pseudo layers: layer name -> visibility
   // flag -> painter -> paint order.  Single source of truth for the
@@ -853,12 +863,15 @@ class TileGenerator
                                    const TileVisibility&) const;
     int z_index;
   };
-  static const std::array<PseudoLayerDef, 4>& pseudoLayerDefs();
+  static const std::array<PseudoLayerDef, 5>& pseudoLayerDefs();
   // Draw a rect's edges clamped to the tile (die/core/region outlines).
   void outlineRectInTile(std::vector<unsigned char>& image,
                          const odb::Rect& r,
                          const Color& c,
                          const TileFrame& frame) const;
+  mutable std::mutex heatmap_mutex_;
+  mutable std::map<std::string, std::shared_ptr<gui::HeatMapDataSource>>
+      heatmaps_;
   mutable std::mutex overlay_cache_mutex_;
   mutable odb::PtrMap<odb::dbBlock, BpinApList> bpin_ap_cache_;
   mutable odb::PtrMap<odb::dbBlock, GridList> gcell_x_cache_;

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -267,11 +267,13 @@ cc_test(
         "//test:nangate45_data",
     ],
     deps = [
+        "//src/gui",
         "//src/gui:gui_stub",
         "//src/odb/src/db",
         "//src/tst:nangate45_fixture",
         "//src/web",
         "//third-party/lodepng",
+        "@boost.json",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/web/test/cpp/TestSaveImage.cpp
+++ b/src/web/test/cpp/TestSaveImage.cpp
@@ -425,9 +425,10 @@ class TestRUDYHeatMap : public gui::HeatMapDataSource
 
 TEST_F(SaveImageTest, RudyHeatmapRendersInSavedImage)
 {
+  auto logger = getLogger();
   gui::registerHeatMapSource(
-      "Estimated Congestion (RUDY)", "RUDY", "RUDY", [this]() {
-        return std::make_shared<TestRUDYHeatMap>(getLogger());
+      "Estimated Congestion (RUDY)", "RUDY", "RUDY", [logger]() {
+        return std::make_shared<TestRUDYHeatMap>(logger);
       });
 
   const std::string path_no_rudy = tempPng("no_rudy");

--- a/src/web/test/cpp/TestSaveImage.cpp
+++ b/src/web/test/cpp/TestSaveImage.cpp
@@ -10,7 +10,9 @@
 #include <string>
 #include <vector>
 
+#include "boost/json/parse.hpp"
 #include "gtest/gtest.h"
+#include "gui/heatMap.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
@@ -343,9 +345,10 @@ TEST_F(SaveImageTest, LayerCompositionOrderMatchesClientZIndex)
   vis.access_points = true;
   vis.regions = true;
   vis.gcell_grid = true;
+  vis.rudy = true;
 
   // zIndex on screen: _instances 0, _pins 1, _mfg_grid 2, tech layers 3.., then
-  // _access_points 1000, _regions 1001, _gcell_grid 1002.
+  // _access_points 1000, _regions 1001, _gcell_grid 1002, _rudy 1003.
   const std::vector<std::string> expected = {"_instances",
                                              "_pins",
                                              "_mfg_grid",
@@ -353,7 +356,8 @@ TEST_F(SaveImageTest, LayerCompositionOrderMatchesClientZIndex)
                                              "metal2",
                                              "_access_points",
                                              "_regions",
-                                             "_gcell_grid"};
+                                             "_gcell_grid",
+                                             "_rudy"};
   EXPECT_EQ(TileGenerator::saveImageLayerOrder(vis, tech_layers), expected);
 }
 
@@ -368,10 +372,87 @@ TEST_F(SaveImageTest, LayerCompositionOrderHonorsVisibility)
   vis.mfg_grid = false;
   vis.access_points = false;
   vis.gcell_grid = false;
+  vis.rudy = false;
 
   EXPECT_EQ(TileGenerator::saveImageLayerOrder(vis, tech_layers),
             (std::vector<std::string>{"_instances", "metal1"}))
       << "hidden overlays must not be composited at all";
+}
+
+TEST_F(SaveImageTest, ParseFromJsonRudyOption)
+{
+  TileVisibility vis;
+  EXPECT_FALSE(vis.rudy);
+  auto json_obj = boost::json::parse("{\"rudy\":true}").as_object();
+  vis.parseFromJson(json_obj);
+  EXPECT_TRUE(vis.rudy);
+}
+
+class TestRUDYHeatMap : public gui::HeatMapDataSource
+{
+ public:
+  explicit TestRUDYHeatMap(utl::Logger* logger)
+      : gui::HeatMapDataSource(logger,
+                               "Estimated Congestion (RUDY)",
+                               "RUDY",
+                               "RUDY")
+  {
+  }
+
+  odb::Rect getBounds() const override
+  {
+    return getBlock() ? getBlock()->getDieArea()
+                      : odb::Rect(0, 0, 100000, 100000);
+  }
+
+ protected:
+  bool populateMap() override
+  {
+    addToMap(odb::Rect(20000, 20000, 80000, 80000), 10.0);
+    return true;
+  }
+
+  void combineMapData(bool /*base_has_value*/,
+                      double& base,
+                      double new_data,
+                      double /*data_area*/,
+                      double /*intersection_area*/,
+                      double /*rect_area*/) override
+  {
+    base = new_data;
+  }
+};
+
+TEST_F(SaveImageTest, RudyHeatmapRendersInSavedImage)
+{
+  gui::registerHeatMapSource(
+      "Estimated Congestion (RUDY)", "RUDY", "RUDY", [this]() {
+        return std::make_shared<TestRUDYHeatMap>(getLogger());
+      });
+
+  const std::string path_no_rudy = tempPng("no_rudy");
+  TileVisibility vis_off;
+  vis_off.rudy = false;
+  tile_gen_->saveImage(path_no_rudy, odb::Rect(0, 0, 0, 0), 512, 0, vis_off);
+
+  const std::string path_rudy = tempPng("with_rudy");
+  TileVisibility vis_on;
+  vis_on.rudy = true;
+  tile_gen_->saveImage(path_rudy, odb::Rect(0, 0, 0, 0), 512, 0, vis_on);
+
+  ASSERT_TRUE(std::filesystem::exists(path_no_rudy));
+  ASSERT_TRUE(std::filesystem::exists(path_rudy));
+
+  unsigned w1 = 0, h1 = 0;
+  auto pixels_no_rudy = decodePngFile(path_no_rudy, w1, h1);
+  unsigned w2 = 0, h2 = 0;
+  auto pixels_rudy = decodePngFile(path_rudy, w2, h2);
+
+  EXPECT_EQ(w1, 512u);
+  EXPECT_EQ(w2, 512u);
+  EXPECT_GT(countNonTransparentPixels(pixels_rudy),
+            countNonTransparentPixels(pixels_no_rudy))
+      << "Enabling rudy heatmap should render additional heatmap pixels";
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Add rudy heatmap view as save_image -web display option. We have flows that run pre-route but we still benefit from early congestion hotspot information.

## Type of Change
- New feature
-
## Impact
New -display_option rudy to save_image -web

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
<!-- Delete next item if this PR is not a bug fix or new feature -->
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**
