### PR TITLE
Cts: fix crash when library has no max_capacitance for clock buffers

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -856,6 +856,12 @@ std::string TritonCTS::selectBestMaxCapBuffer(
     }
   }
 
+  if (nextBestBuf.empty()) {
+    logger_->error(CTS,
+                   2,
+                   "Characterization could not select a buffer: candidate "
+                   "buffers lack max capacitance information.");
+  }
   if (bestBuf.empty()) {
     bestBuf = std::move(nextBestBuf);
   }

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -838,6 +838,10 @@ std::string TritonCTS::selectBestMaxCapBuffer(
     float maxCap = 0.0;
     bool maxCapExists = false;
     out->capacitanceLimit(sta::MinMax::max(), maxCap, maxCapExists);
+    if (!maxCapExists) {
+      // capacitanceLimit leaves maxCap undefined when there is no limit
+      maxCap = 0.0;
+    }
     // clang-format off
     debugPrint(logger_, CTS, "buffering", 1, "{} has cap limit:{}"
                " vs. total cap:{}, derate:{}", name,

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -14,6 +14,7 @@ COMPULSORY_TESTS = [
     "array_max_wl",
     "array_no_blockages",
     "array_repair_clock_nets",
+    "buffer_no_max_cap",
     "buffer_ports",
     "check_buffers",
     "check_buffers_blockages",
@@ -114,6 +115,10 @@ filegroup(
                 "array_tile.lef",
                 "array_tile.lib",
                 "array_max_wl.defok",
+            ],
+            "buffer_no_max_cap": [
+                "16sinks.def",
+                "Nangate45/Nangate45_typ_no_max_cap.lib",
             ],
             "check_buffer_inference1": [
                 "ModNangate45/ModNangate45_typ.lib",

--- a/src/cts/test/CMakeLists.txt
+++ b/src/cts/test/CMakeLists.txt
@@ -9,6 +9,7 @@ or_integration_tests(
     array_max_wl
     array_no_blockages
     array_repair_clock_nets
+    buffer_no_max_cap
     buffer_ports
     check_buffers
     check_buffers_blockages

--- a/src/cts/test/buffer_no_max_cap.ok
+++ b/src/cts/test/buffer_no_max_cap.ok
@@ -1,0 +1,7 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: test_16_sinks
+[INFO ODB-0130]     Created 1 pins.
+[INFO ODB-0131]     Created 16 components and 96 component-terminals.
+[INFO ODB-0133]     Created 1 nets and 16 connections.
+[ERROR CTS-0002] Characterization could not select a buffer: candidate buffers lack max capacitance information.
+CTS-0002

--- a/src/cts/test/buffer_no_max_cap.tcl
+++ b/src/cts/test/buffer_no_max_cap.tcl
@@ -1,0 +1,17 @@
+# Buffer inference fails when liberty buffers have no max capacitance
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ_no_max_cap.lib
+read_def "16sinks.def"
+
+create_clock -period 5 clk
+set_wire_rc -clock -layer metal3
+
+set_cts_config -wire_unit 20 \
+  -buf_list "CLKBUF_X3 CLKBUF_X2 CLKBUF_X1"
+
+catch {
+  clock_tree_synthesis
+} error
+
+puts $error


### PR DESCRIPTION
## Summary
When CTS has to infer the root/sink buffer (selectBestMaxCapBuffer in TritonCTS.cpp:815), it picks the smallest candidate buffer that can drive the estimated wire cap, and otherwise falls back to the candidate with the largest `max_capacitance`. If the buffer CTS is using have no `max_capacitance` CTS would crash, this PR fixes this by issuing an error message to inform the user the library lacks information for CTS to infer root/sink buffers.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
- CTS issues an error message when CTS is not able to infer root/sink buffers instead of crashing.
- Add a unit test with a faulty library to catch the error message (`src/cts/test/buffer_no_max_cap.ok`).

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
<!-- Delete next item if this PR is not a bug fix or new feature -->
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes [#11165](https://github.com/The-OpenROAD-Project/OpenROAD/issues/11165)