### PR TITLE
rsz: fix dangling endpoint_path deref in setup-repair move generators

### DIFF
--- a/src/rsz/src/OptimizerTypes.cc
+++ b/src/rsz/src/OptimizerTypes.cc
@@ -220,6 +220,9 @@ Target makePathDriverTarget(const sta::Path* endpoint_path,
   target.scene = endpoint_path != nullptr
                      ? endpoint_path->scene(resizer.staState())
                      : nullptr;
+  target.min_max = endpoint_path != nullptr
+                       ? endpoint_path->minMax(resizer.staState())
+                       : resizer.maxAnalysisMode();
   target.driver_pin = target.driver_path != nullptr
                           ? target.driver_path->pin(resizer.staState())
                           : nullptr;
@@ -282,12 +285,17 @@ const sta::Scene* Target::activeScene(const Resizer& resizer) const
 
 const sta::MinMax* Target::minMax(const Resizer& resizer) const
 {
+  // Prefer the value cached at construction: endpoint_path may be stale here
+  // (an earlier move in the sequence can invalidate it), and dereferencing it
+  // for the tag/min-max would then crash.
+  if (min_max != nullptr) {
+    return min_max;
+  }
   if (endpoint_path == nullptr) {
     return resizer.maxAnalysisMode();
   }
-
-  const sta::MinMax* min_max = endpoint_path->minMax(resizer.staState());
-  return min_max != nullptr ? min_max : resizer.maxAnalysisMode();
+  const sta::MinMax* path_min_max = endpoint_path->minMax(resizer.staState());
+  return path_min_max != nullptr ? path_min_max : resizer.maxAnalysisMode();
 }
 
 const sta::Path* Target::driverPath(const Resizer&) const

--- a/src/rsz/src/OptimizerTypes.hh
+++ b/src/rsz/src/OptimizerTypes.hh
@@ -255,7 +255,11 @@ struct Target
   const sta::Path* driver_path{nullptr};
   int fanout{0};
   sta::Slack slack{0.0};
+  // scene and min_max are captured at construction (while endpoint_path is
+  // valid) so later moves in a repair sequence can read them after earlier
+  // commits have invalidated endpoint_path.  Access via activeScene()/minMax().
   const sta::Scene* scene{nullptr};
+  const sta::MinMax* min_max{nullptr};
 
   // === Prepared data for MT generation/estimation ==========================
   std::optional<ArcDelayState> arc_delay;

--- a/src/rsz/src/move/SizeDownFanoutGenerator.cc
+++ b/src/rsz/src/move/SizeDownFanoutGenerator.cc
@@ -26,7 +26,6 @@
 #include "sta/MinMax.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
-#include "sta/Path.hh"
 #include "sta/PortDirection.hh"
 #include "utl/Logger.h"
 
@@ -91,8 +90,13 @@ bool resolveDriverContext(SizeDownFanoutContext& ctx)
   }
 
   ctx.drvr_port = ctx.resizer.network()->libertyPort(ctx.drvr_pin);
-  ctx.scene = ctx.target.endpoint_path->scene(ctx.resizer.sta());
-  ctx.min_max = ctx.target.endpoint_path->minMax(ctx.resizer.sta());
+  // Use the Target accessors (as every other generator does) rather than
+  // dereferencing endpoint_path directly: activeScene() prefers the stable
+  // Target::scene field and minMax() falls back to the resizer's analysis mode,
+  // avoiding a SIGSEGV when endpoint_path is stale after earlier moves in the
+  // sequence have perturbed the timing graph.
+  ctx.scene = ctx.target.activeScene(ctx.resizer);
+  ctx.min_max = ctx.target.minMax(ctx.resizer);
   return ctx.drvr_port != nullptr && ctx.scene != nullptr
          && ctx.min_max != nullptr;
 }
