### PR TITLE
ord: Add customizable gzip compression level to write_db

### DIFF
--- a/include/ord/Design.h
+++ b/include/ord/Design.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -138,7 +139,8 @@ class Design
   void readDb(std::istream& stream);
   void readDb(const std::string& file_name);
   void writeDb(std::ostream& stream);
-  void writeDb(const std::string& file_name);
+  void writeDb(const std::string& file_name,
+               std::optional<int> compression_level = std::nullopt);
   void writeDef(const std::string& file_name);
 
   odb::dbBlock* getBlock();

--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -240,7 +241,8 @@ class OpenRoad
   void readDb(std::istream& stream);
   void readDb(const char* filename, bool hierarchy = false);
   void writeDb(std::ostream& stream);
-  void writeDb(const char* filename);
+  void writeDb(const char* filename,
+               std::optional<int> compression_level = std::nullopt);
 
   void setThreadCount(int threads, bool print_info = true);
   void setThreadCount(const char* threads, bool print_info = true);

--- a/src/Design.cc
+++ b/src/Design.cc
@@ -98,9 +98,10 @@ void Design::writeDb(std::ostream& stream)
   getOpenRoad()->writeDb(stream);
 }
 
-void Design::writeDb(const std::string& file_name)
+void Design::writeDb(const std::string& file_name,
+                     std::optional<int> compression_level)
 {
-  getOpenRoad()->writeDb(file_name.c_str());
+  getOpenRoad()->writeDb(file_name.c_str(), compression_level);
 }
 
 void Design::writeDef(const std::string& file_name)

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -597,9 +597,10 @@ void OpenRoad::writeDb(std::ostream& stream)
   db_->write(stream);
 }
 
-void OpenRoad::writeDb(const char* filename)
+void OpenRoad::writeDb(const char* filename,
+                       std::optional<int> compression_level)
 {
-  utl::OutStreamHandler stream_handler(filename, true);
+  utl::OutStreamHandler stream_handler(filename, true, compression_level);
   writeDb(stream_handler.getStream());
 }
 

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -416,10 +416,14 @@ read_db_cmd(const char *filename, bool hierarchy)
 }
 
 void
-write_db_cmd(const char *filename)
+write_db_cmd(const char *filename, int compression_level = -1)
 {
   OpenRoad *ord = getOpenRoad();
-  ord->writeDb(filename);
+  std::optional<int> comp_level;
+  if (compression_level != -1) {
+    comp_level = compression_level;
+  }
+  ord->writeDb(filename, comp_level);
 }
 
 void

--- a/src/OpenRoad.tcl
+++ b/src/OpenRoad.tcl
@@ -257,12 +257,29 @@ proc read_db { args } {
   ord::read_db_cmd $filename $hierarchy
 }
 
-sta::define_cmd_args "write_db" {filename}
+sta::define_cmd_args "write_db" {[-compression level] filename}
 
 proc write_db { args } {
+  sta::parse_key_args "write_db" args \
+    keys {-compression} \
+    flags {}
+
   sta::check_argc_eq1 "write_db" $args
   set filename [file nativename [lindex $args 0]]
-  ord::write_db_cmd $filename
+
+  set compression_level -1
+  if { [info exists keys(-compression)] } {
+    set compression_level $keys(-compression)
+    sta::check_integer "write_db" $compression_level
+    if { $compression_level < 0 || $compression_level > 9 } {
+      utl::error "ORD" 77 "Compression level must be between 0 and 9."
+    }
+    if { ![string match "*.gz" $filename] } {
+      utl::warn "ORD" 78 "Compression level specified but output file is not a gzip file (.gz)."
+    }
+  }
+
+  ord::write_db_cmd $filename $compression_level
 }
 
 sta::define_cmd_args "assign_ndr" { -ndr name (-net name | -all_clocks) }

--- a/src/README.md
+++ b/src/README.md
@@ -150,13 +150,14 @@ read_db reg1.db
 To write a database to disk.
 
 ``` tcl
-write_db filename
+write_db [-compression level] filename
 ```
 ### Options
 
 | Switch Name | Description |
 | ----- | ----- |
