### PR TITLE
docs: fix man page generation coverage, noise and reproducibility

### DIFF
--- a/bazel/man_pages.bzl
+++ b/bazel/man_pages.bzl
@@ -34,9 +34,14 @@ HTML_OUT="$PWD/{html_out}"
 # $(wildcard md/man*/*.md) picks up the freshly generated sources.
 # nproc is GNU coreutils (absent on stock macOS); fall back to sysctl, then 4.
 JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
-make --no-print-directory -C docs -f Makefile preprocess \\
+# -s (silent) suppresses make's per-recipe echo. There are ~3400 man pages and
+# four recipes each, so echoing them emits megabytes of stdout, past Bazel's
+# --experimental_ui_max_stdouterr_bytes, which then drops the whole log --
+# including the pandoc/groff diagnostics that are worth seeing. Those tools
+# name the file they failed on, so the echoed command adds nothing.
+make -s --no-print-directory -C docs -f Makefile preprocess \\
     CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
-make --no-print-directory -j"$JOBS" -C docs -f Makefile cat web \\
+make -s --no-print-directory -j"$JOBS" -C docs -f Makefile cat web \\
     CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
 """.format(
         cat_out = cat_dir.path,

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -10,15 +10,23 @@ man_pages(
     docs_srcs = [
         "Makefile",
         "src/man_fontfix.tmac",
-    ] + glob(["md/**/*.md"]),
+        # md/man1 holds the only checked-in markdown. md/man2 and md/man3 are
+        # written by this rule's own preprocess step, so globbing them would
+        # declare the action's outputs as its inputs: the input set would vary
+        # with leftover files from previous builds, and rewriting them trips
+        # --guard_against_concurrent_changes ("modified during execution").
+    ] + glob(["md/man1/**/*.md"]),
     messages = [
         "//src/ant:messages_txt",
+        "//src/cgt:messages_txt",
         "//src/cts:messages_txt",
         "//src/dbSta:messages_txt",
         "//src/dft:messages_txt",
         "//src/dpl:messages_txt",
         "//src/drt:messages_txt",
         "//src/dst:messages_txt",
+        "//src/est:messages_txt",
+        "//src/exa:messages_txt",
         "//src/fin:messages_txt",
         "//src/gpl:messages_txt",
         "//src/grt:messages_txt",
@@ -30,20 +38,26 @@ man_pages(
         "//src/pdn:messages_txt",
         "//src/ppl:messages_txt",
         "//src/psm:messages_txt",
+        "//src/ram:messages_txt",
         "//src/rcx:messages_txt",
         "//src/rmp:messages_txt",
         "//src/rsz:messages_txt",
         "//src/stt:messages_txt",
+        "//src/syn:messages_txt",
         "//src/tap:messages_txt",
         "//src/upf:messages_txt",
         "//src/utl:messages_txt",
+        "//src/web:messages_txt",
     ],
     readmes = [
         "//src/ant:README.md",
+        "//src/cgt:README.md",
         "//src/cts:README.md",
         "//src/dft:README.md",
         "//src/dpl:README.md",
         "//src/drt:README.md",
+        "//src/est:README.md",
+        "//src/exa:README.md",
         "//src/fin:README.md",
         "//src/gpl:README.md",
         "//src/grt:README.md",
@@ -56,13 +70,16 @@ man_pages(
         "//src/pdn:README.md",
         "//src/ppl:README.md",
         "//src/psm:README.md",
+        "//src/ram:README.md",
         "//src/rcx:README.md",
         "//src/rmp:README.md",
         "//src/rsz:README.md",
         "//src/stt:README.md",
+        "//src/syn:README.md",
         "//src/tap:README.md",
         "//src/upf:README.md",
         "//src/utl:README.md",
+        "//src/web:README.md",
     ],
     scripts = [
         "//docs/src/scripts:link_readmes.sh",
@@ -90,6 +107,19 @@ py_test(
             "_build/**",
             "_readthedocs/**",
             "main/**",
+            # Everything docs/.gitignore lists as intermediate output: the man
+            # page build (//docs:man_pages) writes these into the source tree,
+            # so globbing them would make this test's inputs -- and so its
+            # cache key and result -- depend on whether man pages happen to
+            # have been built here. conf.py excludes all four from the Sphinx
+            # build anyway.
+            "cat/**",
+            "html/**",
+            "man/**",
+            "md/man2/**",
+            "md/man3/**",
+            "build/**",
+            "src/test/results/**",
         ],
     ) + [
         # Staged at the runfiles workspace root so conf.py's setup(app)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -78,8 +78,15 @@ CAT3_PAGES = $(patsubst $(SRC3_DIR)/%.md,$(CAT3_DIR)/%.3,$(MAN3_FILES))
 # Default target
 all: doc web cat
 
-# Target to do symlinks and pandoc-compatible conversion
+# Target to do symlinks and pandoc-compatible conversion.
+# md/man2 and md/man3 hold nothing but generated files, so clear them before
+# regenerating: rename or delete a command and its stale .md would otherwise
+# linger for the cat/web $(wildcard md/man*/*.md) to pick up, keeping an
+# obsolete page alive. //docs:man_pages runs unsandboxed in a persistent
+# execroot and does not declare these as inputs, so nothing else removes them.
+# md/man1 is checked in and must survive.
 preprocess:
+	rm -rf $(SRC_DIR)/$(MAN2) $(SRC_DIR)/$(MAN3)
 	./src/scripts/link_readmes.sh && python3 src/scripts/md_roff_compat.py
 
 # Target to generate all man pages

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,11 +39,13 @@ MAN1 = man1
 MAN2 = man2
 MAN3 = man3
 
-# Exclude these set of keywords
-EXCLUDE_KEYWORDS = ant cts dft dpl drt fin gpl grt gui ifp mpl \
-				   odb pad par pdn ppl psm rcx rmp rsz sta \
-				   stt tap upf utl
-EXCLUDE_FILES := $(addsuffix .md,$(EXCLUDE_KEYWORDS))
+# link_readmes.sh symlinks every src/<module>/README.md into md/man2/ so
+# md_roff_compat.py can read it. Those are whole-module documents, not command
+# pages, so keep them out of the man2 lists. Derive the set from src/ rather
+# than hard-coding it, so a new module cannot silently start emitting a
+# module-wide man page.
+EXCLUDE_MODULES := $(notdir $(patsubst %/,%,$(dir $(wildcard ../src/*/README.md))))
+EXCLUDE_FILES := $(addprefix $(SRC_DIR)/$(MAN2)/,$(addsuffix .md,$(EXCLUDE_MODULES)))
 
 MAN1_DIR = $(MAN_ROOT_DIR)/$(MAN1)
 SRC1_DIR = $(SRC_DIR)/$(MAN1)
@@ -57,7 +59,7 @@ CAT1_PAGES = $(patsubst $(SRC1_DIR)/%.md,$(CAT1_DIR)/%.1,$(MAN1_FILES))
 MAN2_DIR = $(MAN_ROOT_DIR)/$(MAN2)
 SRC2_DIR = $(SRC_DIR)/$(MAN2)
 MAN2_FILES = $(wildcard $(SRC2_DIR)/*.md)
-MAN2_FILES := $(filter-out $(foreach keyword, $(EXCLUDE_FILES), %$(keyword)), $(MAN2_FILES))
+MAN2_FILES := $(filter-out $(EXCLUDE_FILES), $(MAN2_FILES))
 MAN2_PAGES = $(patsubst $(SRC2_DIR)/%.md,$(MAN2_DIR)/%.2,$(MAN2_FILES))
 HTML2_DIR = $(HTML_ROOT_DIR)/html2
 HTML2_PAGES = $(patsubst $(SRC2_DIR)/%.md,$(HTML2_DIR)/%.html,$(MAN2_FILES))
@@ -88,7 +90,6 @@ web: $(HTML1_PAGES) $(HTML2_PAGES) $(HTML3_PAGES)
 
 # Target to generate all cat pages
 cat: $(CAT1_PAGES) $(CAT2_PAGES) $(CAT3_PAGES)
-	@echo $(CAT1_PAGES)
 
 # Rule to create the man directory
 $(MAN1_DIR): 

--- a/docs/src/scripts/extract_utils.py
+++ b/docs/src/scripts/extract_utils.py
@@ -107,8 +107,14 @@ def extract_arguments(text):
     # form these 2 regex styles.
     # ### Header 1 {text} ### Header2; ### Header n-2 {text} ### Header n-1
     # ### Header n {text} ## closest_level2_header
+    # Headers are literal text, so escape them the way extract_description
+    # does. `## C++` (odb) would otherwise read as a possessive quantifier and
+    # capture the wrong span, and `## ... (min-cut partitioning)` (par) as a
+    # group, so the section would not match at all and match[0] below would
+    # raise IndexError.
     first = [
-        rf"### ({level3[i]})(.*?)### ({level3[i+1]})" for i in range(len(level3) - 1)
+        rf"### ({re.escape(level3[i])})(.*?)### ({re.escape(level3[i + 1])})"
+        for i in range(len(level3) - 1)
     ]
 
     # find the next closest level2 header to the last level3 header.
@@ -119,13 +125,14 @@ def extract_arguments(text):
 
     # This will disambiguate cases where different level headers share the same name.
     if trailing_level2:
-        second = [rf"### ({level3[-1]})(.*?)## ({level2[trailing_level2[0]]})"]
+        last3, next2 = level3[-1], level2[trailing_level2[0]]
+        second = [rf"### ({re.escape(last3)})(.*?)## ({re.escape(next2)})"]
     else:
         # No level2 header follows, so the last command section runs to the end
         # of the file. Most READMEs close with `## Authors`/`## License`, which
         # is what bounded this section; without that the lookup used to raise
         # IndexError and drop the module's man pages entirely.
-        second = [rf"### ({level3[-1]})(.*?)$"]
+        second = [rf"### ({re.escape(level3[-1])})(.*?)$"]
     final_options, final_args = [], []
     for idx, regex in enumerate(first + second):
         match = re.findall(regex, text, flags=re.DOTALL)

--- a/docs/src/scripts/extract_utils.py
+++ b/docs/src/scripts/extract_utils.py
@@ -6,20 +6,72 @@
 import re
 
 
+def outside_fences(text):
+    """
+    Predicate: is this offset outside every fenced code block?
+
+    Tcl comments open with `#`, so `# Either run` inside a synopsis block reads
+    as a level-1 heading to a plain regex. That misplaces every heading after
+    it and, in turn, the section each code block belongs to.
+    """
+    spans = [
+        (m.start(), m.end())
+        for m in re.finditer(r"^```.*?^```", text, flags=re.DOTALL | re.MULTILINE)
+    ]
+    return lambda pos: not any(start <= pos < end for start, end in spans)
+
+
 def extract_headers(text, level=1):
     assert isinstance(level, int) and level >= 1
+    outside = outside_fences(text)
     pattern = r"^#{%d}\s+(.*)$" % level
-    headers = re.findall(pattern, text, flags=re.MULTILINE)
+    headers = [
+        m.group(1)
+        for m in re.finditer(pattern, text, flags=re.MULTILINE)
+        if outside(m.start())
+    ]
     # TODO: Handle developer commands
     # if "Useful Developer Commands" in headers: headers.remove("Useful Developer Commands")
     return headers
 
 
+def synopsis_tcl_blocks(text):
+    """
+    The ```tcl block holding each command's synopsis, in document order.
+
+    One `### <command>` section describes one command, so its synopsis is the
+    first tcl block inside it -- the same block `extract_description` stops at.
+    Any later tcl in the section is a worked example, and tcl before the first
+    `###` is introductory usage. Counting those as commands too yielded more
+    names and synopses than descriptions and options, and that count mismatch
+    aborts the whole man2 build. Note the synopsis does not have to sit
+    directly under the `###`: a section may open with `####` prose first.
+    """
+    outside = outside_fences(text)
+    headings = [
+        (m.start(), len(m.group(1)))
+        for m in re.finditer(r"^(#{1,6})\s", text, flags=re.MULTILINE)
+        if outside(m.start())
+    ]
+    synopsis = re.compile(r"```tcl\s+(.*?)```", flags=re.DOTALL)
+    blocks = []
+    for i, (start, level) in enumerate(headings):
+        if level != 3:
+            continue
+        # The section ends at the next heading of the same or higher rank.
+        end = next(
+            (pos for pos, lvl in headings[i + 1 :] if lvl <= 3),
+            len(text),
+        )
+        m = synopsis.search(text, start, end)
+        if m:
+            blocks.append(m)
+    return blocks
+
+
 def extract_tcl_command(text):
     # objective is to extract tcl command from the synopsis
-    pattern = r"```tcl\s*(.*?)\s"
-    headers = re.findall(pattern, text, flags=re.MULTILINE)
-    return headers
+    return [m.group(1).split()[0] for m in synopsis_tcl_blocks(text)]
 
 
 def extract_description(text):
@@ -33,9 +85,8 @@ def extract_description(text):
 
 def extract_tcl_code(text, skip_markers=True):
     # Find all ```tcl blocks along with their position to check for skip markers.
-    pattern = r"```tcl\s+(.*?)```"
     results = []
-    for m in re.finditer(pattern, text, flags=re.DOTALL):
+    for m in synopsis_tcl_blocks(text):
         # Check the text immediately before this block for a skip marker.
         if skip_markers:
             preceding = text[: m.start()]
@@ -64,10 +115,17 @@ def extract_arguments(text):
     closest_level2 = [
         text.find(f"## {x}") - text.find(f"### {level3[-1]}") for x in level2
     ]
-    closest_level2_idx = [idx for idx, x in enumerate(closest_level2) if x > 0][0]
+    trailing_level2 = [idx for idx, x in enumerate(closest_level2) if x > 0]
 
     # This will disambiguate cases where different level headers share the same name.
-    second = [rf"### ({level3[-1]})(.*?)## ({level2[closest_level2_idx]})"]
+    if trailing_level2:
+        second = [rf"### ({level3[-1]})(.*?)## ({level2[trailing_level2[0]]})"]
+    else:
+        # No level2 header follows, so the last command section runs to the end
+        # of the file. Most READMEs close with `## Authors`/`## License`, which
+        # is what bounded this section; without that the lookup used to raise
+        # IndexError and drop the module's man pages entirely.
+        second = [rf"### ({level3[-1]})(.*?)$"]
     final_options, final_args = [], []
     for idx, regex in enumerate(first + second):
         match = re.findall(regex, text, flags=re.DOTALL)

--- a/docs/src/scripts/link_readmes.sh
+++ b/docs/src/scripts/link_readmes.sh
@@ -19,12 +19,11 @@ for MODULE_PATH in "$SRC_BASE_PATH"/*; do
 	    SRC_PATH=$(realpath $SRC_BASE_PATH/$MODULE/README.md)
 	    DEST_PATH="$(realpath $DEST_BASE_PATH/$MODULE).md"
 
-        # Check if README.md exists before copying
+        # Not every directory under src/ is a documented module (src/cmake,
+        # modules whose docs live elsewhere), so a missing README is not an
+        # error here. md_roff_compat.py reports the ones it actually expects.
         if [ -e "$SRC_PATH" ]; then
             ln -s -f "$SRC_PATH" "$DEST_PATH"
-            echo "File linked successfully."
-        else
-            echo "ERROR: README.md not found in $MODULE_PATH"
         fi
     fi
 done

--- a/docs/src/scripts/manpage.py
+++ b/docs/src/scripts/manpage.py
@@ -12,9 +12,33 @@ import os
 import tempfile
 
 
+def page_date(source=None):
+    """
+    Date stamped into a page's footer, as yy/mm/dd.
+
+    Stamping the build date made every generated page differ from one day to
+    the next, so the man page build never hit its Bazel cache across a date
+    boundary even with unchanged sources. Prefer SOURCE_DATE_EPOCH (the
+    reproducible-builds convention -- set it to pin output exactly), then the
+    modification time of the document the page is generated from, which is
+    what the footer date is meant to convey. `now` remains the fallback for
+    callers that construct a page from no file at all.
+    """
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        stamp = datetime.datetime.fromtimestamp(int(epoch), datetime.timezone.utc)
+    elif source and os.path.exists(source):
+        stamp = datetime.datetime.fromtimestamp(
+            os.path.getmtime(source), datetime.timezone.utc
+        )
+    else:
+        stamp = datetime.datetime.now()
+    return stamp.strftime("%y/%m/%d")
+
+
 # identify key section and stored in ManPage class.
 class ManPage:
-    def __init__(self, man_level=2):
+    def __init__(self, man_level=2, source=None):
         assert man_level in [2, 3], "only writable for man2/man3"
         self.name = ""
         self.desc = ""
@@ -23,7 +47,7 @@ class ManPage:
         self.args = {}
         self.examples = []  # List of example dictionaries
         self.see_also = []  # List of related commands/functions
-        self.datetime = datetime.datetime.now().strftime("%y/%m/%d")
+        self.datetime = page_date(source)
         self.man_level = f"man{man_level}"
 
     def add_example(self, description: str, code: str, output: str | None = None):

--- a/docs/src/scripts/manpage.py
+++ b/docs/src/scripts/manpage.py
@@ -24,15 +24,24 @@ def page_date(source=None):
     what the footer date is meant to convey. `now` remains the fallback for
     callers that construct a page from no file at all.
     """
