### PR TITLE
rsz: Preserve dont-touch on hierarchical nets

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -3632,15 +3632,19 @@ bool Resizer::dontTouch(const sta::Instance* inst) const
 
 void Resizer::setDontTouch(const sta::Net* net, bool dont_touch)
 {
-  odb::dbNet* db_net = db_network_->staToDb(net);
+  odb::dbNet* db_net = db_network_->findFlatDbNet(net);
+  if (db_net == nullptr) {
+    logger_->error(RSZ,
+                   224,
+                   "Cannot find the flat net associated with {}.",
+                   db_network_->pathName(net));
+  }
   db_net->setDoNotTouch(dont_touch);
 }
 
 bool Resizer::dontTouch(const sta::Net* net) const
 {
-  odb::dbNet* db_net = nullptr;
-  odb::dbModNet* db_mod_net = nullptr;
-  db_network_->staToDb(net, db_net, db_mod_net);
+  odb::dbNet* db_net = db_network_->findFlatDbNet(net);
   if (db_net == nullptr) {
     return false;
   }

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -497,6 +497,7 @@ cc_test(
         "cpp/TestResizer*.lib",
         "cpp/TestResizer*.v",
     ]) + [
+        "cpp/TestBufferRemoval3_feedthrough.v",
         "inferred_clock_gator_time_borrow.def",
         "latch_borrow_chain.def",
     ],

--- a/src/rsz/test/cpp/TestResizer.cc
+++ b/src/rsz/test/cpp/TestResizer.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -224,6 +225,39 @@ class TestResizer : public tst::IntegratedFixture
     return nullptr;
   }
 };
+
+// Verify dont_touch preserves a hierarchical name and protects its flat net.
+TEST_F(TestResizer, HierarchicalNetDontTouch)
+{
+  readVerilogAndSetup("TestBufferRemoval3_feedthrough.v",
+                      /*init_default_sdc=*/false);
+
+  odb::dbModule* child_module = block_->findModule("child_mod");
+  ASSERT_NE(child_module, nullptr);
+  odb::dbModBTerm* input_port = child_module->findModBTerm("data_i");
+  ASSERT_NE(input_port, nullptr);
+  odb::dbModNet* mod_net = input_port->getModNet();
+  ASSERT_NE(mod_net, nullptr);
+  odb::dbNet* flat_net = mod_net->findRelatedNet();
+  ASSERT_NE(flat_net, nullptr);
+
+  // Compare addresses without dereferencing a potentially corrupted name.
+  const std::uintptr_t name_address
+      = reinterpret_cast<std::uintptr_t>(mod_net->getConstName());
+  const sta::Net* sta_net = db_network_->dbToSta(mod_net);
+  ASSERT_NE(sta_net, nullptr);
+
+  resizer_.setDontTouch(sta_net, true);
+  EXPECT_EQ(reinterpret_cast<std::uintptr_t>(mod_net->getConstName()),
+            name_address);
+  EXPECT_TRUE(flat_net->isDoNotTouch());
+  EXPECT_TRUE(resizer_.dontTouch(sta_net));
+
+  resizer_.setDontTouch(sta_net, false);
+  EXPECT_EQ(reinterpret_cast<std::uintptr_t>(mod_net->getConstName()),
+            name_address);
+  EXPECT_FALSE(flat_net->isDoNotTouch());
+}
 
 TEST_F(TestResizer, WeakerCellFirstOrdersHigherDriveResistanceFirst)
 {


### PR DESCRIPTION
Resolve hierarchical `set_dont_touch` nets to their corresponding flat dbNet.

Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/11180