### PR TITLE
rsz: Fix UB in performEarlySizingRound

### DIFF
--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -130,7 +130,6 @@ void RepairDesign::repairDesign(double max_wire_length,
 void RepairDesign::performEarlySizingRound(int& repaired_net_count)
 {
   debugPrint(logger_, RSZ, "early_sizing", 1, "Performing early sizing round.");
-
   // keep track of user annotations so we don't remove them
   std::set<std::pair<sta::Vertex*, int>> slew_user_annotated;
 
@@ -156,10 +155,10 @@ void RepairDesign::performEarlySizingRound(int& repaired_net_count)
       }
     }
   }
+  findBufferSizes();
 
   sta_->searchPreamble();
   search_->findAllArrivals();
-  findBufferSizes();
 
   for (int i = drvrs.size() - 1; i >= 0; i--) {
     sta::Vertex* drvr = drvrs[i];

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -130,7 +130,6 @@ void RepairDesign::repairDesign(double max_wire_length,
 void RepairDesign::performEarlySizingRound(int& repaired_net_count)
 {
   debugPrint(logger_, RSZ, "early_sizing", 1, "Performing early sizing round.");
-  findBufferSizes();
 
   // keep track of user annotations so we don't remove them
   std::set<std::pair<sta::Vertex*, int>> slew_user_annotated;
@@ -160,6 +159,7 @@ void RepairDesign::performEarlySizingRound(int& repaired_net_count)
 
   sta_->searchPreamble();
   search_->findAllArrivals();
+  findBufferSizes();
 
   for (int i = drvrs.size() - 1; i >= 0; i--) {
     sta::Vertex* drvr = drvrs[i];

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -130,6 +130,8 @@ void RepairDesign::repairDesign(double max_wire_length,
 void RepairDesign::performEarlySizingRound(int& repaired_net_count)
 {
   debugPrint(logger_, RSZ, "early_sizing", 1, "Performing early sizing round.");
+  findBufferSizes();
+
   // keep track of user annotations so we don't remove them
   std::set<std::pair<sta::Vertex*, int>> slew_user_annotated;
 
@@ -155,7 +157,6 @@ void RepairDesign::performEarlySizingRound(int& repaired_net_count)
       }
     }
   }
-  findBufferSizes();
 
   sta_->searchPreamble();
   search_->findAllArrivals();

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -198,7 +198,7 @@ void RepairDesign::performEarlySizingRound(int& repaired_net_count)
           drvr_pin, sta_->cmdMode(), max_, fanout, max_fanout, fanout_slack);
 
       bool repaired_net = false;
-      if (max_fanout <= 0) {
+      if (max_fanout <= 0 || max_fanout > 1e9) {
         max_fanout = 1e9;
       }
 


### PR DESCRIPTION
## Summary
In OpenSTA when a net has no explicit set_max_fanout constraint sta_->checkFanout() returns max_fanout sta::INF, 1e30f. openroad checks (max_fanout <= 0) { max_fanout = 1e9; } which doesn't modify the 1e30f.

When passing max_fanout into performGainBuffering(..., int max_fanout), this results in int overflow (1e30 > INT_MAX), triggers UBSan.

## Type of Change
- Bug fix

## Impact
Prevent ub in repair_design -pre_placement

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
