### PR TITLE
odb: remove bloat, merge, and difference from Polygon

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -45,6 +45,7 @@
 #include "odb/dbTypes.h"
 #include "odb/dbWireGraph.h"
 #include "odb/geom.h"
+#include "odb/geom_boost.h"
 #ifdef ENABLE_QT
 #include "options.h"
 #endif
@@ -1736,7 +1737,8 @@ void DbNetDescriptor::highlight(const std::any& object, Painter& painter) const
           }
           painter.saveState();
           painter.setBrush(painter.getPenColor(), gui::Painter::Brush::kNone);
-          for (const odb::Polygon& outline : odb::Polygon::merge(guide_rects)) {
+          for (const odb::Polygon& outline : odb::geom::extractPolygons(
+                   odb::geom::toPolygonSet(guide_rects))) {
             painter.drawPolygon(outline);
           }
           painter.restoreState();

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1737,8 +1737,8 @@ void DbNetDescriptor::highlight(const std::any& object, Painter& painter) const
           }
           painter.saveState();
           painter.setBrush(painter.getPenColor(), gui::Painter::Brush::kNone);
-          for (const odb::Polygon& outline : odb::geom::extractPolygons(
-                   odb::geom::toPolygonSet(guide_rects))) {
+          for (const odb::Polygon& outline :
+               odb::geom::mergePolygons(guide_rects)) {
             painter.drawPolygon(outline);
           }
           painter.restoreState();

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -485,15 +485,6 @@ class Polygon
   // returns a corrected Polygon with a closed form and counter-clockwise points
   Polygon bloat(int margin) const;
 
-  // Merge a collection of shapes
-  static std::vector<Polygon> merge(const std::vector<Polygon>& polys);
-  static std::vector<Polygon> merge(const std::vector<Rect>& rects);
-  static std::vector<Polygon> merge(const std::vector<Oct>& octs);
-
-  // Returns the geometric difference between this polygon "a" and polygon "b"
-  // results in a vector of polygons.
-  std::vector<Polygon> difference(Polygon b) const;
-
   friend dbIStream& operator>>(dbIStream& stream, Polygon& p);
   friend dbOStream& operator<<(dbOStream& stream, const Polygon& p);
 

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -482,9 +482,6 @@ class Polygon
   int dx() const { return getEnclosingRect().dx(); }
   int dy() const { return getEnclosingRect().dy(); }
 
-  // returns a corrected Polygon with a closed form and counter-clockwise points
-  Polygon bloat(int margin) const;
-
   friend dbIStream& operator>>(dbIStream& stream, Polygon& p);
   friend dbOStream& operator<<(dbOStream& stream, const Polygon& p);
 

--- a/src/odb/include/odb/geom_boost.h
+++ b/src/odb/include/odb/geom_boost.h
@@ -546,4 +546,12 @@ Rect getEnclosingRect(const BoostShapeType& shape)
   return rect;
 }
 
+// Merge a collection of shapes into a single set of polygons.  Overlapping
+// shapes are unioned together, and the result is decomposed back into polygons.
+template <AreaShape T>
+std::vector<Polygon> mergePolygons(const std::vector<T>& shapes)
+{
+  return extractPolygons(toPolygonSet(shapes));
+}
+
 }  // namespace odb::geom

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -30,6 +30,7 @@
 #include <utility>
 #include <vector>
 
+#include "boost/polygon/polygon.hpp"
 #include "dbAccessPoint.h"
 #include "dbBPin.h"
 #include "dbBPinItr.h"
