### PR TITLE
gpl: report HPWL after global placement

### DIFF
--- a/src/gpl/include/gpl/Replace.h
+++ b/src/gpl/include/gpl/Replace.h
@@ -167,6 +167,7 @@ class Replace
                          bool check_density);
   void checkHasCoreRows();
   void checkPlaceIosSupported(const PlaceOptions& options);
+  void reportHpwlMetric();
 
   odb::dbDatabase* db_ = nullptr;
   sta::dbSta* sta_ = nullptr;

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -412,6 +412,8 @@ int Replace::doNesterovPlace(const int threads,
 
   int return_do_nesterov = np_->doNesterovPlace(start_iter);
 
+  reportHpwlMetric();
+
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = end - start;
   debugPrint(log_,
@@ -428,6 +430,16 @@ int Replace::doNesterovPlace(const int threads,
     fr_->globalRoute();
   }
   return return_do_nesterov;
+}
+
+// Same evaluator dpl reports route__wirelength__estimated with, so the
+// global and detailed placement numbers are directly comparable.
+void Replace::reportHpwlMetric()
+{
+  odb::dbBlock* block = db_->getChip()->getBlock();
+  const int64_t hpwl = odb::WireLengthEvaluator(block).hpwl();
+  log_->info(GPL, 1018, "Final HPWL (um): {:.2f}", block->dbuToMicrons(hpwl));
+  log_->metric("route__wirelength__estimated", block->dbuToMicrons(hpwl));
 }
 
 float Replace::getUniformTargetDensity(const PlaceOptions& options,

--- a/src/gpl/test/ar01.ok
+++ b/src/gpl/test/ar01.ok
@@ -77,4 +77,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.6031
 [INFO GPL-1008]     - For 80% usage of free space: 0.6785
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2997.65
 No differences found.

--- a/src/gpl/test/ar02.ok
+++ b/src/gpl/test/ar02.ok
@@ -78,4 +78,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.6029
 [INFO GPL-1008]     - For 80% usage of free space: 0.6782
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2993.31
 No differences found.

--- a/src/gpl/test/cluster_place01.ok
+++ b/src/gpl/test/cluster_place01.ok
@@ -78,4 +78,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.6026
 [INFO GPL-1008]     - For 80% usage of free space: 0.6779
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 3034.72
 No differences found.

--- a/src/gpl/test/convergence01.ok
+++ b/src/gpl/test/convergence01.ok
@@ -161,4 +161,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 14.41
 [INFO GPL-1013] Total timing-driven delta area: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 14.41 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 401.79
 No differences found.

--- a/src/gpl/test/core01.ok
+++ b/src/gpl/test/core01.ok
@@ -77,4 +77,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.6026
 [INFO GPL-1008]     - For 80% usage of free space: 0.6779
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2886.89
 No differences found.

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -83,4 +83,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2597.56
 No differences found.

--- a/src/gpl/test/diverge01.ok
+++ b/src/gpl/test/diverge01.ok
@@ -57,4 +57,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 3354.14
 

--- a/src/gpl/test/error01.ok
+++ b/src/gpl/test/error01.ok
@@ -80,3 +80,4 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2687.65

--- a/src/gpl/test/nograd01.ok
+++ b/src/gpl/test/nograd01.ok
@@ -56,4 +56,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0001
 [INFO GPL-1009]     - For 50% usage of free space: 0.0001
 [INFO GPL-1014] Final placement area: 0.44 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 1140.14
 No differences found.

--- a/src/gpl/test/region01.ok
+++ b/src/gpl/test/region01.ok
@@ -217,4 +217,5 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-1008]     - For 80% usage of free space: 0.2016
 [INFO GPL-1009]     - For 50% usage of free space: 0.3226
 [INFO GPL-1014] Final placement area: 7451.24 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 13846.06
 No differences found.

--- a/src/gpl/test/simple01-obs.ok
+++ b/src/gpl/test/simple01-obs.ok
@@ -79,4 +79,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.9366
 [INFO GPL-1008]     - For 80% usage of free space: 1.0536
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2714.68
 No differences found.

--- a/src/gpl/test/simple01-rd.ok
+++ b/src/gpl/test/simple01-rd.ok
@@ -119,4 +119,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 619.73
 [INFO GPL-1012] Total routability artificial inflation: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2599.69
 No differences found.

--- a/src/gpl/test/simple01-ref.ok
+++ b/src/gpl/test/simple01-ref.ok
@@ -78,4 +78,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2598.54
 No differences found.

--- a/src/gpl/test/simple01-skip-io.ok
+++ b/src/gpl/test/simple01-skip-io.ok
@@ -91,4 +91,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2999.51
 No differences found.

--- a/src/gpl/test/simple01-td-net-percentage.ok
+++ b/src/gpl/test/simple01-td-net-percentage.ok
@@ -158,5 +158,6 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 0.80 (+0.13%)
 [INFO GPL-1014] Final placement area: 601.79 (+0.13%)
+[INFO GPL-1018] Final HPWL (um): 2571.63
 worst slack max 1.37
 No differences found.

--- a/src/gpl/test/simple01-td-repair.ok
+++ b/src/gpl/test/simple01-td-repair.ok
@@ -169,5 +169,6 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 67.74 (+11.27%)
 [INFO GPL-1014] Final placement area: 668.73 (+11.27%)
+[INFO GPL-1018] Final HPWL (um): 2761.28
 worst slack max -0.02
 No differences found.

--- a/src/gpl/test/simple01-td-tune.ok
+++ b/src/gpl/test/simple01-td-tune.ok
@@ -300,5 +300,6 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 0.80 (+0.13%)
 [INFO GPL-1014] Final placement area: 601.79 (+0.13%)
+[INFO GPL-1018] Final HPWL (um): 2591.92
 worst slack max 1.38
 No differences found.

--- a/src/gpl/test/simple01-td.ok
+++ b/src/gpl/test/simple01-td.ok
@@ -155,5 +155,6 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 0.80 (+0.13%)
 [INFO GPL-1014] Final placement area: 601.79 (+0.13%)
+[INFO GPL-1018] Final HPWL (um): 2565.07
 worst slack max 1.38
 No differences found.

--- a/src/gpl/test/simple01-uniform.ok
+++ b/src/gpl/test/simple01-uniform.ok
@@ -77,4 +77,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2651.01
 No differences found.

--- a/src/gpl/test/simple01-vcts-clamp.ok
+++ b/src/gpl/test/simple01-vcts-clamp.ok
@@ -161,4 +161,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 34.58 (+5.75%)
 [INFO GPL-1014] Final placement area: 635.57 (+5.75%)
+[INFO GPL-1018] Final HPWL (um): 2622.73
 worst slack max 1.28

--- a/src/gpl/test/simple01-vcts-noclk.ok
+++ b/src/gpl/test/simple01-vcts-noclk.ok
@@ -125,3 +125,4 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7001
 [INFO GPL-1008]     - For 80% usage of free space: 0.7876
 [INFO GPL-1014] Final placement area: 600.99 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2405.40

--- a/src/gpl/test/simple01-vcts-userlat.ok
+++ b/src/gpl/test/simple01-vcts-userlat.ok
@@ -160,4 +160,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 600.99 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2545.94
 worst slack max 1.02

--- a/src/gpl/test/simple01-vcts.ok
+++ b/src/gpl/test/simple01-vcts.ok
@@ -159,5 +159,6 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 600.99
 [INFO GPL-1013] Total timing-driven delta area: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 600.99 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2552.20
 worst slack max 1.37
 No differences found.

--- a/src/gpl/test/simple01.ok
+++ b/src/gpl/test/simple01.ok
@@ -77,4 +77,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2597.56
 No differences found.

--- a/src/gpl/test/simple02-rd.ok
+++ b/src/gpl/test/simple02-rd.ok
@@ -119,4 +119,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 619.73
 [INFO GPL-1012] Total routability artificial inflation: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2599.69
 No differences found.

--- a/src/gpl/test/simple02.ok
+++ b/src/gpl/test/simple02.ok
@@ -80,4 +80,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7221
 [INFO GPL-1008]     - For 80% usage of free space: 0.8124
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2687.37
 No differences found.

--- a/src/gpl/test/simple03-rd.ok
+++ b/src/gpl/test/simple03-rd.ok
@@ -112,4 +112,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 619.73
 [INFO GPL-1012] Total routability artificial inflation: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2599.69
 No differences found.

--- a/src/gpl/test/simple03.ok
+++ b/src/gpl/test/simple03.ok
@@ -94,4 +94,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2599.69
 No differences found.

--- a/src/gpl/test/simple04-rd.ok
+++ b/src/gpl/test/simple04-rd.ok
@@ -112,4 +112,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1011] Original area (um^2): 619.73
 [INFO GPL-1012] Total routability artificial inflation: 0.00 (+0.00%)
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2599.69
 No differences found.