-    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    epoch = os.environ.get("SOURCE_DATE_EPOCH", "").strip()
     if epoch:
+        # Reject a malformed pin rather than falling through to a date that
+        # varies per machine: the caller asked for reproducible output, and
+        # silently not delivering it is worse than stopping.
+        if not epoch.isdigit():
+            raise ValueError(
+                f"SOURCE_DATE_EPOCH must be a Unix timestamp, got {epoch!r}"
+            )
         stamp = datetime.datetime.fromtimestamp(int(epoch), datetime.timezone.utc)
     elif source and os.path.exists(source):
         stamp = datetime.datetime.fromtimestamp(
             os.path.getmtime(source), datetime.timezone.utc
         )
     else:
-        stamp = datetime.datetime.now()
+        # UTC like the two branches above, so the stamp does not depend on the
+        # builder's timezone.
+        stamp = datetime.datetime.now(datetime.timezone.utc)
     return stamp.strftime("%y/%m/%d")
 
 

--- a/docs/src/scripts/md_roff_compat.py
+++ b/docs/src/scripts/md_roff_compat.py
@@ -6,6 +6,7 @@
 
 import os
 import re
+import sys
 from manpage import ManPage
 from extract_utils import extract_tcl_command, extract_description
 from extract_utils import extract_tcl_code, extract_arguments
@@ -61,12 +62,15 @@ def extract_global_see_also(text):
 
 tools = [
     "ant",
+    "cgt",
     "cts",
     "dbSta",
     "dft",
     "dpl",
     "drt",
     "dst",
+    "est",
+    "exa",
     "fin",
     "gpl",
     "grt",
@@ -79,19 +83,24 @@ tools = [
     "pdn",
     "ppl",
     "psm",
+    "ram",
     "rcx",
     "rmp",
     "rsz",
     "sta",
     "stt",
+    "syn",
     "tap",
     "upf",
     "utl",
+    "web",
 ]
 
-# Process man2 (except odb and sta)
+# Process man2. The excluded modules contribute man3 message pages but no
+# command pages: odb and sta are documented elsewhere (doxygen / upstream),
+# while dbSta and dst ship no README for link_readmes.sh to symlink.
 DEST_DIR2 = SRC_DIR = "./md/man2"
-exclude2 = ["odb", "sta"]
+exclude2 = ["dbSta", "dst", "odb", "sta"]
 docs2 = [f"{SRC_DIR}/{tool}.md" for tool in tools if tool not in exclude2]
 
 # Process man3 (add extra path for ORD messages)
@@ -107,12 +116,16 @@ docs3.append("../messages.txt")
 def man2(path=DEST_DIR2):
     for doc in docs2:
         if not os.path.exists(doc):
-            print(f"{doc} doesn't exist. Continuing")
+            print(f"{doc} doesn't exist. Continuing", file=sys.stderr)
             continue
-        man2_translate(doc, path)
+        man2_translate(doc, path, quiet=True)
 
 
-def man2_translate(doc, path):
+# The per-README parse report is the golden output of the per-module
+# readme_msgs_check tests, which call this directly, so it stays on by default.
+# The whole-tree build above silences it: repeated across every module it
+# drowns out the diagnostics worth reading.
+def man2_translate(doc, path, quiet=False):
     with open(doc) as f:
         text = f.read()
         # new function names (reading tcl synopsis + convert gui:: to gui_)
@@ -134,14 +147,15 @@ def man2_translate(doc, path):
         global_examples = extract_global_examples(text)
         global_see_also = extract_global_see_also(text)
 
-        print(f"{os.path.basename(doc)}")
-        print(f"""Names: {len(func_names)},\
+        if not quiet:
+            print(f"{os.path.basename(doc)}")
+            print(f"""Names: {len(func_names)},\
         Desc: {len(func_descs)},\
         Syn: {len(func_synopsis)},\
         Options: {len(func_options)},\
         Args: {len(func_args)}""")
-        print(f"Global Examples: {'Found' if global_examples else 'None'}")
-        print(f"Global See Also: {'Found' if global_see_also else 'None'}")
+            print(f"Global Examples: {'Found' if global_examples else 'None'}")
+            print(f"Global See Also: {'Found' if global_see_also else 'None'}")
 
         # Identify ### headers that are missing a ```tcl block — these cause count mismatches.
         missing_tcl_headers = []
@@ -181,7 +195,7 @@ def man2_translate(doc, path):
         )
 
         for func_id in range(len(func_synopsis)):
-            manpage = ManPage()
+            manpage = ManPage(source=doc)
             manpage.name = func_names[func_id]
             manpage.desc = func_descs[func_id]
             manpage.synopsis = func_synopsis[func_id]
@@ -218,19 +232,19 @@ def man2_translate(doc, path):
                 ]
 
             manpage.write_roff_file(path)
-    print("Man2 successfully compiled.")
+    if not quiet:
+        print("Man2 successfully compiled.")
 
 
 def man3(path=DEST_DIR3):
     for doc in docs3:
-        print(f"Processing {doc}")
         if not os.path.exists(doc):
-            print(f"{doc} doesn't exist. Continuing")
+            print(f"{doc} doesn't exist. Continuing", file=sys.stderr)
             continue
-        man3_translate(doc, path)
+        man3_translate(doc, path, quiet=True)
 
 
-def man3_translate(doc, path):
+def man3_translate(doc, path, quiet=False):
     with open(doc) as f:
         for line in f:
             parts = line.split()
@@ -240,7 +254,7 @@ def man3_translate(doc, path):
                 " ".join(parts[3:-2]),
                 parts[-2],
             )
-            manpage = ManPage()
+            manpage = ManPage(source=doc)
             manpage.name = f"{module}-{num}"
             if "with-total" in manpage.name:
                 print(parts)
@@ -250,7 +264,8 @@ def man3_translate(doc, path):
             # man3 messages typically don't have examples or see also
             manpage.write_roff_file(path)
 
-    print("Man3 successfully compiled.")
+    if not quiet:
+        print("Man3 successfully compiled.")
 
 
 if __name__ == "__main__":

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -36,10 +36,17 @@ entries:
         title: DEF Grammar Railroad Diagrams
   - file: main/src/gui/README
     title: GUI
+  - file: main/src/web/README
+    title: Web Viewer
+  - file: main/src/syn/README
+    title: Synthesis
   - file: main/src/par/README
     title: Partition Management
   - file: main/src/rmp/README
     title: Restructure
+    entries:
+    - file: main/src/cut/README
+      title: Logic Cut
   - file: main/src/ifp/README
     title: Floorplan Initialization
   - file: main/src/ppl/README
@@ -66,6 +73,8 @@ entries:
     title: Global Placement
   - file: main/src/sta/README
     title: Static Timing Analyzer (external)
+  - file: main/src/est/README
+    title: Parasitics Estimation
   - file: main/src/rsz/README
     title: Gate Resizing
   - file: main/src/cgt/README
@@ -77,8 +86,11 @@ entries:
   - file: main/src/grt/README
     title: Global Routing
     entries:
-    - file: main/src/stt/src/flt/README
-      title: Flute
+    - file: main/src/stt/README
+      title: Rectilinear Steiner Tree
+      entries:
+      - file: main/src/stt/src/flt/README
+        title: Flute
   - file: main/src/ant/README
     title: Antenna Checker
   - file: main/src/drt/README
@@ -100,6 +112,10 @@ entries:
   entries:
   - file: contrib/DeveloperGuide
     title: Developer's Guide
+  - file: main/src/exa/README
+    title: Example Tool
+  - file: main/src/tst/README
+    title: Unit Test Infrastructure
   - file: contrib/CodingPractices
     title: Coding Practices
   - file: contrib/Logger

--- a/src/cgt/BUILD
+++ b/src/cgt/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -84,4 +85,10 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
+)
+
+exports_files(["README.md"])
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/cgt/README.md
+++ b/src/cgt/README.md
@@ -42,6 +42,9 @@ All parameters for clock gating are optional, as indicated by square brackets: `
 
 ### Clock gating
 
+The `clock_gating` command inserts clock gates on registers that share a
+provable gating condition, reducing switching power.
+
 ```tcl
 clock_gating
     [-min_instances min_instances]

--- a/src/est/BUILD
+++ b/src/est/BUILD
@@ -4,6 +4,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -131,4 +132,10 @@ tcl_wrap_cc(
         "../sta",
         "src",
     ],
+)
+
+exports_files(["README.md"])
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/exa/BUILD
+++ b/src/exa/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -108,4 +109,10 @@ python_wrap_cc(
         "include",
         "src",
     ],
+)
+
+exports_files(["README.md"])
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/ram/BUILD
+++ b/src/ram/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -85,4 +86,10 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
+)
+
+exports_files(["README.md"])
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/syn/BUILD
+++ b/src/syn/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -122,4 +123,10 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
+)
+
+exports_files(["README.md"])
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/syn/BUILD
+++ b/src/syn/BUILD
@@ -127,6 +127,25 @@ python_wrap_cc(
 
 exports_files(["README.md"])
 
+# Synthesis keeps most of its logger calls below src/: flow/ in this package,
+# elab/ and ir/ in their own. The macro's default non-recursive src/*.{cc,h,tcl}
+# glob would find only 29 of the 73 messages.
 messages_txt(
+    extra_srcs = [
+        "//src/syn/src/elab:message_srcs",
+        "//src/syn/src/ir:message_srcs",
+    ],
+    src_patterns = [
+        "src/*.cc",
+        "src/*.cpp",
+        "src/*.h",
+        "src/*.hh",
+        "src/*.tcl",
+        "src/flow/*.cc",
+        "src/flow/*.cpp",
+        "src/flow/*.h",
+        "src/flow/*.hh",
+        "src/flow/*.tcl",
+    ],
     visibility = ["//docs:__pkg__"],
 )

--- a/src/syn/src/elab/BUILD
+++ b/src/syn/src/elab/BUILD
@@ -62,3 +62,18 @@ cc_library(
     ],
     alwayslink = True,
 )
+
+filegroup(
+    name = "message_srcs",
+    srcs = glob(
+        [
+            "*.cc",
+            "*.cpp",
+            "*.h",
+            "*.hh",
+            "*.tcl",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//src/syn:__pkg__"],
+)

--- a/src/syn/src/ir/BUILD
+++ b/src/syn/src/ir/BUILD
@@ -37,3 +37,18 @@ cc_library(
         "@abc",
     ],
 )
+
+filegroup(
+    name = "message_srcs",
+    srcs = glob(
+        [
+            "*.cc",
+            "*.cpp",
+            "*.h",
+            "*.hh",
+            "*.tcl",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//src/syn:__pkg__"],
+)

--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -257,4 +258,10 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+exports_files(["README.md"])
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )


### PR DESCRIPTION
The `//docs:man_pages` action emitted 2.5 MB of stdout, past Bazel's `--experimental_ui_max_stdouterr_bytes`, so the whole log was dropped along with any real diagnostic in it. Silencing it exposed several problems underneath.

### Page selection

Module READMEs are symlinked into `md/man2` so `md_roff_compat.py` can read them, and the Makefile excluded them from page generation via a hard-coded list of 24 module names. Eight newer modules were missing from it, so their whole READMEs rendered as man pages — an untitled `()` page with MyST markup leaking through:

```
()                                          ()
1mWeb Viewer0m
    The web viewer module in OpenROAD (web) provides a browser-based...
   1mCommands0m
    {note}  -  Parameters in square brackets `[-param param]` are optional...
```

The list is now derived from `src/*/README.md` so a new module cannot regress this.

That exclusion also used an unanchored suffix pattern, so `%pad.md` matched `place_pad.md` and `place_bondpad.md`, `%upf.md` matched `read_upf.md`/`write_upf.md`, and `%cts.md` matched `report_cts.md`. Those five command pages were being silently dropped; the filter now matches exact paths.

Separately, `cgt`, `est`, `exa`, `ram`, `syn` and `web` were absent from the `tools` list, so their commands never got pages at all. Registering them adds 12 command pages and 187 message pages, and required exporting `README.md` and adding `messages_txt` to those modules' `BUILD` files.

### README parsing

Registering those modules surfaced three parser bugs:

- Headings were matched without regard to code fences, so the Tcl comments in a synopsis block (`# Either run`) read as level-1 headings and misplaced every heading after them.
- Every ` ```tcl ` block counted as a command, so a README with a worked example under `#### Examples` reported more names and synopses than descriptions and options, and the parity assert aborted the build. The synopsis is now the first block in each `###` section — note it may follow `####` prose, as in rsz's *Optimizing Arithmetic Modules*.
- `extract_arguments` needed a trailing `##` heading to bound the final command section and raised `IndexError` without one.

### Reproducibility and noise

- Pages stamped the build date, so every page differed from one day to the next and the build never hit its cache across a date boundary. Now prefers `SOURCE_DATE_EPOCH`, then the source document's mtime.
- `docs_srcs` globbed `md/**`, which are this rule's own preprocess outputs. The input set varied with leftover files from previous builds, and rewriting them tripped `--guard_against_concurrent_changes` on every run. Now globs only the checked-in `md/man1`.
- `sphinx_build_test` swept the same generated directories into its `data`, making its cache key depend on whether man pages had been built locally.
- `make`'s per-recipe echo and the per-README parse report are silenced. That report is the golden output of the `readme_msgs_check` tests, which call the translators directly, so it stays on by default and only the whole-tree drivers pass `quiet=True`.

### Documentation

`cut`, `est`, `exa`, `stt`, `syn`, `tst` and `web` READMEs had no `toc.yml` entry, so their module-level prose would have been rendered nowhere once the accidental man pages went away. They are added, with `stt` nested above its own Flute sub-README rather than leaving Flute parented to `grt`. `cgt`'s `### Clock gating` had no prose between heading and synopsis, leaving the page description empty.

### Result

Command pages go from 230 to 247, message pages from 3128 to 3315. Every page common to both builds is byte-identical apart from the date field. Nothing is unrendered: every `###` command section is covered by a man page and every `##` module section by the Sphinx docs.

### Known limitations, not addressed here

`extract_arguments` assigns `####` blocks by position — first is OPTIONS, all others ARGUMENTS — rather than by heading name. So `save_image`'s `#### Display option keys` three-column table renders under ARGUMENTS with the third column jammed in, and mixed-case `#### Examples` sections (only uppercase `#### EXAMPLES` is recognised) do not reach man pages. Fixing it by matching heading names would silently drop any argument table whose heading does not match the chosen vocabulary, with no assert to catch it, so it wants its own change and a survey of `####` headings across all modules.
