### PR TITLE
web: render layers at the same color as the Qt GUI

### DIFF
--- a/src/web/src/capture.js
+++ b/src/web/src/capture.js
@@ -243,12 +243,12 @@ async function renderToBlob(app) {
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext('2d');
-    // Background matches the viewer (--bg-map); fall back to #111 when the
+    // Background matches the viewer (--bg-map); fall back to #000 when the
     // computed color is empty or fully transparent (both would export a
     // transparent PNG, hiding light elements on white viewers).
     const bg = getComputedStyle(container).backgroundColor;
     ctx.fillStyle = (bg && bg !== 'transparent' && bg !== 'rgba(0, 0, 0, 0)')
-        ? bg : '#111';
+        ? bg : '#000';
     ctx.fillRect(0, 0, w, h);
     drawGridLayers(app, ctx, mapRect);
     drawImageOverlays(app, ctx, mapRect);

--- a/src/web/src/device-pixels.js
+++ b/src/web/src/device-pixels.js
@@ -15,9 +15,10 @@
 // exact) and why they reproduce on both the merged-canvas and the legacy <img>
 // path — this is the browser's layout, not anything either path draws.
 //
-// Overlapping the tiles instead would be worse: routing layers render at 0.7
-// opacity, so an overlapping strip blends twice and a dark seam becomes a bright
-// one. They have to abut exactly, which is what landing on the grid gives.
+// Overlapping the tiles instead would be worse: routing-layer pixels are
+// semi-transparent, so an overlapping strip blends twice and a dark seam becomes
+// a bright one. They have to abut exactly, which is what landing on the grid
+// gives.
 //
 // Why this measures the DOM rather than patching Leaflet: leaflet-src.js keeps
 // setTransform/setPosition as closure-local functions and only publishes

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -121,20 +121,24 @@ export function populateDisplayControls(app, visibility, selectability,
     // A routing layer, as the tree sees it.  In legacy mode this IS the Leaflet
     // layer; in merged mode it is an adapter over one entry of a pane's draw
     // list, exposing the same three things the tree uses.
+    //
+    // Routing layers are drawn at full pane opacity.  The layer transparency is
+    // already baked into the tile: the server paints layer shapes with the
+    // palette alpha of 180/255 (tile_generator.cpp buildLayerColorMap), the same
+    // alpha displayControls.cpp gives the Qt GUI's brush.  Dimming the pane on
+    // top of that would apply the transparency a second time and render the
+    // layout darker than the Qt GUI.
     function makeRoutingLayer(name, zIndex) {
         if (!mergedLayerClass) {
             const layer = new WebSocketTileLayer(app.websocketManager, name, {
-                opacity: 0.7,
+                opacity: 1,
                 zIndex,
             });
             layer._orShow = () => layer.addTo(app.map);
             layer._orHide = () => app.map.removeLayer(layer);
             return layer;
         }
-        // 0.7 matches the legacy per-layer pane opacity.  It is applied inside
-        // the merged canvas; the pane itself must stay opaque or every layer
-        // gets multiplied by 0.7 twice (see MERGED_PANE_OPACITY).
-        const item = { layer: name, opacity: 0.7, visible: false };
+        const item = { layer: name, opacity: 1, visible: false };
         return {
             _orItem: item,
             _orPane: null,

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -1,5 +1,11 @@
 /* ─── Theme Variables ─────────────────────────────────────────────────────── */
 
+/* --bg-map is black in both themes to match the Qt GUI's default background
+   (displayControls.cpp, background_color_ = Qt::black).  Layer shapes are drawn
+   semi-transparent (alpha 180/255), so the background shows through them and
+   any difference here shifts every rendered color away from the Qt GUI's.  It
+   remains user-settable through the Background control. */
+
 html[data-theme="dark"] {
     --bg-main: #1e1e1e;
     --bg-panel: #252525;
@@ -16,7 +22,7 @@ html[data-theme="dark"] {
     --bg-tooltip: rgba(30, 30, 30, 0.95);
     --bg-heatmap-legend: rgba(18, 20, 24, 0.88);
     --bg-rubber-band: rgba(255, 255, 255, 0.1);
-    --bg-map: #111;
+    --bg-map: #000;
 
     --fg-primary: #ccc;
     --fg-secondary: #aaa;
@@ -75,7 +81,7 @@ html[data-theme="light"] {
     --bg-tooltip: rgba(255, 255, 255, 0.95);
     --bg-heatmap-legend: rgba(255, 255, 255, 0.92);
     --bg-rubber-band: rgba(0, 120, 212, 0.15);
-    --bg-map: #111;
+    --bg-map: #000;
 
     --fg-primary: #1e1e1e;
     --fg-secondary: #444;

--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -79,13 +79,14 @@ export function resetBackgroundColor(app) {
 }
 
 // The active theme's own --bg-map value in the "#rrggbb" form an
-// <input type="color"> requires (currently #111 in both themes).
+// <input type="color"> requires (#000 in both themes, matching the Qt GUI's
+// default background so the same layer alpha composites to the same color).
 // Must be read with no inline override active — resetBackgroundColor
 // removes it — otherwise the override value is returned instead.
 export function getThemeDefaultBgColor() {
     return cssColorToHex(
         getComputedStyle(document.documentElement)
-            .getPropertyValue('--bg-map')) ?? '#111111';
+            .getPropertyValue('--bg-map')) ?? '#000000';
 }
 
 // The layout container reads --bg-map live via CSS, but the 3D viewer

--- a/src/web/src/tile-merge.js
+++ b/src/web/src/tile-merge.js
@@ -35,12 +35,13 @@
 
 // ─── Opacity ────────────────────────────────────────────────────────────────
 //
-// Today each layer's opacity is applied by Leaflet to the layer's CONTAINER div,
-// not to the individual tile images: GridLayer._updateOpacity() calls
-// setOpacity(this._container, this.options.opacity).  The values differ per
-// layer — routing layers are created at 0.7, while _instances, _pins and
-// _modules are left at the default 1 — so the merge has to carry opacity
-// per item and cannot assume a single value.
+// Each layer's opacity is applied by Leaflet to the layer's CONTAINER div, not
+// to the individual tile images: GridLayer._updateOpacity() calls
+// setOpacity(this._container, this.options.opacity).  Every layer is created at
+// 1 — layer transparency lives in the tile pixels themselves, painted with the
+// palette alpha the Qt GUI uses — but the merge still carries opacity per item
+// rather than assuming one value, so a pane that does want partial opacity
+// composites correctly.
 //
 // Group opacity on a container is NOT generally the same thing as per-image
 // alpha: a group is rasterized at full alpha and then blended once, so anywhere
@@ -55,10 +56,10 @@
 // DO overlap.  That is pre-existing behaviour at the layer level and applies
 // equally to a merged pane, so it is not made worse here.)
 //
-// The trap: the merged result is itself a tile inside a pane.  If that pane also
-// carried opacity 0.7, every source would be multiplied by 0.7 twice — 0.49 —
-// and the view would wash out.  The per-layer opacities now live INSIDE the
-// canvas, so the pane holding it must be fully opaque.
+// The trap: the merged result is itself a tile inside a pane.  If that pane
+// carried a source's opacity too, every source would be multiplied by it twice
+// — 0.7 becomes 0.49 — and the view would wash out.  The per-layer opacities
+// live INSIDE the canvas, so the pane holding it must be fully opaque.
 export const MERGED_PANE_OPACITY = 1;
 
 // Build the Leaflet options for a merged pane, so a caller cannot forget the

--- a/src/web/test/js/test-display-controls.js
+++ b/src/web/test/js/test-display-controls.js
@@ -421,3 +421,98 @@ describe('layer row selection', () => {
            assert.equal(m1.classList.contains('vis-row-selected'), false);
        });
 });
+
+describe('routing layer opacity', () => {
+    // Layer transparency is baked into the tile pixels: the server paints
+    // layer shapes at the palette alpha of 180/255, the same alpha the Qt GUI
+    // brush carries (displayControls.cpp).  A pane opacity below 1 would apply
+    // that transparency a second time — 0.7 * 180/255 = 0.49 instead of 0.71 —
+    // and the browser would render the layout ~30% darker than the Qt GUI.
+    // Pinned on both paths because the legacy panes and the merged draw list
+    // set the value independently.
+    let created, mergedItems, app, techData;
+
+    class RecordingTileLayer {
+        constructor(wm, name, opts) {
+            created.push({ name, opts: opts || {} });
+            this.name = name;
+            this.options = opts || {};
+        }
+        addTo() { return this; }
+        refreshTiles() {}
+    }
+    class RecordingMergedLayer {
+        constructor(wm, items, opts) {
+            mergedItems.push(...items);
+            this.options = opts || {};
+        }
+        addTo() { return this; }
+        refreshTiles() {}
+        setItems() {}
+    }
+
+    beforeEach(() => {
+        created = [];
+        mergedItems = [];
+        window.sessionStorage.clear();
+        app = {
+            displayControlsEl: document.createElement('div'),
+            allLayers: [],
+            visibleLayers: new Set(),
+            visibleLayerNames: new Set(),
+            selectableLayers: new Set(),
+            layerPatterns: {},
+            visibleChiplets: null,
+            hasLiberty: false,
+            showDbu: false,
+            map: {
+                hasLayer: () => false,
+                removeLayer() {},
+                getContainer: () => document.createElement('div'),
+                on() {},
+            },
+            websocketManager: { request: () => Promise.resolve({}) },
+            updateInspector: () => {},
+            focusComponent: () => {},
+            refreshOverlay: () => {},
+        };
+        techData = {
+            layers: ['metal1', 'metal2'],
+            sites: [],
+            chiplets: [{ path: 'top', name: 'top', parent: null, depth: 0 }],
+            layer_hierarchy: {
+                name: 'top',
+                type: 'block',
+                path: 'top',
+                layers: [
+                    { name: 'metal1', color: [1, 2, 3] },
+                    { name: 'metal2', color: [4, 5, 6] },
+                ],
+                instances: [],
+            },
+        };
+    });
+
+    const render = () => populateDisplayControls(
+        app, {}, {}, RecordingTileLayer, techData, () => {}, class {});
+
+    it('creates legacy per-layer panes fully opaque', () => {
+        render();
+        const routing = created.filter(l => l.name.startsWith('metal'));
+        assert.ok(routing.length >= 2, 'metal layers should get panes');
+        for (const layer of routing) {
+            assert.equal(layer.opts.opacity, 1, layer.name);
+        }
+    });
+
+    it('gives merged draw items an opacity of 1', () => {
+        app.mergeTiles = true;
+        app.MergedTileLayer = RecordingMergedLayer;
+        render();
+        const routing = mergedItems.filter(i => i.layer.startsWith('metal'));
+        assert.ok(routing.length >= 2, 'metal layers should reach the merge');
+        for (const item of routing) {
+            assert.equal(item.opacity, 1, item.layer);
+        }
+    });
+});

--- a/src/web/test/js/test-tile-merge.js
+++ b/src/web/test/js/test-tile-merge.js
@@ -340,9 +340,11 @@ describe('describePlan', () => {
 });
 
 describe('opacity semantics (Leaflet applies it to the container div)', () => {
-    // The layer opacities in play today: routing layers are created at 0.7,
-    // while _instances / _pins / _modules keep the default 1.
-    const ROUTING = 0.7;
+    // Every layer is created opaque today (transparency lives in the tile
+    // pixels), so a partial opacity is exercised here as a stand-in: the
+    // associativity these tests pin down is what keeps the merge honest if a
+    // pane ever does carry one.
+    const PARTIAL = 0.7;
 
     const A = [200, 40, 40, 255];    // opaque red-ish layer
     const B = [40, 200, 40, 180];    // partly transparent green-ish layer
@@ -362,9 +364,9 @@ describe('opacity semantics (Leaflet applies it to the container div)', () => {
         // associative, so rasterizing a contiguous run into one image and
         // drawing that image is identical to drawing the run's members in order.
         const stack = [
-            { rgba: A, opacity: ROUTING },
-            { rgba: B, opacity: ROUTING },
-            { rgba: C, opacity: ROUTING },
+            { rgba: A, opacity: PARTIAL },
+            { rgba: B, opacity: PARTIAL },
+            { rgba: C, opacity: PARTIAL },
         ];
         const direct = compositeStack(stack, BG);
 
@@ -376,13 +378,13 @@ describe('opacity semantics (Leaflet applies it to the container div)', () => {
         near(viaGroup, direct, 1e-9, 'grouped vs direct');
     });
 
-    it('holds when the group mixes opacities, as the real stack does', () => {
-        // _instances at 1 underneath routing layers at 0.7 — grouping those
+    it('holds when the group mixes opacities', () => {
+        // An opaque pane under two partly transparent ones — grouping those
         // together must not change the result.
         const stack = [
             { rgba: C, opacity: 1 },        // _instances
-            { rgba: A, opacity: ROUTING },  // metal1
-            { rgba: B, opacity: ROUTING },  // metal2
+            { rgba: A, opacity: PARTIAL },  // metal1
+            { rgba: B, opacity: PARTIAL },  // metal2
         ];
         const direct = compositeStack(stack, BG);
         const merged = compositeStack(stack, [0, 0, 0, 0]);
@@ -394,8 +396,8 @@ describe('opacity semantics (Leaflet applies it to the container div)', () => {
         // must give the same answer — otherwise the choice of N would change
         // what the user sees.
         const stack = [
-            { rgba: A, opacity: ROUTING },
-            { rgba: B, opacity: ROUTING },
+            { rgba: A, opacity: PARTIAL },
+            { rgba: B, opacity: PARTIAL },
             { rgba: C, opacity: 1 },
             { rgba: A, opacity: 0.5 },
         ];
@@ -410,16 +412,17 @@ describe('opacity semantics (Leaflet applies it to the container div)', () => {
     });
 
     it('DOUBLE-APPLIES if the merged pane keeps the layer opacity', () => {
-        // The trap: leaving the merged pane at 0.7 multiplies every source by
-        // 0.7 twice (0.49) and washes the view out. Pinned as a real numeric
+        // The trap: leaving the merged pane at a source's opacity multiplies
+        // every source by it twice (0.7 -> 0.49) and washes the view out. Pinned
+        // as a real numeric
         // difference so the guard cannot be quietly dropped.
-        const stack = [{ rgba: A, opacity: ROUTING },
-                       { rgba: B, opacity: ROUTING }];
+        const stack = [{ rgba: A, opacity: PARTIAL },
+                       { rgba: B, opacity: PARTIAL }];
         const direct = compositeStack(stack, BG);
         const merged = compositeStack(stack, [0, 0, 0, 0]);
 
         const correct = blendOver(BG, merged, MERGED_PANE_OPACITY);
-        const doubled = blendOver(BG, merged, ROUTING);
+        const doubled = blendOver(BG, merged, PARTIAL);
         near(correct, direct, 1e-9);
         assert.ok(Math.abs(doubled[3] - direct[3]) > 1,
                   'a pane opacity of 0.7 must visibly differ — it is the bug');


### PR DESCRIPTION
The web viewer rendered the layout noticeably darker than the Qt GUI.

Layer transparency is already in the tile pixels: the server paints layer shapes at the palette alpha of 180/255, the same alpha `displayControls.cpp` gives the Qt GUI's brush. The viewer then dimmed each routing pane to 0.7 on top of that, applying the transparency a second time — `0.7 * 180/255 = 0.49` against the GUI's `0.71`, about 30% darker. The routing panes are now created opaque, on both the legacy per-layer path and the merged draw list.

That left the background showing through the alpha: the GUI defaults to black while `--bg-map` was `#111`, lifting every channel by `(1 - 180/255) * 17 = 5`. On Nangate45 gcd a metal7 stripe — base color `(253, 108, 160)` in both palettes — came out `#b34c71` in the GUI and `#b85176` in the browser. `--bg-map` now defaults to black in both themes, and stays user-settable through the Background control.

Two guard tests pin the pane opacity at 1 on both paths, with the arithmetic in the comment; they fail if the 0.7 comes back.