--- a/src/gpl/test/simple04.ok
+++ b/src/gpl/test/simple04.ok
@@ -95,4 +95,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1007]     - For 90% usage of free space: 0.7219
 [INFO GPL-1008]     - For 80% usage of free space: 0.8121
 [INFO GPL-1014] Final placement area: 619.73 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2655.70
 No differences found.

--- a/src/gpl/test/simple05.ok
+++ b/src/gpl/test/simple05.ok
@@ -56,4 +56,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0684
 [INFO GPL-1009]     - For 50% usage of free space: 0.1094
 [INFO GPL-1014] Final placement area: 1.86 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 14.39
 No differences found.

--- a/src/gpl/test/simple07.ok
+++ b/src/gpl/test/simple07.ok
@@ -65,4 +65,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0072
 [INFO GPL-1009]     - For 50% usage of free space: 0.0115
 [INFO GPL-1014] Final placement area: 3.75 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 84.48
 No differences found.

--- a/src/gpl/test/simple08.ok
+++ b/src/gpl/test/simple08.ok
@@ -65,4 +65,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0072
 [INFO GPL-1009]     - For 50% usage of free space: 0.0115
 [INFO GPL-1014] Final placement area: 3.75 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 84.48
 No differences found.

--- a/src/gpl/test/simple09.ok
+++ b/src/gpl/test/simple09.ok
@@ -56,4 +56,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0024
 [INFO GPL-1009]     - For 50% usage of free space: 0.0039
 [INFO GPL-1014] Final placement area: 1.86 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 4.99
 No differences found.

