### PR TITLE
odb: optimize dbSet<T>::size() checks in hot loops

### DIFF
--- a/src/dpl/include/dpl/OptMirror.h
+++ b/src/dpl/include/dpl/OptMirror.h
@@ -86,7 +86,7 @@ class OptimizeMirroring
 
   // Net bounding box size on nets with more instance terminals
   // than this are ignored.
-  static constexpr int mirror_max_iterm_count_ = 100;
+  static constexpr uint32_t mirror_max_iterm_count_ = 100;
 };
 
 }  // namespace dpl

--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -129,8 +129,7 @@ void OptimizeMirroring::findNetBoxes()
                   // Reducing HPWL on large nets (like clocks) is irrelevant
                   // to mirroring criteria. hasMoreThan() walks the iterms
                   // (bounded), so check once here and cache the result.
-                  || net->getITerms().hasMoreThan(
-                      static_cast<uint32_t>(mirror_max_iterm_count_));
+                  || net->getITerms().hasMoreThan(mirror_max_iterm_count_);
     if (ignore) {
       debugPrint(
           logger_, DPL, "opt_mirror", 2, "ignore {}", net->getConstName());

--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -131,7 +131,7 @@ void OptimizeMirroring::findNetBoxes()
                   // Note that getITerms().size() iteractes through the iterms
                   // so it has to be checked once here instead of where it is
                   // needed.
-                  || net->getITerms().size() > mirror_max_iterm_count_;
+                  || net->getITerms().hasMoreThan(mirror_max_iterm_count_);
     if (ignore) {
       debugPrint(
           logger_, DPL, "opt_mirror", 2, "ignore {}", net->getConstName());

--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -127,11 +127,10 @@ void OptimizeMirroring::findNetBoxes()
     bool ignore = net->getSigType().isSupply()
                   || net->isSpecial()
                   // Reducing HPWL on large nets (like clocks) is irrelevant
-                  // to mirroring criterra.
-                  // Note that getITerms().size() iteractes through the iterms
-                  // so it has to be checked once here instead of where it is
-                  // needed.
-                  || net->getITerms().hasMoreThan(mirror_max_iterm_count_);
+                  // to mirroring criteria. hasMoreThan() walks the iterms
+                  // (bounded), so check once here and cache the result.
+                  || net->getITerms().hasMoreThan(
+                      static_cast<uint32_t>(mirror_max_iterm_count_));
     if (ignore) {
       debugPrint(
           logger_, DPL, "opt_mirror", 2, "ignore {}", net->getConstName());

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1021,9 +1021,11 @@ int TritonRoute::main()
   initDesign();
   bool has_routable_nets = false;
   for (auto net : db_->getChip()->getBlock()->getNets()) {
-    if (net->getITerms().hasMoreThan(1)
-        || net->getBTerms().hasMoreThan(1)
-        || (!net->getITerms().empty() && !net->getBTerms().empty())) {
+    auto iterms = net->getITerms();
+    auto bterms = net->getBTerms();
+    if (iterms.hasMoreThan(1)
+        || bterms.hasMoreThan(1)
+        || (!iterms.empty() && !bterms.empty())) {
       has_routable_nets = true;
       break;
     }

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1023,8 +1023,7 @@ int TritonRoute::main()
   for (auto net : db_->getChip()->getBlock()->getNets()) {
     auto iterms = net->getITerms();
     auto bterms = net->getBTerms();
-    if (iterms.hasMoreThan(1)
-        || bterms.hasMoreThan(1)
+    if (iterms.hasMoreThan(1) || bterms.hasMoreThan(1)
         || (!iterms.empty() && !bterms.empty())) {
       has_routable_nets = true;
       break;

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1021,9 +1021,9 @@ int TritonRoute::main()
   initDesign();
   bool has_routable_nets = false;
   for (auto net : db_->getChip()->getBlock()->getNets()) {
-    if (net->getBTerms().hasMoreThan(1)
-        || net->getITerms().hasMoreThan(1)
-        || (!net->getBTerms().empty() && !net->getITerms().empty())) {
+    if (net->getITerms().hasMoreThan(1)
+        || net->getBTerms().hasMoreThan(1)
+        || (!net->getITerms().empty() && !net->getBTerms().empty())) {
       has_routable_nets = true;
       break;
     }

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1021,7 +1021,9 @@ int TritonRoute::main()
   initDesign();
   bool has_routable_nets = false;
   for (auto net : db_->getChip()->getBlock()->getNets()) {
-    if (net->getITerms().size() + net->getBTerms().size() > 1) {
+    if (net->getBTerms().hasMoreThan(1)
+        || net->getITerms().hasMoreThan(1)
+        || (!net->getBTerms().empty() && !net->getITerms().empty())) {
       has_routable_nets = true;
       break;
     }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -469,7 +469,9 @@ void GlobalRouter::globalRoute(bool save_guides)
   bool has_routable_nets = false;
 
   for (auto net : db_->getChip()->getBlock()->getNets()) {
-    if (net->getITerms().size() + net->getBTerms().size() > 1) {
+    if (net->getBTerms().hasMoreThan(1)
+        || net->getITerms().hasMoreThan(1)
+        || (!net->getBTerms().empty() && !net->getITerms().empty())) {
       has_routable_nets = true;
       break;
     }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -469,9 +469,11 @@ void GlobalRouter::globalRoute(bool save_guides)
   bool has_routable_nets = false;
 
   for (auto net : db_->getChip()->getBlock()->getNets()) {
-    if (net->getITerms().hasMoreThan(1)
-        || net->getBTerms().hasMoreThan(1)
-        || (!net->getITerms().empty() && !net->getBTerms().empty())) {
+    auto iterms = net->getITerms();
+    auto bterms = net->getBTerms();
+    if (iterms.hasMoreThan(1)
+        || bterms.hasMoreThan(1)
+        || (!iterms.empty() && !bterms.empty())) {
       has_routable_nets = true;
       break;
     }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -469,9 +469,9 @@ void GlobalRouter::globalRoute(bool save_guides)
   bool has_routable_nets = false;
 
   for (auto net : db_->getChip()->getBlock()->getNets()) {
-    if (net->getBTerms().hasMoreThan(1)
-        || net->getITerms().hasMoreThan(1)
-        || (!net->getBTerms().empty() && !net->getITerms().empty())) {
+    if (net->getITerms().hasMoreThan(1)
+        || net->getBTerms().hasMoreThan(1)
+        || (!net->getITerms().empty() && !net->getBTerms().empty())) {
       has_routable_nets = true;
       break;
     }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -471,8 +471,7 @@ void GlobalRouter::globalRoute(bool save_guides)
   for (auto net : db_->getChip()->getBlock()->getNets()) {
     auto iterms = net->getITerms();
     auto bterms = net->getBTerms();
-    if (iterms.hasMoreThan(1)
-        || bterms.hasMoreThan(1)
+    if (iterms.hasMoreThan(1) || bterms.hasMoreThan(1)
         || (!iterms.empty() && !bterms.empty())) {
       has_routable_nets = true;
       break;

--- a/src/odb/include/odb/dbSet.h
+++ b/src/odb/include/odb/dbSet.h
@@ -139,14 +139,15 @@ class dbSet
   bool hasMoreThan(uint32_t count) const
   {
     iterator it = begin();
+    const iterator end_it = end();
     while (count > 0) {
-      if (it == end()) {
+      if (it == end_it) {
         return false;
       }
       ++it;
       --count;
     }
-    return it != end();
+    return it != end_it;
   }
 
   ///
@@ -155,14 +156,15 @@ class dbSet
   bool hasExactly(uint32_t count) const
   {
     iterator it = begin();
+    const iterator end_it = end();
     while (count > 0) {
-      if (it == end()) {
+      if (it == end_it) {
         return false;
       }
       ++it;
       --count;
     }
-    return it == end();
+    return it == end_it;
   }
 
  private:

--- a/src/odb/include/odb/dbSet.h
+++ b/src/odb/include/odb/dbSet.h
@@ -135,28 +135,36 @@ class dbSet
 
   ///
   /// Returns true if this set has more than `count` elements.
+  /// Walks at most `count` + 1 elements; prefer this over comparing
+  /// against size(), which walks the whole set.
   ///
   bool hasMoreThan(uint32_t count) const
   {
     iterator it = begin();
     const iterator end_it = end();
-    while (count > 0) {
-      if (it == end_it) {
-        return false;
-      }
-      ++it;
-      --count;
-    }
-    return it != end_it;
+    return advanceBy(it, end_it, count) && it != end_it;
   }
 
   ///
   /// Returns true if this set has exactly `count` elements.
+  /// Walks at most `count` + 1 elements; prefer this over comparing
+  /// against size(), which walks the whole set. For `count` == 0
+  /// prefer empty().
   ///
   bool hasExactly(uint32_t count) const
   {
     iterator it = begin();
     const iterator end_it = end();
+    return advanceBy(it, end_it, count) && it == end_it;
+  }
+
+ private:
+  ///
+  /// Advances `it` by up to `count` elements, stopping at `end_it`.
+  /// Returns true if all `count` elements were traversed.
+  ///
+  static bool advanceBy(iterator& it, const iterator& end_it, uint32_t count)
+  {
     while (count > 0) {
       if (it == end_it) {
         return false;
@@ -164,10 +172,9 @@ class dbSet
       ++it;
       --count;
     }
-    return it == end_it;
+    return true;
   }
 
- private:
   dbIterator* itr_{nullptr};
   dbObject* parent_{nullptr};
 };

--- a/src/odb/include/odb/dbSet.h
+++ b/src/odb/include/odb/dbSet.h
@@ -136,7 +136,8 @@ class dbSet
   ///
   /// Returns true if this set has more than `count` elements.
   /// Walks at most `count` + 1 elements; prefer this over comparing
-  /// against size(), which walks the whole set.
+  /// against size(), which walks the whole set. hasMoreThan(0) is
+  /// equivalent to !empty().
   ///
   bool hasMoreThan(uint32_t count) const
   {

--- a/src/odb/include/odb/dbSet.h
+++ b/src/odb/include/odb/dbSet.h
@@ -138,13 +138,15 @@ class dbSet
   ///
   bool hasMoreThan(uint32_t count) const
   {
-    uint32_t c = 0;
-    for (iterator it = begin(); it != end(); ++it) {
-      if (++c > count) {
-        return true;
+    iterator it = begin();
+    while (count > 0) {
+      if (it == end()) {
+        return false;
       }
+      ++it;
+      --count;
     }
-    return false;
+    return it != end();
   }
 
   ///
@@ -152,13 +154,15 @@ class dbSet
   ///
   bool hasExactly(uint32_t count) const
   {
-    uint32_t c = 0;
-    for (iterator it = begin(); it != end(); ++it) {
-      if (++c > count) {
+    iterator it = begin();
+    while (count > 0) {
+      if (it == end()) {
         return false;
       }
+      ++it;
+      --count;
     }
-    return c == count;
+    return it == end();
   }
 
  private:

--- a/src/odb/include/odb/dbSet.h
+++ b/src/odb/include/odb/dbSet.h
@@ -129,9 +129,37 @@ class dbSet
   void reverse() { itr_->reverse(parent_); }
 
   ///
-  /// Returns true if set is empty
+  /// Returns true if this set is empty
   ///
   bool empty() const { return begin() == end(); }
+
+  ///
+  /// Returns true if this set has more than `count` elements.
+  ///
+  bool hasMoreThan(uint32_t count) const
+  {
+    uint32_t c = 0;
+    for (iterator it = begin(); it != end(); ++it) {
+      if (++c > count) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  ///
+  /// Returns true if this set has exactly `count` elements.
+  ///
+  bool hasExactly(uint32_t count) const
+  {
+    uint32_t c = 0;
+    for (iterator it = begin(); it != end(); ++it) {
+      if (++c > count) {
+        return false;
+      }
+    }
+    return c == count;
+  }
 
  private:
   dbIterator* itr_{nullptr};

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -1458,7 +1458,7 @@ bool dbNet::isConnected(const dbModNet* other) const
 
 bool dbNet::isConnectedByAbutment()
 {
-  if (getITermCount() > 2 || getBTermCount() > 0) {
+  if (getITerms().hasMoreThan(2) || !getBTerms().empty()) {
     return false;
   }
 

--- a/src/odb/test/cpp/BUILD
+++ b/src/odb/test/cpp/BUILD
@@ -68,6 +68,17 @@ cc_test(
 )
 
 cc_test(
+    name = "TestDbSet",
+    srcs = ["TestDbSet.cpp"],
+    deps = [
+        "//src/odb/src/db",
+        "//src/odb/test/cpp/helper",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "TestDbWire",
     srcs = ["TestDbWire.cc"],
     data = [

--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(TestGeom TestGeom.cpp)
 add_executable(TestModule TestModule.cpp)
 add_executable(TestLef58Properties TestLef58Properties.cpp)
 add_executable(TestGroup TestGroup.cpp)
+add_executable(TestDbSet TestDbSet.cpp)
 add_executable(TestGCellGrid TestGCellGrid.cpp)
 add_executable(TestJournal TestJournal.cpp)
 add_executable(TestAccessPoint TestAccessPoint.cpp)
@@ -67,6 +68,11 @@ target_link_libraries(TestLef58Properties
         ${GTEST_LIBS}
 )
 target_link_libraries(TestGroup
+        db
+        odb_test_helper
+        ${GTEST_LIBS}
+)
+target_link_libraries(TestDbSet
         db
         odb_test_helper
         ${GTEST_LIBS}
@@ -169,11 +175,12 @@ gtest_discover_tests(OdbGTests
     TEST_FILTER "-TestAccessPoint.*,-TestCallBacks.*,-TestGCellGrid.*,-TestGeom.*,-TestGroup.*,-TestGuide.*,-TestJournal.*-TestLef58Properties.*,-TestMaster.*,-TestModule.*,-TestNetTrack.*,-TestChips.*,-Test3DBloxParser.*,-Test3DBloxChecker.*"
 )
 
-add_dependencies(build_and_test 
-        TestCallBacks 
-        TestGeom 
-        TestModule 
-        TestGroup 
+add_dependencies(build_and_test
+        TestCallBacks
+        TestGeom
+        TestModule
+        TestGroup
+        TestDbSet
         TestGCellGrid 
         TestGuide
         TestNetTrack

--- a/src/odb/test/cpp/TestDbSet.cpp
+++ b/src/odb/test/cpp/TestDbSet.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <cstdint>
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "helper.h"
 #include "odb/db.h"
@@ -61,6 +64,14 @@ TEST_F(TestDbSet, HasExactlyBoundaries)
   EXPECT_FALSE(iterms.hasExactly(1));
   EXPECT_TRUE(iterms.hasExactly(2));
   EXPECT_FALSE(iterms.hasExactly(3));
+}
+
+TEST_F(TestDbSet, HugeCountTerminatesAtEnd)
+{
+  constexpr uint32_t kHuge = std::numeric_limits<uint32_t>::max();
+  dbSet<dbITerm> iterms = block_->findNet("n5")->getITerms();
+  EXPECT_FALSE(iterms.hasMoreThan(kHuge));
+  EXPECT_FALSE(iterms.hasExactly(kHuge));
 }
 
 TEST_F(TestDbSet, SequentialIteratorSet)

--- a/src/odb/test/cpp/TestDbSet.cpp
+++ b/src/odb/test/cpp/TestDbSet.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include "gtest/gtest.h"
+#include "helper.h"
+#include "odb/db.h"
+#include "odb/dbSet.h"
+
+namespace odb {
+namespace {
+
+class TestDbSet : public SimpleDbFixture
+{
+ protected:
+  TestDbSet()
+  {
+    create2LevetDbNoBTerms();
+    block_ = db_->getChip()->getBlock();
+  }
+
+  dbBlock* block_;
+};
+
+TEST_F(TestDbSet, EmptySet)
+{
+  dbSet<dbITerm> iterms = dbNet::create(block_, "unconnected")->getITerms();
+  EXPECT_TRUE(iterms.empty());
+  EXPECT_FALSE(iterms.hasMoreThan(0));
+  EXPECT_FALSE(iterms.hasMoreThan(1));
+  EXPECT_TRUE(iterms.hasExactly(0));
+  EXPECT_FALSE(iterms.hasExactly(1));
+}
+
+TEST_F(TestDbSet, SingleElementSet)
+{
+  // n7 is connected to i3/o only.
+  dbSet<dbITerm> iterms = block_->findNet("n7")->getITerms();
+  EXPECT_EQ(iterms.size(), 1u);
+  EXPECT_TRUE(iterms.hasMoreThan(0));
+  EXPECT_FALSE(iterms.hasMoreThan(1));
+  EXPECT_FALSE(iterms.hasExactly(0));
+  EXPECT_TRUE(iterms.hasExactly(1));
+  EXPECT_FALSE(iterms.hasExactly(2));
+}
+
+TEST_F(TestDbSet, HasMoreThanBoundaries)
+{
+  // n5 is connected to i1/o and i3/a.
+  dbSet<dbITerm> iterms = block_->findNet("n5")->getITerms();
+  EXPECT_EQ(iterms.size(), 2u);
+  EXPECT_TRUE(iterms.hasMoreThan(0));
+  EXPECT_TRUE(iterms.hasMoreThan(1));
+  EXPECT_FALSE(iterms.hasMoreThan(2));
+  EXPECT_FALSE(iterms.hasMoreThan(3));
+}
+
+TEST_F(TestDbSet, HasExactlyBoundaries)
+{
+  dbSet<dbITerm> iterms = block_->findNet("n5")->getITerms();
+  EXPECT_FALSE(iterms.hasExactly(0));
+  EXPECT_FALSE(iterms.hasExactly(1));
+  EXPECT_TRUE(iterms.hasExactly(2));
+  EXPECT_FALSE(iterms.hasExactly(3));
+}
+
+TEST_F(TestDbSet, SequentialIteratorSet)
+{
+  // getInsts() uses a different iterator than getITerms(); i1, i2, i3.
+  dbSet<dbInst> insts = block_->getInsts();
+  EXPECT_EQ(insts.size(), 3u);
+  EXPECT_TRUE(insts.hasMoreThan(2));
+  EXPECT_FALSE(insts.hasMoreThan(3));
+  EXPECT_TRUE(insts.hasExactly(3));
+  EXPECT_FALSE(insts.hasExactly(4));
+}
+
+}  // namespace
+}  // namespace odb

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1680,8 +1680,7 @@ static bool isPortBuffer(sta::dbNetwork* network, sta::Instance* inst)
     odb::dbInst* db_inst = network->staToDb(inst);
     for (odb::dbITerm* iterm : db_inst->getITerms()) {
       odb::dbNet* net = iterm->getNet();
-      if (net && net->getITerms().hasExactly(1)
-          && !net->getBTerms().empty()) {
+      if (net && net->getITerms().hasExactly(1) && !net->getBTerms().empty()) {
         return true;
       }
     }

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1679,7 +1679,7 @@ static bool isPortBuffer(sta::dbNetwork* network, sta::Instance* inst)
   if (network->libertyCell(inst) && network->libertyCell(inst)->isBuffer()) {
     odb::dbInst* db_inst = network->staToDb(inst);
     for (odb::dbITerm* iterm : db_inst->getITerms()) {
-      if (iterm->getNet() && iterm->getNet()->getITerms().size() == 1
+      if (iterm->getNet() && iterm->getNet()->getITerms().hasExactly(1)
           && !iterm->getNet()->getBTerms().empty()) {
         return true;
       }

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1679,8 +1679,9 @@ static bool isPortBuffer(sta::dbNetwork* network, sta::Instance* inst)
   if (network->libertyCell(inst) && network->libertyCell(inst)->isBuffer()) {
     odb::dbInst* db_inst = network->staToDb(inst);
     for (odb::dbITerm* iterm : db_inst->getITerms()) {
-      if (iterm->getNet() && iterm->getNet()->getITerms().hasExactly(1)
-          && !iterm->getNet()->getBTerms().empty()) {
+      odb::dbNet* net = iterm->getNet();
+      if (net && net->getITerms().hasExactly(1)
+          && !net->getBTerms().empty()) {
         return true;
       }
     }

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -2023,7 +2023,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || static_cast<int>(net->getITerms().size()) > kMaxNetFanout) {
+                || net->getITerms().hasMoreThan(kMaxNetFanout)) {
               continue;
             }
             seen_nets.insert(net);
@@ -2065,7 +2065,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || static_cast<int>(net->getITerms().size()) > kMaxNetFanout) {
+                || net->getITerms().hasMoreThan(kMaxNetFanout)) {
               continue;
             }
             seen_nets.insert(net);

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -2023,7 +2023,8 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || net->getITerms().hasMoreThan(static_cast<uint32_t>(kMaxNetFanout))) {
+                || net->getITerms().hasMoreThan(
+                    static_cast<uint32_t>(kMaxNetFanout))) {
               continue;
             }
             seen_nets.insert(net);
@@ -2065,7 +2066,8 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || net->getITerms().hasMoreThan(static_cast<uint32_t>(kMaxNetFanout))) {
+                || net->getITerms().hasMoreThan(
+                    static_cast<uint32_t>(kMaxNetFanout))) {
               continue;
             }
             seen_nets.insert(net);

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -2023,7 +2023,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || net->getITerms().hasMoreThan(kMaxNetFanout)) {
+                || net->getITerms().hasMoreThan(static_cast<uint32_t>(kMaxNetFanout))) {
               continue;
             }
             seen_nets.insert(net);
@@ -2065,7 +2065,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || net->getITerms().hasMoreThan(kMaxNetFanout)) {
+                || net->getITerms().hasMoreThan(static_cast<uint32_t>(kMaxNetFanout))) {
               continue;
             }
             seen_nets.insert(net);

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1987,7 +1987,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
   resp.id = req.id;
   resp.type = WebSocketResponse::kJson;
   static constexpr int kMaxConeInsts = 150;
-  static constexpr int kMaxNetFanout = 30;
+  static constexpr uint32_t kMaxNetFanout = 30;
 
   try {
     const std::string inst_name
@@ -2023,8 +2023,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || net->getITerms().hasMoreThan(
-                    static_cast<uint32_t>(kMaxNetFanout))) {
+                || net->getITerms().hasMoreThan(kMaxNetFanout)) {
               continue;
             }
             seen_nets.insert(net);
@@ -2066,8 +2065,7 @@ WebSocketResponse SelectHandler::handleSchematicCone(
             }
             odb::dbNet* net = iterm->getNet();
             if (!net || seen_nets.contains(net)
-                || net->getITerms().hasMoreThan(
-                    static_cast<uint32_t>(kMaxNetFanout))) {
+                || net->getITerms().hasMoreThan(kMaxNetFanout)) {
               continue;
             }
             seen_nets.insert(net);


### PR DESCRIPTION
In dbNet::getITermCount(), GlobalRouter.cpp, TritonRoute.cpp,
Rebuffer.cc, OptMirror.cpp, and request_handler.cpp, getITerms().size()
is called inside hot loops. Because dbSet<T>::size() iterates
over a linked list, this results in O(N) traversal per call,
severely degrading performance for massive nets. This bites on
designs where an unbuffered high-fanout control net (e.g. a
synchronous reset or scan enable on an ideal network) survives
into placement and routing with 100k+ ITerms; typical designs
never notice because synthesis buffers such nets into trees.

This patch adds generic early-exit idioms hasMoreThan(N) and
hasExactly(N) to dbSet<T>, and updates the hotspots to use these
bounded checks — each walks at most N+1 elements instead of the
whole set — without touching the core memory-optimized _dbNet
struct. Unit tests cover the boundary cases (empty set, N-1, N,
N+1) on two different iterator types.

These early-exit predicates are established practice for linked
lists used as compact storage rather than an invention: LLVM's
ADT/STLExtras.h provides the same idioms for its intrusive lists
(hasNItems, hasNItemsOrMore, hasNItemsOrLess, hasSingleElement),
std::forward_list omits size() entirely so that the O(N) walk is
visible at the call site (std::distance), and the Linux kernel's
list.h names the counting walk explicitly (list_count_nodes(),
list_is_singular()).

Considered and deliberately not done, to keep this PR a single
concern:

- Making dbSet<T>::size() O(1) by caching a count: defeats the
  memory-optimized object structs; the whole point is to avoid
  needing the full count in these checks.
- Renaming or deprecating dbSet<T>::size(): it is not uniformly
  O(N) (some iterators, e.g. dbBlockItr, answer from a vector),
  and there are ~250 call sites. A rename is a separate
  discussion, not a rider on a perf fix.
- Deduplicating the identical routable-nets checks in
  TritonRoute.cpp and GlobalRouter.cpp: the duplication predates
  this PR; hoisting a shared helper into odb is scope creep here.
- Additional variants (hasAtLeast, hasFewerThan, isSingular):
  no caller needs them yet.
- noexcept / [[nodiscard]] on the new methods: no precedent in
  odb headers; style consistency wins.
- Micro-ordering of short-circuit operands among the new bounded
  checks: every operand walks at most 2 elements, all orderings
  are semantically equivalent, the difference is a few pointer
  dereferences and unmeasurable, and automated review has
  proposed both orderings across rounds. The conditions stay in
  natural reading order.
- Converting the remaining getITerms()/getBTerms().size() call
  sites in dbNet.cpp (getITermCount(), getBTermCount(), debug
  report printing): they need the actual count, which is exactly
  what size() is for.
- std::vector/std::string size() comparisons on untouched lines
  in the same files: O(1) already; out of scope.
- Harmonizing signed/unsigned count types across the codebase:
  int is the de-facto style (~150 int-typed count/limit members,
  ~200 static_cast<int>(...size()) call sites). Out of scope;
  only the two single-use constants this PR already touches are
  retyped to uint32_t, which also makes a negative threshold
  unrepresentable rather than runtime-guarded.

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
