### PR TITLE
docs: generate man3 pages in the bazel man page build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bazel:python_wrap_cc.bzl", "PYTHON_EXTENSION_LINKOPTS", "PYTHON_STABLE_API_DEFINE", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     features = [
@@ -509,6 +510,13 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# The ORD messages, which live in src/ itself rather than in a module
+# subdirectory.
+messages_txt(
+    recursive = False,
+    visibility = ["//visibility:public"],
+)
+
 # Lightweight test suites that run without building OpenROAD.
 # Usage:
 #   bazelisk test --test_tag_filters=doc_check //src/... # all documentation checks
@@ -518,8 +526,18 @@ alias(
 sh_test(
     name = "dup_id_test",
     srcs = ["//etc:find_dup_ids.sh"],
-    data = ["//etc:find_messages.py"],
-    tags = ["local"],
+    data = [
+        # The handle the script uses to find the source tree it scans.
+        "MODULE.bazel",
+        "//etc:find_messages.py",
+    ],
+    # external: the sources being scanned are not declared inputs, so nothing
+    # invalidates a cached result when one of them gains a duplicate ID. Without
+    # this the check reports "(cached) PASSED" over a tree it never looked at.
+    tags = [
+        "external",
+        "local",
+    ],
 )
 
 # Make sure the Qt GUI variant keeps building. :openroad is exercised by
@@ -536,6 +554,13 @@ build_test(
 # bazelisk test //:lint_test               — run all lint checks
 # bazelisk run  //:fix_lint                — auto-fix then lint in OpenROAD
 # bazelisk run  //tools/OpenROAD:fix_lint  — auto-fix then lint in ORFS / downstream repos
+#
+# Every check below enumerates the git worktree (git_ls_files.sh) rather than
+# taking the files it inspects as declared inputs -- that is what lets one
+# target cover the whole repo, including files no Bazel target references. The
+# cost is that editing a file cannot invalidate a cached result, so each test is
+# tagged "external" to force it to re-run. Without that they report
+# "(cached) PASSED" over a worktree they never read.
 # ---------------------------------------------------------------------------
 
 # --- TCL linting (tclint) -------------------------------------------------
@@ -554,7 +579,10 @@ sh_test(
         "//bazel:tclint",
         "@git",
     ],
-    tags = ["local"],
+    tags = [
+        "external",
+        "local",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -574,7 +602,10 @@ sh_test(
         "//bazel:tclfmt",
         "@git",
     ],
-    tags = ["local"],
+    tags = [
+        "external",
+        "local",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -613,7 +644,10 @@ sh_test(
         "@buildifier_prebuilt//:buildifier",
         "@git",
     ],
-    tags = ["local"],
+    tags = [
+        "external",
+        "local",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -633,7 +667,10 @@ sh_test(
         "@buildifier_prebuilt//:buildifier",
         "@git",
     ],
-    tags = ["local"],
+    tags = [
+        "external",
+        "local",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -672,7 +709,10 @@ sh_test(
         "//bazel:yamlfix",
         "@git",
     ],
-    tags = ["local"],
+    tags = [
+        "external",
+        "local",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/bazel/man_pages.bzl
+++ b/bazel/man_pages.bzl
@@ -26,6 +26,11 @@ def _man_pages_impl(ctx):
 set -euo pipefail
 CAT_OUT="$PWD/{cat_out}"
 HTML_OUT="$PWD/{html_out}"
+# The messages.txt files that man3 is built from are generated, so they live
+# under bazel-out rather than in the source tree the execroot symlinks in.
+# md_roff_compat.py looks for <root>/src/<module>/messages.txt and
+# <root>/messages.txt, which is exactly the bin dir's layout.
+export MESSAGES_ROOT_DIR="$PWD/{bin_dir}"
 # Two phases: 'preprocess' (serial) generates the md/man*/*.md sources, then
 # 'cat web' fan out pandoc/nroff in parallel. They cannot share one -j make
 # invocation: cat/web read the md files preprocess produces, and a parallel
@@ -44,6 +49,7 @@ make -s --no-print-directory -C docs -f Makefile preprocess \\
 make -s --no-print-directory -j"$JOBS" -C docs -f Makefile cat web \\
     CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
 """.format(
+        bin_dir = ctx.bin_dir.path,
         cat_out = cat_dir.path,
         html_out = html_dir.path,
     )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -17,9 +17,12 @@ man_pages(
         # --guard_against_concurrent_changes ("modified during execution").
     ] + glob(["md/man1/**/*.md"]),
     messages = [
+        # The ORD messages, from src/ itself.
+        "//:messages_txt",
         "//src/ant:messages_txt",
         "//src/cgt:messages_txt",
         "//src/cts:messages_txt",
+        "//src/cut:messages_txt",
         "//src/dbSta:messages_txt",
         "//src/dft:messages_txt",
         "//src/dpl:messages_txt",
@@ -30,6 +33,7 @@ man_pages(
         "//src/fin:messages_txt",
         "//src/gpl:messages_txt",
         "//src/grt:messages_txt",
+        "//src/gui:messages_txt",
         "//src/ifp:messages_txt",
         "//src/mpl:messages_txt",
         "//src/odb:messages_txt",
@@ -45,6 +49,7 @@ man_pages(
         "//src/stt:messages_txt",
         "//src/syn:messages_txt",
         "//src/tap:messages_txt",
+        "//src/tst:messages_txt",
         "//src/upf:messages_txt",
         "//src/utl:messages_txt",
         "//src/web:messages_txt",

--- a/docs/src/scripts/md_roff_compat.py
+++ b/docs/src/scripts/md_roff_compat.py
@@ -64,6 +64,7 @@ tools = [
     "ant",
     "cgt",
     "cts",
+    "cut",
     "dbSta",
     "dft",
     "dpl",
@@ -91,6 +92,7 @@ tools = [
     "stt",
     "syn",
     "tap",
+    "tst",
     "upf",
     "utl",
     "web",
@@ -98,19 +100,30 @@ tools = [
 
 # Process man2. The excluded modules contribute man3 message pages but no
 # command pages: odb and sta are documented elsewhere (doxygen / upstream),
-# while dbSta and dst ship no README for link_readmes.sh to symlink.
+# dbSta and dst ship no README for link_readmes.sh to symlink, and cut and tst
+# expose no Tcl commands (cut is internal, tst is unit-test infrastructure not
+# linked into the application), so their READMEs have no command section to
+# parse.
 DEST_DIR2 = SRC_DIR = "./md/man2"
-exclude2 = ["dbSta", "dst", "odb", "sta"]
+exclude2 = ["cut", "dbSta", "dst", "odb", "sta", "tst"]
 docs2 = [f"{SRC_DIR}/{tool}.md" for tool in tools if tool not in exclude2]
 
-# Process man3 (add extra path for ORD messages)
-SRC_DIR = "../src"
+# Process man3. The pages come from the generated messages.txt files, laid out
+# as <root>/src/<module>/messages.txt plus <root>/messages.txt for the ORD
+# messages. The CMake build writes them into the source tree, so the default
+# root is the repository root. Bazel writes them under bazel-out, so
+# //docs:man_pages sets MESSAGES_ROOT_DIR to its generated tree instead.
+MESSAGES_ROOT_DIR = os.environ.get("MESSAGES_ROOT_DIR", "..")
 DEST_DIR3 = "./md/man3"
 exclude = [
     "sta"
 ]  # sta excluded because its format is different, and no severity level.
-docs3 = [f"{SRC_DIR}/{tool}/messages.txt" for tool in tools if tool not in exclude]
-docs3.append("../messages.txt")
+docs3 = [
+    f"{MESSAGES_ROOT_DIR}/src/{tool}/messages.txt"
+    for tool in tools
+    if tool not in exclude
+]
+docs3.append(f"{MESSAGES_ROOT_DIR}/messages.txt")
 
 
 def man2(path=DEST_DIR2):

--- a/etc/find_dup_ids.sh
+++ b/etc/find_dup_ids.sh
@@ -20,5 +20,21 @@ if [ ! -f "${FIND_MESSAGES}" ]; then
     echo "ERROR: Cannot find find_messages.py at ${FIND_MESSAGES}" >&2
     exit 1
 fi
+# Absolute: the scan below runs from a different directory.
+FIND_MESSAGES="$(realpath "${FIND_MESSAGES}")"
 
-python3 "${FIND_MESSAGES}" -d src
+# Run from the source tree. A test runs in its runfiles directory, which holds
+# nothing but its own declared data, so scanning "src" from there would walk a
+# path that does not exist -- find_messages.py would report zero messages and
+# the check would pass unconditionally. MODULE.bazel is declared as data purely
+# so its runfiles entry is a symlink pointing back at the real workspace, the
+# same handle the lint tests use.
+[ -L MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
+cd "$(dirname "$(readlink MODULE.bazel)")"
+
+# One walk over all of src, so an ID reused across two modules is caught along
+# with one reused inside a single module. This is wider than the per-module
+# //src/<module>:messages_txt targets, which each scan their own module only.
+# find_messages.py exits non-zero naming both sites; its listing of every
+# message goes to stdout and is not interesting here.
+python3 "${FIND_MESSAGES}" -d src > /dev/null

--- a/src/cut/BUILD
+++ b/src/cut/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -45,4 +46,8 @@ cc_library(
         "@boost.phoenix",
         "@boost.spirit",
     ],
+)
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/cut/src/CMakeLists.txt
+++ b/src/cut/src/CMakeLists.txt
@@ -7,7 +7,8 @@ project(cut)
 add_library(cut)
 
 messages(
-TARGET cut
+  TARGET cut
+  OUTPUT_DIR ..
 )
 
 target_include_directories(cut

--- a/src/dft/BUILD
+++ b/src/dft/BUILD
@@ -99,6 +99,15 @@ filegroup(
 )
 
 messages_txt(
+    extra_srcs = [
+        "//src/dft/src/architect:message_srcs",
+        "//src/dft/src/cells:message_srcs",
+        "//src/dft/src/clock_domain:message_srcs",
+        "//src/dft/src/config:message_srcs",
+        "//src/dft/src/replace:message_srcs",
+        "//src/dft/src/stitch:message_srcs",
+        "//src/dft/src/utils:message_srcs",
+    ],
     visibility = [
         "//docs:__pkg__",
         "//src/dft/test:__pkg__",

--- a/src/dft/src/architect/BUILD
+++ b/src/dft/src/architect/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -33,4 +34,8 @@ cc_library(
         "//src/utl",
         "@boost.geometry",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/dft/src/cells/BUILD
+++ b/src/dft/src/cells/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -32,4 +33,8 @@ cc_library(
         "//src/sta:opensta_lib",
         "//src/utl",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/dft/src/clock_domain/BUILD
+++ b/src/dft/src/clock_domain/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -25,4 +26,8 @@ cc_library(
         "//src/dft/src/config",
         "//src/utl",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/dft/src/config/BUILD
+++ b/src/dft/src/config/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -27,4 +28,8 @@ cc_library(
         "//src/dft/src/utils",
         "//src/utl",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/dft/src/replace/BUILD
+++ b/src/dft/src/replace/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -27,4 +28,8 @@ cc_library(
         "//src/sta:opensta_lib",
         "//src/utl",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/dft/src/stitch/BUILD
+++ b/src/dft/src/stitch/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -28,4 +29,8 @@ cc_library(
         "//src/utl",
         "@boost.algorithm",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/dft/src/utils/BUILD
+++ b/src/dft/src/utils/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -30,4 +31,8 @@ cc_library(
         "//src/utl",
         "@spdlog",
     ],
+)
+
+message_srcs(
+    visibility = ["//src/dft:__pkg__"],
 )

--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -209,7 +209,10 @@ filegroup(
 )
 
 messages_txt(
-    visibility = ["//src/gui/test:__pkg__"],
+    visibility = [
+        "//docs:__pkg__",
+        "//src/gui/test:__pkg__",
+    ],
 )
 
 # Desktop entry for GUI builds. Generated from the same template that the

--- a/src/odb/BUILD
+++ b/src/odb/BUILD
@@ -107,6 +107,8 @@ filegroup(
     visibility = ["//src/odb/test:__pkg__"],
 )
 
+# Every directory under src/ is its own package, so the sources come in through
+# extra_srcs and src_patterns only has to cover the public headers.
 messages_txt(
     extra_srcs = [
         "//src/odb/src/3dblox:message_srcs",

--- a/src/odb/src/3dblox/BUILD
+++ b/src/odb/src/3dblox/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -31,11 +32,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob([
-        "*.cpp",
-        "*.h",
-    ]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/cdl/BUILD
+++ b/src/odb/src/cdl/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -21,8 +22,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob(["*.cpp"]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/db/BUILD
+++ b/src/odb/src/db/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -65,11 +66,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob([
-        "*.cpp",
-        "*.h",
-    ]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/defin/BUILD
+++ b/src/odb/src/defin/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -29,11 +30,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob([
-        "*.cpp",
-        "*.h",
-    ]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/defout/BUILD
+++ b/src/odb/src/defout/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -24,11 +25,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob([
-        "*.cpp",
-        "*.h",
-    ]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/gdsin/BUILD
+++ b/src/odb/src/gdsin/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -26,8 +27,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob(["*.cpp"]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/gdsout/BUILD
+++ b/src/odb/src/gdsout/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -22,8 +23,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob(["*.cpp"]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/lefin/BUILD
+++ b/src/odb/src/lefin/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -36,11 +37,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob([
-        "*.cpp",
-        "*.h",
-    ]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/lefout/BUILD
+++ b/src/odb/src/lefout/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026-2026, Precision Innovations Inc.
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -23,8 +24,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob(["*.cpp"]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )

--- a/src/odb/src/swig/BUILD
+++ b/src/odb/src/swig/BUILD
@@ -4,6 +4,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//test:regression.bzl", "message_srcs")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -71,13 +72,7 @@ tcl_encode(
     namespace = "odb",
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob([
-        "**/*.cpp",
-        "**/*.h",
-        "**/*.tcl",
-    ]),
+message_srcs(
     visibility = ["//src/odb:__pkg__"],
 )
 

--- a/src/syn/BUILD
+++ b/src/syn/BUILD
@@ -127,25 +127,12 @@ python_wrap_cc(
 
 exports_files(["README.md"])
 
-# Synthesis keeps most of its logger calls below src/: flow/ in this package,
-# elab/ and ir/ in their own. The macro's default non-recursive src/*.{cc,h,tcl}
-# glob would find only 29 of the 73 messages.
+# Synthesis keeps most of its logger calls below src/: flow/ is covered by the
+# macro's recursive glob, elab/ and ir/ are their own packages.
 messages_txt(
     extra_srcs = [
         "//src/syn/src/elab:message_srcs",
         "//src/syn/src/ir:message_srcs",
-    ],
-    src_patterns = [
-        "src/*.cc",
-        "src/*.cpp",
-        "src/*.h",
-        "src/*.hh",
-        "src/*.tcl",
-        "src/flow/*.cc",
-        "src/flow/*.cpp",
-        "src/flow/*.h",
-        "src/flow/*.hh",
-        "src/flow/*.tcl",
     ],
     visibility = ["//docs:__pkg__"],
 )

--- a/src/syn/src/elab/BUILD
+++ b/src/syn/src/elab/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(features = ["layering_check"])
 
@@ -63,17 +64,6 @@ cc_library(
     alwayslink = True,
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob(
-        [
-            "*.cc",
-            "*.cpp",
-            "*.h",
-            "*.hh",
-            "*.tcl",
-        ],
-        allow_empty = True,
-    ),
+message_srcs(
     visibility = ["//src/syn:__pkg__"],
 )

--- a/src/syn/src/ir/BUILD
+++ b/src/syn/src/ir/BUILD
@@ -2,6 +2,7 @@
 # Copyright (c) 2026, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//test:regression.bzl", "message_srcs")
 
 package(features = ["layering_check"])
 
@@ -38,17 +39,6 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "message_srcs",
-    srcs = glob(
-        [
-            "*.cc",
-            "*.cpp",
-            "*.h",
-            "*.hh",
-            "*.tcl",
-        ],
-        allow_empty = True,
-    ),
+message_srcs(
     visibility = ["//src/syn:__pkg__"],
 )

--- a/src/tst/BUILD
+++ b/src/tst/BUILD
@@ -3,6 +3,7 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("//test:regression.bzl", "messages_txt")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -219,4 +220,8 @@ cc_test(
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
+)
+
+messages_txt(
+    visibility = ["//docs:__pkg__"],
 )

--- a/src/tst/CMakeLists.txt
+++ b/src/tst/CMakeLists.txt
@@ -100,3 +100,11 @@ target_link_libraries(tst_integrated_fixture
     db
     OpenSTA
 )
+
+# The fixtures log through utl, so they contribute man3 message pages like any
+# other module. SOURCE_DIR confines the scan to the library sources, matching
+# the Bazel messages_txt glob.
+messages(
+  TARGET tst_integrated_fixture
+  SOURCE_DIR src
+)

--- a/src/tst/src/IntegratedFixture.cpp
+++ b/src/tst/src/IntegratedFixture.cpp
@@ -167,7 +167,7 @@ void IntegratedFixture::dumpVerilogAndOdb(const std::string& name) const
 void IntegratedFixture::removeFile(const std::string& path)
 {
   if (std::remove(path.c_str()) != 0) {
-    logger_.warn(utl::RSZ, 0, "Could not remove '{}'.", path);
+    logger_.warn(utl::TST, 1, "Could not remove '{}'.", path);
   }
 }
 

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -253,41 +253,72 @@ def doc_check_test(name, **kwargs):
         **kwargs
     )
 
-def messages_txt(name = "messages_txt", src_patterns = None, extra_srcs = None, visibility = None):
+# Extensions find_messages.py scans for logger calls. Keep in sync with the
+# regex in etc/find_messages.py: an extension missing here means every message
+# in those files is missing from messages.txt, and so from its man3 page.
+_MESSAGE_SRC_EXTENSIONS = [
+    "c",
+    "cc",
+    "cpp",
+    "cxx",
+    "h",
+    "hh",
+    "i",
+    "ll",
+    "tcl",
+    "yy",
+]
+
+def message_srcs(name = "message_srcs", visibility = None):
+    """Expose a sub-package's sources to its module's messages_txt target.
+
+    glob() never crosses a package boundary, so a module whose sources live in
+    sub-packages has to collect them through filegroups listed in its
+    messages_txt extra_srcs.
+
+    Args:
+        name: Target name (default: "message_srcs").
+        visibility: Bazel visibility; the owning module's package.
+    """
+    native.filegroup(
+        name = name,
+        srcs = native.glob(
+            ["**/*." + ext for ext in _MESSAGE_SRC_EXTENSIONS],
+            allow_empty = True,
+        ),
+        visibility = visibility,
+    )
+
+def messages_txt(name = "messages_txt", src_patterns = None, recursive = True, extra_srcs = None, visibility = None):
     """Generate messages.txt from source files using find_messages.py.
 
     Replaces per-module genrule boilerplate with a single macro call.
 
     Args:
         name: Target name (default: "messages_txt").
-        src_patterns: Glob patterns for source files. Defaults to all
-            common C++/Tcl extensions. Override for modules with
-            non-standard layouts (e.g., recursive globs for odb).
-        extra_srcs: Additional source labels from other packages (e.g.,
-            filegroups in sub-packages). When provided, files are passed
-            directly to find_messages.py instead of directory walking.
+        src_patterns: Glob patterns for source files. Defaults to every
+            scanned extension under src/. Override for modules that keep
+            messages elsewhere, e.g. odb's public headers.
+        recursive: Whether the default patterns descend into src/
+            subdirectories. Several modules keep logger calls there, so this
+            is on by default; the top-level ORD messages turn it off to avoid
+            swallowing the modules, which have their own messages_txt.
+        extra_srcs: Additional source labels from other packages, i.e.
+            message_srcs filegroups in sub-packages, which glob() cannot reach.
         visibility: Bazel visibility.
     """
     if src_patterns == None:
-        src_patterns = [
-            "src/*.cc",
-            "src/*.cpp",
-            "src/*.h",
-            "src/*.hh",
-            "src/*.tcl",
-        ]
+        prefix = "src/**/*." if recursive else "src/*."
+        src_patterns = [prefix + ext for ext in _MESSAGE_SRC_EXTENSIONS]
 
     srcs = native.glob(src_patterns, allow_empty = True)
     if extra_srcs:
         srcs = srcs + extra_srcs
 
-    # When extra_srcs are present, sources span multiple directories so
-    # the dirname-of-first-src trick doesn't work.  Pass every file
-    # path as a positional arg to find_messages.py instead.
-    if extra_srcs:
-        cmd = "$(PYTHON3) $(location //etc:find_messages.py) $(SRCS) > $@"
-    else:
-        cmd = "$(PYTHON3) $(location //etc:find_messages.py) -d $$(dirname $$(echo $(SRCS) | tr ' ' '\\n' | head -1)) > $@"
+    # Scan exactly the declared srcs. find_messages.py can also walk a
+    # directory, but the sources span several directories and the walk root
+    # would have to be guessed from them.
+    cmd = "$(PYTHON3) $(location //etc:find_messages.py) $(SRCS) > $@"
 
     native.genrule(
         name = name,


### PR DESCRIPTION
`//docs:man_pages` produced **no man3 pages at all** — `bazel-bin/docs/cat/cat3` was empty. `md_roff_compat.py` read `../src/<module>/messages.txt` from the source tree, but those files are generated: CMake writes them in-tree while bazel writes them under `bazel-out`, and the unsandboxed action sees only declared inputs. Every message page was skipped with `doesn't exist. Continuing`. `cat3`/`html3` now hold **3408** pages each.

### Wiring the generated files in

`md_roff_compat.py` takes the layout root from `MESSAGES_ROOT_DIR`, defaulting to the repository root so the CMake paths are byte-identical, and `man_pages.bzl` points it at the bin dir, whose layout already matches (`<bin>/src/<module>/messages.txt`, `<bin>/messages.txt`).

Two inputs had nowhere to come from: the ORD messages, which live in `src/` itself and had no bazel target (new `//:messages_txt`), and `//src/gui:messages_txt`, which existed but was not visible to `//docs`.

### The generated files were themselves incomplete

The `messages_txt` glob was not recursive and omitted `.cxx` and `.i`, so modules keeping logger calls below `src/` lost them — 311 in drt, 90 in grt, 74 in dpl (all `.cxx`), 21 in rsz, 18 in utl, 15 in gui (all `.i`). The default glob now recurses over the extension set `find_messages.py` actually scans, and sub-packages hand their sources over through a shared `message_srcs` macro: new for dft's seven, and replacing three divergent hand-written extension lists in odb and syn.

### cut and tst

Both join the documented modules. `cut`'s `messages()` call was the only one in a `src/<module>/src/CMakeLists.txt` without `OUTPUT_DIR ..`, so CMake wrote `src/cut/src/messages.txt` where every other module writes `src/<module>/messages.txt`; `tst` had no `messages()` call. Neither exposes Tcl commands (parsing either README for command pages raises `IndexError`), so both are excluded from man2.

`tst`'s single logger call named `utl::RSZ, 0` from test-fixture code — not a resizer message — and would have published an `RSZ-0000(3)` page. It is now `utl::TST, 1`.

### `//:dup_id_test` was passing unconditionally

It ran `find_messages.py -d src` from its runfiles directory, which holds only the script, so it walked a nonexistent path, found zero messages and exited 0. An injected duplicate left it green while the same duplicate failed `//src/drt:messages_txt`. It now resolves the workspace through its `MODULE.bazel` runfiles symlink — the handle `lint_bzl_test` and friends already use.

That single walk is also the only check that can see **cross-module** collisions: with `DRT 0100` planted in `src/gpl`, both `//src/gpl:messages_txt` and `//src/drt:messages_txt` build fine, because each module's `messages.txt` is individually duplicate-free when the two sites sit in different modules. It additionally covers `test/` directories, which no `messages_txt` target scans (3426 keys vs the 3408 the genrules cover).

### The lint tests shared the resulting caching hole

`lint_tcl_test`, `fmt_tcl_test`, `lint_bzl_test`, `fmt_bzl_test` and `fmt_yaml_test` enumerate the git worktree rather than taking the inspected files as declared inputs, so nothing invalidates a cached result — all five reported `(cached) PASSED` after a source edit, i.e. they could pass over unformatted files. Tagging them `external` forces a re-run; each was then confirmed to fail on an injected violation through a plain `bazelisk test` with no flags.

Unrelated observation, not addressed here: `fmt_yaml_test` currently checks nothing — all 38 tracked YAML files are listed in `yamlfix.ignore`.