--- a/src/gpl/test/simple10.ok
+++ b/src/gpl/test/simple10.ok
@@ -65,4 +65,5 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0000
 [INFO GPL-1009]     - For 50% usage of free space: 0.0000
 [INFO GPL-1014] Final placement area: 3.75 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 2065.31
 No differences found.

--- a/src/odb/test/replace_hier_mod1.ok
+++ b/src/odb/test/replace_hier_mod1.ok
@@ -226,6 +226,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
       290 |   0.3980 |  1.150865e+02 |   +6.41% |  2.15e-07 |      
 [WARNING GPL-1010] GPL reached the maximum number of iterations for nesterov 300. Placement may have failed to converge.
 [INFO GPL-1014] Final placement area: 54.55 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 125.13
 [INFO GPL-0133] Unlocking all instances
 [INFO GPL-0084] ---- Execute Nesterov Global Placement.
       310 |   0.1280 |  2.494715e+02 | +116.77% |  5.28e-07 |      
@@ -240,6 +241,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0014
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 54.55 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 260.25
 [INFO DPL-0006] Core area: 47872.02 um^2
 [INFO DPL-0007] Movable instances area: 59.85 um^2
 [INFO DPL-0008] Fixed instances area within core: 0.00 um^2
@@ -391,6 +393,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0014
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 55.08 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 256.45
 [INFO GPL-0133] Unlocking all instances
 [INFO GPL-0084] ---- Execute Nesterov Global Placement.
        10 |   0.4167 |  3.478000e+01 |  -86.42% |  1.11e-12 |      
