### PR TITLE
odb: fix dbBox::create for halos

### DIFF
--- a/src/odb/src/db/dbBox.cpp
+++ b/src/odb/src/db/dbBox.cpp
@@ -1004,7 +1004,7 @@ dbBox* dbBox::create(dbInst* inst_, int x1, int y1, int x2, int y2)
   box->flags_.octilinear = false;
   box->flags_.owner_type = dbBoxOwner::INST;
   box->owner_ = inst->getOID();
-  box->shape_.rect.init(x1, y1, x2, y2);
+  box->shape_.rect.reset(x1, y1, x2, y2);
   inst->halo_ = box->getOID();
   return (dbBox*) box;
 }


### PR DESCRIPTION
## Summary
The current `dbBox::create` uses `Rect::init` to create the box that will store halo information, `init` however uses minmax functions to create "valid" boxes, leading to errors in assignment of halos. This is fixed by using `reset` instead, since it simply assigns the values properly. 

## Type of Change
- Bug fix

## Impact
Halos are now correctly created.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
[#11062](https://github.com/The-OpenROAD-Project/OpenROAD/issues/11062)