### PR TITLE
psm: clear stale outputs in report_writers_require_solution test

### DIFF
--- a/src/psm/test/report_writers_require_solution.tcl
+++ b/src/psm/test/report_writers_require_solution.tcl
@@ -16,6 +16,11 @@ set spice_file [make_result_file report_writers_require_solution.sp]
 set voltage_file [make_result_file report_writers_require_solution-voltage.rpt]
 set em_file [make_result_file report_writers_require_solution-em.rpt]
 
+# make_result_file only builds a path, so output from an earlier run in the same
+# results/ is still present. The checks below report whether each writer created
+# its file, which only means anything when the files start out absent.
+file delete -force $spice_file $voltage_file $em_file
+
 catch { write_pg_spice -net VDD -vsrc Vsrc_gcd_vdd.loc $spice_file } err
 puts $err
 puts "spice file written before analysis: [file exists $spice_file]"


### PR DESCRIPTION
## Summary

`src/psm/test/report_writers_require_solution.tcl` failed on every local run
after the first.

The test reports whether each report writer created its output file, and asserts
that `write_pg_spice` creates nothing before a solution exists. But
`make_result_file` only builds a path — it does not clear the file. The same
script writes `$spice_file` for real after `analyze_power_grid`, so each run left
it behind and the next run's pre-analysis check read `1` instead of `0`:

```
< spice file written before analysis: 0
> spice file written before analysis: 1
```

This clears the three output files up front so the checks start from a known
absent state. The voltage and em files are included because a leftover file
would likewise make their post-analysis checks report `1` even if
`analyze_power_grid` wrote nothing.

Fixed in the test rather than in `make_result_file`, since that helper is shared
by thousands of tests and some legitimately re-derive a path for a file written
earlier in the same script.

Bazel gives each run a fresh `TEST_TMPDIR`, so CI never saw this — it only
affected repeated local `ctest` runs.