@@ -450,6 +453,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0014
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 55.08 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 133.54
 [INFO DPL-0006] Core area: 47872.02 um^2
 [INFO DPL-0007] Movable instances area: 60.38 um^2
 [INFO DPL-0008] Fixed instances area within core: 0.00 um^2
@@ -606,6 +610,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0014
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 54.55 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 149.51
 [INFO GPL-0133] Unlocking all instances
 [INFO GPL-0084] ---- Execute Nesterov Global Placement.
        10 |   0.3890 |  3.681500e+01 |  -75.38% |  1.07e-12 |      
@@ -665,6 +670,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0014
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 54.55 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 145.67
 [INFO DPL-0006] Core area: 47872.02 um^2
 [INFO DPL-0007] Movable instances area: 59.85 um^2
 [INFO DPL-0008] Fixed instances area within core: 0.00 um^2

--- a/test/upf_aes.ok
+++ b/test/upf_aes.ok
@@ -1226,6 +1226,7 @@ Divergence occured in 1 regions.
 [INFO GPL-1012] Total routability artificial inflation: 4287.00 (+1.02%)
 [INFO GPL-1013] Total timing-driven delta area: -34326.85 (-8.17%)
 [INFO GPL-1014] Final placement area: 389871.15 (-7.15%)
+[INFO GPL-1018] Final HPWL (um): 1873476.22
 [INFO DPL-0006] Core area: 878902.94 um^2
 [INFO DPL-0007] Movable instances area: 334449.51 um^2
 [INFO DPL-0008] Fixed instances area within core: 0.00 um^2

--- a/test/upf_test.ok
+++ b/test/upf_test.ok
@@ -142,6 +142,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1008]     - For 80% usage of free space: 0.0664
 [INFO GPL-1009]     - For 50% usage of free space: 0.1063
 [INFO GPL-1014] Final placement area: 175.05 (+0.00%)
+[INFO GPL-1018] Final HPWL (um): 1041.24
 [INFO DPL-0006] Core area: 11467.25 um^2
 [INFO DPL-0007] Movable instances area: 158.90 um^2
 [INFO DPL-0008] Fixed instances area within core: 0.00 um^2


### PR DESCRIPTION
## What

Global placement printed HPWL only inside its iteration table and wrote no wirelength metric, so neither the log nor a metrics file had a final global placement number. Now both:

```
[INFO GPL-1018] Final HPWL (um): 2597.56
"route__wirelength__estimated": 2597.56
```

```cpp
void Replace::reportHpwlMetric()
{
  odb::dbBlock* block = db_->getChip()->getBlock();
  const int64_t hpwl = odb::WireLengthEvaluator(block).hpwl();
  log_->info(GPL, 1018, "Final HPWL (um): {:.2f}", block->dbuToMicrons(hpwl));
  log_->metric("route__wirelength__estimated", block->dbuToMicrons(hpwl));
}
```

Called at the end of `Replace::doNesterovPlace()`, after `NesterovPlace::doNesterovPlace()` has updated the db.

## Why this name and this evaluator

`route__wirelength__estimated` measured with `odb::WireLengthEvaluator` is exactly what dpl reports (`src/dpl/src/Opendp.cpp`). Under ORFS metrics stages the two land as `globalplace__route__wirelength__estimated` and `detailedplace__route__wirelength__estimated`, measured the same way, so the gpl -> dpl HPWL delta is meaningful.

## Testing

- `bazelisk test //src/gpl/...`: 102/102 pass. 35 golden logs updated, each with exactly the one new line and nothing else, so placement results are unchanged.
- `openroad -metrics ... src/gpl/test/simple01.tcl` writes `"route__wirelength__estimated": 2597.56`.

## Note

`global_placement -incremental` runs nesterov up to twice, so the metric key can appear twice in one metrics file with the final value last (JSON readers keep the last). Same pattern grt already has with `antenna_diodes_count`.

