### PR TITLE
Revert "utl: Use 64KB buffer for gzip compression and decompression"

### DIFF
--- a/src/utl/src/ScopedTemporaryFile.cpp
+++ b/src/utl/src/ScopedTemporaryFile.cpp
@@ -25,8 +25,6 @@ namespace fs = std::filesystem;
 namespace utl {
 
 namespace {
-constexpr std::streamsize kGzipBufferSize = 65536;
-
 std::string generate_unused_filename(const std::string& prefix)
 {
   int counter = 1;
@@ -97,7 +95,7 @@ OutStreamHandler::OutStreamHandler(const char* filename,
     if (compression_level.has_value()) {
       params.level = compression_level.value();
     }
-    buf_->push(boost::iostreams::gzip_compressor(params, kGzipBufferSize));
+    buf_->push(boost::iostreams::gzip_compressor(params));
     buf_->push(os_);
 
     stream_ = std::make_unique<std::ostream>(buf_.get());
@@ -159,8 +157,7 @@ InStreamHandler::InStreamHandler(const char* filename, bool binary)
   if (boost::ends_with(filename_, ".gz")) {
     buf_ = std::make_unique<boost::iostreams::filtering_istreambuf>();
 
-    buf_->push(boost::iostreams::gzip_decompressor(
-        boost::iostreams::gzip::default_window_bits, kGzipBufferSize));
+    buf_->push(boost::iostreams::gzip_decompressor());
     buf_->push(is_);
 
     stream_ = std::make_unique<std::istream>(buf_.get());


### PR DESCRIPTION
Reverts The-OpenROAD-Project/OpenROAD#11191

**Reason:**
Seems like I got some lucky (or rather unlucky) runs with the 64KB buffer during my initial tests where I saw around an 8% speed improvement. However, as I did more extensive testing with other buffer sizes, I realized the 64KB buffer performance actually degrades under steady-state conditions.

This is because the default 4KB buffer easily fits within the L1 data cache (typically 32KB–48KB). Increasing the buffer size to 64KB spills the working set into the slower L2 cache, adding memory latency to the CPU-bound compression loops inside `zlib`.

To find the optimal sweet spot, I tested buffer sizes of 4KB, 16KB, 32KB, 48KB, and 64KB. Among them, **32KB** is the optimal choice because:
1. It fits comfortably within the CPU L1 data cache.
2. It aligns perfectly with `zlib`'s native 32KB sliding window (15-bit window size), preventing chunk boundary splitting.

To avoid any performance degradation, I will revert this PR. I will do some more testing and create a fresh PR to use 32KB later. Apologies for the inconvenience.
