### PR TITLE
rcx: warn when the spef writer sees nets without cap nodes

### DIFF
--- a/src/rcx/include/rcx/extSpef.h
+++ b/src/rcx/include/rcx/extSpef.h
@@ -372,6 +372,8 @@ class extSpef
   uint32_t _cCnt;
   uint32_t _rCnt;
 
+  int no_cap_node_nets_count_{0};
+
   bool _partial = false;
   bool _btermFound;
 

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1243,6 +1243,8 @@ void extSpef::writeNet(dbNet* net, const double resBound, const uint32_t debug)
       writeRes(netId, rcSet);
     }
     writeKeyword("*END");
+  } else {
+    no_cap_node_nets_count_++;
   }
   for (dbCapNode* node : net->getCapNodes()) {
     node->setSortIndex(0);
@@ -1600,6 +1602,7 @@ void extSpef::writeBlock(const char* nodeCoord,
   _cornerBlock = _block;
 
   uint32_t cnt = 0;
+  no_cap_node_nets_count_ = 0;
 
   for (dbNet* net : getSortedNets(_block)) {
     if (!tnets.empty() && !net->isMarked()) {
@@ -1627,6 +1630,14 @@ void extSpef::writeBlock(const char* nodeCoord,
   }
   logger_->info(RCX, 443, "{} nets finished", cnt);
 
+  if (no_cap_node_nets_count_ > 0) {
+    logger_->warn(RCX,
+                  539,
+                  "Found {} nets without capacitive nodes. They were not "
+                  "written to the SPEF!",
+                  no_cap_node_nets_count_);
+  }
+
   closeOutFile();
 }
 
@@ -1638,6 +1649,7 @@ void extSpef::write_spef_nets(const bool flatten, const bool parallel)
   _cornersPerBlock = _cornerCnt;
 
   uint32_t cnt = 0;
+  no_cap_node_nets_count_ = 0;
 
   for (dbNet* net : getSortedNets(_block)) {
     const dbSigType type = net->getSigType();
@@ -1659,6 +1671,14 @@ void extSpef::write_spef_nets(const bool flatten, const bool parallel)
     }
   }
   logger_->info(RCX, 47, "{} nets finished", cnt);
+
+  if (no_cap_node_nets_count_ > 0) {
+    logger_->warn(RCX,
+                  540,
+                  "Found {} nets without capacitive nodes. They were not "
+                  "written to the SPEF!",
+                  no_cap_node_nets_count_);
+  }
 }
 
 uint32_t extSpef::getMappedBTermId(const uint32_t spefId)

--- a/src/rcx/test/45_gcd.ok
+++ b/src/rcx/test/45_gcd.ok
@@ -15,4 +15,5 @@
 [INFO RCX-0442] 100% of 1954 wires extracted
 [INFO RCX-0045] Extract 350 nets, 2972 rsegs, 2972 caps, 2876 ccs
 [INFO RCX-0443] 350 nets finished
+[WARNING RCX-0539] Found 34 nets without capacitive nodes. They were not written to the SPEF!
 No differences found.

--- a/src/rcx/test/coordinates.ok
+++ b/src/rcx/test/coordinates.ok
@@ -15,4 +15,5 @@
 [INFO RCX-0442] 100% of 1954 wires extracted
 [INFO RCX-0045] Extract 350 nets, 2972 rsegs, 2972 caps, 2876 ccs
 [INFO RCX-0443] 350 nets finished
+[WARNING RCX-0539] Found 34 nets without capacitive nodes. They were not written to the SPEF!
 No differences found.

--- a/src/rcx/test/net_name_consistency.ok
+++ b/src/rcx/test/net_name_consistency.ok
@@ -16,4 +16,5 @@
 [INFO RCX-0045] Extract 2 nets, 8 rsegs, 8 caps, 1 ccs
 No differences found.
 [INFO RCX-0443] 4 nets finished
+[WARNING RCX-0539] Found 1 nets without capacitive nodes. They were not written to the SPEF!
 No differences found.


### PR DESCRIPTION
## Summary
This should help catching odd stuff.

## Type of Change
- New feature

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
Requested by @dsengupta0628 when testing the implementation for #11005.
