### PR TITLE
pad/pdn: add logger report before pausing in GUI to make it easier to determine by it paused

### DIFF
--- a/src/pad/src/ICeWall.cpp
+++ b/src/pad/src/ICeWall.cpp
@@ -1479,7 +1479,7 @@ void ICeWall::routeRDLDebugGUI(bool enable)
 {
   if (enable) {
     if (router_gui_ == nullptr) {
-      router_gui_ = std::make_unique<RDLGui>();
+      router_gui_ = std::make_unique<RDLGui>(logger_);
       if (router_ != nullptr) {
         router_gui_->setRouter(router_.get());
       }

--- a/src/pad/src/PadPlacer.cpp
+++ b/src/pad/src/PadPlacer.cpp
@@ -43,6 +43,12 @@ PadPlacer::PadPlacer(utl::Logger* logger,
   addInstsOverlapCache(insts);
 }
 
+void PadPlacer::guiPause(const std::string& reason) const
+{
+  logger_->report("Pausing pad placement on {}: {}", row_->getName(), reason);
+  gui::Gui::get()->pause();
+}
+
 void PadPlacer::populateInstWidths()
 {
   const odb::dbTransform xform(row_->getOrient());
@@ -663,7 +669,7 @@ void UniformPadPlacer::place()
     offset += target_spacing;
 
     if (gui_debug) {
-      gui::Gui::get()->pause();
+      guiPause(fmt::format("placed {} with uniform spacing", inst->getName()));
     }
   }
 }
@@ -798,7 +804,12 @@ void BumpAlignedPadPlacer::place()
       addInstanceObstructions(ginst);
 
       if (gui_debug) {
-        gui::Gui::get()->pause();
+        guiPause(
+            fmt::format("placed {} at {:.4f}um with a remaining spare gap "
+                        "of {:.4f}um",
+                        ginst->getName(),
+                        select_pos / dbus,
+                        max_travel / dbus));
       }
     }
 
@@ -1072,7 +1083,6 @@ odb::PtrMap<odb::dbInst, int> PlacerPadPlacer::initialPoolMapping() const
 void PlacerPadPlacer::debugPause(const std::string& msg) const
 {
   if (gui::Gui::enabled() && getLogger()->debugCheck(utl::PAD, "Pause", 1)) {
-    debugPrint(getLogger(), utl::PAD, "Pause", 1, msg);
     auto* gui = gui::Gui::get();
     gui->clearHighlights();
     for (const auto& [inst, iterms] : iterm_connections_) {
@@ -1082,7 +1092,7 @@ void PlacerPadPlacer::debugPause(const std::string& msg) const
         }
       }
     }
-    gui::Gui::get()->pause();
+    guiPause(msg);
   }
 }
 
@@ -1823,7 +1833,7 @@ void PlacerPadPlacer::debugCheckPlacement() const
     return;
   }
 
-  bool pause = false;
+  std::vector<odb::dbInst*> invalid;
   for (auto* inst : getInsts()) {
     if (checkInstancePlacement(inst)) {
       debugPrint(getLogger(),
@@ -1832,13 +1842,12 @@ void PlacerPadPlacer::debugCheckPlacement() const
                  1,
                  "Invalid placement for {}",
                  inst->getName());
-      pause = true;
+      invalid.push_back(inst);
     }
   }
 
-  if (pause && gui::Gui::enabled()) {
-    getLogger()->report("Pausing GUI due to invalid positions of pads");
-    gui::Gui::get()->pause();
+  if (!invalid.empty() && gui::Gui::enabled()) {
+    guiPause(fmt::format("invalid position(s) for {}", instNameList(invalid)));
   }
 }
 

--- a/src/pad/src/PadPlacer.h
+++ b/src/pad/src/PadPlacer.h
@@ -79,6 +79,10 @@ class PadPlacer
                                       boost::geometry::index::quadratic<16>>;
   using LayerTermObsTree = odb::PtrMap<odb::dbTechLayer, TermObsTree>;
 