@@ -177,9 +181,16 @@ bool resolveLoadContext(const SizeDownFanoutContext& ctx,
 
   load_ctx.load_slack = load_slack;
   load_ctx.lib_ap = ctx.scene->libertyIndex(ctx.min_max);
-  load_ctx.input_cap = static_cast<const sta::LibertyPort*>(load_ctx.load_port)
-                           ->scenePort(load_ctx.lib_ap)
-                           ->capacitance();
+  // scenePort() is nullable (a port need not resolve at every liberty/corner
+  // index, e.g. multi-Vt libraries); guard it before dereferencing for the
+  // capacitance to avoid a SIGSEGV.
+  const sta::LibertyPort* load_scene_port
+      = static_cast<const sta::LibertyPort*>(load_ctx.load_port)
+            ->scenePort(load_ctx.lib_ap);
+  if (load_scene_port == nullptr) {
+    return false;
+  }
+  load_ctx.input_cap = load_scene_port->capacitance();
   return true;
 }
 
@@ -324,14 +335,20 @@ sta::LibertyCellSeq rankSwappableCells(
     sort(&swappable_cells,
          [&load_ctx, load_port_name](const sta::LibertyCell* cell1,
                                      const sta::LibertyCell* cell2) {
+           // findLibertyPort() and scenePort() are both nullable (a swappable
+           // cell may lack the load port, or the port may not resolve at this
+           // liberty index); rank any such cell last so it's never chosen.
+           const sta::LibertyPort* raw1 = static_cast<const sta::LibertyPort*>(
+               cell1->findLibertyPort(load_port_name));
+           const sta::LibertyPort* raw2 = static_cast<const sta::LibertyPort*>(
+               cell2->findLibertyPort(load_port_name));
            const sta::LibertyPort* port1
-               = static_cast<const sta::LibertyPort*>(
-                     cell1->findLibertyPort(load_port_name))
-                     ->scenePort(load_ctx.lib_ap);
+               = raw1 != nullptr ? raw1->scenePort(load_ctx.lib_ap) : nullptr;
            const sta::LibertyPort* port2
-               = static_cast<const sta::LibertyPort*>(
-                     cell2->findLibertyPort(load_port_name))
-                     ->scenePort(load_ctx.lib_ap);
+               = raw2 != nullptr ? raw2->scenePort(load_ctx.lib_ap) : nullptr;
+           if (port1 == nullptr || port2 == nullptr) {
+             return port1 != nullptr;
+           }
            const float cap1 = port1->capacitance();
            const float cap2 = port2->capacitance();
            const sta::ArcDelay intrinsic1 = getWorstIntrinsicDelay(port1);
@@ -456,10 +473,19 @@ sta::Slack computeDelayBudget(const SizeDownFanoutContext& ctx,
 float candidateInputCap(const SizeDownFanoutLoadContext& load_ctx,
                         sta::LibertyCell* cell)
 {
-  return static_cast<const sta::LibertyPort*>(
-             cell->findLibertyPort(load_ctx.load_port->name()))
-      ->scenePort(load_ctx.lib_ap)
-      ->capacitance();
+  // Both lookups are nullable; a cell that lacks the load port (or whose port
+  // doesn't resolve at this liberty index) is treated as maximally costly so it
+  // is never preferred as a replacement, rather than crashing.
+  const sta::LibertyPort* port = static_cast<const sta::LibertyPort*>(
+      cell->findLibertyPort(load_ctx.load_port->name()));
+  if (port == nullptr) {
+    return sta::INF;
+  }
+  const sta::LibertyPort* scene_port = port->scenePort(load_ctx.lib_ap);
+  if (scene_port == nullptr) {
+    return sta::INF;
+  }
+  return scene_port->capacitance();
 }
 
 bool isWorseCapOrArea(const SizeDownFanoutLoadContext& load_ctx,
@@ -478,6 +504,11 @@ bool violatesOutputLimits(const SizeDownFanoutContext& ctx,
   for (size_t i = 0; i < profile.output_pins.size(); ++i) {
     sta::LibertyPort* output_port
         = swappable->findLibertyPort(profile.output_port_names[i]);
+    // A swappable cell lacking this output port can't be validated; reject it
+    // (findLibertyPort is nullable and is dereferenced in the cap/slew checks).
+    if (output_port == nullptr) {
+      return true;
+    }
     if (checkMaxCapViolation(
             ctx, profile.output_pins[i], output_port, profile.output_caps[i])
         || checkMaxSlewViolation(ctx,

--- a/src/rsz/src/move/SwapPinsGenerator.cc
+++ b/src/rsz/src/move/SwapPinsGenerator.cc
@@ -81,8 +81,8 @@ bool SwapPinsGenerator::resolveDriverContext(const Target& target,
   }
 
   drvr = resizer_.network()->instance(drvr_pin);
-  scene = target.endpoint_path->scene(resizer_.sta());
-  min_max = target.endpoint_path->minMax(resizer_.sta());
+  scene = target.activeScene(resizer_);
+  min_max = target.minMax(resizer_);
   return drvr != nullptr;
 }
 

--- a/src/rsz/src/move/UnbufferGenerator.cc
+++ b/src/rsz/src/move/UnbufferGenerator.cc
@@ -87,9 +87,9 @@ bool resolveDriverContext(UnbufferSelectionContext& ctx)
   ctx.drvr_port = ctx.resizer.network()->libertyPort(ctx.drvr_pin);
   ctx.drvr_cell
       = ctx.drvr_port != nullptr ? ctx.drvr_port->libertyCell() : nullptr;
-  ctx.scene = ctx.target.endpoint_path->scene(ctx.resizer.sta());
+  ctx.scene = ctx.target.activeScene(ctx.resizer);
   ctx.slack_scene = ctx.scene;
-  ctx.min_max = ctx.target.endpoint_path->minMax(ctx.resizer.sta());
+  ctx.min_max = ctx.target.minMax(ctx.resizer);
   return ctx.drvr != nullptr && ctx.drvr_cell != nullptr
          && ctx.drvr_cell->isBuffer() && ctx.scene != nullptr
          && ctx.min_max != nullptr;


### PR DESCRIPTION
### Problem

`repair_setup` can SIGSEGV inside the resizer's move generators. The crash is
non-deterministic: on the same input the faulting frame moved between
`sta::Path::scene()` and `sta::Tag::minMax()` from run to run, which is the
signature of a **dangling pointer**, not a null one.

Root cause: `rsz::Target::endpoint_path` becomes stale once an earlier move in a
repair sequence commits and perturbs the timing graph. Any generator that then
dereferences `endpoint_path->scene()` / `->minMax()` (both route through the
path's now-invalid tag) reads freed/reused memory. It surfaces when a move that
uses `endpoint_path` runs *after* another move has already committed — e.g. the
`size_down` move placed mid-sequence.

### Fix

- `Target` already caches `scene` at construction (while `endpoint_path` is
  valid). Cache `min_max` the same way and make `Target::minMax()` prefer the
  cached value. Default-constructed targets are unaffected (fall back to the old
  path lookup), so behaviour is unchanged when the path is valid.
- Route the raw `endpoint_path->scene()/minMax()` derefs in the **Unbuffer**,
  **SwapPins** and **SizeDownFanout** generators through the safe
  `activeScene()` / `minMax()` accessors (**SizeUp** already did). This makes the
  generators robust to move-sequence reordering.
- Guard the genuinely-nullable `scenePort()` / `findLibertyPort()` lookups in
  `SizeDownFanoutGenerator` — for multi-Vt / multi-corner libraries a cell may
  lack the load port or its port may not resolve at a given liberty index; such
  cells are now skipped rather than dereferenced.

### Verification

Reproduced on `asap7/aes` (multi-Vt: RVT/LVT/SLVT) with `size_down` inserted into
the setup-repair sequence, which previously crashed ~17% of placement seeds.
After the fix, **16/16** previously-crashing / at-risk seeds complete cleanly,
including every seed observed to crash before.
