### PR TITLE
(DO NOT MERGE) dbSta: Add delay calculator runtime regressions

### DIFF
--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -444,8 +444,8 @@ filegroup(
 [
     regression_test(
         name = test_name,
-        check_log = False if test_name in PASSFAIL_TESTS else True,
-        check_passfail = True if test_name in PASSFAIL_TESTS else False,
+        check_log = test_name not in PASSFAIL_TESTS,
+        check_passfail = test_name in PASSFAIL_TESTS,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -28,7 +28,7 @@ package(features = ["layering_check"])
 exports_files(["synthetic_linear.lib"])
 
 # From CMakeLists.txt or_integration_tests(TESTS
-ALL_TESTS = [
+TESTS = [
     "3dic_cross",
     "3dic_get_cells",
     "3dic_read_db",
@@ -106,6 +106,23 @@ ALL_TESTS = [
     "write_verilog9_hier",
 ]
 
+# From CMakeLists.txt or_integration_tests(PASSFAIL_TESTS
+# Runtime measurements are nondeterministic, so these tests self-check timing
+# stability and print "pass" instead of diffing elapsed values.
+PASSFAIL_TESTS = [
+    "dcalc_full_update_runtime",
+    "dcalc_full_update_runtime_asap7_aes",
+    "dcalc_full_update_runtime_asap7_gcd",
+    "dcalc_full_update_runtime_asap7_riscv",
+    "dcalc_full_update_runtime_gcd",
+    "dcalc_full_update_runtime_gf180_jpeg",
+    "dcalc_full_update_runtime_mock_array",
+    "dcalc_full_update_runtime_nangate45_dynamic_node",
+    "dcalc_full_update_runtime_nangate45_ibex",
+]
+
+ALL_TESTS = TESTS + PASSFAIL_TESTS
+
 filegroup(
     name = "regression_resources",
     srcs = [
@@ -119,6 +136,7 @@ filegroup(
         "Nangate45/Nangate45_stdcell.lef",
         "Nangate45/Nangate45_tech.lef",
         "Nangate45/Nangate45_typ.lib",
+        "dcalc_full_update_runtime_helpers.tcl",
         "helpers.tcl",
         "liberty1.lef",
         "liberty1.lib",
@@ -159,6 +177,86 @@ filegroup(
                 "example1_typ.lib",
                 "example1.def",
                 "example1.lef",
+            ],
+            "dcalc_full_update_runtime": [
+                "example1.dspef",
+                "example1.def",
+                "example1.lef",
+                "example1_slow.lib",
+            ],
+            "dcalc_full_update_runtime_asap7_aes": [
+                "//src/psm/test:asap7_aes_runtime_fixture",
+                "asap7/asap7_tech_1x_201209.lef",
+                "asap7/asap7sc7p5t_28_R_1x_220121a.lef",
+                "asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz",
+                "asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib",
+                "asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz",
+                "asap7/setRC.tcl",
+            ],
+            "dcalc_full_update_runtime_asap7_gcd": [
+                "//src/rsz/test:gcd_asap7_runtime_fixture",
+                "asap7/asap7_tech_1x_201209.lef",
+                "asap7/asap7sc7p5t_28_L_1x_220121a.lef",
+                "asap7/asap7sc7p5t_28_R_1x_220121a.lef",
+                "asap7/asap7sc7p5t_28_SL_1x_220121a.lef",
+                "asap7/asap7sc7p5t_AO_LVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_AO_SLVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_INVBUF_LVT_FF_nldm_220122.lib.gz",
+                "asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz",
+                "asap7/asap7sc7p5t_INVBUF_SLVT_FF_nldm_220122.lib.gz",
+                "asap7/asap7sc7p5t_OA_LVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_OA_SLVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_SEQ_LVT_FF_nldm_220123.lib",
+                "asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib",
+                "asap7/asap7sc7p5t_SEQ_SLVT_FF_nldm_220123.lib",
+                "asap7/asap7sc7p5t_SIMPLE_LVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_SIMPLE_SLVT_FF_nldm_211120.lib.gz",
+                "asap7/setRC.tcl",
+            ],
+            "dcalc_full_update_runtime_asap7_riscv": [
+                "//src/psm/test:asap7_riscv_runtime_fixture",
+                "asap7/asap7_tech_1x_201209.lef",
+                "asap7/asap7sc7p5t_28_R_1x_220121a.lef",
+                "asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz",
+                "asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib",
+                "asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz",
+                "asap7/fakeram7_256x32.lef",
+                "asap7/fakeram7_256x32.lib",
+                "asap7/setRC.tcl",
+            ],
+            "dcalc_full_update_runtime_gcd": [
+                "//src/rsz/test:gcd_nangate45_runtime_fixture",
+            ],
+            "dcalc_full_update_runtime_gf180_jpeg": [
+                "//src/rsz/test:gf180_jpeg_runtime_fixture",
+                "//src/tap/test:gf180_jpeg_runtime_fixture",
+            ],
+            "dcalc_full_update_runtime_mock_array": [
+                "Element.spef",
+                "Element.v",
+                "MockArray.sdc",
+                "MockArray.spef",
+                "MockArray.v",
+                "asap7/asap7_tech_1x_201209.lef",
+                "asap7/asap7sc7p5t_28_R_1x_220121a.lef",
+                "asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz",
+                "asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz",
+                "asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib",
+                "asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz",
+            ],
+            "dcalc_full_update_runtime_nangate45_dynamic_node": [
+                "//src/gpl/test:dynamic_node_runtime_fixture",
+            ],
+            "dcalc_full_update_runtime_nangate45_ibex": [
+                "//src/gpl/test:ibex_runtime_fixture",
             ],
             "find_clks1": [
                 "pad.lef",
@@ -346,6 +444,8 @@ filegroup(
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
+        check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -76,6 +76,18 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+  PASSFAIL_TESTS
+    # Runtime measurements are nondeterministic; these tests self-check timing
+    # stability and print "pass" instead of diffing elapsed values.
+    dcalc_full_update_runtime
+    dcalc_full_update_runtime_asap7_aes
+    dcalc_full_update_runtime_asap7_gcd
+    dcalc_full_update_runtime_asap7_riscv
+    dcalc_full_update_runtime_gcd
+    dcalc_full_update_runtime_gf180_jpeg
+    dcalc_full_update_runtime_mock_array
+    dcalc_full_update_runtime_nangate45_dynamic_node
+    dcalc_full_update_runtime_nangate45_ibex
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/dcalc_full_update_runtime.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime.tcl
@@ -1,0 +1,15 @@
+# Compare full timing-update runtime for the Elmore and Lambert-W delay calculators.
+set test_name dcalc_full_update_runtime
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_lef example1.lef
+read_liberty example1_slow.lib
+read_def example1.def
+read_spef example1.dspef
+
+create_clock -name clk -period 10 {clk1 clk2 clk3}
+set_input_delay -clock clk 0 {in1 in2}
+set_output_delay -clock clk 0 out
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_asap7_aes.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_asap7_aes.tcl
@@ -1,0 +1,19 @@
+# Compare full timing-update runtime on the placed ASAP7 AES design.
+set test_name dcalc_full_update_runtime_asap7_aes
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_lef asap7/asap7_tech_1x_201209.lef
+read_lef asap7/asap7sc7p5t_28_R_1x_220121a.lef
+read_liberty asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
+read_def ../../psm/test/asap7_data/aes_place.def
+read_sdc ../../psm/test/asap7_data/aes_place.sdc
+
+source asap7/setRC.tcl
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_asap7_gcd.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_asap7_gcd.tcl
@@ -1,0 +1,31 @@
+# Compare full timing-update runtime on the placed ASAP7 GCD design.
+set test_name dcalc_full_update_runtime_asap7_gcd
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
+read_liberty asap7/asap7sc7p5t_AO_LVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_LVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_LVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_LVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_LVT_FF_nldm_220123.lib
+read_liberty asap7/asap7sc7p5t_AO_SLVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_SLVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_SLVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_SLVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_SLVT_FF_nldm_220123.lib
+read_lef asap7/asap7_tech_1x_201209.lef
+read_lef asap7/asap7sc7p5t_28_R_1x_220121a.lef
+read_lef asap7/asap7sc7p5t_28_L_1x_220121a.lef
+read_lef asap7/asap7sc7p5t_28_SL_1x_220121a.lef
+read_def ../../rsz/test/gcd_asap7_placed.def
+read_sdc ../../rsz/test/gcd.sdc
+
+source asap7/setRC.tcl
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_asap7_riscv.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_asap7_riscv.tcl
@@ -15,7 +15,7 @@ read_lef asap7/fakeram7_256x32.lef
 read_def ../../psm/test/asap7_data/riscv.def
 
 set clk_port [get_ports clk]
-set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set non_clock_inputs [all_inputs -no_clocks]
 create_clock -name clk -period 3000 $clk_port
 set_input_delay 0 -clock clk $non_clock_inputs
 set_output_delay 0 -clock clk [all_outputs]

--- a/src/dbSta/test/dcalc_full_update_runtime_asap7_riscv.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_asap7_riscv.tcl
@@ -1,0 +1,26 @@
+# Compare full timing-update runtime on the placed ASAP7 RISC-V design.
+set test_name dcalc_full_update_runtime_asap7_riscv
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
+read_liberty asap7/fakeram7_256x32.lib
+read_lef asap7/asap7_tech_1x_201209.lef
+read_lef asap7/asap7sc7p5t_28_R_1x_220121a.lef
+read_lef asap7/fakeram7_256x32.lef
+read_def ../../psm/test/asap7_data/riscv.def
+
+set clk_port [get_ports clk]
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+create_clock -name clk -period 3000 $clk_port
+set_input_delay 0 -clock clk $non_clock_inputs
+set_output_delay 0 -clock clk [all_outputs]
+
+source asap7/setRC.tcl
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_gcd.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_gcd.tcl
@@ -1,0 +1,15 @@
+# Compare full timing-update runtime on the placed Nangate45 GCD design.
+set test_name dcalc_full_update_runtime_gcd
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def ../../rsz/test/gcd_nangate45_placed.def
+read_sdc ../../rsz/test/gcd_nangate45.sdc
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_gf180_jpeg.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_gf180_jpeg.tcl
@@ -1,0 +1,16 @@
+# Compare full timing-update runtime on the placed GF180 JPEG design.
+set test_name dcalc_full_update_runtime_gf180_jpeg
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty ../../rsz/test/gf180/gf180mcu_fd_sc_mcu9t5v0__tt_025C_5v00.lib.gz
+read_lef ../../rsz/test/gf180/gf180mcu_5LM_1TM_9K_9t_tech.lef
+read_lef ../../rsz/test/gf180/gf180mcu_5LM_1TM_9K_9t_sc.lef
+read_def ../../tap/test/gf180/jpeg.def
+read_sdc ../../rsz/test/jpeg.sdc
+set ::env(METAL_OPTION) 5
+set ::env(CORNER) TT
+source ../../rsz/test/gf180/setRC.tcl
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_helpers.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_helpers.tcl
@@ -1,0 +1,69 @@
+# Shared full timing-update runtime comparison for delay models.
+proc dcalc_measure_full_update {} {
+  set start_us [clock microseconds]
+  sta::find_requireds
+  set elapsed_us [expr { [clock microseconds] - $start_us }]
+  set wns [sta::worst_slack -max]
+  set tns [sta::total_negative_slack -max]
+  return [list $elapsed_us $wns $tns]
+}
+
+proc dcalc_check_close { metric actual expected tolerance } {
+  if { abs($actual - $expected) > $tolerance } {
+    error "$metric changed: actual=$actual expected=$expected"
+  }
+}
+
+proc run_dcalc_full_update_runtime { { sample_count 3 } } {
+  set models {
+    dmp_ceff_elmore
+    dmp_ceff_lambert_w
+  }
+
+  # Warm both implementations before collecting interleaved samples.
+  foreach model $models {
+    set_delay_calculator $model
+    sta::find_requireds
+  }
+
+  array set runtime_sum_us {}
+  array set reference_wns {}
+  array set reference_tns {}
+
+  # Interleave samples without asserting a machine-dependent speed relationship.
+  for { set round 1 } { $round <= $sample_count } { incr round } {
+    foreach model $models {
+      set_delay_calculator $model
+      lassign [dcalc_measure_full_update] elapsed_us wns tns
+
+      if { $elapsed_us <= 0 } {
+        error "$model full timing update reported a non-positive runtime"
+      }
+      if { $round == 1 } {
+        set reference_wns($model) $wns
+        set reference_tns($model) $tns
+        set runtime_sum_us($model) 0
+      } else {
+        dcalc_check_close \
+          "$model WNS" $wns $reference_wns($model) 1e-12
+        dcalc_check_close \
+          "$model TNS" $tns $reference_tns($model) 1e-12
+      }
+
+      incr runtime_sum_us($model) $elapsed_us
+      puts [format \
+        "round=%2d model=%-20s runtime_us=%10d wns=%16.6f tns=%16.6f" \
+        $round $model $elapsed_us $wns $tns]
+    }
+  }
+
+  # Report both averages
+  foreach model $models {
+    set average_us [expr { $runtime_sum_us($model) / double($sample_count) }]
+    puts [format \
+      "average  model=%-20s runtime_us=%10.0f wns=%16.6f tns=%16.6f" \
+      $model $average_us $reference_wns($model) $reference_tns($model)]
+  }
+
+  puts "pass"
+}

--- a/src/dbSta/test/dcalc_full_update_runtime_helpers.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_helpers.tcl
@@ -1,5 +1,5 @@
 # Shared full timing-update runtime comparison for delay models.
-proc dcalc_measure_full_update {} {
+proc dcalc_measure_full_update { } {
   set start_us [clock microseconds]
   sta::find_requireds
   set elapsed_us [expr { [clock microseconds] - $start_us }]

--- a/src/dbSta/test/dcalc_full_update_runtime_mock_array.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_mock_array.tcl
@@ -1,0 +1,20 @@
+# Compare full timing-update runtime on the hierarchical ASAP7 MockArray design.
+set test_name dcalc_full_update_runtime_mock_array
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
+read_lef asap7/asap7_tech_1x_201209.lef
+read_lef asap7/asap7sc7p5t_28_R_1x_220121a.lef
+read_verilog MockArray.v
+read_verilog Element.v
+link_design -hier MockArray
+read_sdc MockArray.sdc
+read_spef MockArray.spef
+read_spef -path ces_0_0 Element.spef
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_nangate45_dynamic_node.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_nangate45_dynamic_node.tcl
@@ -1,0 +1,14 @@
+# Compare full timing-update runtime on the placed Nangate45 dynamic-node design.
+set test_name dcalc_full_update_runtime_nangate45_dynamic_node
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def ../../gpl/test/design/nangate45/dynamic_node_top_wrap/dynamic_node_top_wrap.def
+read_sdc ../../gpl/test/design/nangate45/dynamic_node_top_wrap/dynamic_node_top_wrap.sdc
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/dbSta/test/dcalc_full_update_runtime_nangate45_ibex.tcl
+++ b/src/dbSta/test/dcalc_full_update_runtime_nangate45_ibex.tcl
@@ -1,0 +1,14 @@
+# Compare full timing-update runtime on the placed Nangate45 Ibex design.
+set test_name dcalc_full_update_runtime_nangate45_ibex
+source "helpers.tcl"
+source "dcalc_full_update_runtime_helpers.tcl"
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def ../../gpl/test/design/nangate45/ibex_core/ibex_core.def
+read_sdc ../../gpl/test/design/nangate45/ibex_core/ibex_core.sdc
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+run_dcalc_full_update_runtime

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -94,6 +94,24 @@ filegroup(
 )
 
 filegroup(
+    name = "dynamic_node_runtime_fixture",
+    srcs = [
+        "design/nangate45/dynamic_node_top_wrap/dynamic_node_top_wrap.def",
+        "design/nangate45/dynamic_node_top_wrap/dynamic_node_top_wrap.sdc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "ibex_runtime_fixture",
+    srcs = [
+        "design/nangate45/ibex_core/ibex_core.def",
+        "design/nangate45/ibex_core/ibex_core.sdc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "test_resources",
     # overly broad glob, could be refined later, but
     # symlinks are cheap and OpenROAD binary changes, the common

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -55,6 +55,21 @@ COMPULSORY_TESTS = [
 ALL_TESTS = COMPULSORY_TESTS
 
 filegroup(
+    name = "asap7_aes_runtime_fixture",
+    srcs = [
+        "asap7_data/aes_place.def",
+        "asap7_data/aes_place.sdc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "asap7_riscv_runtime_fixture",
+    srcs = ["asap7_data/riscv.def"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "regression_resources",
     # Dependencies could be specified more narrowly per test case,
     # but at least it is not a glob of everything and there are

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -281,6 +281,36 @@ filegroup(
 )
 
 filegroup(
+    name = "gf180_jpeg_runtime_fixture",
+    srcs = [
+        "gf180/gf180mcu_5LM_1TM_9K_9t_sc.lef",
+        "gf180/gf180mcu_5LM_1TM_9K_9t_tech.lef",
+        "gf180/gf180mcu_fd_sc_mcu9t5v0__tt_025C_5v00.lib.gz",
+        "gf180/setRC.tcl",
+        "jpeg.sdc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "gcd_asap7_runtime_fixture",
+    srcs = [
+        "gcd.sdc",
+        "gcd_asap7_placed.def",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "gcd_nangate45_runtime_fixture",
+    srcs = [
+        "gcd_nangate45.sdc",
+        "gcd_nangate45_placed.def",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "test_resources",
     # overly broad glob, could be refined later, but
     # symlinks are cheap and OpenROAD binary changes, the common

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -56,6 +56,12 @@ COMPULSORY_TESTS = [
 ALL_TESTS = COMPULSORY_TESTS
 
 filegroup(
+    name = "gf180_jpeg_runtime_fixture",
+    srcs = ["gf180/jpeg.def"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "regression_resources",
     # Dependencies could be specified more narrowly per test case,
     # but at least it is not a glob of everything and there are


### PR DESCRIPTION
Adds Tcl regressions comparing `dmp_ceff_elmore` and `dmp_ceff_lambert_w` with full `find_requireds` timing updates
- In a few `-threads 64` tests, Lambert W dcalc is slower.


### STA full timing update runtime
- T1: `-threads 1`
- T64: `-threads t64`
- Default: `dmp_ceff_elmore` delay calculator
- Lambert: `dmp_ceff_lambert_w` delay calculator
- Runtime unit: ms

### Runtime measurement

```tcl
set_delay_calculator $model
set start_us [clock microseconds]
sta::find_requireds
set elapsed_us [expr {[clock microseconds] - $start_us}]
```

| Regression design | T1 Default | T1 Lambert | T1 delta | T64 Default | T64 Lambert | T64 delta | Default scaling (T1→T64) | Lambert scaling (T1→T64) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `asap7_aes` | 996.0 | 657.8 | -34.0% | 309.4 | 367.7 | +18.8% | 3.2x | 1.8x |
| `asap7_gcd` | 18.1 | 11.4 | -36.7% | 18.1 | 12.8 | -29.4% | 1.0x | 0.9x |
| `asap7_riscv` | 345.7 | 350.0 | +1.2% | 170.6 | 186.1 | +9.1% | 2.0x | 1.9x |
| `example1` | 0.1 | 0.1 | -21.1% | 0.1 | 0.1 | -11.6% | 0.9x | 0.8x |
| `gf180_jpeg` | 1950.3 | 1997.1 | +2.4% | 669.0 | 791.1 | +18.2% | 2.9x | 2.5x |
| `mock_array` | 485.4 | 435.9 | -10.2% | 359.4 | 369.2 | +2.7% | 1.4x | 1.2x |
| `nangate45_dynamic_node` | 338.2 | 346.0 | +2.3% | 189.9 | 210.0 | +10.6% | 1.8x | 1.6x |
| `nangate45_gcd` | 13.8 | 9.7 | -29.8% | 16.7 | 12.6 | -24.2% | 0.8x | 0.8x |
| `nangate45_ibex` | 785.8 | 799.2 | +1.7% | 405.1 | 442.6 | +9.2% | 1.9x | 1.8x |

### How to run `asap7/aes` with 64 threads

```bash
bazel build //:openroad
cd src/dbSta/test
../../../bazel-bin/openroad -threads 64 -no_splash -no_init -exit dcalc_full_update_runtime_asap7_aes.tcl
```

Example output

```text
...
average  model=dmp_ceff_elmore      runtime_us=    322024 wns=      -77.106266 tns=    -7171.530065
average  model=dmp_ceff_lambert_w   runtime_us=    363738 wns=      -11.645074 tns=      -74.446227
pass
```