@@ -2320,6 +2321,8 @@ void dbBlock::setDieArea(const Rect& new_area)
 
 void dbBlock::setDieArea(const Polygon& new_area)
 {
+  using boost::polygon::operators::operator-;
+
   _dbBlock* block = (_dbBlock*) this;
   block->die_area_ = new_area;
   for (auto callback : block->callbacks_) {
@@ -2342,9 +2345,10 @@ void dbBlock::setDieArea(const Polygon& new_area)
   // into rectangles. Which are then used to create obstructions and
   // placement blockages.
 
-  Polygon bounding_rect = block->die_area_.getEnclosingRect();
-  std::vector<Polygon> results = bounding_rect.difference(block->die_area_);
-  for (odb::Polygon& blockage_area : results) {
+  const Polygon bounding_rect = block->die_area_.getEnclosingRect();
+  const std::vector<Polygon> results = geom::extractPolygons(
+      geom::toPolygonSet(bounding_rect) - geom::toPolygonSet(block->die_area_));
+  for (const odb::Polygon& blockage_area : results) {
     std::vector<Rect> blockages;
     decompose_polygon(blockage_area.getPoints(), blockages);
     for (odb::Rect& blockage_rect : blockages) {
@@ -2420,7 +2424,7 @@ Polygon dbBlock::computeCoreArea()
   }
 
   if (!rows.empty()) {
-    const auto polys = Polygon::merge(rows);
+    const auto polys = geom::extractPolygons(geom::toPolygonSet(rows));
 
     if (polys.size() > 1) {
       odb::Rect area;

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -2424,7 +2424,7 @@ Polygon dbBlock::computeCoreArea()
   }
 
   if (!rows.empty()) {
-    const auto polys = geom::extractPolygons(geom::toPolygonSet(rows));
+    const auto polys = geom::mergePolygons(rows);
 
     if (polys.size() > 1) {
       odb::Rect area;

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "boost/geometry/geometry.hpp"
-#include "boost/polygon/polygon.hpp"
 #include "odb/geom_boost.h"
 
 namespace odb {
@@ -15,21 +14,6 @@ void Polygon::setPoints(const std::vector<Point>& points)
 {
   points_ = points;
   boost::geometry::correct(points_);
-}
-
-Polygon Polygon::bloat(int margin) const
-{
-  using boost::polygon::operators::operator+;
-
-  // bloat polygon set
-  const geom::BoostPolygonSet poly_out_set = geom::toPolygonSet(*this) + margin;
-
-  // extract new polygon
-  const auto polygons = geom::extractPolygons(poly_out_set);
-  if (polygons.empty()) {
-    return Polygon();
-  }
-  return polygons[0];
 }
 
 }  // namespace odb

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -32,33 +32,4 @@ Polygon Polygon::bloat(int margin) const
   return polygons[0];
 }
 
-std::vector<Polygon> Polygon::merge(const std::vector<Oct>& octs)
-{
-  std::vector<Polygon> polys(octs.begin(), octs.end());
-  return Polygon::merge(polys);
-}
-
-std::vector<Polygon> Polygon::merge(const std::vector<Rect>& rects)
-{
-  std::vector<Polygon> polys(rects.begin(), rects.end());
-  return Polygon::merge(polys);
-}
-
-std::vector<Polygon> Polygon::merge(const std::vector<Polygon>& polys)
-{
-  // extract the merged polygons
-  return geom::extractPolygons(geom::toPolygonSet(polys));
-}
-
-std::vector<Polygon> Polygon::difference(Polygon b) const
-{
-  using boost::polygon::operators::operator-;
-
-  const geom::BoostPolygonSet difference_set
-      = geom::toPolygonSet(*this) - geom::toPolygonSet(b);
-
-  // extract new polygons
-  return geom::extractPolygons(difference_set);
-}
-
 }  // namespace odb

--- a/src/odb/test/cpp/TestGeom.cpp
+++ b/src/odb/test/cpp/TestGeom.cpp
@@ -140,19 +140,6 @@ TEST(geom, test_polygon_is_rect)
   // too few points to close a shape
   const std::vector<Point> line_points = {Point(0, 0), Point(100, 0)};
   EXPECT_FALSE(Polygon(line_points).isRect());
-
-  // rects recovered from set operations do not start at a predictable corner
-  const std::vector<Polygon> cut
-      = Polygon(Rect(0, 0, 100, 100)).difference(Rect(50, 0, 100, 100));
-  ASSERT_EQ(cut.size(), 1);
-  EXPECT_TRUE(cut[0].isRect());
-  EXPECT_EQ(cut[0].getEnclosingRect(), Rect(0, 0, 50, 100));
-
-  const std::vector<Polygon> merged = Polygon::merge(
-      std::vector<Rect>{Rect(0, 0, 50, 100), Rect(50, 0, 100, 100)});
-  ASSERT_EQ(merged.size(), 1);
-  EXPECT_TRUE(merged[0].isRect());
-  EXPECT_EQ(merged[0].getEnclosingRect(), Rect(0, 0, 100, 100));
 }
 TEST(geom, test_isotropy)
 {

--- a/src/odb/test/cpp/TestGeom.cpp
+++ b/src/odb/test/cpp/TestGeom.cpp
@@ -200,6 +200,30 @@ TEST(geom, test_isotropy)
 // that can hold the 45 degree edges of an Oct, and a Manhattan only
 // polygon_90 set that cannot.  Both are covered below.
 
+// The distinct corners of a polygon, sorted so that two descriptions of the
+// same shape compare equal whichever vertex they start from.
+std::vector<Point> corners(const Polygon& polygon)
+{
+  std::vector<Point> points = polygon.getPoints();
+  std::sort(points.begin(), points.end());
+  points.erase(std::unique(points.begin(), points.end()), points.end());
+  return points;
+}
+
+// The bounding boxes of a set of polygons, sorted so that checks do not
+// depend on the order boost hands the polygons back in.
+std::vector<Rect> enclosingRects(const std::vector<Polygon>& polygons)
+{
+  std::vector<Rect> rects;
+  rects.reserve(polygons.size());
+  for (const Polygon& polygon : polygons) {
+    rects.push_back(polygon.getEnclosingRect());
+  }
+  std::sort(rects.begin(), rects.end());
+
+  return rects;
+}
+
 TEST(geom, test_boost_to_polygon_set)
 {
   const Rect rect(0, 0, 100, 50);
@@ -254,12 +278,6 @@ TEST(geom, test_boost_oct_keeps_45_degree_edges)
 
   // all eight corners of the octagon come back, so no 45 degree edge was
   // collapsed on the way through boost
-  auto corners = [](const Polygon& polygon) {
-    std::vector<Point> points = polygon.getPoints();
-    std::sort(points.begin(), points.end());
-    points.erase(std::unique(points.begin(), points.end()), points.end());
-    return points;
-  };
   const Polygon as_polygon(oct);
   EXPECT_EQ(corners(polys[0]).size(), 8);
   EXPECT_EQ(corners(polys[0]), corners(as_polygon));
@@ -399,6 +417,160 @@ TEST(geom, test_boost_enclosing_rect)
   EXPECT_EQ(geom::getEnclosingRect(geom::BoostPolygon90Set()),
             Rect(0, 0, 0, 0));
   EXPECT_EQ(geom::getEnclosingRect(geom::BoostPolygonSet()), Rect(0, 0, 0, 0));
+}
+
+// mergePolygons is the one entry point that takes any of the three odb area
+// shapes, so each of Rect, Oct and Polygon is exercised through it below.
+
+TEST(geom, test_boost_merge_polygons_rects)
+{
+  // abutting rects come back as a single shape
+  const std::vector<Polygon> abutting = geom::mergePolygons(
+      std::vector<Rect>{Rect(0, 0, 50, 100), Rect(50, 0, 100, 100)});
+  ASSERT_EQ(abutting.size(), 1);
+  EXPECT_TRUE(abutting[0].isRect());
+  EXPECT_EQ(abutting[0].getEnclosingRect(), Rect(0, 0, 100, 100));
+
+  // as do overlapping ones, with the overlap counted once
+  const std::vector<Polygon> overlapping = geom::mergePolygons(
+      std::vector<Rect>{Rect(0, 0, 60, 100), Rect(40, 0, 100, 100)});
+  ASSERT_EQ(overlapping.size(), 1);
+  EXPECT_TRUE(overlapping[0].isRect());
+  EXPECT_EQ(overlapping[0].getEnclosingRect(), Rect(0, 0, 100, 100));
+  // the seams where the inputs met survive as collinear vertices, so a
+  // merged rect carries more than four points
+  EXPECT_EQ(corners(overlapping[0]),
+            (std::vector<Point>{Point(0, 0),
+                                Point(0, 100),
+                                Point(40, 0),
+                                Point(40, 100),
+                                Point(60, 0),
+                                Point(60, 100),
+                                Point(100, 0),
+                                Point(100, 100)}));
+
+  // a union that is not itself a rect keeps its outline rather than
+  // collapsing to the bounding box
+  const std::vector<Polygon> l_shape = geom::mergePolygons(
+      std::vector<Rect>{Rect(0, 0, 100, 50), Rect(0, 50, 50, 100)});
+  ASSERT_EQ(l_shape.size(), 1);
+  EXPECT_FALSE(l_shape[0].isRect());
+  EXPECT_EQ(l_shape[0].getEnclosingRect(), Rect(0, 0, 100, 100));
+  EXPECT_EQ(corners(l_shape[0]),
+            (std::vector<Point>{Point(0, 0),
+                                Point(0, 50),
+                                Point(0, 100),
+                                Point(50, 50),
+                                Point(50, 100),
+                                Point(100, 0),
+                                Point(100, 50)}));
+
+  // disjoint rects stay apart
+  EXPECT_EQ(enclosingRects(geom::mergePolygons(
+                std::vector<Rect>{Rect(90, 90, 100, 100), Rect(0, 0, 10, 10)})),
+            (std::vector<Rect>{Rect(0, 0, 10, 10), Rect(90, 90, 100, 100)}));
+
+  // a lone rect survives the round trip as a rect
+  const std::vector<Polygon> single
+      = geom::mergePolygons(std::vector<Rect>{Rect(0, 0, 100, 50)});
+  ASSERT_EQ(single.size(), 1);
+  EXPECT_TRUE(single[0].isRect());
+  EXPECT_EQ(single[0].getEnclosingRect(), Rect(0, 0, 100, 50));
+
+  // and a repeated rect does not grow the result
+  EXPECT_EQ(geom::mergePolygons(
+                std::vector<Rect>{Rect(0, 0, 100, 50), Rect(0, 0, 100, 50)}),
+            single);
+
+  // an empty collection merges to nothing
+  EXPECT_TRUE(geom::mergePolygons(std::vector<Rect>{}).empty());
+}
+
+TEST(geom, test_boost_merge_polygons_octs)
+{
+  const Oct oct(Point(0, 0), Point(400, 400), 40);
+
+  // a lone oct passes through with all eight corners intact, so merging
+  // never quietly squares off a 45 degree edge
+  const std::vector<Polygon> single
+      = geom::mergePolygons(std::vector<Oct>{oct});
+  ASSERT_EQ(single.size(), 1);
+  EXPECT_FALSE(single[0].isRect());
+  EXPECT_EQ(single[0].getEnclosingRect(), Rect(-20, -20, 420, 420));
+  EXPECT_EQ(corners(single[0]).size(), 8);
+  EXPECT_EQ(corners(single[0]), corners(Polygon(oct)));
+
+  // octs overlapping along their diagonal union into one shape that still
+  // reaches past the corners of either
+  const std::vector<Polygon> merged = geom::mergePolygons(
+      std::vector<Oct>{oct, Oct(Point(200, 200), Point(600, 600), 40)});
+  ASSERT_EQ(merged.size(), 1);
+  EXPECT_FALSE(merged[0].isRect());
+  EXPECT_EQ(merged[0].getEnclosingRect(), Rect(-20, -20, 620, 620));
+
+  // disjoint octs stay apart, each keeping its own eight corners
+  const std::vector<Polygon> apart = geom::mergePolygons(
+      std::vector<Oct>{oct, Oct(Point(1000, 1000), Point(1400, 1400), 40)});
+  ASSERT_EQ(apart.size(), 2);
+  EXPECT_EQ(enclosingRects(apart),
+            (std::vector<Rect>{Rect(-20, -20, 420, 420),
+                               Rect(980, 980, 1420, 1420)}));
+  for (const Polygon& polygon : apart) {
+    EXPECT_FALSE(polygon.isRect());
+    EXPECT_EQ(corners(polygon).size(), 8);
+  }
+
+  EXPECT_TRUE(geom::mergePolygons(std::vector<Oct>{}).empty());
+}
+
+TEST(geom, test_boost_merge_polygons_polygons)
+{
+  const Polygon l_shape({Point(0, 0),
+                         Point(100, 0),
+                         Point(100, 50),
+                         Point(50, 50),
+                         Point(50, 100),
+                         Point(0, 100)});
+
+  // an L and the rect that fills its notch merge back into a full square
+  const std::vector<Polygon> filled = geom::mergePolygons(
+      std::vector<Polygon>{l_shape, Polygon(Rect(50, 50, 100, 100))});
+  ASSERT_EQ(filled.size(), 1);
+  EXPECT_TRUE(filled[0].isRect());
+  EXPECT_EQ(filled[0].getEnclosingRect(), Rect(0, 0, 100, 100));
+
+  // 45 degree edges survive a merge of arbitrary angle polygons
+  const Polygon diamond(
+      {Point(0, 50), Point(50, 0), Point(100, 50), Point(50, 100)});
+  const std::vector<Polygon> diamonds
+      = geom::mergePolygons(std::vector<Polygon>{diamond,
+                                                 Polygon({Point(50, 50),
+                                                          Point(100, 0),
+                                                          Point(150, 50),
+                                                          Point(100, 100)})});
+  ASSERT_EQ(diamonds.size(), 1);
+  EXPECT_FALSE(diamonds[0].isRect());
+  EXPECT_EQ(diamonds[0].getEnclosingRect(), Rect(0, 0, 150, 100));
+
+  // a repeated polygon comes back as the one shape it describes
+  const std::vector<Polygon> duplicate
+      = geom::mergePolygons(std::vector<Polygon>{diamond, diamond});
+  ASSERT_EQ(duplicate.size(), 1);
+  EXPECT_EQ(corners(duplicate[0]), corners(diamond));
+
+  // disjoint polygons stay apart
+  EXPECT_EQ(enclosingRects(geom::mergePolygons(std::vector<Polygon>{
+                Polygon(Rect(90, 90, 100, 100)), l_shape})),
+            (std::vector<Rect>{Rect(0, 0, 100, 100), Rect(90, 90, 100, 100)}));
+
+  // the same shapes merge the same way whether they arrive as Rects or as
+  // Polygons
+  const std::vector<Rect> rects{Rect(0, 0, 100, 50), Rect(0, 50, 50, 100)};
+  EXPECT_EQ(geom::mergePolygons(rects),
+            geom::mergePolygons(
+                std::vector<Polygon>{Polygon(rects[0]), Polygon(rects[1])}));
+
+  EXPECT_TRUE(geom::mergePolygons(std::vector<Polygon>{}).empty());
 }
 
 }  // namespace

--- a/src/pad/src/PadPlacer.cpp
+++ b/src/pad/src/PadPlacer.cpp
@@ -445,7 +445,8 @@ std::optional<odb::Polygon> PadPlacer::getMasterOutline(
     return odb::Polygon(master_obs.front());
   }
 
-  const auto overlaps = odb::Polygon::merge(master_obs);
+  const auto overlaps
+      = odb::geom::extractPolygons(odb::geom::toPolygonSet(master_obs));
   if (overlaps.size() == 1) {
     return overlaps.front();
   }

--- a/src/pad/src/PadPlacer.cpp
+++ b/src/pad/src/PadPlacer.cpp
@@ -445,8 +445,7 @@ std::optional<odb::Polygon> PadPlacer::getMasterOutline(
     return odb::Polygon(master_obs.front());
   }
 
-  const auto overlaps
-      = odb::geom::extractPolygons(odb::geom::toPolygonSet(master_obs));
+  const auto overlaps = odb::geom::mergePolygons(master_obs);
   if (overlaps.size() == 1) {
     return overlaps.front();
   }

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1843,6 +1843,9 @@ std::set<odb::Polygon> RDLRouter::getITermShapes(odb::dbITerm* iterm) const
 
 void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
 {
+  using boost::polygon::operators::operator+=;
+  using boost::polygon::operators::operator-=;
+
   std::vector<ObsValue> obstructions;
 
   const int bloat = getBloatFactor();
@@ -1873,10 +1876,6 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
         bloat_poly.getEnclosingRect(), bloat_poly, net, src);
   };
 
-  using BoostPolygon = boost::polygon::polygon_data<int>;
-  using BoostPolygonSet = boost::polygon::polygon_set_data<int>;
-  using boost::polygon::operators::operator+=;
-  using boost::polygon::operators::operator-=;
   odb::PtrMap<odb::dbMaster, std::vector<odb::Polygon>> master_obstruction_map;
 
   // Get placed instanced obstructions
@@ -1890,10 +1889,10 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
     auto* master = inst->getMaster();
     auto& master_obs = master_obstruction_map[master];
     if (master_obs.empty()) {
-      BoostPolygonSet master_obstruction;
+      odb::geom::BoostPolygonSet master_obstruction;
 
       // Collect all polygons to add (obstructions)
-      std::vector<BoostPolygon> polys_to_add;
+      std::vector<odb::geom::BoostPolygon> polys_to_add;
       for (auto* obs : master->getPolygonObstructions()) {
         if (obs->getTechLayer() != layer_) {
           continue;
@@ -1917,12 +1916,12 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
       // Build temporary set for all additions, then assign to
       // master_obstruction
       if (!polys_to_add.empty()) {
-        master_obstruction
-            = BoostPolygonSet(polys_to_add.begin(), polys_to_add.end());
+        master_obstruction = odb::geom::BoostPolygonSet(polys_to_add.begin(),
+                                                        polys_to_add.end());
       }
 
       // Collect all polygons to subtract (iterm shapes)
-      std::vector<BoostPolygon> polys_to_subtract;
+      std::vector<odb::geom::BoostPolygon> polys_to_subtract;
       for (auto* mterm : master->getMTerms()) {
         for (auto* mpin : mterm->getMPins()) {
           for (auto* geom : mpin->getPolygonGeometry()) {
@@ -1949,11 +1948,11 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
       // Build temporary set for all subtractions, then subtract from
       // master_obstruction
       if (!polys_to_subtract.empty()) {
-        master_obstruction -= BoostPolygonSet(polys_to_subtract.begin(),
-                                              polys_to_subtract.end());
+        master_obstruction -= odb::geom::BoostPolygonSet(
+            polys_to_subtract.begin(), polys_to_subtract.end());
       }
 
-      std::vector<BoostPolygon> output_polygons;
+      std::vector<odb::geom::BoostPolygon> output_polygons;
       master_obstruction.get(output_polygons);
       for (const auto& polygon_out : output_polygons) {
         std::vector<odb::Point> new_coord;

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1843,6 +1843,7 @@ std::set<odb::Polygon> RDLRouter::getITermShapes(odb::dbITerm* iterm) const
 
 void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
 {
+  using boost::polygon::operators::operator+;
   using boost::polygon::operators::operator+=;
   using boost::polygon::operators::operator-=;
 
@@ -1870,10 +1871,11 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
                                                  odb::dbNet* net,
                                                  odb::dbObject* src,
                                                  int bloat) {
-    const odb::Polygon bloat_poly = poly.bloat(bloat);
-
-    obstructions.emplace_back(
-        bloat_poly.getEnclosingRect(), bloat_poly, net, src);
+    for (const auto& bloat_poly :
+         odb::geom::extractPolygons(odb::geom::toPolygonSet(poly) + bloat)) {
+      obstructions.emplace_back(
+          bloat_poly.getEnclosingRect(), bloat_poly, net, src);
+    }
   };
 
   odb::PtrMap<odb::dbMaster, std::vector<odb::Polygon>> master_obstruction_map;
@@ -1898,9 +1900,11 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
           continue;
         }
 
-        const odb::Polygon bloat_poly = obs->getPolygon().bloat(bloat);
-        const auto pts = bloat_poly.getPoints();
-        polys_to_add.emplace_back(pts.begin(), pts.end());
+        for (const auto& bloat_poly : odb::geom::extractPolygons(
+                 odb::geom::toPolygonSet(obs->getPolygon()) + bloat)) {
+          const auto pts = bloat_poly.getPoints();
+          polys_to_add.emplace_back(pts.begin(), pts.end());
+        }
       }
       for (auto* obs : master->getObstructions(false)) {
         if (obs->getTechLayer() != layer_) {
@@ -1929,9 +1933,11 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
               continue;
             }
 
-            const odb::Polygon bloat_poly = geom->getPolygon().bloat(bloat);
-            const auto pts = bloat_poly.getPoints();
-            polys_to_subtract.emplace_back(pts.begin(), pts.end());
+            for (const auto& bloat_poly : odb::geom::extractPolygons(
+                     odb::geom::toPolygonSet(geom->getPolygon()) + bloat)) {
+              const auto pts = bloat_poly.getPoints();
+              polys_to_subtract.emplace_back(pts.begin(), pts.end());
+            }
           }
           for (auto* geom : mpin->getGeometry(false)) {
             if (geom->getTechLayer() != layer_) {
@@ -2066,6 +2072,8 @@ odb::dbTechLayer* RDLRouter::getOtherLayer(odb::dbTechVia* via) const
 odb::PtrMap<odb::dbITerm, std::vector<RouteTarget>>
 RDLRouter::generateRoutingTargets(odb::dbNet* net) const
 {
+  using boost::polygon::operators::operator-;
+
   odb::PtrMap<odb::dbITerm, std::vector<RouteTarget>> targets;
   odb::dbTechLayer* bump_pin_layer = getOtherLayer(bump_accessvia_);
   odb::dbTechLayer* pad_pin_layer = getOtherLayer(pad_accessvia_);
@@ -2128,10 +2136,6 @@ RDLRouter::generateRoutingTargets(odb::dbNet* net) const
           targets[iterm].push_back(
               {via_rect.center(), via_rect, iterm, found_layer, {}});
         } else {
-          // find rectangles that make suitable targets
-          const odb::Polygon small_poly = box.bloat(-width_ / 2);
-          const auto points = small_poly.getPoints();
-
           auto make_rect = [this](const odb::Point& pt0,
                                   const odb::Point& pt1) -> odb::Rect {
             const odb::Point center((pt0.x() + pt1.x()) / 2,
@@ -2144,27 +2148,32 @@ RDLRouter::generateRoutingTargets(odb::dbNet* net) const
             return rect;
           };
 
-          // first try and add only rects that abut the 90degree egdes
-          bool targets_added = false;
-          for (std::size_t i = 1; i < points.size(); i++) {
-            const auto& pt0 = points[i - 1];
-            const auto& pt1 = points[i];
-            if (pt0.x() == pt1.x() || pt0.y() == pt1.y()) {
-              const odb::Rect rect = make_rect(pt0, pt1);
-              targets[iterm].push_back(
-                  {rect.center(), rect, iterm, found_layer, {}});
-              targets_added = true;
-            }
-          }
-
-          if (!targets_added) {
-            // go ahead and add all if no targets could be added
+          // find rectangles that make suitable targets
+          for (const auto& small_poly : odb::geom::extractPolygons(
+                   odb::geom::toPolygonSet(box) - width_ / 2)) {
+            const auto points = small_poly.getPoints();
+            // first try and add only rects that abut the 90degree egdes
+            bool targets_added = false;
             for (std::size_t i = 1; i < points.size(); i++) {
               const auto& pt0 = points[i - 1];
               const auto& pt1 = points[i];
-              const odb::Rect rect = make_rect(pt0, pt1);
-              targets[iterm].push_back(
-                  {rect.center(), rect, iterm, found_layer, {}});
+              if (pt0.x() == pt1.x() || pt0.y() == pt1.y()) {
+                const odb::Rect rect = make_rect(pt0, pt1);
+                targets[iterm].push_back(
+                    {rect.center(), rect, iterm, found_layer, {}});
+                targets_added = true;
+              }
+            }
+
+            if (!targets_added) {
+              // go ahead and add all if no targets could be added
+              for (std::size_t i = 1; i < points.size(); i++) {
+                const auto& pt0 = points[i - 1];
+                const auto& pt1 = points[i];
+                const odb::Rect rect = make_rect(pt0, pt1);
+                targets[iterm].push_back(
+                    {rect.center(), rect, iterm, found_layer, {}});
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
Remove remaining bloat, merge, and difference from Polygon

## Type of Change
- Breaking change
- Refactoring

## Impact
Users will need to perform the boost operations themselves and use the provided converters to go to and from boost if they want  need to.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**
