### PR TITLE
rcx: create struct for the unit scale factors to avoid duplicated code on 3D pass

### DIFF
--- a/src/rcx/include/rcx/extSpef.h
+++ b/src/rcx/include/rcx/extSpef.h
@@ -36,6 +36,13 @@ struct SpefHeader
   std::string inductance_unit_word{"HENRY"};
 };
 
+// For converting db values (FF and OHM) to the declared units.
+struct ScaleFactors
+{
+  double capacitance{1.0};
+  double resistance{1.0};
+};
+
 class extSpef
 {
  public:
@@ -45,6 +52,9 @@ class extSpef
           const char* version,
           extMain* extmain);
   ~extSpef();
+
+  static ScaleFactors computeScaleFactors(const std::string& capacitance_unit,
+                                          const std::string& resistance_unit);
 
   void reinit();
   bool setOutSpef(const char* filename);
@@ -346,10 +356,7 @@ class extSpef
   uint32_t _blockId = 0;
 
   SpefHeader spef_header_;
-
-  // Scale factors derived from the header units, not header text.
-  double _res_unit = 1.0;
-  double _cap_unit = 1.0;
+  ScaleFactors scale_factors_;
 
   uint32_t _cornerCnt = 0;
   uint32_t _cornersPerBlock;

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -481,7 +481,7 @@ void extSpef::writeCapITerm(const uint32_t node, const uint32_t capIndex)
   writeCNodeNumber();
 
   writeITermNode(node);
-  writeRCvalue(_nodeCapTable->geti(capIndex), _cap_unit);
+  writeRCvalue(_nodeCapTable->geti(capIndex), scale_factors_.capacitance);
 
   fprintf(_outFP, "\n");
 }
@@ -491,7 +491,7 @@ void extSpef::writeCapName(dbCapNode* capNode, const uint32_t capIndex)
   writeCNodeNumber();
 
   writeNameNode(capNode);
-  writeRCvalue(_nodeCapTable->geti(capIndex), _cap_unit);
+  writeRCvalue(_nodeCapTable->geti(capIndex), scale_factors_.capacitance);
 
   fprintf(_outFP, "\n");
 }
@@ -502,7 +502,7 @@ void extSpef::writeCapPort(const uint32_t node, const uint32_t capIndex)
 
   writeBTerm(node);
 
-  writeRCvalue(_nodeCapTable->geti(capIndex), _cap_unit);
+  writeRCvalue(_nodeCapTable->geti(capIndex), scale_factors_.capacitance);
   fprintf(_outFP, "\n");
 }
 
@@ -539,9 +539,12 @@ void extSpef::writePort(const uint32_t node)
 void extSpef::writeSingleRC(const double val, const bool delimiter)
 {
   if (delimiter) {
-    fprintf(_outFP, "%s%g", spef_header_.delimiter.c_str(), val * _cap_unit);
+    fprintf(_outFP,
+            "%s%g",
+            spef_header_.delimiter.c_str(),
+            val * scale_factors_.capacitance);
   } else {
-    fprintf(_outFP, "%g", val * _cap_unit);
+    fprintf(_outFP, "%g", val * scale_factors_.capacitance);
   }
 }
 
@@ -567,7 +570,7 @@ void extSpef::writeDnet(uint32_t netId, const double* totCap)
             "\n*D_NET %s ",
             addEscChar(tinkerSpefName((char*) _d_net->getConstName()), false));
   }
-  writeRCvalue(totCap, _cap_unit);
+  writeRCvalue(totCap, scale_factors_.capacitance);
   fprintf(_outFP, "\n");
 }
 
@@ -751,7 +754,7 @@ void extSpef::writeNodeCap(const uint32_t netId,
 {
   writeCNodeNumber();
   writeNode(netId, ii);
-  writeRCvalue(_nodeCapTable->geti(capIndex), _cap_unit);
+  writeRCvalue(_nodeCapTable->geti(capIndex), scale_factors_.capacitance);
   fprintf(_outFP, "\n");
 }
 
@@ -970,13 +973,16 @@ void extSpef::writeCouplingCapsNoSort(dbSet<dbCCSeg>& capSet,
     writeCapNode(cc->getSourceCapNode()->getId(), netId);
     writeCapNode(cc->getTargetCapNode()->getId(), netId);
 
-    fprintf(
-        _outFP, "%g", cc->getCapacitance(_active_corner_number[0]) * _cap_unit);
+    fprintf(_outFP,
+            "%g",
+            cc->getCapacitance(_active_corner_number[0])
+                * scale_factors_.capacitance);
     for (int ii = 1; ii < _active_corner_cnt; ii++) {
       fprintf(_outFP,
               "%s%g",
               spef_header_.delimiter.c_str(),
-              cc->getCapacitance(_active_corner_number[ii]) * _cap_unit);
+              cc->getCapacitance(_active_corner_number[ii])
+                  * scale_factors_.capacitance);
     }
     fprintf(_outFP, "\n");
   }
@@ -997,13 +1003,16 @@ void extSpef::writeCouplingCaps(dbSet<dbCCSeg>& capSet, const uint32_t netId)
     writeCapNode(cc->getSourceCapNode()->getId(), netId);
     writeCapNode(cc->getTargetCapNode()->getId(), netId);
 
-    fprintf(
-        _outFP, "%g", cc->getCapacitance(_active_corner_number[0]) * _cap_unit);
+    fprintf(_outFP,
+            "%g",
+            cc->getCapacitance(_active_corner_number[0])
+                * scale_factors_.capacitance);
     for (int ii = 1; ii < _active_corner_cnt; ii++) {
       fprintf(_outFP,
               "%s%g",
               spef_header_.delimiter.c_str(),
-              cc->getCapacitance(_active_corner_number[ii]) * _cap_unit);
+              cc->getCapacitance(_active_corner_number[ii])
+                  * scale_factors_.capacitance);
     }
     fprintf(_outFP, "\n");
   }
@@ -1048,12 +1057,14 @@ void extSpef::writeCouplingCaps(const std::vector<dbCCSeg*>& vec_cc,
               "CC of net %d %s with capacitance %g",
               _d_net->getId(),
               _d_net->getConstName(),
-              cc->getCapacitance(_active_corner_number[0]) * _cap_unit);
+              cc->getCapacitance(_active_corner_number[0])
+                  * scale_factors_.capacitance);
       for (int ii = 1; ii < _active_corner_cnt; ii++) {
         sprintf(&msg1[0],
                 "%s%g",
                 spef_header_.delimiter.c_str(),
-                cc->getCapacitance(_active_corner_number[ii]) * _cap_unit);
+                cc->getCapacitance(_active_corner_number[ii])
+                    * scale_factors_.capacitance);
         strcat(_bufString, &msg1[0]);
       }
       strcat(_bufString, " has both capNodes ");
@@ -1066,13 +1077,16 @@ void extSpef::writeCouplingCaps(const std::vector<dbCCSeg*>& vec_cc,
     writeCapNode(cc->getSourceCapNode(), netId);
     writeCapNode(cc->getTargetCapNode(), netId);
 
-    fprintf(
-        _outFP, "%g", cc->getCapacitance(_active_corner_number[0]) * _cap_unit);
+    fprintf(_outFP,
+            "%g",
+            cc->getCapacitance(_active_corner_number[0])
+                * scale_factors_.capacitance);
     for (int ii = 1; ii < _active_corner_cnt; ii++) {
       fprintf(_outFP,
               "%s%g",
               spef_header_.delimiter.c_str(),
-              cc->getCapacitance(_active_corner_number[ii]) * _cap_unit);
+              cc->getCapacitance(_active_corner_number[ii])
+                  * scale_factors_.capacitance);
     }
 
     fprintf(_outFP, "\n");
@@ -1142,13 +1156,16 @@ void extSpef::writeRes(const uint32_t netId, dbSet<dbRSeg>& rSet)
     writeCapNode(rc->getSourceNode(), netId);
     writeCapNode(rc->getTargetNode(), netId);
 
-    fprintf(
-        _outFP, "%g", rc->getResistance(_active_corner_number[0]) * _res_unit);
+    fprintf(_outFP,
+            "%g",
+            rc->getResistance(_active_corner_number[0])
+                * scale_factors_.resistance);
     for (int ii = 1; ii < _active_corner_cnt; ii++) {
       fprintf(_outFP,
               "%s%g",
               spef_header_.delimiter.c_str(),
-              rc->getResistance(_active_corner_number[ii]) * _res_unit);
+              rc->getResistance(_active_corner_number[ii])
+                  * scale_factors_.resistance);
     }
     fprintf(_outFP, " \n");
   }
@@ -1551,17 +1568,11 @@ void extSpef::writeBlock(const char* nodeCoord,
   }
 
   if (!_stopBeforeDnets && !_stopAfterNameMap) {
-    if (strcmp("PF", capUnit) == 0) {
-      _cap_unit = 0.001;
-      spef_header_.capacitance_unit_word = capUnit;
-    }
-    if (strcmp("MOHM", resUnit) == 0) {
-      _res_unit = 1000.0;
-      spef_header_.resistance_unit_word = resUnit;
-    } else if (strcmp("KOHM", resUnit) == 0) {
-      _res_unit = 0.001;
-      spef_header_.resistance_unit_word = resUnit;
-    }
+    scale_factors_ = computeScaleFactors(capUnit, resUnit);
+
+    spef_header_.capacitance_unit_word = capUnit;
+    spef_header_.resistance_unit_word = resUnit;
+
     setCornerCnt(_block->getCornerCount());
 
     if (!_preserveCapValues) {
@@ -1704,6 +1715,24 @@ std::string SpefHeader::string(utl::Logger* logger) const
   out << "*L_UNIT 1 " << inductance_unit_word << "\n";
 
   return out.str();
+}
+
+ScaleFactors extSpef::computeScaleFactors(const std::string& capacitance_unit,
+                                          const std::string& resistance_unit)
+{
+  ScaleFactors scale_factors;
+
+  if (capacitance_unit == "PF") {
+    scale_factors.capacitance = 0.001;
+  }
+
+  if (resistance_unit == "MOHM") {
+    scale_factors.resistance = 1000.0;
+  } else if (resistance_unit == "KOHM") {
+    scale_factors.resistance = 0.001;
+  }
+
+  return scale_factors;
 }
 
 }  // namespace rcx

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1726,9 +1726,7 @@ ScaleFactors extSpef::computeScaleFactors(const std::string& capacitance_unit,
     scale_factors.capacitance = 0.001;
   }
 
-  if (resistance_unit == "MOHM") {
-    scale_factors.resistance = 1000.0;
-  } else if (resistance_unit == "KOHM") {
+  if (resistance_unit == "KOHM") {
     scale_factors.resistance = 0.001;
   }
 

--- a/src/rcx/src/extSpefIn.cpp
+++ b/src/rcx/src/extSpefIn.cpp
@@ -2909,9 +2909,6 @@ bool extSpef::readHeaderInfo(const uint32_t debug, const bool skipFlag)
       spef_header_.resistance_unit_word = required_word(2, "*R_UNIT");
 
       scale_factors_.resistance = 1.0;
-      if (spef_header_.resistance_unit_word == "MOHM") {
-        scale_factors_.resistance = 0.001 * _parser->getInt(1);
-      }
       if (spef_header_.resistance_unit_word == "KOHM") {
         scale_factors_.resistance = 1000.0 * _parser->getInt(1);
       }

--- a/src/rcx/src/extSpefIn.cpp
+++ b/src/rcx/src/extSpefIn.cpp
@@ -648,7 +648,8 @@ uint32_t extSpef::getCapNodeId(const char* nodeWord,
     } else {
       if (_readAllCorners) {
         for (uint32_t ii = 0; ii < capCnt; ii++) {
-          double capVal = _cap_unit * _nodeParser->getDouble(ii);
+          double capVal
+              = scale_factors_.capacitance * _nodeParser->getDouble(ii);
           if (_addRepeatedCapValue) {
             cap->addCapacitance(capVal, ii);
           } else {
@@ -656,7 +657,8 @@ uint32_t extSpef::getCapNodeId(const char* nodeWord,
           }
         }
       } else {
-        double capVal = _cap_unit * _nodeParser->getDouble(_in_spef_corner);
+        double capVal = scale_factors_.capacitance
+                        * _nodeParser->getDouble(_in_spef_corner);
         if (_addRepeatedCapValue) {
           cap->addCapacitance(capVal, _db_ext_corner);
         } else {
@@ -917,16 +919,18 @@ uint32_t extSpef::diffNetCap(dbNet* net)
   if (_readAllCorners) {
     for (uint32_t ii = 0; ii < capCnt; ii++) {
       const double dbCap = net->getTotalCapacitance(ii, true);
-      const double refCap = _cap_unit * _nodeParser->getDouble(ii);
+      const double refCap
+          = scale_factors_.capacitance * _nodeParser->getDouble(ii);
 
       printDiff(net, dbCap, refCap, "netCap", ii);
     }
   } else {
-    printDiff(net,
-              net->getTotalCapacitance(_db_ext_corner, true),
-              _cap_unit * _nodeParser->getDouble(_in_spef_corner),
-              "netCap",
-              _db_ext_corner);
+    printDiff(
+        net,
+        net->getTotalCapacitance(_db_ext_corner, true),
+        scale_factors_.capacitance * _nodeParser->getDouble(_in_spef_corner),
+        "netCap",
+        _db_ext_corner);
   }
 
   return capCnt;
@@ -1193,10 +1197,11 @@ uint32_t extSpef::collectRefCCap(dbNet* srcNet,
   float refCap = 0.0;
   if (_readAllCorners) {
     for (uint32_t i = 0; i < capCnt; i++) {
-      refCap += _cap_unit * _nodeParser->getDouble(i);
+      refCap += scale_factors_.capacitance * _nodeParser->getDouble(i);
     }
   } else {
-    refCap += _cap_unit * _nodeParser->getDouble(_in_spef_corner);
+    refCap
+        += scale_factors_.capacitance * _nodeParser->getDouble(_in_spef_corner);
   }
   dbNet* otherNet;
   if (_d_corner_net == srcNet) {
@@ -1225,7 +1230,7 @@ uint32_t extSpef::diffCCap(dbNet* srcNet,
                            const uint32_t capCnt)
 {
   for (uint32_t i = 0; i < capCnt; i++) {
-    double refCap = _cap_unit * _nodeParser->getDouble(i);
+    double refCap = scale_factors_.capacitance * _nodeParser->getDouble(i);
     _netCCapTable[i] += refCap;
   }
   if (_calib) {
@@ -1252,20 +1257,22 @@ uint32_t extSpef::diffCCap(dbNet* srcNet,
 
   if (_readAllCorners) {
     for (uint32_t ii = 0; ii < capCnt; ii++) {
-      const double refCap = _cap_unit * _nodeParser->getDouble(ii);
+      const double refCap
+          = scale_factors_.capacitance * _nodeParser->getDouble(ii);
       const double dbCap = ccap->getCapacitance(ii);
 
       printDiffCC(srcNet, tgtNet, srcId, dstId, dbCap, refCap, "ccCap", ii);
     }
   } else {
-    printDiffCC(srcNet,
-                tgtNet,
-                srcId,
-                dstId,
-                ccap->getCapacitance(_db_ext_corner),
-                _cap_unit * _nodeParser->getDouble(_in_spef_corner),
-                "ccCap",
-                _db_ext_corner);
+    printDiffCC(
+        srcNet,
+        tgtNet,
+        srcId,
+        dstId,
+        ccap->getCapacitance(_db_ext_corner),
+        scale_factors_.capacitance * _nodeParser->getDouble(_in_spef_corner),
+        "ccCap",
+        _db_ext_corner);
   }
   return capCnt;
 }
@@ -1279,7 +1286,7 @@ uint32_t extSpef::diffGndCap(dbNet* net,
   }
 
   for (uint32_t ii = 0; ii < capCnt; ii++) {
-    double refCap = _cap_unit * _nodeParser->getDouble(ii);
+    double refCap = scale_factors_.capacitance * _nodeParser->getDouble(ii);
     _netGndCapTable[ii] += refCap;
   }
   return 0;  // TODO - have to get cap from Rseg!
@@ -1995,11 +2002,13 @@ uint32_t extSpef::readDNet(const uint32_t debug)
             if (_readAllCorners) {
               for (uint32_t ii = 0; ii < capCnt; ii++) {
                 srcCapNode->addCapacitance(
-                    _cap_unit * _nodeParser->getDouble(ii), ii);
+                    scale_factors_.capacitance * _nodeParser->getDouble(ii),
+                    ii);
               }
             } else {
               srcCapNode->addCapacitance(
-                  _cap_unit * _nodeParser->getDouble(_in_spef_corner),
+                  scale_factors_.capacitance
+                      * _nodeParser->getDouble(_in_spef_corner),
                   _db_ext_corner);
             }
             continue;
@@ -2007,12 +2016,13 @@ uint32_t extSpef::readDNet(const uint32_t debug)
           dbCCSeg* ccap = dbCCSeg::create(srcCapNode, tgtCapNode, true);
           if (_readAllCorners) {
             for (uint32_t ii = 0; ii < capCnt; ii++) {
-              ccap->setCapacitance(_cap_unit * _nodeParser->getDouble(ii), ii);
+              ccap->setCapacitance(
+                  scale_factors_.capacitance * _nodeParser->getDouble(ii), ii);
             }
           } else {
-            ccap->setCapacitance(
-                _cap_unit * _nodeParser->getDouble(_in_spef_corner),
-                _db_ext_corner);
+            ccap->setCapacitance(scale_factors_.capacitance
+                                     * _nodeParser->getDouble(_in_spef_corner),
+                                 _db_ext_corner);
           }
         }
       }
@@ -2046,7 +2056,7 @@ uint32_t extSpef::readDNet(const uint32_t debug)
         if (_diff) {
           uint32_t resCnt = _nodeParser->mkWords(_parser->get(3));
           for (uint32_t ii = 0; ii < resCnt; ii++) {
-            double res = _res_unit * _nodeParser->getDouble(ii);
+            double res = scale_factors_.resistance * _nodeParser->getDouble(ii);
             _netResTable[ii] += res;
           }
           continue;
@@ -2087,12 +2097,13 @@ uint32_t extSpef::readDNet(const uint32_t debug)
           uint32_t resCnt = _nodeParser->mkWords(_parser->get(3));
           if (_readAllCorners) {
             for (uint32_t ii = 0; ii < resCnt; ii++) {
-              rseg->setResistance(_res_unit * _nodeParser->getDouble(ii), ii);
+              rseg->setResistance(
+                  scale_factors_.resistance * _nodeParser->getDouble(ii), ii);
             }
           } else {
-            rseg->setResistance(
-                _res_unit * _nodeParser->getDouble(_in_spef_corner),
-                _db_ext_corner);
+            rseg->setResistance(scale_factors_.resistance
+                                    * _nodeParser->getDouble(_in_spef_corner),
+                                _db_ext_corner);
           }
 
           rseg->setSourceNode(srcCapNodeId);
@@ -2897,22 +2908,22 @@ bool extSpef::readHeaderInfo(const uint32_t debug, const bool skipFlag)
     } else if (_parser->isKeyword(0, "*R_UNIT")) {
       spef_header_.resistance_unit_word = required_word(2, "*R_UNIT");
 
-      _res_unit = 1.0;
+      scale_factors_.resistance = 1.0;
       if (spef_header_.resistance_unit_word == "MOHM") {
-        _res_unit = 0.001 * _parser->getInt(1);
+        scale_factors_.resistance = 0.001 * _parser->getInt(1);
       }
       if (spef_header_.resistance_unit_word == "KOHM") {
-        _res_unit = 1000.0 * _parser->getInt(1);
+        scale_factors_.resistance = 1000.0 * _parser->getInt(1);
       }
 
     } else if (_parser->isKeyword(0, "*C_UNIT")) {
       spef_header_.capacitance_unit_word = required_word(2, "*C_UNIT");
 
-      _cap_unit = 1.0;
+      scale_factors_.capacitance = 1.0;
       if (spef_header_.capacitance_unit_word == "PF") {
-        _cap_unit = 1000.0 * _parser->getInt(1);
+        scale_factors_.capacitance = 1000.0 * _parser->getInt(1);
       } else if (spef_header_.capacitance_unit_word == "FF") {
-        _cap_unit = 1.0 * _parser->getInt(1);
+        scale_factors_.capacitance = 1.0 * _parser->getInt(1);
       }
     } else if (_parser->isKeyword(0, "*L_UNIT")) {
       continue;


### PR DESCRIPTION
## Summary
We'll use the new struct/method to ensure that all SPEFs have consistent units on #11124.

## Type of Change
- New feature

## Impact
None.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
#11005.
