### PR TITLE
 dbSta: read cross-die parasitics on 3D-IC designs

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -195,6 +195,17 @@ class dbNetwork : public ConcreteNetwork
   // A bump's timing pin is its pad inst's single dbITerm (flat model);
   // nullptr for spare (unbound) bumps.
   odb::dbITerm* bumpPadITerm(odb::dbUnfoldedChipBumpInst* bump) const;
+  // The chip-net above a chiplet boundary, reached from the boundary port, the
+  // die-side net, or the bump's pad iterm. Null if the boundary is unbonded.
+  // This is the net a cross-die parasitic network is keyed on, and the net the
+  // 3D RCX bonds SPEF is written at.
+  //
+  // Read the bonds SPEF before the per-die SPEFs. A top-scope read replaces a
+  // net's parasitic network where a -path read merges into it, so the other
+  // order discards the die contributions without warning.
+  odb::dbChipNet* chipNetAbove(odb::dbBTerm* bterm) const;
+  odb::dbChipNet* chipNetAboveNet(const Net* net) const;
+  odb::dbChipNet* chipNetOfPadITerm(odb::dbITerm* iterm) const;
   // Raw chip-inst / chip-net -> their per-unfold-path objects (built in
   // setTopChip). Used by the chip-aware iterators to enumerate unfolded bumps.
   odb::dbUnfoldedChipInst* unfoldedChipInst(odb::dbChipInst* chip_inst) const;
@@ -622,6 +633,8 @@ class dbNetwork : public ConcreteNetwork
   //   raw chip-inst -> its unfolded chip-inst (for the pin iterator)
   //   raw chip-net  -> its unfolded chip-net  (for the net-pin iterator)
   mutable odb::PtrMap<odb::dbITerm, odb::dbChipNet*> bump_to_chip_net_;
+  // Die-side net -> the chip-net it reaches through one of its bump pads.
+  mutable odb::PtrMap<odb::dbNet, odb::dbChipNet*> net_to_chip_net_;
   mutable odb::PtrMap<odb::dbChipInst, odb::dbUnfoldedChipInst*>
       chip_inst_to_unfolded_;
   mutable odb::PtrMap<odb::dbChipNet, odb::dbUnfoldedChipNet*>

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -925,6 +925,7 @@ void dbNetwork::clear()
   chip_master_cells_.clear();
   chip_master_lib_ = nullptr;
   bump_to_chip_net_.clear();
+  net_to_chip_net_.clear();
   chip_inst_to_unfolded_.clear();
   chip_net_to_unfolded_.clear();
 }
@@ -1068,6 +1069,7 @@ void dbNetwork::setTopChip(odb::dbChip* chip)
   block_to_chip_inst_.clear();
   block_disc_.clear();
   bump_to_chip_net_.clear();
+  net_to_chip_net_.clear();
   chip_inst_to_unfolded_.clear();
   chip_net_to_unfolded_.clear();
   unfolded_built_ = false;
@@ -1194,13 +1196,10 @@ odb::dbBlock* dbNetwork::blockOf(odb::dbChipInst* chip_inst) const
 // vertex id, its MTerm carries direction, and it sits directly on the
 // chiplet's inner net). Returns nullptr for spare bumps (no bound bterm) and
 // for pad insts with no iterm -- neither is a logical endpoint.
-odb::dbITerm* dbNetwork::bumpPadITerm(odb::dbUnfoldedChipBumpInst* bump) const
+// A bump's timing pin is the single dbITerm of its pad instance.
+static odb::dbITerm* padITerm(odb::dbChipBump* chip_bump)
 {
-  odb::dbChipBump* cb = bump->getChipBumpInst()->getChipBump();
-  if (cb->getBTerm() == nullptr) {
-    return nullptr;
-  }
-  odb::dbInst* pad_inst = cb->getInst();
+  odb::dbInst* pad_inst = chip_bump ? chip_bump->getInst() : nullptr;
   if (pad_inst == nullptr) {
     return nullptr;
   }
@@ -1208,11 +1207,47 @@ odb::dbITerm* dbNetwork::bumpPadITerm(odb::dbUnfoldedChipBumpInst* bump) const
   return iterms.empty() ? nullptr : *iterms.begin();
 }
 
