### PR TITLE
utl: Use 64KB buffer for gzip compression and decompression

### DIFF
--- a/src/utl/src/ScopedTemporaryFile.cpp
+++ b/src/utl/src/ScopedTemporaryFile.cpp
@@ -24,6 +24,8 @@ namespace fs = std::filesystem;
 
 namespace utl {
 
+constexpr int kGzipBufferSize = 65536;
+
 namespace {
 std::string generate_unused_filename(const std::string& prefix)
 {
@@ -95,7 +97,7 @@ OutStreamHandler::OutStreamHandler(const char* filename,
     if (compression_level.has_value()) {
       params.level = compression_level.value();
     }
-    buf_->push(boost::iostreams::gzip_compressor(params));
+    buf_->push(boost::iostreams::gzip_compressor(params, kGzipBufferSize));
     buf_->push(os_);
 
     stream_ = std::make_unique<std::ostream>(buf_.get());
@@ -157,7 +159,8 @@ InStreamHandler::InStreamHandler(const char* filename, bool binary)
   if (boost::ends_with(filename_, ".gz")) {
     buf_ = std::make_unique<boost::iostreams::filtering_istreambuf>();
 
-    buf_->push(boost::iostreams::gzip_decompressor());
+    buf_->push(boost::iostreams::gzip_decompressor(
+        boost::iostreams::gzip::default_window_bits, kGzipBufferSize));
     buf_->push(is_);
 
     stream_ = std::make_unique<std::istream>(buf_.get());

--- a/src/utl/src/ScopedTemporaryFile.cpp
+++ b/src/utl/src/ScopedTemporaryFile.cpp
@@ -24,9 +24,9 @@ namespace fs = std::filesystem;
 
 namespace utl {
 
-constexpr int kGzipBufferSize = 65536;
-
 namespace {
+constexpr std::streamsize kGzipBufferSize = 65536;
+
 std::string generate_unused_filename(const std::string& prefix)
 {
   int counter = 1;


### PR DESCRIPTION
## Summary
In PR #11161, a customizable `-compression` flag was added to `write_db` for gzip compression. However, the `boost::iostreams::gzip_compressor` and `gzip_decompressor` in `ScopedTemporaryFile.cpp` were left using the default internal 4KB buffer. This PR introduces a 64KB `kGzipBufferSize` optimization to significantly speed up compression and decompression throughput for large `.odb.gz` database files.

## Type of Change
- Refactoring
- Performance Optimization

## Impact
This change significantly improves the execution speed of `write_db` and `read_db` when handling compressed `.odb.gz` files by increasing the underlying I/O buffer from 4KB to 64KB, reducing chunked I/O overhead during zlib compression/decompression.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have signed my commits (DCO).

## Related Issues
Follow-up to #11161
