### PR TITLE
gui: avoid call to sortItems since that triggers from bazel segfault

### DIFF
--- a/src/gui/src/helpWidget.cpp
+++ b/src/gui/src/helpWidget.cpp
@@ -10,8 +10,11 @@
 #include <QTextStream>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <algorithm>
 #include <filesystem>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace gui {
 
@@ -97,6 +100,12 @@ void HelpWidget::changeCategory()
 
   help_list_->clear();
 
+  // Order the pages before inserting them rather than calling
+  // QListWidget::sortItems(), which compares through QCollator and so has to
+  // load ICU locale data just to order a directory listing of ASCII file
+  // names. Sorting here keeps opening the GUI independent of whether that data
+  // can be found.
+  std::vector<std::pair<QString, QString>> pages;  // {display stem, full path}
   for (auto const& dir_entry : std::filesystem::directory_iterator{dir}) {
     const auto& path = dir_entry.path();
 
@@ -104,12 +113,21 @@ void HelpWidget::changeCategory()
       continue;
     }
 
-    auto* qitem = new QListWidgetItem(QString::fromStdString(path.stem()));
-    qitem->setData(Qt::UserRole, QString::fromStdString(path));
-    help_list_->addItem(qitem);
+    pages.emplace_back(QString::fromStdString(path.stem()),
+                       QString::fromStdString(path));
   }
 
-  help_list_->sortItems();
+  std::sort(pages.begin(), pages.end(), [](const auto& lhs, const auto& rhs) {
+    const int cmp = QString::compare(lhs.first, rhs.first, Qt::CaseInsensitive);
+    // Break ties case-sensitively so the ordering is total.
+    return cmp != 0 ? cmp < 0 : lhs.first < rhs.first;
+  });
+
+  for (const auto& [stem, path] : pages) {
+    auto* qitem = new QListWidgetItem(stem);
+    qitem->setData(Qt::UserRole, path);
+    help_list_->addItem(qitem);
+  }
 }
 
 void HelpWidget::showHelpInformation(QListWidgetItem* item)


### PR DESCRIPTION
## Summary

## Problem

A GUI-enabled `openroad` that has been installed dies with SIGSEGV the moment
`gui::show` runs, on any design including none at all. This kills the
image-generation stage of every SiliconCompiler APR step, which drives the GUI
headlessly via `gui::show "source .../write_images.tcl" false`.

Reproducer, no design data needed:

```console
$ printf 'gui::show "exit" false\n' > /tmp/t.tcl
$ QT_QPA_PLATFORM=offscreen openroad -no_init -exit /tmp/t.tcl
Signal 11 received
$ echo $?
139
```

## Cause

`HelpWidget::init()` adds the help categories to a `QComboBox`. Qt auto-selects
row 0 as soon as the first item lands, which fires `changeCategory()`, which
called `help_list_->sortItems()`. That sort compares through `QCollator`, whose
constructor loads ICU locale data:

```
HelpWidget::changeCategory -> QListModel::sort -> QListWidgetItem::operator<
  -> QAbstractItemModelPrivate::variantLessThan -> QCollator::defaultCompare
  -> QCollator::QCollator() -> ucol_open -> CollationRoot::load
  -> doOpenChoice -> u_getDataDirectory
  -> rules_cc::cc::runfiles::Runfiles::Rlocation   <-- SIGSEGV
```

The fault is in the Bazel Central Registry overlay for `icu`, which patches
`u_getDataDirectory()` to find the packaged `icudt76l.dat` through the runfiles
tree using three unchecked calls:

```cpp
std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", BAZEL_CURRENT_REPOSITORY));
std::string dat_path = runfiles->Rlocation(ICU_DATA_DIR_BAZEL);
path = dat_path.c_str();
```

`Runfiles::Create()` is documented to return `nullptr` on error, and it fails
whenever no runfiles tree is reachable; the next line dereferences it. Since
`argv0` is passed as `""`, rules_cc skips its `<argv0>.runfiles` fallback, so
only `$RUNFILES_DIR` and `$RUNFILES_MANIFEST_FILE` are ever consulted --
neither of which is set for an installed binary. Keeping a runfiles tree beside
the binary does not help for the same reason (verified).

Two conditions must hold, and `bazel/install.sh` arranges both: the man pages
are installed (line 64), so `HelpWidget::init()` gets past its path validation;
and `openroad.runfiles` is deliberately removed after unpacking (lines 47-58).
CLI builds are unaffected -- `icu` reaches the build only via `qt-bazel`, so
`//:openroad`'s runfiles contain no `icu_dat`.

## Fix

Order the page list in `changeCategory()` instead of calling `sortItems()`.
Sorting a directory listing of ASCII file names does not need locale-aware
collation, and doing it here means opening the GUI no longer depends on ICU
data being findable. The visible order is preserved: entries are compared
case-insensitively with a case-sensitive tiebreak so the ordering is total.

## Scope

This removes OpenROAD's only unconditional ICU dependency at GUI startup; it
does not fix the underlying `icu` defect, which is being reported upstream. Any
other collated sort in an installed GUI build -- for example clicking a header
on the sortable timing tables, or a file dialog's `QFileSystemModel` -- would
still reach the same unchecked pointer. Those paths were not observed to fire
during headless image generation, but they are not guarded by this change. The
alternative, a `single_version_override` patching `icu`'s `putil.cpp`, fixes it
for all consumers and can be added if preferred.

Note that every `icu` version currently in the BCR carries this code, including
`76.1.bcr.4` (byte-identical patch) and the newest `78.2.bcr.2`, so a version
bump is not a workaround.

## Verification

Built `--stamp //:openroad-qt`; ICU left unpatched. All runs with `RUNFILES_DIR`
and `RUNFILES_MANIFEST_FILE` unset.

| case | before | after |
|---|---|---|
| man pages installed | SIGSEGV 139 | exit 0 |
| man pages installed, valid `RUNFILES_DIR` | collator built | collator built |
| man pages installed, bogus `RUNFILES_DIR`/manifest | GUI-0076 warning | exit 0 |
| no man pages | exit 0 | exit 0 |

Row 2 is the no-regression check: where the runfiles tree really is present the
`.dat` is still found. After the change no `QCollator` is constructed at all, so
the `GUI-0076 Could not create collator` warning no longer appears either.

Real design data, using SiliconCompiler's own image call (`read_db`, then
`gui::show "save_image -resolution <sc_image_resolution 1000> -area {...}"`) on
the ODB from a `floorplan.init` step: before, SIGSEGV and no image; after,
exit 0 and a valid 1099x1099 PNG.

`bazel test //src/gui/...` passes (3/3). Those tests are man-page and message
consistency checks and do not exercise `HelpWidget`, so they confirm nothing
regressed rather than covering the change; there is no C++ unit-test harness
under `src/gui/test` to add a `HelpWidget` test to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Type of Change
- Bug fix

## Impact

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**
