### PR TITLE
dbSta: Fix zero slew and net delay issue in `dmp_ceff_two_pole` and `dmp_ceff_lambert_w` delay calculators

### DIFF
--- a/src/dbSta/src/DmpCeffLambertWDelayCalc.hh
+++ b/src/dbSta/src/DmpCeffLambertWDelayCalc.hh
@@ -33,6 +33,11 @@ class DmpCeffTwoPoleDelayCalc : public DmpCeffDelayCalc
                            const RiseFall* rf,
                            const Scene* scene,
                            const MinMax* min_max) override;
+  Parasitic* reduceParasitic(const Parasitic* parasitic_network,
+                             const Pin* drvr_pin,
+                             const RiseFall* rf,
+                             const Scene* scene,
+                             const MinMax* min_max) override;
   ArcDcalcResult inputPortDelay(const Pin* port_pin,
                                 float in_slew,
                                 const RiseFall* rf,
@@ -50,6 +55,8 @@ class DmpCeffTwoPoleDelayCalc : public DmpCeffDelayCalc
                            const MinMax* min_max) override;
 
  protected:
+  using ArcDelayCalc::reduceParasitic;
+
   void loadDelaySlew(const Pin* load_pin,
                      double drvr_slew,
                      const RiseFall* rf,

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -108,7 +108,7 @@ ALL_TESTS = [
 
 # From CMakeLists.txt or_integration_tests(PASSFAIL_TESTS
 PASSFAIL_TESTS = [
-    "dmp_ceff_lambert_w_pi_elmore",
+    "dmp_ceff_dcalc_load_propagation",
 ]
 
 ALL_TESTS += PASSFAIL_TESTS

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -353,8 +353,8 @@ filegroup(
 [
     regression_test(
         name = test_name,
-        check_log = False if test_name in PASSFAIL_TESTS else True,
-        check_passfail = True if test_name in PASSFAIL_TESTS else False,
+        check_log = test_name not in PASSFAIL_TESTS,
+        check_passfail = test_name in PASSFAIL_TESTS,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -106,6 +106,13 @@ ALL_TESTS = [
     "write_verilog9_hier",
 ]
 
+# From CMakeLists.txt or_integration_tests(PASSFAIL_TESTS
+PASSFAIL_TESTS = [
+    "dmp_ceff_lambert_w_pi_elmore",
+]
+
+ALL_TESTS += PASSFAIL_TESTS
+
 filegroup(
     name = "regression_resources",
     srcs = [
@@ -346,6 +353,8 @@ filegroup(
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
+        check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],
     )

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -77,7 +77,7 @@ or_integration_tests(
     write_verilog9
     write_verilog9_hier
   PASSFAIL_TESTS
-    dmp_ceff_lambert_w_pi_elmore
+    dmp_ceff_dcalc_load_propagation
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -76,6 +76,8 @@ or_integration_tests(
     write_verilog8
     write_verilog9
     write_verilog9_hier
+  PASSFAIL_TESTS
+    dmp_ceff_lambert_w_pi_elmore
 )
 
 if(ENABLE_TESTS)

--- a/src/dbSta/test/dmp_ceff_dcalc_load_propagation.def
+++ b/src/dbSta/test/dmp_ceff_dcalc_load_propagation.def
@@ -1,7 +1,7 @@
 VERSION 5.8 ;
 DIVIDERCHAR "/" ;
 BUSBITCHARS "[]" ;
-DESIGN lambert_w_pi_elmore ;
+DESIGN dmp_ceff_dcalc_load_propagation ;
 UNITS DISTANCE MICRONS 1000 ;
 DIEAREA ( 0 0 ) ( 400000 100000 ) ;
 

--- a/src/dbSta/test/dmp_ceff_dcalc_load_propagation.def
+++ b/src/dbSta/test/dmp_ceff_dcalc_load_propagation.def
@@ -5,9 +5,10 @@ DESIGN dmp_ceff_dcalc_load_propagation ;
 UNITS DISTANCE MICRONS 1000 ;
 DIEAREA ( 0 0 ) ( 400000 100000 ) ;
 
-COMPONENTS 2 ;
+COMPONENTS 3 ;
 - u1 BUF_X1 + PLACED ( 100000 40000 ) N ;
 - u2 BUF_X1 + PLACED ( 200000 40000 ) N ;
+- u3 BUF_X1 + PLACED ( 200000 80000 ) N ;
 END COMPONENTS
 
 PINS 2 ;
@@ -19,7 +20,7 @@ END PINS
 
 NETS 3 ;
 - in ( PIN in ) ( u1 A ) + USE SIGNAL ;
-- n1 ( u1 Z ) ( u2 A ) + USE SIGNAL ;
+- n1 ( u1 Z ) ( u2 A ) ( u3 A ) + USE SIGNAL ;
 - out ( u2 Z ) ( PIN out ) + USE SIGNAL ;
 END NETS
 

--- a/src/dbSta/test/dmp_ceff_dcalc_load_propagation.tcl
+++ b/src/dbSta/test/dmp_ceff_dcalc_load_propagation.tcl
@@ -12,6 +12,7 @@ proc wire_delay { from_pin to_pin } {
 proc report_model { label calculator } {
   puts "\n=== $label ==="
   set_delay_calculator $calculator
+  estimate_parasitics -placement
   sta::find_requireds
   report_checks \
     -unconstrained \
@@ -26,12 +27,10 @@ read_lef Nangate45/Nangate45.lef
 read_liberty Nangate45/Nangate45_typ.lib
 read_def dmp_ceff_dcalc_load_propagation.def
 
-# Build PiElmore parasitics with nonzero resistance and capacitance.
+# Configure placement parasitics with nonzero resistance and capacitance.
 set_input_transition 0 [get_ports in]
 source Nangate45/Nangate45.rc
 set_wire_rc -layer metal3
-set_delay_calculator dmp_ceff_elmore
-estimate_parasitics -placement
 
 set input_port [get_ports in]
 set input_load [get_pins u1/A]
@@ -52,7 +51,7 @@ if {
   error "Elmore control did not produce positive slew and net delays"
 }
 
-# Capture the missing propagation under TwoPole.
+# Verify physical propagation with TwoPole.
 set failures {}
 report_model "TwoPole (dmp_ceff_two_pole)" dmp_ceff_two_pole
 set two_pole_input_slew [get_property $input_load slew_max_rise]
@@ -74,7 +73,7 @@ if { $two_pole_driver_slew == $two_pole_load_slew } {
   lappend failures "TwoPole: u2/A load slew equals u1/Z driver slew"
 }
 
-# Capture the same missing propagation under Lambert-W.
+# Verify physical propagation with Lambert-W.
 report_model "Lambert-W (dmp_ceff_lambert_w)" dmp_ceff_lambert_w
 set lambert_input_slew [get_property $input_load slew_max_rise]
 set lambert_input_delay [wire_delay $input_port $input_load]
@@ -95,10 +94,10 @@ if { $lambert_driver_slew == $lambert_load_slew } {
   lappend failures "Lambert-W: u2/A load slew equals u1/Z driver slew"
 }
 
-# Fail until both models propagate input-port and internal-net RC effects.
+# Verify both models propagate input-port and internal-net RC effects.
 if { [llength $failures] > 0 } {
   set failure_details [join $failures "\n  - "]
-  error "PiElmore propagation failed:\n  - $failure_details"
+  error "DMP Ceff load propagation failed:\n  - $failure_details"
 }
 
 puts "pass"

--- a/src/dbSta/test/dmp_ceff_dcalc_load_propagation.tcl
+++ b/src/dbSta/test/dmp_ceff_dcalc_load_propagation.tcl
@@ -1,4 +1,4 @@
-# Check that Lambert-W propagates nonzero slew and delay for PiElmore parasitics.
+# Check that DMP Ceff delay calculators propagate load delay and slew.
 source "helpers.tcl"
 
 proc wire_delay { from_pin to_pin } {
@@ -24,7 +24,7 @@ proc report_model { label calculator } {
 
 read_lef Nangate45/Nangate45.lef
 read_liberty Nangate45/Nangate45_typ.lib
-read_def dmp_ceff_lambert_w_pi_elmore.def
+read_def dmp_ceff_dcalc_load_propagation.def
 
 # Build PiElmore parasitics with nonzero resistance and capacitance.
 set_input_transition 0 [get_ports in]
@@ -52,7 +52,29 @@ if {
   error "Elmore control did not produce positive slew and net delays"
 }
 
-# Show the missing propagation after switching only the delay calculator.
+# Capture the missing propagation under TwoPole.
+set failures {}
+report_model "TwoPole (dmp_ceff_two_pole)" dmp_ceff_two_pole
+set two_pole_input_slew [get_property $input_load slew_max_rise]
+set two_pole_input_delay [wire_delay $input_port $input_load]
+set two_pole_driver_slew [get_property $internal_driver slew_max_rise]
+set two_pole_load_slew [get_property $internal_load slew_max_rise]
+set two_pole_internal_delay [wire_delay $internal_driver $internal_load]
+
+if { $two_pole_input_slew <= 0.0 } {
+  lappend failures "TwoPole: u1/A load slew is zero"
+}
+if { $two_pole_input_delay <= 0.0 } {
+  lappend failures "TwoPole: in -> u1/A net delay is zero"
+}
+if { $two_pole_internal_delay <= 0.0 } {
+  lappend failures "TwoPole: u1/Z -> u2/A net delay is zero"
+}
+if { $two_pole_driver_slew == $two_pole_load_slew } {
+  lappend failures "TwoPole: u2/A load slew equals u1/Z driver slew"
+}
+
+# Capture the same missing propagation under Lambert-W.
 report_model "Lambert-W (dmp_ceff_lambert_w)" dmp_ceff_lambert_w
 set lambert_input_slew [get_property $input_load slew_max_rise]
 set lambert_input_delay [wire_delay $input_port $input_load]
@@ -60,24 +82,23 @@ set lambert_driver_slew [get_property $internal_driver slew_max_rise]
 set lambert_load_slew [get_property $internal_load slew_max_rise]
 set lambert_internal_delay [wire_delay $internal_driver $internal_load]
 
-# Fail until Lambert-W propagates both input-port and internal-net RC effects.
-set failures {}
 if { $lambert_input_slew <= 0.0 } {
-  lappend failures "u1/A load slew is zero"
+  lappend failures "Lambert-W: u1/A load slew is zero"
 }
 if { $lambert_input_delay <= 0.0 } {
-  lappend failures "in -> u1/A net delay is zero"
+  lappend failures "Lambert-W: in -> u1/A net delay is zero"
 }
 if { $lambert_internal_delay <= 0.0 } {
-  lappend failures "u1/Z -> u2/A net delay is zero"
+  lappend failures "Lambert-W: u1/Z -> u2/A net delay is zero"
 }
 if { $lambert_driver_slew == $lambert_load_slew } {
-  lappend failures "u2/A load slew equals u1/Z driver slew"
+  lappend failures "Lambert-W: u2/A load slew equals u1/Z driver slew"
 }
 
+# Fail until both models propagate input-port and internal-net RC effects.
 if { [llength $failures] > 0 } {
   set failure_details [join $failures "\n  - "]
-  error "Lambert-W PiElmore propagation failed:\n  - $failure_details"
+  error "PiElmore propagation failed:\n  - $failure_details"
 }
 
 puts "pass"

--- a/src/dbSta/test/dmp_ceff_lambert_w_pi_elmore.def
+++ b/src/dbSta/test/dmp_ceff_lambert_w_pi_elmore.def
@@ -1,0 +1,26 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN lambert_w_pi_elmore ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 400000 100000 ) ;
+
+COMPONENTS 2 ;
+- u1 BUF_X1 + PLACED ( 100000 40000 ) N ;
+- u2 BUF_X1 + PLACED ( 200000 40000 ) N ;
+END COMPONENTS
+
+PINS 2 ;
+- in + NET in + DIRECTION INPUT + USE SIGNAL
+  + FIXED ( 0 40000 ) N + LAYER metal1 ( 0 0 ) ( 0 0 ) ;
+- out + NET out + DIRECTION OUTPUT + USE SIGNAL
+  + FIXED ( 300000 40000 ) N + LAYER metal1 ( 0 0 ) ( 0 0 ) ;
+END PINS
+
+NETS 3 ;
+- in ( PIN in ) ( u1 A ) + USE SIGNAL ;
+- n1 ( u1 Z ) ( u2 A ) + USE SIGNAL ;
+- out ( u2 Z ) ( PIN out ) + USE SIGNAL ;
+END NETS
+
+END DESIGN

--- a/src/dbSta/test/dmp_ceff_lambert_w_pi_elmore.tcl
+++ b/src/dbSta/test/dmp_ceff_lambert_w_pi_elmore.tcl
@@ -1,0 +1,81 @@
+# Check that Lambert-W propagates nonzero slew and delay for PiElmore parasitics.
+source "helpers.tcl"
+
+proc wire_delay { from_pin to_pin } {
+  set edges [get_timing_edges -from $from_pin -to $to_pin]
+  if { [llength $edges] != 1 } {
+    error "expected one timing edge from $from_pin to $to_pin"
+  }
+  return [get_property [lindex $edges 0] delay_max_rise]
+}
+
+proc report_model { label calculator } {
+  puts "\n=== $label ==="
+  set_delay_calculator $calculator
+  sta::find_requireds
+  report_checks \
+    -unconstrained \
+    -from [get_ports in] \
+    -to [get_ports out] \
+    -format full_clock_expanded \
+    -fields {capacitance slew fanout input_pin net} \
+    -digits 6
+}
+
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_def dmp_ceff_lambert_w_pi_elmore.def
+
+# Build PiElmore parasitics with nonzero resistance and capacitance.
+set_input_transition 0 [get_ports in]
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+set_delay_calculator dmp_ceff_elmore
+estimate_parasitics -placement
+
+set input_port [get_ports in]
+set input_load [get_pins u1/A]
+set internal_driver [get_pins u1/Z]
+set internal_load [get_pins u2/A]
+
+# Show physical propagation with the default delay calculator.
+report_model "Default (dmp_ceff_elmore)" dmp_ceff_elmore
+set elmore_input_slew [get_property $input_load slew_max_rise]
+set elmore_input_delay [wire_delay $input_port $input_load]
+set elmore_internal_delay [wire_delay $internal_driver $internal_load]
+
+if { $elmore_input_slew <= 0.0
+     || $elmore_input_delay <= 0.0
+     || $elmore_internal_delay <= 0.0 } {
+  error "Elmore control did not produce positive slew and net delays"
+}
+
+# Show the missing propagation after switching only the delay calculator.
+report_model "Lambert-W (dmp_ceff_lambert_w)" dmp_ceff_lambert_w
+set lambert_input_slew [get_property $input_load slew_max_rise]
+set lambert_input_delay [wire_delay $input_port $input_load]
+set lambert_driver_slew [get_property $internal_driver slew_max_rise]
+set lambert_load_slew [get_property $internal_load slew_max_rise]
+set lambert_internal_delay [wire_delay $internal_driver $internal_load]
+
+# Fail until Lambert-W propagates both input-port and internal-net RC effects.
+set failures {}
+if { $lambert_input_slew <= 0.0 } {
+  lappend failures "u1/A load slew is zero"
+}
+if { $lambert_input_delay <= 0.0 } {
+  lappend failures "in -> u1/A net delay is zero"
+}
+if { $lambert_internal_delay <= 0.0 } {
+  lappend failures "u1/Z -> u2/A net delay is zero"
+}
+if { $lambert_driver_slew == $lambert_load_slew } {
+  lappend failures "u2/A load slew equals u1/Z driver slew"
+}
+
+if { [llength $failures] > 0 } {
+  set failure_details [join $failures "\n  - "]
+  error "Lambert-W PiElmore propagation failed:\n  - $failure_details"
+}
+
+puts "pass"

--- a/src/dbSta/test/dmp_ceff_lambert_w_pi_elmore.tcl
+++ b/src/dbSta/test/dmp_ceff_lambert_w_pi_elmore.tcl
@@ -44,9 +44,11 @@ set elmore_input_slew [get_property $input_load slew_max_rise]
 set elmore_input_delay [wire_delay $input_port $input_load]
 set elmore_internal_delay [wire_delay $internal_driver $internal_load]
 
-if { $elmore_input_slew <= 0.0
-     || $elmore_input_delay <= 0.0
-     || $elmore_internal_delay <= 0.0 } {
+if {
+  $elmore_input_slew <= 0.0
+  || $elmore_input_delay <= 0.0
+  || $elmore_internal_delay <= 0.0
+} {
   error "Elmore control did not produce positive slew and net delays"
 }
 


### PR DESCRIPTION
## Summary
- Fixes placement RC reduction for `dmp_ceff_two_pole` and `dmp_ceff_lambert_w` delay calculators.

## Problem
- `dmp_ceff_two_pole` and `dmp_ceff_lambert_w` wrongly calculate wire load slew and delay while `dmp_ceff_elmore` calculates it correctly.

`bazel test //src/dbSta/test:dmp_ceff_dcalc_load_propagation-tcl_test --test_output=all --nocache_test_results`

```text
  === Default (dmp_ceff_elmore) ===
  Startpoint: in (input port)
  Endpoint: out (output port)
  Path Group: unconstrained
  Path Type: max

  Fanout         Cap        Slew       Delay        Time   Description
  ---------------------------------------------------------------------------------------------
                                    0.000000    0.000000 ^ input external delay
       1    8.546090    0.000000    0.000000    0.000000 ^ in (in)
                                                           in (net)
                        0.001452    0.001188    0.001188 ^ u1/A (BUF_X1)
       2   12.446165    0.029541    0.043706    0.044894 ^ u1/Z (BUF_X1)
                                                           n1 (net)
                        0.029703    0.003075    0.047969 ^ u2/A (BUF_X1)
       1    7.534790    0.019359    0.041592    0.089562 ^ u2/Z (BUF_X1)
                                                           out (net)
                        0.019370    0.001344    0.090906 ^ out (out)
                                                0.090906   data arrival time
  ---------------------------------------------------------------------------------------------
  (Path is unconstrained)



  === TwoPole (dmp_ceff_two_pole) ===
  Startpoint: in (input port)
  Endpoint: out (output port)
  Path Group: unconstrained
  Path Type: max

  Fanout         Cap        Slew       Delay        Time   Description
  ---------------------------------------------------------------------------------------------
                                    0.000000    0.000000 ^ input external delay
       1    8.546090    0.000000    0.000000    0.000000 ^ in (in)
                                                           in (net)
                        0.000000    0.000000    0.000000 ^ u1/A (BUF_X1)
       2   12.446165    0.029540    0.043105    0.043105 ^ u1/Z (BUF_X1)
                                                           n1 (net)
                        0.029540    0.000000    0.043105 ^ u2/A (BUF_X1)
       1    7.534790    0.019358    0.041559    0.084664 ^ u2/Z (BUF_X1)
                                                           out (net)
                        0.019358    0.000000    0.084664 ^ out (out)
                                                0.084664   data arrival time
  ---------------------------------------------------------------------------------------------
  (Path is unconstrained)



  === Lambert-W (dmp_ceff_lambert_w) ===
  Startpoint: in (input port)
  Endpoint: out (output port)
  Path Group: unconstrained
  Path Type: max

  Fanout         Cap        Slew       Delay        Time   Description
  ---------------------------------------------------------------------------------------------
                                    0.000000    0.000000 ^ input external delay
       1    8.546090    0.000000    0.000000    0.000000 ^ in (in)
                                                           in (net)
                        0.000000    0.000000    0.000000 ^ u1/A (BUF_X1)
       2   12.446165    0.026673    0.039863    0.039863 ^ u1/Z (BUF_X1)
                                                           n1 (net)
                        0.026673    0.000000    0.039863 ^ u2/A (BUF_X1)
       1    7.534790    0.020074    0.041402    0.081265 ^ u2/Z (BUF_X1)
                                                           out (net)
                        0.020074    0.000000    0.081265 ^ out (out)
                                                0.081265   data arrival time
  ---------------------------------------------------------------------------------------------
  (Path is unconstrained)


  Error: dmp_ceff_dcalc_load_propagation.tcl, 101 DMP Ceff load propagation failed:
    - TwoPole: u1/A load slew is zero
    - TwoPole: in -> u1/A net delay is zero
    - TwoPole: u1/Z -> u2/A net delay is zero
    - TwoPole: u2/A load slew equals u1/Z driver slew
    - Lambert-W: u1/A load slew is zero
    - Lambert-W: in -> u1/A net delay is zero
    - Lambert-W: u1/Z -> u2/A net delay is zero
    - Lambert-W: u2/A load slew equals u1/Z driver slew
```

## Cause
- `estimate_parasitics -placement` reduces RC according to delay calculator model.
- `dmp_ceff_two_pole` and `dmp_ceff_lambert_w` require `PiPoleResidue2` parasitic data while `dmp_ceff_elmore` model requires `PiElmore` parasitic data.
- However, the `reduceParasitic(..., Pin*, ...)` API of `dmp_ceff_two_pole` and `dmp_ceff_lambert_w` generates `PiElmore` parasitic data instead of `PiPoleResidue2` because the `reduceParasitic()` API overriding is missing in `DmpCeffTwoPoleDelayCalc` implementation.
-  If `PiElmore` parasitic data is wrongly fed into `dmp_ceff_two_pole` or `dmp_ceff_lambert_w` delay calculator, wire delay and slew calculation logic is skipped and the following initial values are returned.

```
  double wire_delay = 0.0;                // MAKE WIRE DELAY 0
  double load_slew = in_slew;           // LOAD SLEW = DRIVER SLEW
```

## Solution
- Override `DmpCeffTwoPoleDelayCalc::reduceParasitic()` in OpenSTA so the reduction calls `reduceToPiPoleResidue2()` instead of inheriting `PiElmore` reduction.
- Mirrors the restored virtual hook in dbSta so Lambert-W inherits the corrected TwoPole reduction path.

`bazel test //src/dbSta/test:dmp_ceff_dcalc_load_propagation-tcl_test --test_output=all --nocache_test_results`

```text
  === Default (dmp_ceff_elmore) ===
  Startpoint: in (input port)
  Endpoint: out (output port)
  Path Group: unconstrained
  Path Type: max

  Fanout         Cap        Slew       Delay        Time   Description
  ---------------------------------------------------------------------------------------------
                                    0.000000    0.000000 ^ input external delay
       1    8.546090    0.000000    0.000000    0.000000 ^ in (in)
                                                           in (net)
                        0.001452    0.001188    0.001188 ^ u1/A (BUF_X1)
       2   12.446165    0.029541    0.043706    0.044894 ^ u1/Z (BUF_X1)
                                                           n1 (net)
                        0.029703    0.003075    0.047969 ^ u2/A (BUF_X1)
       1    7.534790    0.019359    0.041592    0.089562 ^ u2/Z (BUF_X1)
                                                           out (net)
                        0.019370    0.001344    0.090906 ^ out (out)
                                                0.090906   data arrival time
  ---------------------------------------------------------------------------------------------
  (Path is unconstrained)



  === TwoPole (dmp_ceff_two_pole) ===
  Startpoint: in (input port)
  Endpoint: out (output port)
  Path Group: unconstrained
  Path Type: max

  Fanout         Cap        Slew       Delay        Time   Description
  ---------------------------------------------------------------------------------------------
                                    0.000000    0.000000 ^ input external delay
       1    8.546090    0.000000    0.000000    0.000000 ^ in (in)
                                                           in (net)
                        0.001452    0.001188    0.001188 ^ u1/A (BUF_X1)
       2   12.446165    0.029541    0.043706    0.044894 ^ u1/Z (BUF_X1)
                                                           n1 (net)
                        0.029542    0.003100    0.047994 ^ u2/A (BUF_X1)
       1    7.534790    0.019358    0.041560    0.089554 ^ u2/Z (BUF_X1)
                                                           out (net)
                        0.019358    0.001350    0.090903 ^ out (out)
                                                0.090903   data arrival time
  ---------------------------------------------------------------------------------------------
  (Path is unconstrained)



  === Lambert-W (dmp_ceff_lambert_w) ===
  Startpoint: in (input port)
  Endpoint: out (output port)
  Path Group: unconstrained
  Path Type: max

  Fanout         Cap        Slew       Delay        Time   Description
  ---------------------------------------------------------------------------------------------
                                    0.000000    0.000000 ^ input external delay
       1    8.546090    0.000000    0.000000    0.000000 ^ in (in)
                                                           in (net)
                        0.001452    0.001188    0.001188 ^ u1/A (BUF_X1)
       2   12.446165    0.026984    0.040794    0.041982 ^ u1/Z (BUF_X1)
                                                           n1 (net)
                        0.026986    0.003099    0.045082 ^ u2/A (BUF_X1)
       1    7.534790    0.020076    0.041465    0.086547 ^ u2/Z (BUF_X1)
                                                           out (net)
                        0.020076    0.001350    0.087897 ^ out (out)
                                                0.087897   data arrival time
  ---------------------------------------------------------------------------------------------
  (Path is unconstrained)


  pass
```

## Required OpenSTA fix
- https://github.com/The-OpenROAD-Project/OpenSTA/pull/407
