### PR TITLE
rsz: remove buffer insertion limit during parasitics estimation

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -430,7 +430,8 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
       double buffer_gain,
       bool match_cell_footprint,
       bool reroute,
-      bool verbose);
+      bool is_estimation = false,
+      bool verbose = false);
   int repairDesignBufferCount() const;
   // Try to reroute the net driven by drvr_pin to a lower-resistance layer.
   // Returns true if the reroute was accepted (net marked dirty for incremental

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -430,8 +430,8 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
       double buffer_gain,
       bool match_cell_footprint,
       bool reroute,
-      bool is_estimation = false,
-      bool verbose = false);
+      bool verbose,
+      bool is_estimation);
   int repairDesignBufferCount() const;
   // Try to reroute the net driven by drvr_pin to a lower-resistance layer.
   // Returns true if the reroute was accepted (net marked dirty for incremental

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -102,8 +102,8 @@ void RepairDesign::repairDesign(double max_wire_length,
                                 double slew_margin,
                                 double cap_margin,
                                 double buffer_gain,
-                                bool is_estimation,
-                                bool verbose)
+                                bool verbose,
+                                bool is_estimation)
 {
   init();
 
@@ -113,8 +113,8 @@ void RepairDesign::repairDesign(double max_wire_length,
                slew_margin,
                cap_margin,
                buffer_gain != 0.0,
-               is_estimation,
                verbose,
+               is_estimation,
                repaired_net_count,
                slew_violations,
                cap_violations,
@@ -245,8 +245,8 @@ void RepairDesign::repairDesign(
     double slew_margin,
     double cap_margin,
     bool initial_sizing,
-    bool is_estimation,
     bool verbose,
+    bool is_estimation,
     int& repaired_net_count,
     int& slew_violations,
     int& cap_violations,

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -102,6 +102,7 @@ void RepairDesign::repairDesign(double max_wire_length,
                                 double slew_margin,
                                 double cap_margin,
                                 double buffer_gain,
+                                bool is_estimation,
                                 bool verbose)
 {
   init();
@@ -111,7 +112,8 @@ void RepairDesign::repairDesign(double max_wire_length,
   repairDesign(max_wire_length,
                slew_margin,
                cap_margin,
-               buffer_gain,
+               buffer_gain != 0.0,
+               is_estimation,
                verbose,
                repaired_net_count,
                slew_violations,
@@ -243,6 +245,7 @@ void RepairDesign::repairDesign(
     double slew_margin,
     double cap_margin,
     bool initial_sizing,
+    bool is_estimation,
     bool verbose,
     int& repaired_net_count,
     int& slew_violations,
@@ -356,7 +359,7 @@ void RepairDesign::repairDesign(
     const int max_allowed_buffers
         = std::max(5000, static_cast<int>(driver_vertices.size() * 0.05));
     for (int i = driver_vertices.size() - 1; i >= 0; i--) {
-      if (inserted_buffer_count_ > max_allowed_buffers) {
+      if (!is_estimation && inserted_buffer_count_ > max_allowed_buffers) {
         logger_->warn(
             RSZ,
             3310,

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -55,14 +55,14 @@ class RepairDesign : sta::dbStaState
                     double slew_margin,
                     double cap_margin,
                     double buffer_gain,
-                    bool is_estimation,
-                    bool verbose);
+                    bool verbose,
+                    bool is_estimation);
   void repairDesign(double max_wire_length,  // zero for none (meters)
                     double slew_margin,
                     double cap_margin,
                     bool initial_sizing,
-                    bool is_estimation,
                     bool verbose,
+                    bool is_estimation,
                     int& repaired_net_count,
                     int& slew_violations,
                     int& cap_violations,

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -55,11 +55,13 @@ class RepairDesign : sta::dbStaState
                     double slew_margin,
                     double cap_margin,
                     double buffer_gain,
+                    bool is_estimation,
                     bool verbose);
   void repairDesign(double max_wire_length,  // zero for none (meters)
                     double slew_margin,
                     double cap_margin,
                     bool initial_sizing,
+                    bool is_estimation,
                     bool verbose,
                     int& repaired_net_count,
                     int& slew_violations,

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -3169,8 +3169,9 @@ void Resizer::findResizeSlacks(bool run_journal_restore,
   repair_design_->repairDesign(max_wire_length_,
                                0.0,
                                0.0,
-                               0.0,
-                               false,
+                               false,  // initial_sizing
+                               true,   // is_estimation
+                               false,  // verbose
                                repaired_net_count,
                                slew_violations,
                                cap_violations,
@@ -4989,6 +4990,7 @@ void Resizer::repairDesign(double max_wire_length,
                            double buffer_gain,
                            bool match_cell_footprint,
                            bool reroute,
+                           bool is_estimation,
                            bool verbose)
 {
   utl::Timer timer;
@@ -5002,8 +5004,12 @@ void Resizer::repairDesign(double max_wire_length,
     opendp_->initMacrosAndGrid();
   }
   utl::SetAndRestore set_reroute(repair_design_->reroute_, reroute);
-  repair_design_->repairDesign(
-      max_wire_length, slew_margin, cap_margin, buffer_gain, verbose);
+  repair_design_->repairDesign(max_wire_length,
+                               slew_margin,
+                               cap_margin,
+                               buffer_gain,
+                               is_estimation,
+                               verbose);
   logger_->info(RSZ, 504, "Runtime: {:.2f}s", timer.elapsed());
 }
 

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -3170,8 +3170,8 @@ void Resizer::findResizeSlacks(bool run_journal_restore,
                                0.0,
                                0.0,
                                false,  // initial_sizing
-                               true,   // is_estimation
                                false,  // verbose
+                               true,   // is_estimation
                                repaired_net_count,
                                slew_violations,
                                cap_violations,
@@ -4990,8 +4990,8 @@ void Resizer::repairDesign(double max_wire_length,
                            double buffer_gain,
                            bool match_cell_footprint,
                            bool reroute,
-                           bool is_estimation,
-                           bool verbose)
+                           bool verbose,
+                           bool is_estimation)
 {
   utl::Timer timer;
   utl::SetAndRestore set_match_footprint(match_cell_footprint_,
@@ -5008,8 +5008,8 @@ void Resizer::repairDesign(double max_wire_length,
                                slew_margin,
                                cap_margin,
                                buffer_gain,
-                               is_estimation,
-                               verbose);
+                               verbose,
+                               is_estimation);
   logger_->info(RSZ, 504, "Runtime: {:.2f}s", timer.elapsed());
 }
 

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -320,6 +320,7 @@ repair_design_cmd(double max_length,
                         pre_placement,
                         match_cell_footprint,
                         reroute,
+                        false, // is_estimation
                         verbose);
 }
 

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -320,8 +320,8 @@ repair_design_cmd(double max_length,
                         pre_placement,
                         match_cell_footprint,
                         reroute,
-                        false, // is_estimation
-                        verbose);
+                        verbose,
+                        false); // is_estimation
 }
 
 int

--- a/src/rsz/test/rsz_aux.py
+++ b/src/rsz/test/rsz_aux.py
@@ -60,6 +60,7 @@ def repair_design(
         match_cell_footprint,
         reroute,
         verbose,
+        False,
     )
 
 


### PR DESCRIPTION
Global placement can generate topologies with exceptionally high fanout (e.g., synchronous reset networks in MegaBoom or CoralNPU), causing OpenSTA to stall computing delay on massive unbuffered RC nets. `repair_design` is invoked as a pre-processing step to linearize delay computation. The default hard limit of 5,000 buffers causes it to silently bail out on large networks, defeating the estimation pass and resulting in severely pessimistic and inaccurate timing-driven placement.

This bypasses the buffer limit when `repairDesign` is called in estimation mode, enabling complete linearization and significantly faster, more accurate timing estimation for large designs.

## Alternatives considered

- **Raising or scaling the cap instead of bypassing it**: any finite cap re-introduces the silent bail-out on sufficiently large designs; the estimation pass needs complete linearization to produce meaningful delays.
- **Removing the cap in the normal `repair_design` flow as well**: out of scope here; the cap remains as a zero-config futility guard for user-invoked repair.
- **A user-facing option to control the limit**: the limit is an internal guard rather than a tuning knob; no new Tcl surface is added.
- **An `enum class` mode instead of a `bool`**: a single internal caller sets it and there is no third mode to express; an enum adds API surface without distinguishing anything.
- **Carrying the mode as member state (`SetAndRestore`) on `RepairDesign` instead of threading a parameter**: the parameter keeps the mode visible at each call site through the overload chain.
- **Default argument values for the new parameter**: dropped after review feedback; defaulted bools ahead of `verbose` can silently remap positional arguments of existing callers. All call sites now pass both flags explicitly, so a stale caller fails to compile instead of changing behavior.
- **A regression test that triggers the limit**: exercising the cap requires a design that inserts more than 5,000 buffers, which is beyond regression-suite scale; the change is exercised by large-design flow runs (MegaBoom, CoralNPU).