+odb::dbITerm* dbNetwork::bumpPadITerm(odb::dbUnfoldedChipBumpInst* bump) const
+{
+  odb::dbChipBump* cb = bump->getChipBumpInst()->getChipBump();
+  return cb->getBTerm() == nullptr ? nullptr : padITerm(cb);
+}
+
+odb::dbChipNet* dbNetwork::chipNetOfPadITerm(dbITerm* iterm) const
+{
+  if (iterm == nullptr) {
+    return nullptr;
+  }
+  ensureUnfoldedMapsFresh();
+  auto it = bump_to_chip_net_.find(iterm);
+  return it == bump_to_chip_net_.end() ? nullptr : it->second;
+}
+
+odb::dbChipNet* dbNetwork::chipNetAbove(dbBTerm* bterm) const
+{
+  return chipNetOfPadITerm(bterm ? padITerm(bterm->getChipBump()) : nullptr);
+}
+
+odb::dbChipNet* dbNetwork::chipNetAboveNet(const Net* net) const
+{
+  dbNet* db_net = flatNet(net);
+  if (db_net == nullptr) {
+    return nullptr;
+  }
+  // Uses an index built in buildUnfoldedMaps. Delay calculation calls this per
+  // driver pin, so scanning the net's iterms would be O(fanout) every time --
+  // including on big nets that never reach a bump.
+  ensureUnfoldedMapsFresh();
+  auto it = net_to_chip_net_.find(db_net);
+  return it == net_to_chip_net_.end() ? nullptr : it->second;
+}
+
 void dbNetwork::buildUnfoldedMaps() const
 {
   chip_inst_to_unfolded_.clear();
   chip_net_to_unfolded_.clear();
   bump_to_chip_net_.clear();
+  net_to_chip_net_.clear();
   //   raw chip-inst -> unfolded chip-inst (single-level: path is one element)
   for (odb::dbUnfoldedChipInst* uci : db_->getUnfoldedChipInsts()) {
     std::vector<odb::dbChipInst*> path = uci->getChipInstPath();
@@ -1232,6 +1267,9 @@ void dbNetwork::buildUnfoldedMaps() const
     for (odb::dbUnfoldedChipBumpInst* ub : ucn->getConnectedBumps()) {
       if (odb::dbITerm* pad_iterm = bumpPadITerm(ub)) {
         bump_to_chip_net_[pad_iterm] = chip_net;
+        if (dbNet* die_net = pad_iterm->getNet()) {
+          net_to_chip_net_[die_net] = chip_net;
+        }
       }
     }
   }
@@ -2172,11 +2210,20 @@ Net* dbNetwork::net(const Pin* pin) const
       return dbToSta(dnet);
     }
   }
