### PR TITLE
dbSta: report_cell_usage should account for data size in column widths

### DIFF
--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <format>
 #include <fstream>
 #include <functional>
 #include <map>
@@ -780,15 +779,15 @@ void dbSta::reportCellUsage(odb::dbModule* module,
   const int area_width
       = std::max(10,
                  static_cast<int>(
-                     std::format("{:.2f}", total_area / area_to_microns).size())
+                     fmt::format("{:.2f}", total_area / area_to_microns).size())
                      + column_padding);
   const int type_width = std::max({37,
                                    max_master_name_length + column_padding,
                                    max_type_name_length + column_padding});
 
-  const std::string header_format = std::format(
+  const std::string header_format = fmt::format(
       "{{:{}}} {{:>{}}} {{:>{}}}", type_width, count_width, area_width);
-  const std::string format = std::format("  {{:{}}} {{:>{}}} {{:>{}.2f}}",
+  const std::string format = fmt::format("  {{:{}}} {{:>{}}} {{:>{}.2f}}",
                                          type_width - 2,
                                          count_width,
                                          area_width);

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <format>
 #include <fstream>
 #include <functional>
 #include <map>
@@ -739,8 +740,6 @@ void dbSta::reportCellUsage(odb::dbModule* module,
   auto block = db_->getChip()->getBlock();
   const double area_to_microns = std::pow(block->getDbUnitsPerMicron(), 2);
 
-  const char* header_format = "{:37} {:>7} {:>10}";
-  const char* format = "  {:35} {:>7} {:>10.2f}";
   if (block->getTopModule() != module) {
     logger_->report("Cell type report for {} ({})",
                     module->getModInst()->getHierarchicalName(),
@@ -748,7 +747,6 @@ void dbSta::reportCellUsage(odb::dbModule* module,
   } else {
     countPhysicalOnlyInstancesByType(instances_types, insts);
   }
-  logger_->report(header_format, "Cell type report:", "Count", "Area");
 
   const std::regex regexp(" |/|-");
   std::string metrics_suffix;
@@ -756,17 +754,50 @@ void dbSta::reportCellUsage(odb::dbModule* module,
     metrics_suffix = fmt::format("__in_module:{}", module->getName());
   }
 
+  int max_type_name_length = 0;
+  int max_master_name_length = 0;
   int total_usage = 0;
   int64_t total_area = 0;
   for (auto [type, stats] : instances_types) {
     total_usage += stats.count;
+    total_area += stats.area;
+    max_type_name_length
+        = std::max(max_type_name_length,
+                   static_cast<int>(getInstanceTypeText(type).size()));
+  }
+  if (verbose) {
+    for (auto inst : insts) {
+      auto master = inst->getMaster();
+      max_master_name_length = std::max(
+          max_master_name_length, static_cast<int>(master->getName().size()));
+    }
   }
 
+  const int column_padding = 2;
+
+  const int count_width = std::max(
+      7, static_cast<int>(std::to_string(total_usage).size()) + column_padding);
+  const int area_width
+      = std::max(10,
+                 static_cast<int>(
+                     std::format("{:.2f}", total_area / area_to_microns).size())
+                     + column_padding);
+  const int type_width = std::max({37,
+                                   max_master_name_length + column_padding,
+                                   max_type_name_length + column_padding});
+
+  const std::string header_format = std::format(
+      "{{:{}}} {{:>{}}} {{:>{}}}", type_width, count_width, area_width);
+  const std::string format = std::format("  {{:{}}} {{:>{}}} {{:>{}.2f}}",
+                                         type_width - 2,
+                                         count_width,
+                                         area_width);
+
+  logger_->report(header_format, "Cell type report:", "Count", "Area");
   for (auto [type, stats] : instances_types) {
     const std::string type_name = getInstanceTypeText(type);
     logger_->report(
         format, type_name, stats.count, stats.area / area_to_microns);
-    total_area += stats.area;
 
     const std::string type_class
         = toLowerCase(regex_replace(type_name, regexp, "_"));

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -59,6 +59,7 @@ ALL_TESTS = [
     "report_cell_usage_modinsts",
     "report_cell_usage_modinsts_metrics",
     "report_cell_usage_physical_only",
+    "report_cell_usage_wide_columns",
     "report_json1",
     "report_timing_histogram",
     "report_logic_depth_histogram",
@@ -229,6 +230,10 @@ filegroup(
             ],
             "report_cell_usage_physical_only": [
                 "report_cell_usage_no_taps.def",
+            ],
+            "report_cell_usage_wide_columns": [
+                "Nangate45/fakeram45_1024x32.lef",
+                "report_cell_usage.def",
             ],
             "report_json1": [
                 "reg6.def",

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -49,6 +49,7 @@ or_integration_tests(
     report_cell_usage_modinsts
     report_cell_usage_modinsts_metrics
     report_cell_usage_physical_only
+    report_cell_usage_wide_columns
     report_json1
     report_timing_histogram
     report_logic_depth_histogram

--- a/src/dbSta/test/report_cell_usage_wide_columns.ok
+++ b/src/dbSta/test/report_cell_usage_wide_columns.ok
@@ -1,0 +1,51 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0227] LEF file: Nangate45/fakeram45_1024x32.lef, created 1 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 676 components and 2850 component-terminals.
+[INFO ODB-0133]     Created 579 nets and 1498 connections.
+Cell type report:                        Count          Area
+  Macro                                    400   13284040.00
+  Fill cell                                168         44.69
+  Buffer                                120202      95980.25
+  Inverter                                  30         16.49
+  Sequential cell                           35        158.27
+  Multi-Input combinational cell           241        316.54
+  Total                                 121076   13380556.24
+
+Cell instance report:
+  AND2_X1                                   22         23.41
+  fakeram45_1024x32                        400   13284040.00
+  AND3_X1                                    8         10.64
+  AND4_X1                                    1          1.60
+  AOI211_X1                                  3          3.99
+  AOI21_X1                                   7          7.45
+  AOI221_X1                                  1          1.60
+  AOI221_X4                                  1          3.46
+  AOI22_X1                                   3          3.99
+  BUF_X1                                120016      95772.77
+  BUF_X2                                     8          8.51
+  BUF_X4                                    53         98.69
+  CLKBUF_X1                                123         98.15
+  CLKBUF_X2                                  2          2.13
+  DFF_X1                                    35        158.27
+  FILLCELL_X1                              168         44.69
+  INV_X1                                    28         14.90
+  INV_X2                                     2          1.60
+  MUX2_X1                                   46         85.65
+  NAND2_X1                                  28         22.34
+  NAND2_X2                                   1          1.33
+  NAND3_X1                                   6          6.38
+  NAND4_X1                                   4          5.32
+  NOR2_X1                                   22         17.56
+  NOR2_X2                                    1          1.33
+  NOR3_X1                                    6          6.38
+  NOR4_X1                                    3          3.99
+  OAI211_X1                                 16         21.28
+  OAI21_X1                                  27         28.73
+  OR2_X1                                     1          1.06
+  OR2_X2                                     1          1.33
+  OR3_X1                                     5          6.65
+  XNOR2_X1                                  18         28.73
+  XNOR2_X2                                   6         15.96
+  XOR2_X1                                    4          6.38

--- a/src/dbSta/test/report_cell_usage_wide_columns.tcl
+++ b/src/dbSta/test/report_cell_usage_wide_columns.tcl
@@ -13,13 +13,13 @@ set block [ord::get_db_block]
 
 # Widen the count column: 120000 buffers on top of the 676 cells in the design.
 set buffer [$db findMaster "BUF_X1"]
-for {set i 0} {$i < 120000} {incr i} {
+for { set i 0 } { $i < 120000 } { incr i } {
   odb::dbInst_create $block $buffer "wide_buf_$i"
 }
 
 # Widen the area column: each macro is 104.5 x 317.8 = 33210.1 um^2.
 set macro [$db findMaster "fakeram45_1024x32"]
-for {set i 0} {$i < 400} {incr i} {
+for { set i 0 } { $i < 400 } { incr i } {
   odb::dbInst_create $block $macro "wide_macro_$i"
 }
 

--- a/src/dbSta/test/report_cell_usage_wide_columns.tcl
+++ b/src/dbSta/test/report_cell_usage_wide_columns.tcl
@@ -1,0 +1,26 @@
+# report_cell_usage with values too large for the default column widths.
+# The count column defaults to 7 characters and the area column to 10, so
+# instantiate enough cells to push both past those defaults: >100k instances
+# and >10,000,000 um^2 of area.
+source "helpers.tcl"
+read_lef "Nangate45/Nangate45.lef"
+read_lef "Nangate45/fakeram45_1024x32.lef"
+read_liberty "Nangate45/Nangate45_typ.lib"
+read_def "report_cell_usage.def"
+
+set db [ord::get_db]
+set block [ord::get_db_block]
+
+# Widen the count column: 120000 buffers on top of the 676 cells in the design.
+set buffer [$db findMaster "BUF_X1"]
+for {set i 0} {$i < 120000} {incr i} {
+  odb::dbInst_create $block $buffer "wide_buf_$i"
+}
+
+# Widen the area column: each macro is 104.5 x 317.8 = 33210.1 um^2.
+set macro [$db findMaster "fakeram45_1024x32"]
+for {set i 0} {$i < 400} {incr i} {
+  odb::dbInst_create $block $macro "wide_macro_$i"
+}
+
+report_cell_usage -verbose


### PR DESCRIPTION
## Summary
When working on design with a lot of cells or large areas the columns in this report would get messed up, this ensures we don't get up with a poorly formatted report.

Before:
```
Cell type report:                       Count       Area
  Macro                                   400 13284040.00
  Buffer                               120202   95980.25
  Total                                121076 13380556.24
```

After:
```
Cell type report:                        Count          Area
  Macro                                    400   13284040.00
  Buffer                                120202      95980.25
  Total                                 121076   13380556.24
```

## Type of Change
- Bug fix (ish)

## Impact
Improve report formatting

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**