+  // Halt the flow so the current state can be inspected in the GUI.  The
+  // reason is reported so the pause is actionable.
+  void guiPause(const std::string& reason) const;
+
   int placeInstance(int index,
                     odb::dbInst* inst,
                     const odb::dbOrientType& base_orient,

--- a/src/pad/src/RDLGui.cpp
+++ b/src/pad/src/RDLGui.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <map>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -13,10 +14,11 @@
 #include "gui/gui.h"
 #include "odb/PtrSetMap.h"
 #include "odb/geom.h"
+#include "utl/Logger.h"
 
 namespace pad {
 
-RDLGui::RDLGui()
+RDLGui::RDLGui(utl::Logger* logger) : logger_(logger)
 {
   addDisplayControl(kDrawVertex, true);
   addDisplayControl(kDrawEdge, true);
@@ -268,8 +270,10 @@ void RDLGui::setRouter(RDLRouter* router)
   }
 }
 
-void RDLGui::pause(bool timeout) const
+void RDLGui::pause(const std::string& reason, bool timeout) const
 {
+  logger_->report("Pausing RDL router: {}", reason);
+
   gui::Gui::get()->redraw();
 
   if (timeout) {

--- a/src/pad/src/RDLGui.h
+++ b/src/pad/src/RDLGui.h
@@ -4,10 +4,15 @@
 #pragma once
 
 #include <set>
+#include <string>
 #include <utility>
 
 #include "gui/gui.h"
 #include "odb/geom.h"
+
+namespace utl {
+class Logger;
+}  // namespace utl
 
 namespace pad {
 
@@ -16,7 +21,7 @@ class RDLRouter;
 class RDLGui : public gui::Renderer
 {
  public:
-  RDLGui();
+  explicit RDLGui(utl::Logger* logger);
   ~RDLGui() override;
 
   void setRouter(RDLRouter* router);
@@ -29,9 +34,12 @@ class RDLGui : public gui::Renderer
   void addSnap(const odb::Point& pt0, const odb::Point& pt1);
   void zoomToSnap(bool preview);
 
-  void pause(bool timeout) const;
+  // Halt the router so the current state can be inspected in the GUI.  The
+  // reason is reported so the pause is actionable.
+  void pause(const std::string& reason, bool timeout) const;
 
  private:
+  utl::Logger* logger_;
   RDLRouter* router_ = nullptr;
 
   std::set<std::pair<odb::Point, odb::Point>> snap_;

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -406,7 +406,7 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
   remove_edges.clear();
 
   if (gui_ != nullptr) {
-    gui_->pause(false);
+    gui_->pause("routing graph and terminal access points are built", false);
   }
 
   // Build list of routes
@@ -611,7 +611,12 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
     if (gui_ != nullptr
         && (logger_->debugCheck(utl::PAD, "Router", 3) || isDebugNet(net))) {
       const bool use_timeout = route->isRouted() && !isDebugNet(net);
-      gui_->pause(use_timeout);
+      gui_->pause(fmt::format("{} {} on {} ({} route(s) left in the queue)",
+                              route->isRouted() ? "routed" : "failed to route",
+                              src->getName(),
+                              net->getName(),
+                              route_queue.size()),
+                  use_timeout);
     }
 
     if (route_queue.empty() && iteration_count < max_router_iterations_) {
@@ -639,7 +644,11 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
 
       if (gui_ != nullptr
           && (logger_->debugCheck(utl::PAD, "Router", 2) || isDebugNet(net))) {
-        gui_->pause(false);
+        gui_->pause(fmt::format("{} route(s) failed at the end of routing "
+                                "iteration {}, before ripup",
+                                failed.size(),
+                                iteration_count),
+                    false);
       }
 
       debugPrint(logger_,
@@ -711,7 +720,13 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
       }
 
       if (gui_ != nullptr && logger_->debugCheck(utl::PAD, "Router", 2)) {
-        gui_->pause(false);
+        gui_->pause(
+            fmt::format("ripped up {} route(s) and requeued {} failed route(s) "
+                        "in routing iteration {}",
+                        ripup.size(),
+                        failed.size(),
+                        iteration_count),
+            false);
       }
     }
   }
@@ -867,7 +882,11 @@ void RDLRouter::populateTerminalAccessPoints(
       gui_->addSnap(target.center, snap);
     }
     gui_->zoomToSnap(true);
-    gui_->pause(false);
+    gui_->pause(fmt::format("{} candidate access point(s) for {} before "
+                            "violations are removed",
+                            snap_pts.size(),
+                            target.terminal->getName()),
+                false);
     gui_->clearSnap();
   }
 
@@ -973,8 +992,12 @@ void RDLRouter::populateTerminalAccessPoints(
       gui_->addSnap(target.center, snap);
     }
     gui_->zoomToSnap(true);
-    gui_->pause(!isDebugNet(target.terminal->getNet())
-                && !isDebugPin(target.terminal));
+    gui_->pause(
+        fmt::format("{} access point(s) remain for {} after violations "
+                    "are removed",
+                    snap_pts.size(),
+                    target.terminal->getName()),
+        !isDebugNet(target.terminal->getNet()) && !isDebugPin(target.terminal));
     gui_->clearSnap();
   }
 
@@ -1060,8 +1083,12 @@ RDLRouter::TerminalAccess RDLRouter::insertTerminalAccess(
       gui_->addSnap(target.center, snap);
     }
     gui_->zoomToSnap(true);
-    gui_->pause(!isDebugNet(target.terminal->getNet())
-                && !isDebugPin(target.terminal));
+    gui_->pause(
+        fmt::format("{} access point(s) usable for {} after points "
+                    "conflicting with committed routes are removed",
+                    snap_pts.size(),
+                    target.terminal->getName()),
+        !isDebugNet(target.terminal->getNet()) && !isDebugPin(target.terminal));
     gui_->clearSnap();
   }
 
@@ -1158,8 +1185,12 @@ RDLRouter::TerminalAccess RDLRouter::insertTerminalAccess(
 
   if (logger_->debugCheck(utl::PAD, "Terminal", 1) && gui_ != nullptr) {
     gui_->zoomToSnap(false);
-    gui_->pause(!isDebugNet(target.terminal->getNet())
-                && !isDebugPin(target.terminal));
+    gui_->pause(
+        fmt::format("terminal access for {} is inserted into the "
+                    "routing graph, {} edge(s) removed",
+                    target.terminal->getName(),
+                    access.removed_edges.size()),
+        !isDebugNet(target.terminal->getNet()) && !isDebugPin(target.terminal));
     gui_->clearSnap();
   }
 

--- a/src/pdn/src/PdnGen.cc
+++ b/src/pdn/src/PdnGen.cc
@@ -738,7 +738,7 @@ void PdnGen::setDebugRenderer(bool on)
 {
   if (on && gui::Gui::enabled()) {
     if (debug_renderer_ == nullptr) {
-      debug_renderer_ = std::make_unique<PDNRenderer>(this);
+      debug_renderer_ = std::make_unique<PDNRenderer>(this, logger_);
       rendererRedraw();
     }
   } else {

--- a/src/pdn/src/renderer.cpp
+++ b/src/pdn/src/renderer.cpp
@@ -16,6 +16,7 @@
 #include "pdn/PdnGen.hh"
 #include "shape.h"
 #include "straps.h"
+#include "utl/Logger.h"
 #include "via.h"
 
 namespace pdn {
@@ -35,7 +36,8 @@ const gui::Painter::Color PDNRenderer::kRepairColor
 const gui::Painter::Color PDNRenderer::kRepairOutlineColor
     = gui::Painter::Color(gui::Painter::kYellow, 100);
 
-PDNRenderer::PDNRenderer(PdnGen* pdn) : pdn_(pdn)
+PDNRenderer::PDNRenderer(PdnGen* pdn, utl::Logger* logger)
+    : pdn_(pdn), logger_(logger)
 {
   addDisplayControl(kGridObsText, false);
   addDisplayControl(kInitialObsText, false);
@@ -291,8 +293,9 @@ void PDNRenderer::drawObjects(gui::Painter& painter)
   legend.draw(painter);
 }
 
-void PDNRenderer::pause()
+void PDNRenderer::pause(const std::string& reason)
 {
+  logger_->report("Pausing power grid debug view: {}", reason);
   gui::Gui::get()->pause();
 }
 

--- a/src/pdn/src/renderer.h
+++ b/src/pdn/src/renderer.h
@@ -15,6 +15,10 @@ namespace odb {
 class Rect;
 }  // namespace odb
 
+namespace utl {
+class Logger;
+}  // namespace utl
+
 namespace pdn {
 
 class PdnGen;
@@ -23,7 +27,7 @@ class PdnGen;
 class PDNRenderer : public gui::Renderer
 {
  public:
-  explicit PDNRenderer(PdnGen* pdn);
+  PDNRenderer(PdnGen* pdn, utl::Logger* logger);
 
   void update();
 
@@ -38,10 +42,13 @@ class PDNRenderer : public gui::Renderer
     initial_obstructions_ = initial_obstructions;
   }
 
-  void pause();
+  // Halt the flow so the current state can be inspected in the GUI.  The
+  // reason is reported so the pause is actionable.
+  void pause(const std::string& reason);
 
  private:
   PdnGen* pdn_;
+  utl::Logger* logger_;
   Shape::ShapeTreeMap shapes_;
   Shape::ObstructionTreeMap grid_obstructions_;
   Shape::ObstructionTreeMap initial_obstructions_;

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -2357,7 +2357,8 @@ void RepairChannelStraps::repairGridChannels(
 
   if (!channels.empty() && renderer != nullptr) {
     renderer->update();
-    renderer->pause();
+    renderer->pause(fmt::format(
+        "{} channel(s) to repair in {}", channels.size(), grid->getLongName()));
   }
 
   if (channels.empty()) {


### PR DESCRIPTION
## Summary
No functional changes, just attempt to make debugging less of a guessing game when the GUI pauses.

## Type of Change
- Refactoring

## Impact
None, developer change only

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**