-| `filename` | Path to the file to be written, if the filename ends with `.gz` the file will be compressed using gzip. |
+| `-compression` | Gzip compression level. Must be between 0 (no compression) and 9 (best compression). Default is 6. Only applicable if the filename ends with `.gz`. |
+| `filename` | Path to the file to be written. If the filename ends with `.gz`, the file will be compressed. |
 
 ### Examples
 ```

--- a/src/utl/include/utl/ScopedTemporaryFile.h
+++ b/src/utl/include/utl/ScopedTemporaryFile.h
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <istream>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -46,7 +47,9 @@ class OutStreamHandler
 {
  public:
   // Set binary to true to open in binary mode
-  OutStreamHandler(const char* filename, bool binary = false);
+  OutStreamHandler(const char* filename,
+                   bool binary = false,
+                   std::optional<int> compression_level = std::nullopt);
   ~OutStreamHandler();
   std::ostream& getStream();
   void close();

--- a/src/utl/src/ScopedTemporaryFile.cpp
+++ b/src/utl/src/ScopedTemporaryFile.cpp
@@ -66,7 +66,9 @@ ScopedTemporaryFile::~ScopedTemporaryFile()
   }
 }
 
-OutStreamHandler::OutStreamHandler(const char* filename, bool binary)
+OutStreamHandler::OutStreamHandler(const char* filename,
+                                   bool binary,
+                                   std::optional<int> compression_level)
     : filename_(filename)
 {
   if (filename_.empty()) {
@@ -89,7 +91,11 @@ OutStreamHandler::OutStreamHandler(const char* filename, bool binary)
   if (boost::ends_with(filename_, ".gz")) {
     buf_ = std::make_unique<boost::iostreams::filtering_ostreambuf>();
 
-    buf_->push(boost::iostreams::gzip_compressor());
+    boost::iostreams::gzip_params params;
+    if (compression_level.has_value()) {
+      params.level = compression_level.value();
+    }
+    buf_->push(boost::iostreams::gzip_compressor(params));
     buf_->push(os_);
 
     stream_ = std::make_unique<std::ostream>(buf_.get());

--- a/src/utl/test/cpp/TestCFileUtils.cpp
+++ b/src/utl/test/cpp/TestCFileUtils.cpp
@@ -160,6 +160,51 @@ TEST(Utl, stream_handler_write_and_read_gzip)
   std::filesystem::remove(filename);
 }
 
+TEST(Utl, stream_handler_gzip_compression_levels)
+{
+  const char* filename_l1 = "test_l1.txt.gz";
+  const char* filename_l9 = "test_l9.txt.gz";
+
+  std::string kTestData;
+  kTestData.reserve(100000 * 27);
+  for (int i = 0; i < 100000; ++i) {
+    kTestData.append("abcdefghijklmnopqrstuvwxyz\n");
+  }
+
+  {
+    OutStreamHandler sh(filename_l1, true, 1);
+    std::ostream& os = sh.getStream();
+    os.write(kTestData.c_str(), kTestData.size());
+  }
+
+  {
+    OutStreamHandler sh(filename_l9, true, 9);
+    std::ostream& os = sh.getStream();
+    os.write(kTestData.c_str(), kTestData.size());
+  }
+
+  {
+    InStreamHandler ish(filename_l1);
+    std::string contents((std::istreambuf_iterator<char>(ish.getStream())),
+                         std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, kTestData);
+  }
+  {
+    InStreamHandler ish(filename_l9);
+    std::string contents((std::istreambuf_iterator<char>(ish.getStream())),
+                         std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, kTestData);
+  }
+
+  std::uintmax_t size_l1 = std::filesystem::file_size(filename_l1);
+  std::uintmax_t size_l9 = std::filesystem::file_size(filename_l9);
+
+  EXPECT_LE(size_l9, size_l1);
+
+  std::filesystem::remove(filename_l1);
+  std::filesystem::remove(filename_l9);
+}
+
 TEST(Utl, stream_handler_temp_file_handling)
 {
   const char* filename = "test_temp_file_handling.txt";


### PR DESCRIPTION
Allow users to specify the compression level when writing the database. This helps speed up checkpointing in performance-critical flows by allowing lower compression levels (e.g., level 1 or 2) which are significantly faster while keeping file size increase acceptable.

Also migrates compression_level parameters in C++ APIs to `std::optional` to avoid sentinel values.

## Summary
*   **TCL/CLI**: Added a new optional `-compression` key-value argument to the `write_db` command (valid values are integers, typically 1-9).
*   **SWIG**: Updated SWIG bindings in `OpenRoad.i` (`write_db_cmd`) to accept `compression_level` and translate it to C++ `std::optional<int>`.
*   **C++ API**: Migrated `OpenRoad::writeDb` signature to accept `std::optional<int> compression_level` (defaulting to `std::nullopt`).
*   **Utilities (`utl`)**: Updated `OutStreamHandler` to accept `std::optional<int>` and conditionally apply it to `boost::iostreams::gzip_params::level`.
*   **Tests**: Added a new unit test `stream_handler_gzip_compression_levels` in `TestCFileUtils.cpp` to verify that different compression levels result in different file sizes as expected.

## Type of Change
- New feature
- Refactoring

## Impact
*   Provides users with control over database write performance. Lower compression levels (e.g., 1) can be used to significantly reduce checkpointing time in exchange for slightly larger file sizes.
*   No breaking change for existing TCL flows: `write_db` without the `-compression` flag retains the default Boost compression level behavior.
*   Improves C++ code quality by replacing sentinel values (e.g., `-1` for default) with `std::optional`.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**