-  // only pins which act as bterms are top levels and have no net
+  // A bterm pin is a top-level port and has no net, except on a chiplet
+  // boundary.
   if (bterm) {
-    //    dbNet* dnet = bterm -> getNet();
-    //    return dbToSta(dnet);
-    ;
+    // Return the chip-net above the boundary, not the die-side net below it.
+    // SpefReader::dspfBegin climbs term -> pin -> net to find which net owns a
+    // parasitic network, so this has to move up a level. Returning the die-side
+    // net would make that climb return where it started, and the unguarded
+    // recursions in ReportPath::hierPinsAbove and Network::hierarchyLevel then
+    // overflow the stack.
+    if (has3DicChip()) {
+      if (odb::dbChipNet* chip_net = chipNetAbove(bterm)) {
+        return dbToSta(chip_net);
+      }
+    }
   }
   if (moditerm) {
     if (odb::dbModNet* mnet = moditerm->getModNet()) {
@@ -2806,11 +2853,9 @@ void dbNetwork::visitConnectedPins(const Net* net,
     // branch above descends back down into each connected chiplet;
     // visited_nets breaks the cycle.
     if (has3DicChip()) {
-      ensureUnfoldedMapsFresh();
       for (dbITerm* iterm : db_net->getITerms()) {
-        auto it = bump_to_chip_net_.find(iterm);
-        if (it != bump_to_chip_net_.end()) {
-          visitConnectedPins(dbToSta(it->second), visitor, visited_nets);
+        if (odb::dbChipNet* chip_net = chipNetOfPadITerm(iterm)) {
+          visitConnectedPins(dbToSta(chip_net), visitor, visited_nets);
         }
       }
     }
@@ -2820,15 +2865,25 @@ void dbNetwork::visitConnectedPins(const Net* net,
 // Caution:
 //- Network::highestConnectedNet(Net *net) retrieves the highest hierarchical
 // net connected to the given net.
-// - But `dbNetwork::highestConnectedNet(Net* net)` retrieves the corresponding
-// flat net for the given net.
+// - `dbNetwork::highestConnectedNet(Net* net)` retrieves the corresponding
+// flat net for the given net. On a 3DIC design it returns the dbChipNet above
+// a bonded die-side net instead, which is neither a dbNet nor a dbModNet.
 // - It behaves differently to cope with the issue 9724.
 // - This redefinition may cause another issue later when
 // `Network::highestConnectedNet(Net *net)` is used elsewhere.
 const Net* dbNetwork::highestConnectedNet(Net* net) const
 {
   const Net* flat = findFlatNet(net);
-  return flat ? flat : net;
+  const Net* highest = flat ? flat : net;
+  // A cross-die net's parasitics are merged into one network keyed on the
+  // chip-net. Parasitics::findParasiticNet looks parasitics up through here, so
+  // returning the chip-net is what lets a driver on either die find them.
+  if (has3DicChip()) {
+    if (odb::dbChipNet* chip_net = chipNetAboveNet(highest)) {
+      return dbToSta(chip_net);
+    }
+  }
+  return highest;
 }
 
 ////////////////////////////////////////////////////////////////
@@ -3829,6 +3884,12 @@ void dbNetwork::staToDb(const Instance* instance,
 dbNet* dbNetwork::staToDb(const Net* net) const
 {
   dbNet* db_net = reinterpret_cast<dbNet*>(const_cast<Net*>(net));
+  // net(pin) returns a dbChipNet on a chiplet boundary, so a caller expecting
+  // a flat net can arrive here with one. Return null rather than casting it:
+  // the assert below is compiled out under NDEBUG, leaving a garbage pointer.
+  if (db_net != nullptr && db_net->getObjectType() != odb::dbNetObj) {
+    return nullptr;
+  }
   assert(!db_net || db_net->getObjectType() == odb::dbNetObj);
   return db_net;
 }
@@ -4750,9 +4811,7 @@ bool dbNetwork::isConnected(const Net* net, const Pin* pin) const
     if (iterm == nullptr) {
       return false;
     }
-    ensureUnfoldedMapsFresh();
-    auto it = bump_to_chip_net_.find(iterm);
-    return it != bump_to_chip_net_.end() && it->second == chip_net;
+    return chipNetOfPadITerm(iterm) == chip_net;
   }
 
   dbNet* dbnet;
@@ -6080,6 +6139,16 @@ Net* dbNetwork::highestNetAbove(Net* net) const
   staToDb(net, dbnet, modnet);
 
   if (dbnet) {
+    // Must return the same net as highestConnectedNet. ensureParasiticNode
+    // marks a node external when highestNetAbove(net(pin)) differs from the
+    // network's net, so returning the die-side net here would mark every node
+    // of a merged cross-die network external -- the node_count_ = 0 crash
+    // described below, reproducible with -delay_calculator arnoldi.
+    if (has3DicChip()) {
+      if (odb::dbChipNet* chip_net = chipNetAboveNet(net)) {
+        return dbToSta(chip_net);
+      }
+    }
     // If a flat net, return it.
     // - We should not return the highest modnet related to the flat net.
     // - Otherwise, it breaks estimate_parasitics function.

--- a/src/dbSta/test/3dic_spef.a.spef
+++ b/src/dbSta/test/3dic_spef.a.spef
@@ -1,0 +1,27 @@
+// chipA side of the bond net: driver out to the bump pad.
+*SPEF "IEEE 1481-1999"
+*DESIGN "flop_chip_a"
+*DATE "Tue Aug 19 00:00:00 2026"
+*VENDOR "The OpenROAD Project"
+*PROGRAM "OpenROAD"
+*VERSION "test"
+*DESIGN_FLOW "NAME_SCOPE LOCAL" "PIN_CAP NONE"
+*DIVIDER /
+*DELIMITER :
+*BUS_DELIMITER []
+*T_UNIT 1 NS
+*C_UNIT 1 FF
+*R_UNIT 1 OHM
+*L_UNIT 1 HENRY
+
+*D_NET q 2
+*CONN
+*I buf:Z O
+*I bump_q:PAD I
+*CAP
+1 q:1 1
+2 bump_q:PAD 1
+*RES
+1 buf:Z q:1 10
+2 q:1 bump_q:PAD 10
+*END

--- a/src/dbSta/test/3dic_spef.b.spef
+++ b/src/dbSta/test/3dic_spef.b.spef
@@ -1,0 +1,27 @@
+// chipB side of the bond net: bump pad in to the receiver.
+*SPEF "IEEE 1481-1999"
+*DESIGN "flop_chip_b"
+*DATE "Tue Aug 19 00:00:00 2026"
+*VENDOR "The OpenROAD Project"
+*PROGRAM "OpenROAD"
+*VERSION "test"
+*DESIGN_FLOW "NAME_SCOPE LOCAL" "PIN_CAP NONE"
+*DIVIDER /
+*DELIMITER :
+*BUS_DELIMITER []
+*T_UNIT 1 NS
+*C_UNIT 1 FF
+*R_UNIT 1 OHM
+*L_UNIT 1 HENRY
+
+*D_NET d 100
+*CONN
+*I bump_d:PAD I
+*I buf:A I
+*CAP
+1 d:1 50
+2 buf:A 50
+*RES
+1 bump_d:PAD d:1 10
+2 d:1 buf:A 10
+*END

--- a/src/dbSta/test/3dic_spef.bonds.spef
+++ b/src/dbSta/test/3dic_spef.bonds.spef
@@ -1,0 +1,24 @@
+// The die-to-die bond itself, at top scope: one resistor between the two bump
+// pads, named <chip_inst>:<bterm> the way the 3D RCX writer names them.
+*SPEF "IEEE 1481-1999"
+*DESIGN "top"
+*DATE "Tue Aug 19 00:00:00 2026"
+*VENDOR "The OpenROAD Project"
+*PROGRAM "OpenROAD"
+*VERSION "test"
+*DESIGN_FLOW "NAME_SCOPE LOCAL" "PIN_CAP NONE"
+*DIVIDER /
+*DELIMITER :
+*BUS_DELIMITER []
+*T_UNIT 1 NS
+*C_UNIT 1 FF
+*R_UNIT 1 OHM
+*L_UNIT 1 HENRY
+
+*D_NET bridge 0
+*CONN
+*I chipA:q O
+*I chipB:d I
+*RES
+1 chipA:q chipB:d 2000
+*END

--- a/src/dbSta/test/3dic_spef.ok
+++ b/src/dbSta/test/3dic_spef.ok
@@ -1,0 +1,45 @@
+[INFO ODB-0227] LEF file: ../../odb/test/Nangate45/Nangate45_tech.lef, created 22 layers, 27 vias
+[INFO ODB-0227] LEF file: ../../odb/test/Nangate45/Nangate45_stdcell.lef, created 135 library cells
+[INFO ODB-0227] LEF file: ../../odb/test/Nangate45/fake_bumps.lef, created 1 library cells
+[INFO ODB-0128] Design: flop_chip_a
+[INFO ODB-0252]     Updated 3 pins.
+[INFO ODB-0131]     Created 3 components and 14 component-terminals.
+[INFO ODB-0133]     Created 5 nets and 7 connections.
+[WARNING STA-1140] ../../odb/test/Nangate45/Nangate45_typ.lib line 37, library NangateOpenCellLibrary already exists.
+[INFO ODB-0128] Design: flop_chip_b
+[INFO ODB-0252]     Updated 3 pins.
+[INFO ODB-0131]     Created 3 components and 14 component-terminals.
+[INFO ODB-0133]     Created 5 nets and 7 connections.
+Found 11 unannotated drivers.
+Found 0 partially unannotated drivers.
+Startpoint: chipA/ff (rising edge-triggered flip-flop clocked by clk)
+Endpoint: chipB/ff (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: max
+
+    Cap   Delay    Time   Description
+----------------------------------------------------------------
+           0.00    0.00   clock clk (rise edge)
+           0.00    0.00   clock network delay (ideal)
+           0.00    0.00 ^ chipA/ff/CK (DFF_X1)
+   1.55    0.08    0.08 v chipA/ff/Q (DFF_X1)
+   0.97    0.01    0.09 ^ chipA/inv/ZN (INV_X1)
+ 102.97    0.08    0.17 ^ chipA/buf/Z (BUF_X1)
+   1.70    0.24    0.41 ^ chipB/buf/Z (BUF_X1)
+   1.06    0.01    0.41 v chipB/inv/ZN (INV_X1)
+           0.00    0.41 v chipB/ff/D (DFF_X1)
+                   0.41   data arrival time
+
+           1.00    1.00   clock clk (rise edge)
+           0.00    1.00   clock network delay (ideal)
+           0.00    1.00   clock reconvergence pessimism
+                   1.00 ^ chipB/ff/CK (DFF_X1)
+          -0.04    0.96   library setup time
+                   0.96   data required time
+----------------------------------------------------------------
+                   0.96   data required time
+                  -0.41   data arrival time
+----------------------------------------------------------------
+                   0.55   slack (MET)
+
+

--- a/src/dbSta/test/3dic_spef.tcl
+++ b/src/dbSta/test/3dic_spef.tcl
@@ -1,0 +1,24 @@
+# Cross-die parasitics. One bond net arrives as three SPEF pieces -- chipA's
+# wiring (2 fF), the die-to-die bond resistor (2 kohm), and chipB's wiring
+# (100 fF). read_spef must merge them onto the chip-net so chipA's driver sees
+# the far die's load through the bond; without that it sees only its own 2 fF
+# and the path delay collapses from ~0.41 ns to ~0.15 ns.
+#
+# The bonds SPEF is top-scope and must be read first: a top-scope read replaces
+# the net's parasitic network, while a -path read merges into it.
+#
+# The hierarchical_pin report at the end is a regression guard: it walks
+# term -> pin -> net, which must ascend to the chip-net. If it ever resolves
+# back to the die-side net the walk becomes a self-loop and this crashes.
+source "helpers.tcl"
+
+read_3dbx 3dic_cross.3dbx
+
+create_clock -name clk -period 1.0 [get_pins -of_objects [get_nets clk_top]]
+
+read_spef 3dic_spef.bonds.spef
+read_spef -path chipA 3dic_spef.a.spef
+read_spef -path chipB 3dic_spef.b.spef
+
+report_parasitic_annotation
+report_checks -path_delay max -group_path_count 1 -fields {cap hierarchical_pin}

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -32,6 +32,7 @@ ALL_TESTS = [
     "3dic_cross",
     "3dic_get_cells",
     "3dic_read_db",
+    "3dic_spef",
     "block_sta1",
     "check_axioms",
     "clock_pin",
@@ -125,6 +126,20 @@ filegroup(
     ],
 )
 
+# The two-chiplet 3DIC fixture, shared by every test that reads 3dic_cross.3dbx.
+# 3dic_cross itself omits the .3dbx because its own test_name + ".*" glob
+# already picks it up.
+_3DIC_CROSS_FIXTURES = [
+    "//src/odb/test:regression_resources",
+    "3dic_cross.3dbx",
+    "3dic_cross_flop.3dbv",
+    "3dic_cross_flop_a.bmap",
+    "3dic_cross_flop_a.def",
+    "3dic_cross_flop_b.bmap",
+    "3dic_cross_flop_b.def",
+    "3dic_cross_top.v",
+]
+
 [
     filegroup(
         name = test_name + "_resources",
@@ -145,16 +160,8 @@ filegroup(
             "3dic_get_cells": [
                 "//src/odb/test:regression_resources",
             ],
-            "3dic_read_db": [
-                "//src/odb/test:regression_resources",
-                "3dic_cross.3dbx",
-                "3dic_cross_flop.3dbv",
-                "3dic_cross_flop_a.bmap",
-                "3dic_cross_flop_a.def",
-                "3dic_cross_flop_b.bmap",
-                "3dic_cross_flop_b.def",
-                "3dic_cross_top.v",
-            ],
+            "3dic_read_db": _3DIC_CROSS_FIXTURES,
+            "3dic_spef": _3DIC_CROSS_FIXTURES,
             "block_sta1": [
                 "example1_typ.lib",
                 "example1.def",

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -4,6 +4,7 @@ or_integration_tests(
     3dic_cross
     3dic_get_cells
     3dic_read_db
+    3dic_spef
     block_sta1
     check_axioms
     clock_pin


### PR DESCRIPTION
## Problem

A cross-die net is one physical wire, but the 3D RCX flow writes it as three SPEF pieces — each die's wiring, plus the die-to-die bond resistor:

```mermaid
graph LR
    D["driver"] ---|"top.die1.spef"| PA["bump pad"]
    PA ---|"top.bonds.spef"| PB["bump pad"]
    PB ---|"top.die2.spef"| R["receiver"]
    style PA fill:#fef7e0,stroke:#f9ab00
    style PB fill:#fef7e0,stroke:#f9ab00
```

Reading all three left the pieces on three different nets. The delay calculator fetches parasitics by the driver pin's net, so it saw one third of the wire and cross-die paths came out optimistic.

## Fix

The top chip already holds a `dbChipNet` per bond. That is the net above both dies, and the net the bonds SPEF is written against. Three `dbNetwork` overrides now ascend to it, so all three pieces land on one net and every driver finds them:

| function | before | after |
|---|---|---|
| `net(const Pin*)` on a chiplet boundary port | `nullptr` | the `dbChipNet` above |
| `highestConnectedNet()` on a bonded die net | the die net | the `dbChipNet` above |
| `highestNetAbove()` on a bonded die net | the die net | the `dbChipNet` above |

`net()` is what `SpefReader::dspfBegin` climbs to decide which net owns a parasitic network, so that one makes the merge happen. `highestConnectedNet()` is what `Parasitics::findParasiticNet` canonicalizes through, so that one makes the driver find it. `highestNetAbove()` decides whether a parasitic node is "external" and has to give the same answer, or every node of a merged network is dropped.

## Usage

```tcl
read_3dbx top.3dbx
read_spef top.bonds.spef                        ;# top scope, read FIRST
read_spef -path die_1  top.die1.spef
read_spef -path die_2 top.die2.spef
report_checks ...                               ;# carries cross-die wire RC
```

**Order matters.** A top-scope read replaces a net's parasitic network where a `-path` read merges into it, so reading the bonds SPEF last silently discards the die contributions. Documented in `dbNetwork.hh`; making it order-independent is a `SpefReader` change and out of scope here.

## Test

`src/dbSta/test/3dic_spef` — reuses the existing `3dic_cross` two-chiplet fixture with three hand-written SPEFs: 2 fF near side, 2 kΩ bond, 100 fF far side. The far-side capacitance sits behind the bond, so the driver only sees it if the merge worked: arrival 0.15 ns → 0.41 ns, and its load reads 102.97 fF in the golden.

Uses hand-written SPEFs rather than extraction, so it does not depend on the unmerged rcx half of #11124.

Verified: full `dbSta` and `est` suites pass (2560 tests); `dmp_ceff_elmore`, `arnoldi` and `prima` all run on the merged network.


## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
https://github.com/The-OpenROAD-Project/OpenROAD/pull/10664
