### PR TITLE
odb: ensure that if a bterm fully overlaps with a cover bump, `orderWires` uses the bterm to anchor the wire

### DIFF
--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -58,6 +58,13 @@ static void tmg_getDriveTerm(dbNet* net, dbITerm** iterm, dbBTerm** bterm)
   }
 }
 
+bool tmg_rcterm::isBumpPin() const
+{
+  return iterm
+         && iterm->getInst()->getMaster()->getType()
+                == dbMasterType::COVER_BUMP;
+}
+
 tmg_conn::tmg_conn(utl::Logger* logger) : logger_(logger)
 {
   rcV_.reserve(1024);
@@ -494,6 +501,12 @@ void tmg_conn::detachTilePins()
     for (int k = 0; !sliceDone && k < termV_.size(); k++) {
       tmg_rcterm* tx = &termV_[k];
       if (tx->bterm) {
+        continue;
+      }
+      if (tx->isBumpPin()) {
+        // A bump pad pin is a special case, because a bterm with the same
+        // geometry should exist and be the actual terminal of this point.
+        // Based on that, we don't need to detach the bterm from it.
         continue;
       }
       dbMTerm* mterm = tx->iterm->getMTerm();
@@ -1003,8 +1016,19 @@ static void removePointFromTerm(tmg_rcpt* pt, tmg_rcterm* x)
   pt->next_for_term = nullptr;
 }
 
+void tmg_conn::replaceBumpPinByBTerm(tmg_rcpt& pt)
+{
+  termV_[pt.tindex].replaced_by_bterm = true;
+  removePointFromTerm(&pt, &termV_[pt.tindex]);
+  pt.tindex = -1;
+}
+
 void tmg_conn::connectTerm(const int j, const bool soft)
 {
+  if (termV_[j].replaced_by_bterm) {
+    return;
+  }
+
   csV_ = &csVV_[j];
   csN_ = csNV_[j];
   if (!csN_) {
@@ -1123,6 +1147,9 @@ void tmg_conn::connectTerm(const int j, const bool soft)
         removePointFromTerm(pt, &termV_[pt->tindex]);
         pt->tindex = -1;
       }
+      if (pt->tindex >= 0 && x->bterm && termV_[pt->tindex].isBumpPin()) {
+        replaceBumpPinByBTerm(*pt);
+      }
       if (pt->tindex >= 0) {
         logger_->error(ODB,
                        390,
@@ -1152,6 +1179,9 @@ void tmg_conn::connectTerm(const int j, const bool soft)
         // override old connection if it is on the other
         removePointFromTerm(pt, &termV_[pt->tindex]);
         pt->tindex = -1;
+      }
+      if (pt->tindex >= 0 && x->bterm && termV_[pt->tindex].isBumpPin()) {
+        replaceBumpPinByBTerm(*pt);
       }
       if (pt->tindex >= 0) {
         logger_->error(ODB,
@@ -1188,6 +1218,9 @@ void tmg_conn::connectTerm(const int j, const bool soft)
         // override old connection if it is on the other
         removePointFromTerm(pt, &termV_[pt->tindex]);
         pt->tindex = -1;
+      }
+      if (pt->tindex >= 0 && x->bterm && termV_[pt->tindex].isBumpPin()) {
+        replaceBumpPinByBTerm(*pt);
       }
       if (pt->tindex >= 0) {
         logger_->error(ODB,
@@ -1360,7 +1393,7 @@ void tmg_conn::analyzeNet(dbNet* net)
 bool tmg_conn::checkConnected()
 {
   for (const tmg_rcterm& x : termV_) {
-    if (x.pt == nullptr) {
+    if (x.pt == nullptr && !x.replaced_by_bterm) {
       return false;
     }
   }
@@ -1435,7 +1468,7 @@ bool tmg_conn::checkConnected()
   }
   bool con = true;
   for (tmg_rcterm& x : termV_) {
-    if (!x.first_pt) {
+    if (!x.first_pt && !x.replaced_by_bterm) {
       con = false;
     }
     x.first_pt = nullptr;  // cleanup
@@ -1464,7 +1497,7 @@ void tmg_conn::treeReorder(const bool no_convert)
   }
   for (tmg_rcterm& x : termV_) {
     x.first_pt = nullptr;
-    if (x.pt == nullptr) {
+    if (x.pt == nullptr && !x.replaced_by_bterm) {
       connected_ = false;
     }
   }

--- a/src/odb/src/db/tmg_conn.h
+++ b/src/odb/src/db/tmg_conn.h
@@ -103,10 +103,18 @@ struct tmg_rcterm
 {
   tmg_rcterm(dbITerm* iterm) : iterm(iterm), bterm(nullptr) {}
   tmg_rcterm(dbBTerm* bterm) : iterm(nullptr), bterm(bterm) {}
+
+  bool isBumpPin() const;
+
   dbITerm* const iterm;
   dbBTerm* const bterm;
   tmg_rcpt* pt;        // list of points
   tmg_rcpt* first_pt;  // first point in dfs
+
+  // This is a PAD terminal that should be ignored, because there
+  // is a bterm with the same placement which is the terminal that
+  // actually exercises the logical connection.
+  bool replaced_by_bterm{false};
 };
 
 struct tmg_rcshort
@@ -191,6 +199,7 @@ class tmg_conn
   void connectShapes(int j, int k);
   void connectTerm(int j, bool soft);
   void connectTermSoft(int j, int rt, Rect& rect, int k);
+  void replaceBumpPinByBTerm(tmg_rcpt& pt);
   void addShort(int i0, int i1);
   void relocateShorts();
   void setSring();

--- a/src/odb/test/cpp/TestOrderWires.cpp
+++ b/src/odb/test/cpp/TestOrderWires.cpp
@@ -71,6 +71,26 @@ class TestOrderWires : public tst::Fixture
     return bump_net;
   }
 
+  dbMaster* createBumpMaster()
+  {
+    dbLib* lib = dbLib::create(db_.get(), "bump_lib", db_->getTech(), ',');
+    dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
+
+    dbMaster* bump_master = dbMaster::create(lib, "bump_pad");
+    bump_master->setWidth(4000);
+    bump_master->setHeight(4000);
+    bump_master->setType(dbMasterType::COVER_BUMP);
+
+    dbMTerm* bump_mterm = dbMTerm::create(
+        bump_master, "PAD", dbIoType::INOUT, dbSigType::SIGNAL);
+    dbMPin* bump_mpin = dbMPin::create(bump_mterm);
+    dbBox::create(bump_mpin, metal1, 0, 0, 4000, 4000);
+
+    bump_master->setFrozen();
+
+    return bump_master;
+  }
+
   dbBlock* block_;
 };
 
@@ -117,6 +137,95 @@ TEST_F(TestOrderWires, InputBumpNetWithPatchAtTheBeginning)
   EXPECT_EQ(y, bump_net.receiver_y);
   EXPECT_EQ(decoder.next(), dbWireDecoder::ITERM);
   EXPECT_EQ(decoder.getITerm(), bump_net.receiver_iterm);
+
+  EXPECT_EQ(decoder.next(), dbWireDecoder::END_DECODE);
+}
+
+// A bterm has the exact same geometry as a bump pad pin of its net, so
+// the bterm is the terminal that actually exercises the logical connection:
+//
+//  receiver                         bump
+//                                   +-------------------------+
+//  +-----------+                    | PAD pin (the bterm pin  |
+//  |         A o--------------------o has the same box)       |
+//  +-----------+       wire         |                         |
+//                                   +-------------------------+
+//
+// The wire should be anchored at the bterm, not the bump pin.
+TEST_F(TestOrderWires, UseBTermInsteadOfBumpIterm)
+{
+  dbTechLayer* metal1 = db_->getTech()->findLayer("metal1");
+
+  dbInst* receiver = makeInst(block_,
+                              db_->findMaster("INV_X1"),
+                              "receiver",
+                              {.location = {10000, 10000},
+                               .status = dbPlacementStatus::PLACED,
+                               .iterms = {{"net", "A"}}});
+
+  dbITerm* receiver_iterm = receiver->findITerm("A");
+  int receiver_x, receiver_y;
+  receiver_iterm->getAvgXY(&receiver_x, &receiver_y);
+
+  // Align the bump pad y center with the receiver pin so a single horizontal
+  // segment connects them.
+  dbMaster* bump_master = createBumpMaster();
+  const int bump_y = receiver_y - bump_master->getHeight() / 2;
+  dbInst* bump = makeInst(block_,
+                          bump_master,
+                          "bump",
+                          {.location = {50000, bump_y},
+                           .status = dbPlacementStatus::PLACED,
+                           .iterms = {{"net", "PAD"}}});
+
+  const Rect bump_pin_shape = bump->findITerm("PAD")->getBBox();
+  dbBTerm* bterm = makeBTerm(block_,
+                             "net",
+                             {.io_type = dbIoType::INPUT,
+                              .bpins = {{.layer_name = "metal1",
+                                         .rect = bump_pin_shape,
+                                         .status = dbPlacementStatus::FIRM}}});
+
+  dbNet* net = block_->findNet("net");
+  const int pad_x = bump_pin_shape.xCenter();
+  const int pad_y = bump_pin_shape.yCenter();
+
+  dbWire* wire = dbWire::create(net);
+  dbWireEncoder encoder;
+  encoder.begin(wire);
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(receiver_x, receiver_y);
+  encoder.addPoint(pad_x, pad_y);
+  encoder.end();
+
+  orderWires(&logger_, block_);
+  EXPECT_TRUE(net->isWireOrdered());
+
+  // Despite the name, isDisconnected does not mean the net lost a connection:
+  // it only tells that the ordered wire failed to reach every terminal. A
+  // replaced bump pin must not be counted as such a terminal.
+  EXPECT_FALSE(net->isDisconnected());
+
+  dbWireDecoder decoder;
+  decoder.begin(net->getWire());
+  EXPECT_EQ(decoder.next(), dbWireDecoder::PATH);
+
+  // Operation codes of the bterm.
+  EXPECT_EQ(decoder.next(), dbWireDecoder::POINT);
+  int x, y;
+  decoder.getPoint(x, y);
+  EXPECT_EQ(x, pad_x);
+  EXPECT_EQ(y, pad_y);
+  EXPECT_EQ(decoder.next(), dbWireDecoder::BTERM);
+  EXPECT_EQ(decoder.getBTerm(), bterm);
+
+  // Operation codes of the receiver's terminal.
+  EXPECT_EQ(decoder.next(), dbWireDecoder::POINT);
+  decoder.getPoint(x, y);
+  EXPECT_EQ(x, receiver_x);
+  EXPECT_EQ(y, receiver_y);
+  EXPECT_EQ(decoder.next(), dbWireDecoder::ITERM);
+  EXPECT_EQ(decoder.getITerm(), receiver_iterm);
 
   EXPECT_EQ(decoder.next(), dbWireDecoder::END_DECODE);
 }


### PR DESCRIPTION
Resolve #11015.

## Summary
If a bpin has the exact same shape of (i.e., fully overlaps with) a cover bump, `orderWires` will fail, because its model considers that each wire point must belong to a single terminal. This type of situation can happen when a bterm is only logically defined in a DEF **and** the mechanism on [#11233](https://github.com/The-OpenROAD-Project/OpenROAD/pull/11233) is used to create a geometry for the bterm from the cover bump.

**This PR adds support for such a situation**: it ensures that, when a cover bump and a bterm fully overlap and therefore sit on the same wire point, _the terminal that actually exercises the logical connection is the bterm, so it should be the one to anchor the wire._

That said, the changes here touch three internal `orderWires` mechanisms:

#### 1. The overlapping-pin pre-pass: `detachTilePins`

Before any pin is connected, `orderWires` compares every bterm shape against the iterm shapes of the same net. An iterm is real metal and cannot move; a bterm's shape is only a marker of where the block connects. So when the two overlap, the pass shrinks the marker down to the part that sticks out of the iterm, and each terminal ends up with a region of its own.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/e58f008c-e7d1-445f-a138-f66f4a657db4" /> <br>

A marker fully inside an iterm has no such region, and that case is an error.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/29265d1c-de19-4aee-8ec9-102621aa30dd" /> <br>

**What changed:** bump iterms are skipped by this pass. A bterm placed over a bump keeps its full shape — shrinking it makes no sense when the bterm is meant to be the terminal of exactly that spot — and the containment error no longer applies to it.

#### 2. The pin connection pass: `connectTerm`

This pass attaches each terminal to the wire: it finds the wire points that fall inside each pin shape and records the terminal on them, one terminal per wire point. When a point is already taken, the pass tries to relocate the earlier claim; if nothing frees the point, the net is reported as a short between two terminals — and when one pin shape lies entirely inside the other, that is guaranteed: any wire point the inner shape contains, both shapes contain.

**What changed:** when the point holder is a bump iterm and the claimer is the bterm, the bterm takes the point over. The bump iterm is marked as replaced and stays off the wire; every other kind of double claim is still reported as before.

#### 3. The connectivity checkers: `checkConnected` and `treeReorder`

After connecting, `orderWires` verifies that every terminal owns a point and that the wire reaches all of them. A terminal that owns nothing makes the net count as not fully connected, which triggers a retry that attaches leftover terminals to the nearest wire point, and marks the net as disconnected if that also fails.

**What changed:** a replaced bump iterm is skipped. It owns no wire point on purpose, so it must not drag the net into the retry — which would glue it back to some arbitrary nearby point — nor make the net read as disconnected.

## Type of Change
- New feature

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues

