### PR TITLE
web: put the viewer's visual language on a token scale

### DIFF
--- a/src/web/src/3d-viewer-widget.js
+++ b/src/web/src/3d-viewer-widget.js
@@ -93,7 +93,7 @@ export class ThreeDViewerWidget {
 
     // Tooltip shown on chiplet hover (raycasting).
     this._tooltip = document.createElement('div');
-    this._tooltip.className = 'three-d-tooltip';
+    this._tooltip.className = 'or-tooltip';
     this._canvasContainer.appendChild(this._tooltip);
 
     this._optionsOverlay = this._createOptionsOverlay();
@@ -306,10 +306,12 @@ export class ThreeDViewerWidget {
     const btnRow = document.createElement('div');
     btnRow.style.cssText = 'margin-top:4px; display:flex; gap:4px;';
     const savePng = document.createElement('button');
+    savePng.className = 'or-btn or-btn-sm';
     savePng.textContent = 'Save PNG';
     savePng.title = 'Save the 3D view as a PNG image (2x resolution)';
     savePng.addEventListener('click', () => this._exportPng(2));
     const copyBtn = document.createElement('button');
+    copyBtn.className = 'or-btn or-btn-sm';
     copyBtn.textContent = 'Copy';
     copyBtn.title = 'Copy the 3D view image to the clipboard';
     copyBtn.addEventListener('click', () => this._copyImage(2));

--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -217,7 +217,7 @@ export class ChartsWidget {
         toolbar.className = 'charts-toolbar';
 
         this._updateBtn = document.createElement('button');
-        this._updateBtn.className = 'timing-btn';
+        this._updateBtn.className = 'or-btn';
         this._updateBtn.textContent = 'Update';
         if (isStaticMode(this._app)) {
             this._updateBtn.style.display = 'none';
@@ -228,12 +228,12 @@ export class ChartsWidget {
         this._chartSelect.className = 'charts-select';
 
         this._csvBtn = document.createElement('button');
-        this._csvBtn.className = 'timing-btn';
+        this._csvBtn.className = 'or-btn';
         this._csvBtn.textContent = 'CSV';
         this._csvBtn.title = 'Export the current chart data as CSV';
 
         this._pngBtn = document.createElement('button');
-        this._pngBtn.className = 'timing-btn';
+        this._pngBtn.className = 'or-btn';
         this._pngBtn.textContent = 'PNG';
         this._pngBtn.title = 'Export the current chart as a PNG image';
 
@@ -283,7 +283,7 @@ export class ChartsWidget {
 
         // Tooltip
         this._tooltip = document.createElement('div');
-        this._tooltip.className = 'charts-tooltip';
+        this._tooltip.className = 'or-tooltip';
         this._tooltip.style.display = 'none';
         el.appendChild(this._tooltip);
 

--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -531,7 +531,7 @@ export class ChartsWidget {
 
         if (!this._bars || this._bars.length === 0) {
             ctx.fillStyle = tc.canvasText;
-            ctx.font = '14px monospace';
+            ctx.font = '14px ' + tc.fontSans;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             const msg = isStaticMode(this._app)
@@ -566,7 +566,7 @@ export class ChartsWidget {
 
         // Y axis ticks and labels
         ctx.fillStyle = tc.canvasLabel;
-        ctx.font = '11px monospace';
+        ctx.font = '11px ' + tc.fontMono;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'middle';
         const chartHeight = ca.bottom - ca.top;
@@ -596,7 +596,7 @@ export class ChartsWidget {
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillStyle = tc.canvasTitle;
-        ctx.font = '11px monospace';
+        ctx.font = '11px ' + tc.fontMono;
         ctx.fillText(this._logY ? 'Nets (log)'
                                 : (netCount ? 'Nets' : 'Endpoints'), 0, 0);
         ctx.restore();
@@ -605,7 +605,7 @@ export class ChartsWidget {
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
         ctx.fillStyle = tc.canvasLabel;
-        ctx.font = '10px monospace';
+        ctx.font = '10px ' + tc.fontMono;
 
         const bins = this._histogramData.bins;
         const unit = this._histogramData.time_unit
@@ -627,7 +627,7 @@ export class ChartsWidget {
 
         // X axis title
         ctx.fillStyle = tc.canvasTitle;
-        ctx.font = '11px monospace';
+        ctx.font = '11px ' + tc.fontMono;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
         let xTitle;
@@ -686,7 +686,7 @@ export class ChartsWidget {
         const series = this._stackedSeries();
         const ca = this._chartArea;
         if (!series || !ca) return;
-        ctx.font = '10px monospace';
+        ctx.font = '10px ' + tc.fontMono;
         ctx.textAlign = 'left';
         ctx.textBaseline = 'top';
         const lx = ca.right - 120;
@@ -708,7 +708,7 @@ export class ChartsWidget {
             title = `${mode} Endpoint Slack`;
         }
         ctx.fillStyle = tc.fgPrimary;
-        ctx.font = '13px monospace';
+        ctx.font = '13px ' + tc.fontSans;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
         ctx.fillText(title, canvasWidth / 2, 8);
@@ -949,7 +949,7 @@ export class ChartsWidget {
         const pts = chart.points;
         if (!pts || pts.length === 0) {
             ctx.fillStyle = tc.canvasText;
-            ctx.font = '14px monospace';
+            ctx.font = '14px ' + tc.fontSans;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.fillText('No data points yet', w / 2, h / 2);
@@ -993,7 +993,7 @@ export class ChartsWidget {
         ctx.stroke();
 
         ctx.fillStyle = tc.canvasLabel;
-        ctx.font = '10px monospace';
+        ctx.font = '10px ' + tc.fontMono;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'middle';
         const nYTicks = 5;
@@ -1026,12 +1026,12 @@ export class ChartsWidget {
         }
 
         ctx.fillStyle = tc.canvasTitle;
-        ctx.font = '11px monospace';
+        ctx.font = '11px ' + tc.fontMono;
         ctx.textAlign = 'center';
         ctx.fillText(chart.x_label || '', (cLeft + cRight) / 2, cBottom + 22);
 
         ctx.fillStyle = tc.fgPrimary;
-        ctx.font = '13px monospace';
+        ctx.font = '13px ' + tc.fontSans;
         ctx.textBaseline = 'top';
         ctx.fillText(chart.name, w / 2, 4);
 
@@ -1050,7 +1050,7 @@ export class ChartsWidget {
         }
 
         if (numSeries > 1 && chart.y_labels) {
-            ctx.font = '10px monospace';
+            ctx.font = '10px ' + tc.fontMono;
             ctx.textAlign = 'left';
             ctx.textBaseline = 'top';
             const lx = cLeft + 8;

--- a/src/web/src/clock-tree-widget.js
+++ b/src/web/src/clock-tree-widget.js
@@ -200,16 +200,16 @@ export class ClockTreeWidget {
         const toolbar = document.createElement('div');
         toolbar.className = 'clock-tree-toolbar';
         this._updateBtn = document.createElement('button');
-        this._updateBtn.className = 'timing-btn';
+        this._updateBtn.className = 'or-btn';
         this._updateBtn.textContent = 'Update';
         if (isStaticMode(this._app)) {
             this._updateBtn.style.display = 'none';
         }
         this._fitBtn = document.createElement('button');
-        this._fitBtn.className = 'timing-btn';
+        this._fitBtn.className = 'or-btn';
         this._fitBtn.textContent = 'Fit';
         this._pngBtn = document.createElement('button');
-        this._pngBtn.className = 'timing-btn';
+        this._pngBtn.className = 'or-btn';
         this._pngBtn.textContent = 'PNG';
         this._pngBtn.title = 'Export the clock tree as a PNG image';
         this._statusLabel = document.createElement('span');
@@ -232,7 +232,7 @@ export class ClockTreeWidget {
 
         // Tooltip
         this._tooltip = document.createElement('div');
-        this._tooltip.className = 'clock-tree-tooltip';
+        this._tooltip.className = 'or-tooltip';
         this._tooltip.style.display = 'none';
         el.appendChild(this._tooltip);
 

--- a/src/web/src/clock-tree-widget.js
+++ b/src/web/src/clock-tree-widget.js
@@ -435,7 +435,7 @@ export class ClockTreeWidget {
 
         if (!this._layout.length) {
             ctx.fillStyle = tc.canvasText;
-            ctx.font = '14px monospace';
+            ctx.font = '14px ' + tc.fontSans;
             ctx.textAlign = 'center';
             const msg = isStaticMode(this._app)
                 ? 'No clock tree data available'
@@ -631,7 +631,7 @@ export class ClockTreeWidget {
         ctx.save();
         ctx.fillStyle = tc.canvasLabel;
         ctx.strokeStyle = tc.canvasAxis;
-        ctx.font = '11px monospace';
+        ctx.font = '11px ' + tc.fontMono;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'middle';
 

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -1706,7 +1706,7 @@ export function populateDisplayControls(app, visibility, selectability,
         }
 
         const rebuild = document.createElement('button');
-        rebuild.className = 'heatmap-rebuild';
+        rebuild.className = 'or-btn or-btn-sm heatmap-rebuild';
         rebuild.textContent = 'Rebuild data';
         rebuild.addEventListener('click', () => {
             sendHeatMapUpdate({

--- a/src/web/src/drc-widget.js
+++ b/src/web/src/drc-widget.js
@@ -32,7 +32,7 @@ export class DrcWidget {
         toolbar.appendChild(this._categorySelect);
 
         this._loadBtn = document.createElement('button');
-        this._loadBtn.className = 'drc-btn';
+        this._loadBtn.className = 'or-btn or-btn-sm';
         this._loadBtn.textContent = 'Load...';
         toolbar.appendChild(this._loadBtn);
 
@@ -569,8 +569,8 @@ class DrcFileDialog {
                        placeholder="Server-side path to .rpt, .drc, or .json file">
                 <div class="modal-error" style="display:none"></div>
                 <div class="modal-buttons">
-                    <button class="cancel">Cancel</button>
-                    <button class="primary ok" disabled>Load</button>
+                    <button class="or-btn cancel">Cancel</button>
+                    <button class="or-btn or-btn-primary ok" disabled>Load</button>
                 </div>
             </div>`;
         document.body.appendChild(this._overlay);

--- a/src/web/src/edit-dialogs.js
+++ b/src/web/src/edit-dialogs.js
@@ -48,7 +48,7 @@ function showError(errorDiv, msg) {
 function addButton(parent, label, { primary = false } = {}) {
     const btn = document.createElement('button');
     btn.textContent = label;
-    if (primary) btn.className = 'primary';
+    btn.className = 'or-btn' + (primary ? ' or-btn-primary' : '');
     parent.appendChild(btn);
     return btn;
 }
@@ -112,6 +112,7 @@ export function showGlobalConnectDialog(app) {
                     row.innerHTML = `<span>${esc(r.inst)}</span><span>${esc(r.pin)}</span>`
                         + `<span>${esc(r.net)}</span><span>${esc(r.region || 'All')}</span>`;
                     const del = document.createElement('button');
+                    del.className = 'or-btn or-btn-sm or-btn-icon';
                     del.textContent = '✕';
                     del.title = 'Delete rule';
                     del.addEventListener('click', () => {

--- a/src/web/src/hierarchy-browser.js
+++ b/src/web/src/hierarchy-browser.js
@@ -49,7 +49,7 @@ export class HierarchyBrowser {
         toolbar.className = 'timing-toolbar';
 
         this._updateBtn = document.createElement('button');
-        this._updateBtn.className = 'timing-btn';
+        this._updateBtn.className = 'or-btn';
         this._updateBtn.textContent = 'Update';
         if (isStaticMode(this._app)) {
             this._updateBtn.style.display = 'none';

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -1096,12 +1096,18 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             if (Array.isArray(data.actions) && !isStaticMode(app)) {
                 for (const name of data.actions) {
                     const btn = document.createElement('button');
-                    btn.className = 'or-btn or-btn-icon inspector-action-btn';
+                    btn.className = 'or-btn inspector-action-btn';
                     btn.title = name;
                     if (name === 'Delete') {
+                        // The only action drawn as a glyph, so the only one
+                        // that gets the square icon variant.
+                        btn.classList.add('or-btn-icon', 'or-btn-danger-hover');
                         btn.innerHTML = DELETE_SVG;
-                        btn.classList.add('or-btn-danger-hover');
                     } else {
+                        // Any action the server does not suppress arrives here
+                        // by name ("Change color", "Report Path", ...), so this
+                        // has to size to its label.
+                        btn.classList.add('or-btn-sm');
                         btn.textContent = name;
                     }
                     btn.addEventListener('click', () => triggerAction(name, data));

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -1009,7 +1009,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             toolbar.className = 'inspector-toolbar';
 
             const backBtn = document.createElement('button');
-            backBtn.className = 'inspector-btn';
+            backBtn.className = 'or-btn or-btn-icon';
             backBtn.title = 'Back';
             backBtn.innerHTML = BACK_SVG;
             backBtn.disabled = !data.can_navigate_back;
@@ -1018,7 +1018,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
 
             if (data.bbox) {
                 const zoomBtn = document.createElement('button');
-                zoomBtn.className = 'inspector-btn';
+                zoomBtn.className = 'or-btn or-btn-icon';
                 zoomBtn.title = 'Zoom to';
                 zoomBtn.innerHTML = ZOOM_TO_SVG;
                 zoomBtn.addEventListener('click', () => zoomToBBox(data.bbox));
@@ -1029,7 +1029,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             if (data.type === 'Net' && data.name) {
                 const isFocused = app.focusNets.has(data.name);
                 const focusBtn = document.createElement('button');
-                focusBtn.className = 'inspector-btn';
+                focusBtn.className = 'or-btn or-btn-icon';
                 focusBtn.title = isFocused ? 'De-focus net' : 'Focus net';
                 focusBtn.innerHTML = isFocused ? DEFOCUS_SVG : FOCUS_SVG;
                 focusBtn.addEventListener('click', () => toggleFocusNet(data.name));
@@ -1040,7 +1040,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             if (data.type === 'Net' && data.name && data.has_guides) {
                 const isShowing = app.routeGuideNets.has(data.name);
                 const guideBtn = document.createElement('button');
-                guideBtn.className = 'inspector-btn';
+                guideBtn.className = 'or-btn or-btn-icon';
                 guideBtn.title = isShowing ? 'Hide route guides' : 'Show route guides';
                 guideBtn.innerHTML = isShowing ? HIDE_ROUTE_GUIDE_SVG : ROUTE_GUIDE_SVG;
                 guideBtn.addEventListener('click', () => toggleRouteGuides(data.name));
@@ -1052,7 +1052,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             // itself (drivers<=1), so it is always offered for a Net here.
             if (data.type === 'Net' && data.name && app.showInsertBufferDialog) {
                 const bufBtn = document.createElement('button');
-                bufBtn.className = 'inspector-btn';
+                bufBtn.className = 'or-btn or-btn-icon';
                 bufBtn.title = 'Insert buffer';
                 bufBtn.innerHTML = BUFFER_SVG;
                 bufBtn.addEventListener('click', () => app.showInsertBufferDialog(data.name));
@@ -1062,7 +1062,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             // Clear all focus nets button
             if (app.focusNets.size > 0) {
                 const clearBtn = document.createElement('button');
-                clearBtn.className = 'inspector-btn';
+                clearBtn.className = 'or-btn or-btn-icon';
                 clearBtn.title = 'Clear focus nets';
                 clearBtn.innerHTML = CLEAR_FOCUS_SVG;
                 clearBtn.addEventListener('click', () => clearFocusNets());
@@ -1075,7 +1075,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             if (typeof data.highlight_group === 'number' && !isStaticMode(app)
                 && (app.techData?.highlight_colors || []).length) {
                 const hlBtn = document.createElement('button');
-                hlBtn.className = 'inspector-btn inspector-highlight-btn';
+                hlBtn.className = 'or-btn or-btn-icon inspector-highlight-btn';
                 const group = data.highlight_group;
                 hlBtn.title = group >= 0
                     ? 'Highlight group ' + (group + 1)
@@ -1096,11 +1096,11 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             if (Array.isArray(data.actions) && !isStaticMode(app)) {
                 for (const name of data.actions) {
                     const btn = document.createElement('button');
-                    btn.className = 'inspector-btn inspector-action-btn';
+                    btn.className = 'or-btn or-btn-icon inspector-action-btn';
                     btn.title = name;
                     if (name === 'Delete') {
                         btn.innerHTML = DELETE_SVG;
-                        btn.classList.add('inspector-btn-danger');
+                        btn.classList.add('or-btn-danger-hover');
                     } else {
                         btn.textContent = name;
                     }
@@ -1121,7 +1121,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             nav.className = 'inspector-selection-nav';
 
             const prevBtn = document.createElement('button');
-            prevBtn.className = 'inspector-btn';
+            prevBtn.className = 'or-btn or-btn-icon';
             prevBtn.title = 'Previous (Shift+click to multi-select)';
             prevBtn.innerHTML = CHEVRON_LEFT_SVG;
             prevBtn.addEventListener('click', () => cycleSelection(-1));
@@ -1131,7 +1131,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             label.textContent = (selIndex + 1) + ' / ' + selCount;
 
             const nextBtn = document.createElement('button');
-            nextBtn.className = 'inspector-btn';
+            nextBtn.className = 'or-btn or-btn-icon';
             nextBtn.title = 'Next';
             nextBtn.innerHTML = CHEVRON_RIGHT_SVG;
             nextBtn.addEventListener('click', () => cycleSelection(+1));

--- a/src/web/src/label-manager.js
+++ b/src/web/src/label-manager.js
@@ -231,7 +231,7 @@ export class LabelManager {
             // Avoid stacking duplicate delete buttons across re-selections.
             if (toolbar.querySelector('.delete-label-btn')) return;
             const btn = document.createElement('button');
-            btn.className = 'inspector-btn delete-label-btn';
+            btn.className = 'or-btn or-btn-icon delete-label-btn';
             btn.title = 'Delete label';
             btn.innerHTML =
                 '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">'

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -661,6 +661,23 @@ function createLayoutViewer(container) {
     mapDiv.appendChild(progress);
     app.tileProgressEl = progress;
 
+    // Closing the panel discards this DOM, so drop the references to it.  Both
+    // readers null-check (setTileProgress here, updateHeatMapLegend in
+    // display-controls.js), and createLayoutViewer sets them again if the panel
+    // is reopened.
+    //
+    // app.map is deliberately left alone.  Calling map.remove() and nulling it
+    // would be the matching cleanup, but ~140 call sites across eleven modules
+    // reach app.map, many of them unguarded -- the View menu's zoom items, the
+    // inspector's zoom-to, the rulers, the display controls -- so nulling it
+    // turns a detached-but-harmless map into a dozen ways to throw while the
+    // panel is closed.  Guarding those is a lifecycle change, not a styling
+    // one.
+    container.on('destroy', () => {
+        app.tileProgressEl = null;
+        app.heatMapLegendEl = null;
+    });
+
     app.map = L.map(mapDiv, buildMapOptions());
     // On a fractional dpr, Leaflet's whole-CSS-pixel placement leaves tile
     // boundaries mid-device-pixel and they show as dark hairlines; this nudges
@@ -738,7 +755,19 @@ function createLayoutViewer(container) {
         coordBar.textContent = `X: ${app.formatDbu(dbuX)}  Y: ${app.formatDbu(dbuY)}`;
         syncHud();
     });
-    app.map.on('mouseout', () => { app.lastMouseLatLng = null; });
+    app.map.on('mouseout', (e) => {
+        app.lastMouseLatLng = null;
+        // Leaflet raises mouseout for a move onto anything inside the
+        // container too -- a zoom control, a marker, the HUD itself -- and the
+        // readout should hold its value for those.  Only a move that actually
+        // leaves the viewer clears it.
+        const to = e.originalEvent && e.originalEvent.relatedTarget;
+        if (to && mapDiv.contains(to)) {
+            return;
+        }
+        coordBar.textContent = '';
+        syncHud();
+    });
 
     const SB_H = 22;       // svg height
     const SB_BAR_H = 8;    // bracket height

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -24,8 +24,9 @@ import { createInspectorPanel } from './inspector.js';
 import { SelectionBrowser } from './selection-browser.js';
 import { applySelectionFlags, beginSelection, boundsEqual, buildMapOptions,
          buildVisibilityFlags, computeBoundsTransforms, computeScaleBar,
-         formatDbu, formatDistance, isCurrentSelection, isStaticMode,
-         maxUsefulZoom, parseDbu, rafCoalesce, showToast, unitLabel }
+         decorateTabIcons, formatDbu, formatDistance, isCurrentSelection,
+         isStaticMode, maxUsefulZoom, parseDbu, rafCoalesce, showToast,
+         unitLabel }
     from './ui-utils.js';
 import { populateDisplayControls } from './display-controls.js';
 import { createMenuBar } from './menu-bar.js';
@@ -49,6 +50,10 @@ import { captureLayout } from './capture.js';
 const statusDiv = document.getElementById('websocket-status');
 let disconnectTimeout = null;
 const DISCONNECT_DELAY_MS = 2000; // Show banner after 2 seconds of disconnection
+// Outstanding tile requests are normal while panning; this many at once means
+// the server is not keeping up, which is worth a number rather than just the
+// progress line.
+const PENDING_BACKLOG = 20;
 
 function updateStatus() {
     const isConnected = app.websocketManager && app.websocketManager.isConnected;
@@ -70,24 +75,33 @@ function updateStatus() {
             }, DISCONNECT_DELAY_MS);
         }
     } else {
-        // Connected - clear timeout and show pending indicator if needed
         if (disconnectTimeout) {
             clearTimeout(disconnectTimeout);
             disconnectTimeout = null;
         }
-        
-        if (pendingCount === 0) {
-            statusDiv.style.display = 'none';
-        } else {
-            statusDiv.innerHTML = `<div class="or-hud or-hud-top-right pending-indicator">pending: ${pendingCount}</div>`;
+        // Ordinary tile traffic is the progress line's job.  The count only
+        // earns space on screen once the queue is long enough to be the
+        // explanation for a viewer that feels stuck.
+        if (pendingCount > PENDING_BACKLOG) {
+            statusDiv.innerHTML = '<div class="or-hud or-hud-top-right '
+                + `pending-indicator">pending: ${pendingCount}</div>`;
             statusDiv.style.display = 'block';
-            // The indicator is an .or-hud, so its ink comes from the HUD
-            // tokens rather than the panel's -- see style.css.
-            const color = pendingCount > 20
-                ? 'var(--sem-error)' : 'var(--fg-hud)';
-            statusDiv.querySelector('.pending-indicator').style.color = color;
+        } else {
+            statusDiv.style.display = 'none';
         }
     }
+    setTileProgress(pendingCount);
+}
+
+// Show the tile-request line while requests are outstanding.  A no-op when the
+// Layout panel is closed, which is the only place the line lives.
+function setTileProgress(pendingCount) {
+    const el = app.tileProgressEl;
+    if (!el) return;
+    el.classList.toggle('active', pendingCount > 0);
+    // The count is worth keeping for anyone diagnosing a slow server, just not
+    // worth a chip on screen.
+    el.title = pendingCount > 0 ? `${pendingCount} tile requests pending` : '';
 }
 
 // ─── Component Factories ────────────────────────────────────────────────────
@@ -638,6 +652,15 @@ function createLayoutViewer(container) {
     mapDiv.appendChild(heatMapLegend);
     app.heatMapLegendEl = heatMapLegend;
 
+    // Tile requests in flight, as a line along the top of the canvas.  Held on
+    // app because updateStatus runs from the socket callbacks, which know
+    // nothing about this panel -- and the panel can be closed, so every write
+    // to it goes through setTileProgress below.
+    const progress = document.createElement('div');
+    progress.className = 'or-progress';
+    mapDiv.appendChild(progress);
+    app.tileProgressEl = progress;
+
     app.map = L.map(mapDiv, buildMapOptions());
     // On a fractional dpr, Leaflet's whole-CSS-pixel placement leaves tile
     // boundaries mid-device-pixel and they show as dark hairlines; this nudges
@@ -983,7 +1006,10 @@ function createStubPanel(container, title, description) {
 
 // ─── Layout Configuration ───────────────────────────────────────────────────
 
+const kHeaderHeight = 28;
+
 const defaultLayoutConfig = {
+    dimensions: { headerHeight: kHeaderHeight },
     root: {
         type: 'row',
         content: [
@@ -1129,7 +1155,11 @@ const savedVersion = parseInt(localStorage.getItem('gl-layout-version'), 10);
 if (savedLayout && savedVersion === LAYOUT_VERSION) {
     try {
         const resolved = JSON.parse(savedLayout);
-        app.goldenLayout.loadLayout(LayoutConfig.fromResolved(resolved));
+        const restored = LayoutConfig.fromResolved(resolved);
+        restored.dimensions = {
+            ...restored.dimensions, headerHeight: kHeaderHeight,
+        };
+        app.goldenLayout.loadLayout(restored);
     } catch (e) {
         app.goldenLayout.loadLayout(defaultLayoutConfig);
     }
@@ -1137,10 +1167,22 @@ if (savedLayout && savedVersion === LAYOUT_VERSION) {
     app.goldenLayout.loadLayout(defaultLayoutConfig);
 }
 localStorage.setItem('gl-layout-version', LAYOUT_VERSION);
+addTabIcons();
+
+// Add the per-panel tab icons and, if any were added, make Golden Layout
+// measure the headers again -- it chose which tabs fit before the icons
+// widened them, so without this the tabs that no longer fit overlap the
+// stack's controls instead of moving into the overflow dropdown.
+function addTabIcons() {
+    if (decorateTabIcons() > 0) {
+        app.goldenLayout.updateSize();
+    }
+}
 
 // Persist layout on changes (drag, resize, close, etc.)
 app.goldenLayout.on('stateChanged', () => {
     localStorage.setItem('gl-layout', JSON.stringify(app.goldenLayout.saveLayout()));
+    addTabIcons();
 });
 
 // Resize GoldenLayout to the space #gl-container actually has.  The container

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -756,15 +756,15 @@ function createLayoutViewer(container) {
         syncHud();
     });
     app.map.on('mouseout', (e) => {
-        app.lastMouseLatLng = null;
         // Leaflet raises mouseout for a move onto anything inside the
-        // container too -- a zoom control, a marker, the HUD itself -- and the
-        // readout should hold its value for those.  Only a move that actually
-        // leaves the viewer clears it.
+        // container too -- a zoom control, a marker, the HUD itself -- and
+        // both the readout and the zoom anchor should hold their values for
+        // those.  Only a move that actually leaves the viewer clears them.
         const to = e.originalEvent && e.originalEvent.relatedTarget;
         if (to && mapDiv.contains(to)) {
             return;
         }
+        app.lastMouseLatLng = null;
         coordBar.textContent = '';
         syncHud();
     });

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -79,9 +79,12 @@ function updateStatus() {
         if (pendingCount === 0) {
             statusDiv.style.display = 'none';
         } else {
-            statusDiv.innerHTML = `<div class="pending-indicator">pending: ${pendingCount}</div>`;
+            statusDiv.innerHTML = `<div class="or-hud or-hud-top-right pending-indicator">pending: ${pendingCount}</div>`;
             statusDiv.style.display = 'block';
-            const color = pendingCount > 20 ? 'var(--error)' : 'var(--fg-bright)';
+            // The indicator is an .or-hud, so its ink comes from the HUD
+            // tokens rather than the panel's -- see style.css.
+            const color = pendingCount > 20
+                ? 'var(--sem-error)' : 'var(--fg-hud)';
             statusDiv.querySelector('.pending-indicator').style.color = color;
         }
     }
@@ -631,7 +634,7 @@ function createLayoutViewer(container) {
     container.element.appendChild(mapDiv);
 
     const heatMapLegend = document.createElement('div');
-    heatMapLegend.className = 'heatmap-map-legend hidden';
+    heatMapLegend.className = 'or-hud or-hud-bottom-right heatmap-map-legend hidden';
     mapDiv.appendChild(heatMapLegend);
     app.heatMapLegendEl = heatMapLegend;
 
@@ -673,10 +676,35 @@ function createLayoutViewer(container) {
         app.map.invalidateSize({ animate: false });
     }).observe(mapDiv);
 
-    // Coordinate readout overlay (bottom-left of the layout viewer).
+    // Scale bar and coordinate readout share one HUD at the bottom-left of
+    // the viewer.  The scale bar is a display option and hides on its own, so
+    // the divider beside it goes when it does, and the HUD itself disappears
+    // when neither readout has anything to show -- otherwise an empty chip
+    // sits on the layout before the pointer has ever entered it.
+    const hud = document.createElement('div');
+    hud.className = 'or-hud or-hud-bottom-left hidden';
+    const scaleBar = document.createElement('div');
+    scaleBar.id = 'scale-bar';
+    const hudDivider = document.createElement('span');
+    hudDivider.className = 'or-hud-divider';
     const coordBar = document.createElement('div');
     coordBar.id = 'coord-bar';
-    mapDiv.appendChild(coordBar);
+    hud.appendChild(scaleBar);
+    hud.appendChild(hudDivider);
+    hud.appendChild(coordBar);
+    mapDiv.appendChild(hud);
+
+    function syncHud() {
+        // Content, not just the display property: the scale bar starts out
+        // display:'' but empty -- updateScaleBar has not run yet -- and an
+        // empty div would otherwise count as a visible readout.
+        const scale = scaleBar.style.display !== 'none'
+            && scaleBar.childElementCount > 0;
+        const coord = coordBar.textContent !== '';
+        hudDivider.style.display = (scale && coord) ? '' : 'none';
+        hud.classList.toggle('hidden', !scale && !coord);
+    }
+    syncHud();
 
     app.map.on('mousemove', (e) => {
         app.lastMouseLatLng = e.latlng;
@@ -685,14 +713,9 @@ function createLayoutViewer(container) {
             e.latlng.lat, e.latlng.lng, app.designScale, app.designMaxDXDY,
             app.designOriginX, app.designOriginY);
         coordBar.textContent = `X: ${app.formatDbu(dbuX)}  Y: ${app.formatDbu(dbuY)}`;
+        syncHud();
     });
     app.map.on('mouseout', () => { app.lastMouseLatLng = null; });
-
-    // Scale bar overlay (bottom-left, above coord bar).  Content is an
-    // inline SVG rebuilt on each update (bracket + ticks + 0/total labels).
-    const scaleBar = document.createElement('div');
-    scaleBar.id = 'scale-bar';
-    mapDiv.appendChild(scaleBar);
 
     const SB_H = 22;       // svg height
     const SB_BAR_H = 8;    // bracket height
@@ -731,6 +754,7 @@ function createLayoutViewer(container) {
     function updateScaleBar() {
         if (!app.designScale || !visibility.scale_bar) {
             scaleBar.style.display = 'none';
+            syncHud();
             return;
         }
         // Pixels per DBU at current zoom: designScale * 2^zoom.
@@ -745,10 +769,12 @@ function createLayoutViewer(container) {
         });
         if (!sb) {
             scaleBar.style.display = 'none';
+            syncHud();
             return;
         }
         scaleBar.style.display = '';
         renderScaleBar(sb.barPx, sb.label, sb.segments);
+        syncHud();
     }
 
     // Coalesce updates during continuous zoom gestures so the bar tracks

--- a/src/web/src/menu-bar.js
+++ b/src/web/src/menu-bar.js
@@ -381,8 +381,8 @@ function showPathDialog(app, title, tclCmd) {
                    placeholder="Server-side file path (e.g. /path/to/design.odb)">
             <div class="modal-error" style="display:none"></div>
             <div class="modal-buttons">
-                <button class="cancel">Cancel</button>
-                <button class="primary ok" disabled>${isSave ? 'Save' : 'Open'}</button>
+                <button class="or-btn cancel">Cancel</button>
+                <button class="or-btn or-btn-primary ok" disabled>${isSave ? 'Save' : 'Open'}</button>
             </div>
         </div>`;
 

--- a/src/web/src/ruler.js
+++ b/src/web/src/ruler.js
@@ -577,7 +577,7 @@ export class RulerManager {
             if (!toolbar) return;
 
             const deleteBtn = document.createElement('button');
-            deleteBtn.className = 'inspector-btn';
+            deleteBtn.className = 'or-btn or-btn-icon';
             deleteBtn.title = 'Delete ruler';
             deleteBtn.innerHTML =
                 '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">' +

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -32,15 +32,15 @@ export class SchematicWidget {
             '<input id="schematic-fanin-depth"  type="number" value="1" min="0" max="10" style="width:40px;">' +
             '<label style="font-size:12px;">Fanout</label>' +
             '<input id="schematic-fanout-depth" type="number" value="1" min="0" max="10" style="width:40px;">' +
-            '<button id="schematic-refresh">Refresh</button>' +
-            '<button id="schematic-fit">Fit</button>' +
-            '<button id="schematic-zoom-in"  title="Zoom in">+</button>'  +
-            '<button id="schematic-zoom-out" title="Zoom out">−</button>' +
-            '<button id="schematic-select" title="Select mode" style="min-width:64px">Select</button>' +
-            '<button id="schematic-zoom-to" title="Zoom to selected cell" disabled>Zoom To</button>' +
-            '<button id="schematic-save-svg" title="Save schematic as SVG (vector)">SVG</button>' +
-            '<button id="schematic-save-png" title="Save schematic as PNG (2x)">PNG</button>' +
-            '<button id="schematic-copy" title="Copy schematic image to clipboard">Copy</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-refresh">Refresh</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-fit">Fit</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-zoom-in"  title="Zoom in">+</button>'  +
+            '<button class="or-btn or-btn-sm" id="schematic-zoom-out" title="Zoom out">−</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-select" title="Select mode" style="min-width:64px">Select</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-zoom-to" title="Zoom to selected cell" disabled>Zoom To</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-save-svg" title="Save schematic as SVG (vector)">SVG</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-save-png" title="Save schematic as PNG (2x)">PNG</button>' +
+            '<button class="or-btn or-btn-sm" id="schematic-copy" title="Copy schematic image to clipboard">Copy</button>' +
             '<span id="schematic-status" style="color:var(--fg-muted); flex:1;">Select an instance in the layout to view its schematic.</span>';
         this.element.appendChild(this.controls);
 

--- a/src/web/src/search-nav.js
+++ b/src/web/src/search-nav.js
@@ -20,8 +20,8 @@ function buildModal(title, bodyHtml, okLabel) {
             ${bodyHtml}
             <div class="modal-error" style="display:none"></div>
             <div class="modal-buttons">
-                <button class="cancel">Cancel</button>
-                <button class="primary ok">${okLabel}</button>
+                <button class="or-btn cancel">Cancel</button>
+                <button class="or-btn or-btn-primary ok">${okLabel}</button>
             </div>
         </div>`;
     document.body.appendChild(overlay);

--- a/src/web/src/selection-browser.js
+++ b/src/web/src/selection-browser.js
@@ -224,14 +224,14 @@ export class SelectionBrowser {
             tabs.appendChild(tab);
         }
         const refreshBtn = document.createElement('button');
-        refreshBtn.className = 'sb-tool';
+        refreshBtn.className = 'or-btn or-btn-sm sb-tool';
         refreshBtn.title = 'Refresh';
         refreshBtn.textContent = '⟳';
         refreshBtn.addEventListener('click', () => this.refresh());
         tabs.appendChild(refreshBtn);
         if (this._tab === 'highlighted' && hlCount > 0) {
             const clearBtn = document.createElement('button');
-            clearBtn.className = 'sb-tool';
+            clearBtn.className = 'or-btn or-btn-sm sb-tool';
             clearBtn.title = 'Clear all highlights';
             clearBtn.textContent = 'Clear';
             clearBtn.addEventListener('click', () => this._clearHighlights());

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -1,127 +1,250 @@
 /* ─── Theme Variables ─────────────────────────────────────────────────────── */
 
-/* --bg-map is black in both themes to match the Qt GUI's default background
-   (displayControls.cpp, background_color_ = Qt::black).  Layer shapes are drawn
-   semi-transparent (alpha 180/255), so the background shows through them and
-   any difference here shifts every rendered color away from the Qt GUI's.  It
-   remains user-settable through the Background control. */
+/* Colors live in two layers.
+ *
+ * The scales -- --surface-*, --line-*, --ink-*, --accent-*, --sem-* -- are the
+ * palette, and each theme block below defines the whole set.  The role names
+ * after them (--bg-*, --fg-*, --border*, --accent, --canvas-*, ...) are what
+ * every component rule uses, and each is an alias for a scale step.  A palette
+ * change is therefore a scale edit, not a sweep through the component rules.
+ *
+ * Two constraints on the aliases:
+ *
+ *   - Anything paired with --fg-white in a component rule (--bg-selected,
+ *     --accent) has to stay a solid step dark enough to carry white text in
+ *     BOTH themes, so those alias --accent-solid rather than a tint.  Row
+ *     highlights that carry --fg-primary instead (--bg-selected-row) are the
+ *     tints.
+ *   - getThemeColors() in theme.js reads --canvas-*, --fg-primary, --fg-muted,
+ *     --bg-panel and --bg-map off the computed style and hands them to Canvas
+ *     2D.  var() in a custom property is substituted at computed-value time,
+ *     so aliasing them is safe; a raw `var(...)` string reaching fillStyle
+ *     would be silently ignored, so keep them resolving to a color.
+ *
+ * --bg-map is black in both themes to match the Qt GUI's default background
+ * (displayControls.cpp, background_color_ = Qt::black).  Layer shapes are drawn
+ * semi-transparent (alpha 180/255), so the background shows through them and
+ * any difference here shifts every rendered color away from the Qt GUI's.  It
+ * remains user-settable through the Background control, so it is a literal
+ * rather than an alias -- an inline override replaces this declaration. */
+
+/* Theme-independent scales.  Corner radii were picked per rule -- five values
+ * across 46 declarations -- so they are collapsed to three steps chosen by
+ * what the element is, not by how big it happens to be. */
+:root {
+    --radius-xs: 2px;   /* color swatches, chips, badges */
+    --radius-sm: 4px;   /* controls: buttons, inputs, list rows */
+    --radius-md: 7px;   /* panels, dialogs, floating surfaces */
+
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
 
 html[data-theme="dark"] {
-    --bg-main: #1e1e1e;
-    --bg-panel: #252525;
-    --bg-input: #1a1a1a;
-    --bg-input-deep: #111;
-    --bg-header: #2d2d2d;
-    --bg-hover: #3c3c3c;
-    --bg-selected: #094771;
-    --bg-selected-row: #1a3a5c;
-    --bg-selected-alt: #3a3a1c;
-    --bg-context: #2a2a2a;
-    --bg-overlay: rgba(0, 0, 0, 0.5);
-    --bg-status: rgba(0, 0, 0, 0.7);
-    --bg-tooltip: rgba(30, 30, 30, 0.95);
-    --bg-heatmap-legend: rgba(18, 20, 24, 0.88);
-    --bg-rubber-band: rgba(255, 255, 255, 0.1);
+    /* Native scrollbars, <select> popups and other UA-drawn chrome follow
+     * color-scheme; accent-color points checkboxes at the palette. */
+    color-scheme: dark;
+
+    /* Scales.  Surfaces are three deliberate elevation steps plus a sunken
+     * pair for inputs, all biased cool so they sit with the accent. */
+    --surface-ground: #0a0d11;
+    --surface-panel: #11171d;
+    --surface-raised: #182027;
+    --surface-float: #1c252d;
+    --surface-sunken: #0c1115;
+    --surface-deep: #080b0e;
+    --surface-hover: #232d35;
+    --surface-tint: #16272f;      /* accent at ~9% over --surface-panel */
+    --surface-tint-warm: #363323; /* second highlight, distinct from tint */
+
+    --line-1: #1b242c;
+    --line-2: #29343d;
+    --line-3: #3a4753;
+
+    --ink-0: #f1f6f9;
+    --ink-1: #dce5eb;
+    --ink-2: #9cadba;
+    --ink-3: #7a8d9b;
+    --ink-4: #4f606c;
+
+    --accent-solid: #0b6d84;   /* carries --fg-white at 5.5:1 */
+    --accent-solid-hover: #0d7f99;
+    --accent-bright: #46c9e0;  /* strokes and underlines on dark */
+    --accent-on-surface: #7ddcee;  /* accent as text */
+    --accent-alpha-strong: rgba(70, 201, 224, 0.22);
+    --accent-alpha: rgba(70, 201, 224, 0.16);
+
+    --sem-error: #f0616a;
+    --sem-error-text: #ff7d84;
+    --sem-danger: #7a2226;         /* destructive action */
+    --sem-danger-line: #a33338;
+    --sem-danger-hover: #94282d;
+    --sem-warn: #f2c000;           /* debug pause, deliberately loud */
+    --sem-warn-ink: #0a0d11;
+
+    /* Roles. */
+    --bg-main: var(--surface-ground);
+    --bg-panel: var(--surface-panel);
+    --bg-input: var(--surface-sunken);
+    --bg-input-deep: var(--surface-deep);
+    --bg-header: var(--surface-raised);
+    --bg-hover: var(--surface-hover);
+    --bg-selected: var(--accent-solid);
+    --bg-selected-row: var(--surface-tint);
+    --bg-selected-alt: var(--surface-tint-warm);
+    --bg-context: var(--surface-float);
+    --bg-overlay: rgba(4, 7, 10, 0.58);
+    --bg-status: rgba(10, 14, 18, 0.76);
+    --bg-tooltip: rgba(24, 32, 39, 0.96);
+    --bg-heatmap-legend: rgba(12, 18, 24, 0.88);
+    --bg-rubber-band: var(--accent-alpha);
     --bg-map: #000;
 
-    --fg-primary: #ccc;
-    --fg-secondary: #aaa;
-    --fg-muted: #888;
-    --fg-disabled: #666;
-    --fg-bright: #eee;
+    --fg-primary: var(--ink-1);
+    --fg-secondary: var(--ink-2);
+    --fg-muted: var(--ink-3);
+    --fg-disabled: var(--ink-4);
+    --fg-bright: var(--ink-0);
     --fg-white: #fff;
-    --fg-heatmap-title: #f2f2f2;
-    --fg-heatmap-units: #9ca3af;
+    --fg-heatmap-title: var(--ink-0);
+    --fg-heatmap-units: var(--ink-3);
 
-    --border: #444;
-    --border-subtle: #333;
-    --border-strong: #555;
+    --border: var(--line-2);
+    --border-subtle: var(--line-1);
+    --border-strong: var(--line-3);
     --border-heatmap-legend: rgba(255, 255, 255, 0.14);
 
-    --accent: #094771;
-    --accent-hover: #0b5a8f;
-    --accent-link: #4fc3f7;
-    --accent-text: #87cfff;
-    --accent-breadcrumb: #6cb0f6;
-    --accent-tab: #4fc3f7;
+    --accent: var(--accent-solid);
+    --accent-hover: var(--accent-solid-hover);
+    --accent-link: var(--accent-on-surface);
+    --accent-text: var(--accent-on-surface);
+    --accent-breadcrumb: var(--accent-on-surface);
+    --accent-tab: var(--accent-bright);
 
-    --error: #f88;
-    --error-text: #f55;
+    --error: var(--sem-error);
+    --error-text: var(--sem-error-text);
 
-    --shadow: rgba(0, 0, 0, 0.5);
-    --shadow-strong: rgba(0, 0, 0, 0.35);
-    --col-resize: rgba(255, 255, 255, 0.15);
+    --shadow: rgba(0, 0, 0, 0.55);
+    --shadow-strong: rgba(0, 0, 0, 0.4);
+    --col-resize: var(--accent-alpha-strong);
 
-    --canvas-bg: #1a1a1a;
-    --canvas-text: #666;
-    --canvas-axis: #555;
-    --canvas-label: #aaa;
-    --canvas-grid: #333;
-    --canvas-title: #888;
+    /* --canvas-bg matches the panel so a canvas widget has no visible seam
+     * against the panel it is docked in. */
+    --canvas-bg: var(--surface-panel);
+    --canvas-text: var(--ink-3);
+    --canvas-axis: var(--ink-4);
+    --canvas-label: var(--ink-2);
+    --canvas-grid: var(--line-2);
+    --canvas-title: var(--ink-3);
 
-    --spinner-track: #555;
-    --spinner-head: #ccc;
+    --spinner-track: var(--line-3);
+    --spinner-head: var(--ink-1);
 
-    --ruler-label-bg: rgba(0, 0, 0, 0.75);
+    --ruler-label-bg: rgba(10, 14, 18, 0.78);
+
+    accent-color: var(--accent);
 }
 
 html[data-theme="light"] {
-    --bg-main: #ffffff;
-    --bg-panel: #f5f5f5;
-    --bg-input: #ffffff;
-    --bg-input-deep: #f0f0f0;
-    --bg-header: #e8e8e8;
-    --bg-hover: #d0d0d0;
-    --bg-selected: #0078d4;
-    --bg-selected-row: #cce5ff;
-    --bg-selected-alt: #fff8dc;
-    --bg-context: #f0f0f0;
-    --bg-overlay: rgba(0, 0, 0, 0.3);
-    --bg-status: rgba(255, 255, 255, 0.85);
-    --bg-tooltip: rgba(255, 255, 255, 0.95);
-    --bg-heatmap-legend: rgba(255, 255, 255, 0.92);
-    --bg-rubber-band: rgba(0, 120, 212, 0.15);
+    color-scheme: light;
+
+    /* Light is picked against its own ground, not derived from the dark set.
+     * Note --surface-ground is the lightest step here and the darkest one in
+     * dark mode: the roles keep their meaning, the ordering does not carry
+     * over. */
+    --surface-ground: #ffffff;
+    --surface-panel: #f4f7f9;
+    --surface-raised: #e9eff3;
+    --surface-float: #ffffff;
+    --surface-sunken: #ffffff;
+    --surface-deep: #f1f5f7;
+    --surface-hover: #e2eaee;
+    --surface-tint: #e4eff2;
+    --surface-tint-warm: #faf0d5;
+
+    --line-1: #e4eaee;
+    --line-2: #d5dfe4;
+    --line-3: #b9c7ce;
+
+    --ink-0: #0b1218;
+    --ink-1: #16212a;
+    --ink-2: #40525e;
+    --ink-3: #5b6f7b;
+    --ink-4: #93a4ae;
+
+    --accent-solid: #0b7089;   /* carries --fg-white at 5.4:1 */
+    --accent-solid-hover: #095b70;
+    --accent-bright: #0b7089;
+    --accent-on-surface: #075c70;
+    --accent-alpha-strong: rgba(11, 112, 137, 0.2);
+    --accent-alpha: rgba(11, 112, 137, 0.15);
+
+    --sem-error: #c8332f;
+    --sem-error-text: #a8271f;
+    --sem-danger: #b3282d;         /* destructive action */
+    --sem-danger-line: #98211f;
+    --sem-danger-hover: #9c2126;
+    --sem-warn: #e8b100;           /* debug pause, deliberately loud */
+    --sem-warn-ink: #101a21;
+
+    /* Roles. */
+    --bg-main: var(--surface-ground);
+    --bg-panel: var(--surface-panel);
+    --bg-input: var(--surface-sunken);
+    --bg-input-deep: var(--surface-deep);
+    --bg-header: var(--surface-raised);
+    --bg-hover: var(--surface-hover);
+    --bg-selected: var(--accent-solid);
+    --bg-selected-row: var(--surface-tint);
+    --bg-selected-alt: var(--surface-tint-warm);
+    --bg-context: var(--surface-float);
+    --bg-overlay: rgba(16, 26, 33, 0.32);
+    --bg-status: rgba(255, 255, 255, 0.88);
+    --bg-tooltip: rgba(255, 255, 255, 0.97);
+    --bg-heatmap-legend: rgba(255, 255, 255, 0.93);
+    --bg-rubber-band: var(--accent-alpha);
     --bg-map: #000;
 
-    --fg-primary: #1e1e1e;
-    --fg-secondary: #444;
-    --fg-muted: #666;
-    --fg-disabled: #999;
-    --fg-bright: #111;
+    --fg-primary: var(--ink-1);
+    --fg-secondary: var(--ink-2);
+    --fg-muted: var(--ink-3);
+    --fg-disabled: var(--ink-4);
+    --fg-bright: var(--ink-0);
     --fg-white: #fff;
-    --fg-heatmap-title: #222;
-    --fg-heatmap-units: #666;
+    --fg-heatmap-title: var(--ink-0);
+    --fg-heatmap-units: var(--ink-3);
 
-    --border: #d0d0d0;
-    --border-subtle: #e0e0e0;
-    --border-strong: #bbb;
+    --border: var(--line-2);
+    --border-subtle: var(--line-1);
+    --border-strong: var(--line-3);
     --border-heatmap-legend: rgba(0, 0, 0, 0.12);
 
-    --accent: #0078d4;
-    --accent-hover: #106ebe;
-    --accent-link: #0058a3;
-    --accent-text: #0058a3;
-    --accent-breadcrumb: #0058a3;
-    --accent-tab: #0078d4;
+    --accent: var(--accent-solid);
+    --accent-hover: var(--accent-solid-hover);
+    --accent-link: var(--accent-on-surface);
+    --accent-text: var(--accent-on-surface);
+    --accent-breadcrumb: var(--accent-on-surface);
+    --accent-tab: var(--accent-bright);
 
-    --error: #d32f2f;
-    --error-text: #c62828;
+    --error: var(--sem-error);
+    --error-text: var(--sem-error-text);
 
-    --shadow: rgba(0, 0, 0, 0.15);
-    --shadow-strong: rgba(0, 0, 0, 0.12);
-    --col-resize: rgba(0, 0, 0, 0.1);
+    --shadow: rgba(16, 26, 33, 0.16);
+    --shadow-strong: rgba(16, 26, 33, 0.13);
+    --col-resize: var(--accent-alpha-strong);
 
-    --canvas-bg: #ffffff;
-    --canvas-text: #999;
-    --canvas-axis: #999;
-    --canvas-label: #555;
-    --canvas-grid: #e0e0e0;
-    --canvas-title: #666;
+    --canvas-bg: var(--surface-panel);
+    --canvas-text: var(--ink-3);
+    --canvas-axis: var(--ink-4);
+    --canvas-label: var(--ink-2);
+    --canvas-grid: var(--line-1);
+    --canvas-title: var(--ink-3);
 
-    --spinner-track: #ccc;
-    --spinner-head: #333;
+    --spinner-track: var(--line-3);
+    --spinner-head: var(--ink-1);
 
-    --ruler-label-bg: rgba(255, 255, 255, 0.85);
+    --ruler-label-bg: rgba(255, 255, 255, 0.9);
+
+    accent-color: var(--accent);
 }
 
 /* ─── Ruler overlay ──────────────────────────────────────────────────────── */
@@ -139,7 +262,7 @@ html[data-theme="light"] {
     background: var(--ruler-label-bg);
     color: var(--fg-bright);
     padding: 2px 6px;
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     font: 12px monospace;
     white-space: nowrap;
     pointer-events: none;
@@ -177,7 +300,7 @@ html, body {
     margin: 0;
     overflow: hidden;
     background: var(--bg-main);
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: var(--font-sans);
     color: var(--fg-primary);
 }
 
@@ -211,7 +334,7 @@ body {
     height: 24px;
     background: var(--bg-header);
     border-bottom: 1px solid var(--bg-input);
-    font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font: 13px var(--font-sans);
     color: var(--fg-primary);
     user-select: none;
     z-index: 10001;
@@ -318,8 +441,8 @@ body {
     background: var(--bg-input);
     color: var(--fg-primary);
     border: 1px solid var(--border);
-    border-radius: 4px;
-    font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    border-radius: var(--radius-sm);
+    font: 12px var(--font-sans);
     cursor: pointer;
     user-select: none;
     white-space: nowrap;
@@ -356,7 +479,7 @@ body {
     position: relative;
     background: var(--bg-header);
     border: 1px solid var(--border-strong);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     padding: 16px 20px;
     min-width: 400px;
     color: var(--fg-primary);
@@ -390,7 +513,7 @@ body {
     padding: 6px 8px;
     background: var(--bg-main);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
     font: 13px monospace;
     box-sizing: border-box;
@@ -408,7 +531,7 @@ body {
 .modal-dialog button {
     padding: 5px 14px;
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     background: var(--bg-hover);
     color: var(--fg-primary);
     font: 13px sans-serif;
@@ -507,7 +630,7 @@ body {
     background: var(--bg-main);
     padding: 4px 8px;
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     margin-bottom: 8px;
     font-size: 12px;
     white-space: nowrap;
@@ -526,7 +649,7 @@ body {
 .fb-file-list {
     background: var(--bg-main);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     max-height: 320px;
     min-height: 160px;
     overflow-y: auto;
@@ -544,6 +667,13 @@ body {
 }
 .fb-entry.fb-selected {
     background: var(--bg-selected);
+    color: var(--fg-white);
+}
+/* The size column is muted against the panel; on the selected row it has to
+ * come off --fg-white instead or it drops out against the accent. */
+.fb-entry.fb-selected .fb-size {
+    color: var(--fg-white);
+    opacity: 0.75;
 }
 .fb-icon {
     flex-shrink: 0;
@@ -606,7 +736,7 @@ body {
     overflow-y: auto !important;
     overflow-x: hidden;
     padding: 2px 0;
-    border-radius: 0 0 4px 4px;
+    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 .lm_header .lm_tabdropdown_list .lm_tab {
     display: flex;
@@ -669,7 +799,7 @@ body {
 .leaflet-popup-content-wrapper {
     background: var(--bg-context);
     color: var(--fg-bright);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
 }
 .leaflet-popup-content {
     font-family: monospace;
@@ -691,10 +821,10 @@ body {
     top: 40px;
     left: 50%;
     transform: translateX(-50%);
-    background: linear-gradient(135deg, var(--error) 0%, #cc3333 100%);
-    color: white;
+    background: linear-gradient(135deg, var(--error) 0%, var(--sem-danger-hover) 100%);
+    color: var(--fg-white);
     padding: 16px 24px;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     font-size: 16px;
     font-weight: bold;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
@@ -711,7 +841,7 @@ body {
     color: var(--fg-secondary);
     padding: 4px 10px;
     font: 12px monospace;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     display: inline-block;
 }
 
@@ -747,7 +877,7 @@ body {
     color: var(--fg-secondary);
     padding: 2px 8px;
     font: 12px monospace;
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     pointer-events: none;
 }
 
@@ -760,7 +890,7 @@ body {
     z-index: 900;
     background: var(--bg-status);
     color: var(--fg-secondary);  /* SVG strokes use currentColor */
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 1px 4px;
     line-height: 0;  /* wrap the inline SVG snugly */
     pointer-events: none;
@@ -918,7 +1048,7 @@ body {
     display: inline-block;
     width: 12px;
     height: 12px;
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
     margin-right: 6px;
     vertical-align: middle;
     border: 1px solid var(--border-strong);
@@ -1007,7 +1137,7 @@ body {
     position: fixed;
     background: var(--bg-context);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     min-width: 180px;
     z-index: 10000;
     padding: 4px 0;
@@ -1056,7 +1186,7 @@ body {
     display: none;
     background: var(--bg-context);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     min-width: 160px;
     padding: 4px 0;
     box-shadow: 0 2px 8px var(--shadow);
@@ -1186,7 +1316,7 @@ body {
 .help-panel kbd {
     background: var(--border-subtle);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 1px 6px;
     font-family: monospace;
     font-size: 12px;
@@ -1248,7 +1378,7 @@ body {
 .inspector-prop-value::-webkit-scrollbar-thumb,
 .inspector-table-scroll::-webkit-scrollbar-thumb {
     background: var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
 }
 .inspector-editable {
     cursor: text;
@@ -1272,7 +1402,7 @@ body {
     background: var(--bg-input);
     color: var(--fg-primary);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     font: inherit;
     max-width: 100%;
 }
@@ -1289,14 +1419,14 @@ body {
     color: var(--fg-bright);
 }
 .inspector-btn-danger:hover {
-    background: #7a2020;
-    border-color: #a03030;
-    color: #fff;
+    background: var(--sem-danger);
+    border-color: var(--sem-danger-line);
+    color: var(--fg-white);
 }
 .or-modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--bg-overlay);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1306,11 +1436,11 @@ body {
     background: var(--bg-panel);
     color: var(--fg-primary);
     border: 1px solid var(--border-strong);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     min-width: 280px;
     max-width: 420px;
     padding: 14px 16px;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
+    box-shadow: 0 8px 30px var(--shadow);
 }
 .or-modal-title {
     font-weight: 600;
@@ -1331,7 +1461,7 @@ body {
     padding: 5px 14px;
     background: var(--border-subtle);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
     cursor: pointer;
 }
@@ -1339,12 +1469,12 @@ body {
     background: var(--border);
 }
 .or-modal-btn-danger {
-    background: #7a2020;
-    border-color: #a03030;
-    color: #fff;
+    background: var(--sem-danger);
+    border-color: var(--sem-danger-line);
+    color: var(--fg-white);
 }
 .or-modal-btn-danger:hover {
-    background: #942828;
+    background: var(--sem-danger-hover);
 }
 .selection-browser {
     display: flex;
@@ -1364,20 +1494,20 @@ body {
     padding: 3px 10px;
     background: var(--bg-panel);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-secondary);
     cursor: pointer;
 }
 .sb-tab.active {
     background: var(--accent);
-    color: #fff;
+    color: var(--fg-white);
 }
 .sb-tool {
     margin-left: auto;
     padding: 3px 8px;
     background: var(--border-subtle);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
     cursor: pointer;
 }
@@ -1389,7 +1519,7 @@ body {
     padding: 3px 6px;
     background: var(--bg-input);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
 }
 .sb-truncated {
@@ -1435,7 +1565,7 @@ body {
     width: 10px;
     height: 10px;
     border: 1px solid var(--border-strong);
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
     vertical-align: middle;
 }
 .sb-actions {
@@ -1459,10 +1589,10 @@ body {
     position: fixed;
     background: var(--bg-panel);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 6px;
     z-index: 3000;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 4px 16px var(--shadow);
 }
 .highlight-swatch-grid {
     display: grid;
@@ -1473,7 +1603,7 @@ body {
     width: 22px;
     height: 22px;
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     padding: 0;
 }
@@ -1491,7 +1621,7 @@ body {
     padding: 3px 6px;
     background: var(--border-subtle);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
     cursor: pointer;
     font-size: 11px;
@@ -1509,7 +1639,7 @@ body {
     background: var(--bg-status);
     color: var(--fg-primary);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 12px;
     z-index: 3000;
     opacity: 0;
@@ -1623,7 +1753,7 @@ body {
     padding: 0;
     background: var(--border-subtle);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
     cursor: pointer;
 }
@@ -1659,9 +1789,9 @@ body {
     right: 12px;
     z-index: 10000;
     padding: 8px 16px;
-    background: #fc0;
-    color: #000;
-    border: 1px solid #000;
+    background: var(--sem-warn);
+    color: var(--sem-warn-ink);
+    border: 1px solid var(--sem-warn-ink);
     font-weight: bold;
     display: none;
     cursor: pointer;
@@ -1733,7 +1863,7 @@ body {
 .timing-btn {
     background: var(--border-subtle);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     color: var(--fg-primary);
     padding: 4px 12px;
     cursor: pointer;
@@ -1824,7 +1954,7 @@ body {
     position: fixed;
     background: var(--bg-tooltip);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 6px 10px;
     font-size: 12px;
     color: var(--fg-primary);
@@ -1922,7 +2052,7 @@ body {
     display: inline-block;
     width: 12px;
     height: 12px;
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
     border: 1px solid var(--border-strong);
     margin-right: 4px;
     vertical-align: middle;
@@ -1964,7 +2094,7 @@ body {
     position: absolute;
     background: var(--bg-tooltip);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 6px 10px;
     font-size: 12px;
     color: var(--fg-primary);
@@ -1993,7 +2123,7 @@ body {
     position: absolute;
     background: var(--bg-tooltip);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 6px 10px;
     font-size: 12px;
     color: var(--fg-primary);
@@ -2010,7 +2140,7 @@ body {
     z-index: 100;
     background: var(--bg-tooltip);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 4px 8px;
     font-size: 12px;
     color: var(--fg-primary);
@@ -2049,7 +2179,7 @@ body {
     background: var(--bg-context);
     color: var(--fg-primary);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 3px 6px;
     font-family: monospace;
     font-size: 12px;
@@ -2070,7 +2200,7 @@ body {
     position: absolute;
     background: var(--bg-tooltip);
     border: 1px solid var(--border-strong);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 6px 10px;
     font-size: 12px;
     color: var(--fg-primary);
@@ -2118,7 +2248,7 @@ body {
     background: var(--bg-input);
     color: var(--fg-bright);
     border: 1px solid var(--border-strong);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 2px 4px;
     font-family: monospace;
     font-size: 12px;
@@ -2129,7 +2259,7 @@ body {
     background: var(--bg-context);
     color: var(--fg-bright);
     border: 1px solid var(--fg-disabled);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 4px 8px;
     cursor: pointer;
 }
@@ -2145,7 +2275,7 @@ body {
     width: 14px;
     height: 14px;
     border: 1px solid var(--fg-disabled);
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
     flex: 0 0 auto;
 }
 
@@ -2159,7 +2289,7 @@ body {
     padding: 10px 12px;
     background: var(--bg-heatmap-legend);
     border: 1px solid var(--border-heatmap-legend);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     box-shadow: 0 6px 20px var(--shadow-strong);
     color: var(--fg-bright);
     font-family: monospace;
@@ -2219,7 +2349,7 @@ html[data-theme="dark"] .schematic-widget svg {
     background: var(--bg-input);
     color: var(--fg-primary);
     border: 1px solid var(--border);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 3px 4px;
     font-size: 12px;
 }
@@ -2228,7 +2358,7 @@ html[data-theme="dark"] .schematic-widget svg {
     background: var(--bg-input);
     color: var(--fg-secondary);
     border: 1px solid var(--border);
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     padding: 3px 8px;
     cursor: pointer;
     font-size: 12px;
@@ -2263,7 +2393,7 @@ html[data-theme="dark"] .schematic-widget svg {
     align-items: center;
     gap: 4px;
     padding: 2px 4px;
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
 }
 .drc-tree-header:hover {
     background: var(--bg-hover);
@@ -2307,7 +2437,7 @@ html[data-theme="dark"] .schematic-widget svg {
     align-items: center;
     gap: 4px;
     padding: 2px 4px;
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
     cursor: pointer;
 }
 .drc-marker-row:hover {
@@ -2339,7 +2469,7 @@ html[data-theme="dark"] .schematic-widget svg {
     background: var(--bg-input);
     color: var(--fg-secondary);
     border: 1px solid var(--border);
-    border-radius: 2px;
+    border-radius: var(--radius-xs);
     padding: 0 4px;
     font-size: 10px;
     flex-shrink: 0;

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -864,13 +864,86 @@ body {
     background: var(--bg-panel);
     overflow: hidden;
 }
+/* Golden Layout's own tabs are distinguished only by a slightly different
+   background, which at these surface steps is nearly invisible.  The active
+   tab gets the accent underline the timing widget already uses on its own tab
+   bar, so the two tab bars in a stacked panel read the same way.  The height
+   comes from the layout config (dimensions.headerHeight in main.js), not from
+   here -- Golden Layout measures it in JS. */
 .lm_header .lm_tab {
-    background: var(--bg-header);
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    /* Golden Layout gives the tab a 14px content height plus its own drop
+       shadows, which in a 28px header leaves it floating in the strip.  The
+       height has to be stated rather than stretched: .lm_tabs is absolutely
+       positioned and shrink-wraps its content, so `align-self: stretch` has
+       nothing to stretch against.  And it is a content-box height -- the
+       header forces `box-sizing: content-box !important` on every lm_ element
+       inside it -- so 26 + the 2px underline is the 28px header. */
+    height: 26px;
+    margin-top: 0;
+    padding: 0 25px 0 var(--space-md);
+    background: transparent;
+    box-shadow: none;
+    color: var(--fg-muted);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    border-bottom: 2px solid transparent;
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    transition: background-color 120ms ease, color 120ms ease;
+}
+.lm_header .lm_tab:hover {
+    background: var(--bg-hover);
     color: var(--fg-secondary);
 }
+/* The full border-bottom, not just its colour: Golden Layout's theme sets
+   `border-bottom: none` on the active tab at this same specificity, so a
+   colour alone would apply to a zero-width border. */
 .lm_header .lm_tab.lm_active {
     background: var(--bg-panel);
+    box-shadow: none;
     color: var(--fg-bright);
+    border-bottom: 2px solid var(--accent-tab);
+    padding-bottom: 0;
+}
+/* The close button and the stack controls are positioned against the old
+   header height, so they sit high in a taller one. */
+/* The light theme pads .lm_title by 1px, which content-box adds to the tab's
+   height and pushes it past the header. */
+.lm_header .lm_tab .lm_title {
+    padding-top: 0;
+}
+.lm_header .lm_tab .lm_close_tab {
+    top: 50%;
+    transform: translateY(-50%);
+}
+.lm_header .lm_controls {
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+/* The per-panel icon, prepended by decorateTabIcons (ui-utils.js).  It is the
+   fastest way to find a panel in a stack of six similarly-worded titles. */
+.lm_header .lm_tab .or-tab-icon {
+    display: flex;
+    flex: none;
+    width: 13px;
+    height: 13px;
+    opacity: 0.7;
+}
+.lm_header .lm_tab.lm_active .or-tab-icon {
+    color: var(--accent-tab);
+    opacity: 1;
+}
+.lm_header .lm_tab .or-tab-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+/* Same icon, in the overflow dropdown. */
+.lm_header .lm_tabdropdown_list .lm_tab .or-tab-icon {
+    margin-right: var(--space-sm);
 }
 .lm_splitter {
     background: var(--border-subtle);
@@ -972,6 +1045,55 @@ body {
 .layout-viewer {
     position: relative;
 }
+/* Drawn as an overlay rather than a border, for two reasons: a border on this
+   element would change the size Leaflet measures for the map, and an inset
+   box-shadow would be painted under the tile panes and never seen.  z-index
+   800 puts it over the panes (Leaflet's go up to 700) but under the HUD (900)
+   and Leaflet's own controls (1000), so it frames the canvas without drawing
+   a line across either.  The inner shadow is invisible against the default
+   black and does its work when the Background control is set to something
+   light. */
+.layout-viewer::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 800;
+    pointer-events: none;
+    border: 1px solid var(--border-strong);
+    box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.35);
+}
+
+/* Tile requests in flight: a 2px indeterminate line along the top of the
+   canvas.  It replaces a grey "pending: N" chip, which said the same thing in
+   a corner nobody watches -- the count survives as the element's tooltip. */
+.or-progress {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    z-index: 850;
+    overflow: hidden;
+    pointer-events: none;
+    display: none;
+}
+.or-progress.active {
+    display: block;
+}
+.or-progress::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 34%;
+    background: linear-gradient(90deg, transparent, var(--accent-tab),
+                                transparent);
+    animation: or-progress-sweep 1.9s linear infinite;
+}
+@keyframes or-progress-sweep {
+    from { left: -34%; }
+    to { left: 100%; }
+}
 
 /* Leaflet popups */
 .leaflet-popup-content-wrapper {
@@ -1007,12 +1129,14 @@ body {
     font-weight: bold;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
     text-align: center;
-    animation: slideDown 0.3s ease-out, pulse 2s ease-in-out infinite 0.5s;
+    animation: slideDown 0.3s ease-out, pulse 2s ease-in-out 3 0.5s;
     letter-spacing: 0.5px;
 }
 
+/* Only shown once the request queue is backed up (PENDING_BACKLOG in
+   main.js), so it is coloured as a warning rather than as a neutral readout. */
 #websocket-status .pending-indicator {
-    color: var(--fg-hud-muted);
+    color: var(--sem-error);
 }
 
 @keyframes slideDown {

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -36,6 +36,21 @@
     --radius-sm: 4px;   /* controls: buttons, inputs, list rows */
     --radius-md: 7px;   /* panels, dialogs, floating surfaces */
 
+    --space-sm: 6px;
+    --space-md: 8px;
+    --space-lg: 12px;
+    --space-xl: 16px;
+
+    /* Floating overlays on the layout canvas -- scale bar, coordinate
+     * readout, heat-map legend, Leaflet's zoom and Fit controls.  These do
+     * not flip with the theme: they sit on --bg-map, which is black in both
+     * themes for Qt parity, so a light surface here would be a bright block
+     * on black and light-theme ink on it would be unreadable. */
+    --bg-hud: rgba(12, 18, 24, 0.88);
+    --border-hud: rgba(255, 255, 255, 0.14);
+    --fg-hud: #eef4f8;
+    --fg-hud-muted: #9fb0bc;
+
     --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -93,9 +108,7 @@ html[data-theme="dark"] {
     --bg-selected-alt: var(--surface-tint-warm);
     --bg-context: var(--surface-float);
     --bg-overlay: rgba(4, 7, 10, 0.58);
-    --bg-status: rgba(10, 14, 18, 0.76);
     --bg-tooltip: rgba(24, 32, 39, 0.96);
-    --bg-heatmap-legend: rgba(12, 18, 24, 0.88);
     --bg-rubber-band: var(--accent-alpha);
     --bg-map: #000;
 
@@ -105,13 +118,10 @@ html[data-theme="dark"] {
     --fg-disabled: var(--ink-4);
     --fg-bright: var(--ink-0);
     --fg-white: #fff;
-    --fg-heatmap-title: var(--ink-0);
-    --fg-heatmap-units: var(--ink-3);
 
     --border: var(--line-2);
     --border-subtle: var(--line-1);
     --border-strong: var(--line-3);
-    --border-heatmap-legend: rgba(255, 255, 255, 0.14);
 
     --accent: var(--accent-solid);
     --accent-hover: var(--accent-solid-hover);
@@ -139,7 +149,6 @@ html[data-theme="dark"] {
     --spinner-track: var(--line-3);
     --spinner-head: var(--ink-1);
 
-    --ruler-label-bg: rgba(10, 14, 18, 0.78);
 
     accent-color: var(--accent);
 }
@@ -198,9 +207,7 @@ html[data-theme="light"] {
     --bg-selected-alt: var(--surface-tint-warm);
     --bg-context: var(--surface-float);
     --bg-overlay: rgba(16, 26, 33, 0.32);
-    --bg-status: rgba(255, 255, 255, 0.88);
     --bg-tooltip: rgba(255, 255, 255, 0.97);
-    --bg-heatmap-legend: rgba(255, 255, 255, 0.93);
     --bg-rubber-band: var(--accent-alpha);
     --bg-map: #000;
 
@@ -210,13 +217,10 @@ html[data-theme="light"] {
     --fg-disabled: var(--ink-4);
     --fg-bright: var(--ink-0);
     --fg-white: #fff;
-    --fg-heatmap-title: var(--ink-0);
-    --fg-heatmap-units: var(--ink-3);
 
     --border: var(--line-2);
     --border-subtle: var(--line-1);
     --border-strong: var(--line-3);
-    --border-heatmap-legend: rgba(0, 0, 0, 0.12);
 
     --accent: var(--accent-solid);
     --accent-hover: var(--accent-solid-hover);
@@ -242,7 +246,6 @@ html[data-theme="light"] {
     --spinner-track: var(--line-3);
     --spinner-head: var(--ink-1);
 
-    --ruler-label-bg: rgba(255, 255, 255, 0.9);
 
     accent-color: var(--accent);
 }
@@ -259,8 +262,8 @@ html[data-theme="light"] {
     cursor: crosshair !important;
 }
 .ruler-label {
-    background: var(--ruler-label-bg);
-    color: var(--fg-bright);
+    background: var(--bg-hud);
+    color: var(--fg-hud);
     padding: 2px 6px;
     border-radius: var(--radius-sm);
     font: 12px monospace;
@@ -275,8 +278,8 @@ html[data-theme="light"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: var(--ruler-label-bg, #00ffff);
-    border: 1px solid var(--fg-bright, #fff);
+    background: var(--bg-hud);
+    border: 1px solid var(--fg-hud);
     box-sizing: border-box;
     cursor: move;
 }
@@ -432,37 +435,194 @@ body {
 #toolbar:empty {
     display: none;
 }
-#toolbar .toolbar-button {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    height: 22px;
-    padding: 0 10px;
-    background: var(--bg-input);
-    color: var(--fg-primary);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    font: 12px var(--font-sans);
-    cursor: pointer;
-    user-select: none;
-    white-space: nowrap;
-}
-#toolbar .toolbar-button:hover {
-    background: var(--bg-hover);
-}
-#toolbar .toolbar-button.active {
-    background: var(--bg-selected);
-    color: var(--fg-white);
-    border-color: var(--bg-selected);
-}
-#toolbar .toolbar-button .toolbar-icon {
+/* A Tcl-registered button carries an icon slot ahead of its label; the button
+ * itself is a plain .or-btn. */
+#toolbar .toolbar-icon {
     font-size: 13px;
     line-height: 1;
 }
-#toolbar .toolbar-button .toolbar-icon img {
+/* Unlike the inline SVGs elsewhere, this is a user-supplied image of unknown
+   size, so it is constrained rather than left at its intrinsic size. */
+#toolbar .toolbar-icon img {
     width: 14px;
     height: 14px;
     display: block;
+}
+
+/* ─── Buttons ─────────────────────────────────────────────────────────────── */
+
+/* One rule for every push button in the viewer.  It replaces eight
+ * near-identical blocks that differed only by a pixel of padding or radius --
+ * .toolbar-button, .timing-btn, .drc-btn, .inspector-btn, .sb-tool,
+ * .heatmap-rebuild, .or-modal-btn and a bare `.modal-dialog button` -- so a
+ * new control picks a variant instead of adding a ninth.  Size is a variant
+ * (.or-btn-sm, .or-btn-icon), emphasis is a variant (.or-btn-primary,
+ * .or-btn-danger), and toggle state is .active.
+ *
+ * Deliberately not part of this: controls that are shaped like something else
+ * and only happen to be <button> elements -- .timing-tab and .sb-tab (tabs),
+ * .sb-row-btn and .inspector-edit-btn (bare glyph affordances inside a row),
+ * .modal-close, .highlight-swatch, .bg-color-reset and .debug-continue-btn.
+ *
+ * Ordering matters here: the variants and states are all one class plus one
+ * pseudo-class, so they tie on specificity with .or-btn:hover and win only by
+ * coming after it.  Keep :disabled last. */
+.or-btn {
+    --or-btn-h: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-sm);
+    flex: none;
+    box-sizing: border-box;
+    height: var(--or-btn-h);
+    padding: 0 var(--space-lg);
+    background: var(--bg-header);
+    color: var(--fg-primary);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: 12px var(--font-sans);
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 120ms ease, border-color 120ms ease,
+                color 120ms ease;
+}
+.or-btn:hover {
+    background: var(--bg-hover);
+    color: var(--fg-bright);
+}
+.or-btn:active {
+    background: var(--bg-context);
+}
+.or-btn-sm {
+    --or-btn-h: 22px;
+    padding: 0 var(--space-md);
+    font-size: 11px;
+}
+/* Square, for a button whose whole label is one glyph or icon. */
+.or-btn-icon {
+    width: var(--or-btn-h);
+    padding: 0;
+}
+.or-btn-primary,
+.or-btn.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--fg-white);
+}
+.or-btn-primary:hover,
+.or-btn.active:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+    color: var(--fg-white);
+}
+/* Always red: a destructive action the user is being asked to confirm, where
+ * the button is the point of the dialog. */
+.or-btn-danger {
+    background: var(--sem-danger);
+    border-color: var(--sem-danger-line);
+    color: var(--fg-white);
+}
+.or-btn-danger:hover,
+/* Red on hover only: a destructive action sitting in a row of neutral icon
+ * buttons.  The inspector's toolbar is on screen the whole session, and one
+ * permanently red icon among six would read as an alert rather than an
+ * action. */
+.or-btn-danger-hover:hover {
+    background: var(--sem-danger-hover);
+    border-color: var(--sem-danger-line);
+    color: var(--fg-white);
+}
+.or-btn:disabled {
+    background: var(--bg-header);
+    border-color: var(--border);
+    color: var(--fg-muted);
+    opacity: 0.55;
+    cursor: default;
+}
+.or-btn svg {
+    display: block;  /* no inline baseline gap under the glyph */
+    flex: none;
+}
+
+/* ─── Tooltips ────────────────────────────────────────────────────────────── */
+
+/* Replaces four identical blocks (.timing-header-tooltip, .clock-tree-tooltip,
+ * .three-d-tooltip, .charts-tooltip).  Hidden by default; each widget toggles
+ * display between 'block' and 'none' explicitly, never ''. */
+.or-tooltip {
+    position: absolute;
+    z-index: 100;
+    display: none;
+    max-width: 420px;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-tooltip);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 4px 14px var(--shadow);
+    color: var(--fg-primary);
+    font-size: 12px;
+    /* `pre`, not `nowrap`: the timing column help arrives as a multi-line
+     * string and has to keep its newlines.  Single-line content renders the
+     * same under either. */
+    white-space: pre;
+    pointer-events: none;
+}
+/* For a tooltip positioned in viewport coordinates rather than inside its
+ * widget's box. */
+.or-tooltip-fixed {
+    position: fixed;
+}
+
+/* ─── Floating overlays on the canvas ─────────────────────────────────────── */
+
+/* The scale bar, coordinate readout, heat-map legend and pending-request
+ * indicator were four separately styled chips.  They share one surface now:
+ * translucent over the layout, hairline border, and enough blur to stay
+ * legible over dense routing. */
+.or-hud {
+    position: absolute;
+    z-index: 900;
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-hud);
+    border: 1px solid var(--border-hud);
+    border-radius: var(--radius-md);
+    box-shadow: 0 6px 20px var(--shadow-strong);
+    backdrop-filter: blur(3px);
+    color: var(--fg-hud);
+    font: 12px monospace;
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+}
+.or-hud-bottom-left {
+    left: var(--space-lg);
+    bottom: var(--space-lg);
+}
+.or-hud-bottom-right {
+    right: var(--space-lg);
+    bottom: var(--space-lg);
+}
+/* Fixed rather than absolute: the request indicator lives in #websocket-status,
+ * which is not inside the layout viewer. */
+.or-hud-top-right {
+    position: fixed;
+    top: var(--space-md);
+    right: var(--space-md);
+}
+/* Separator between two readouts sharing one HUD. */
+.or-hud-divider {
+    flex: none;
+    align-self: stretch;
+    width: 1px;
+    background: var(--border-hud);
+}
+.or-hud.hidden {
+    display: none;
 }
 
 /* Modal dialog (Open/Save DB) */
@@ -528,34 +688,10 @@ body {
     gap: 8px;
     margin-top: 12px;
 }
-.modal-dialog button {
-    padding: 5px 14px;
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    background: var(--bg-hover);
-    color: var(--fg-primary);
-    font: 13px sans-serif;
-    cursor: pointer;
-}
-.modal-dialog button:hover {
-    background: var(--bg-context);
-}
-.modal-dialog button.primary {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: var(--fg-white);
-}
-.modal-dialog button.primary:hover {
-    background: var(--accent-hover);
-}
 .modal-dialog .modal-error {
     color: var(--error);
     margin-top: 8px;
     font-size: 12px;
-}
-.modal-dialog button:disabled {
-    opacity: 0.5;
-    cursor: default;
 }
 
 /* Search & navigation dialogs (Find / Go to) */
@@ -611,7 +747,11 @@ body {
 .gc-row.gc-head { background: var(--bg-header); color: var(--fg-muted); font-weight: bold; }
 .gc-row span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .gc-form { display: flex; flex-direction: column; gap: 4px; border-top: 1px solid var(--bg-input); padding-top: 8px; }
-.gc-invalid { outline: 1px solid var(--error); }
+/* A ring rather than an outline: the focus ring added at the end of this file
+   is an outline too, and while the field is focused one would replace the
+   other -- an invalid field would stop looking invalid exactly when the user
+   is fixing it. */
+.gc-invalid { box-shadow: 0 0 0 1px var(--error); }
 .buf-pins {
     flex: 1;
     max-height: 180px;
@@ -771,6 +911,31 @@ body {
 .leaflet-container {
     cursor: default !important;
 }
+/* Leaflet draws its own control chrome (white background, dark border), which
+   is the app's theme only by coincidence.  Restyle the bar rather than each
+   control, so the zoom buttons and the Fit button below them match. */
+.leaflet-bar {
+    border: 1px solid var(--border-hud);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 4px 14px var(--shadow-strong);
+    overflow: hidden;
+}
+.leaflet-bar a,
+.leaflet-bar a:hover {
+    background: var(--bg-hud);
+    color: var(--fg-hud);
+    border-bottom-color: var(--border-hud);
+    backdrop-filter: blur(3px);
+    transition: background-color 120ms ease, color 120ms ease;
+}
+.leaflet-bar a:hover {
+    background: rgba(255, 255, 255, 0.14);
+    color: #fff;
+}
+.leaflet-bar a.leaflet-disabled {
+    background: var(--bg-hud);
+    color: rgba(238, 244, 248, 0.4);
+}
 /* "Fit" control button — inherits .leaflet-bar sizing from Leaflet's CSS. */
 .leaflet-control-fit a {
     font-size: 16px;
@@ -834,15 +999,7 @@ body {
 }
 
 #websocket-status .pending-indicator {
-    position: fixed;
-    top: 8px;
-    right: 8px;
-    background: var(--bg-status);
-    color: var(--fg-secondary);
-    padding: 4px 10px;
-    font: 12px monospace;
-    border-radius: var(--radius-sm);
-    display: inline-block;
+    color: var(--fg-hud-muted);
 }
 
 @keyframes slideDown {
@@ -867,33 +1024,14 @@ body {
     }
 }
 
-/* Coordinate readout (bottom-left of layout viewer) */
-#coord-bar {
-    position: absolute;
-    bottom: 4px;
-    left: 4px;
-    z-index: 900;
-    background: var(--bg-status);
-    color: var(--fg-secondary);
-    padding: 2px 8px;
-    font: 12px monospace;
-    border-radius: var(--radius-sm);
-    pointer-events: none;
-}
-
-/* Scale bar (bottom-left, above coord bar).  Content is an inline SVG
-   (bracket + ticks + 0/total labels) rebuilt by updateScaleBar. */
+/* Scale bar and coordinate readout share one HUD at the bottom-left of the
+   layout viewer (see .or-hud).  The scale bar's content is an inline SVG
+   (bracket + ticks + 0/total labels) rebuilt by updateScaleBar; the scale bar
+   hides on its own -- it is a display option -- so the divider beside it goes
+   with it. */
 #scale-bar {
-    position: absolute;
-    bottom: 26px;
-    left: 4px;
-    z-index: 900;
-    background: var(--bg-status);
-    color: var(--fg-secondary);  /* SVG strokes use currentColor */
-    border-radius: var(--radius-sm);
-    padding: 1px 4px;
     line-height: 0;  /* wrap the inline SVG snugly */
-    pointer-events: none;
+    color: var(--fg-hud-muted);  /* SVG strokes use currentColor */
 }
 /* Tick/label text drawn inside the scale-bar SVG. */
 .scale-bar-text {
@@ -1418,11 +1556,6 @@ body {
 .inspector-edit-btn:hover {
     color: var(--fg-bright);
 }
-.inspector-btn-danger:hover {
-    background: var(--sem-danger);
-    border-color: var(--sem-danger-line);
-    color: var(--fg-white);
-}
 .or-modal-overlay {
     position: fixed;
     inset: 0;
@@ -1457,25 +1590,6 @@ body {
     justify-content: flex-end;
     gap: 8px;
 }
-.or-modal-btn {
-    padding: 5px 14px;
-    background: var(--border-subtle);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    color: var(--fg-primary);
-    cursor: pointer;
-}
-.or-modal-btn:hover {
-    background: var(--border);
-}
-.or-modal-btn-danger {
-    background: var(--sem-danger);
-    border-color: var(--sem-danger-line);
-    color: var(--fg-white);
-}
-.or-modal-btn-danger:hover {
-    background: var(--sem-danger-hover);
-}
 .selection-browser {
     display: flex;
     flex-direction: column;
@@ -1504,12 +1618,6 @@ body {
 }
 .sb-tool {
     margin-left: auto;
-    padding: 3px 8px;
-    background: var(--border-subtle);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    color: var(--fg-primary);
-    cursor: pointer;
 }
 .sb-tool + .sb-tool {
     margin-left: 4px;
@@ -1635,11 +1743,12 @@ body {
     left: 50%;
     transform: translateX(-50%);
     max-width: 60%;
-    padding: 8px 14px;
-    background: var(--bg-status);
+    padding: var(--space-md) var(--space-xl);
+    background: var(--bg-context);
     color: var(--fg-primary);
     border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius-md);
+    box-shadow: 0 6px 20px var(--shadow-strong);
     font-size: 12px;
     z-index: 3000;
     opacity: 0;
@@ -1744,29 +1853,6 @@ body {
     border-bottom: 1px solid var(--border-subtle);
     margin-bottom: 4px;
 }
-.inspector-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    padding: 0;
-    background: var(--border-subtle);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    color: var(--fg-primary);
-    cursor: pointer;
-}
-.inspector-btn:hover {
-    background: var(--border);
-    color: var(--fg-bright);
-}
-.inspector-btn:disabled {
-    opacity: 0.45;
-    cursor: default;
-    background: var(--bg-context);
-    color: var(--fg-muted);
-}
 .inspector-selection-nav {
     display: flex;
     align-items: center;
@@ -1860,18 +1946,6 @@ body {
     flex-shrink: 0;
 }
 
-.timing-btn {
-    background: var(--border-subtle);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    color: var(--fg-primary);
-    padding: 4px 12px;
-    cursor: pointer;
-    font-size: 12px;
-}
-.timing-btn:hover { background: var(--border); color: var(--fg-bright); }
-.timing-btn:disabled { opacity: 0.5; cursor: default; }
-
 .timing-path-count {
     color: var(--fg-muted);
     font-size: 12px;
@@ -1948,20 +2022,6 @@ body {
     border-bottom: 1px solid var(--border);
     font-weight: 600;
     white-space: nowrap;
-}
-
-.timing-header-tooltip {
-    position: fixed;
-    background: var(--bg-tooltip);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    padding: 6px 10px;
-    font-size: 12px;
-    color: var(--fg-primary);
-    pointer-events: none;
-    white-space: pre;
-    z-index: 100;
-    display: none;
 }
 
 .timing-table thead th.sortable {
@@ -2090,20 +2150,6 @@ body {
     display: block;
 }
 
-.clock-tree-tooltip {
-    position: absolute;
-    background: var(--bg-tooltip);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    padding: 6px 10px;
-    font-size: 12px;
-    color: var(--fg-primary);
-    pointer-events: none;
-    white-space: nowrap;
-    z-index: 100;
-    display: none;
-}
-
 /* ─── 3D Viewer Widget ───────────────────────────────────────────────── */
 
 .three-d-viewer-widget {
@@ -2117,20 +2163,6 @@ body {
     width: 100%;
     height: 100%;
     position: relative;
-}
-
-.three-d-tooltip {
-    position: absolute;
-    background: var(--bg-tooltip);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    padding: 6px 10px;
-    font-size: 12px;
-    color: var(--fg-primary);
-    pointer-events: none;
-    white-space: nowrap;
-    z-index: 100;
-    display: none;
 }
 
 .three-d-options {
@@ -2196,20 +2228,6 @@ body {
     display: block;
 }
 
-.charts-tooltip {
-    position: absolute;
-    background: var(--bg-tooltip);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
-    padding: 6px 10px;
-    font-size: 12px;
-    color: var(--fg-primary);
-    pointer-events: none;
-    white-space: pre;
-    z-index: 100;
-    display: none;
-}
-
 .heatmap-controls {
     margin-top: 12px;
     padding-top: 8px;
@@ -2255,20 +2273,20 @@ body {
 }
 
 .heatmap-rebuild {
-    margin-top: 6px;
-    background: var(--bg-context);
-    color: var(--fg-bright);
-    border: 1px solid var(--fg-disabled);
-    border-radius: var(--radius-sm);
-    padding: 4px 8px;
-    cursor: pointer;
+    margin-top: var(--space-sm);
 }
 
 .heatmap-legend-row {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--space-md);
     color: var(--fg-secondary);
+}
+/* The same row appears in two places on two different grounds: in the Display
+   Controls panel, where it takes the panel's ink, and inside the legend on the
+   canvas, where it has to take the HUD's. */
+.heatmap-map-legend .heatmap-legend-row {
+    color: var(--fg-hud-muted);
 }
 
 .heatmap-legend-swatch {
@@ -2279,37 +2297,24 @@ body {
     flex: 0 0 auto;
 }
 
+/* An .or-hud, but a stacked one: title over units over the swatch list. */
 .heatmap-map-legend {
-    position: absolute;
-    right: 14px;
-    bottom: 14px;
-    z-index: 900;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
     min-width: 140px;
     max-width: 220px;
-    padding: 10px 12px;
-    background: var(--bg-heatmap-legend);
-    border: 1px solid var(--border-heatmap-legend);
-    border-radius: var(--radius-md);
-    box-shadow: 0 6px 20px var(--shadow-strong);
-    color: var(--fg-bright);
-    font-family: monospace;
-    font-size: 12px;
-    pointer-events: none;
-    backdrop-filter: blur(2px);
-}
-
-.heatmap-map-legend.hidden {
-    display: none;
+    padding: var(--space-md) var(--space-lg);
 }
 
 .heatmap-map-legend-title {
-    color: var(--fg-heatmap-title);
+    color: var(--fg-hud);
     font-weight: 700;
     margin-bottom: 2px;
 }
 
 .heatmap-map-legend-units {
-    color: var(--fg-heatmap-units);
+    color: var(--fg-hud-muted);
     margin-bottom: 8px;
 }
 
@@ -2353,18 +2358,6 @@ html[data-theme="dark"] .schematic-widget svg {
     padding: 3px 4px;
     font-size: 12px;
 }
-
-.drc-btn {
-    background: var(--bg-input);
-    color: var(--fg-secondary);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 3px 8px;
-    cursor: pointer;
-    font-size: 12px;
-    white-space: nowrap;
-}
-.drc-btn:hover { background: var(--border); color: var(--fg-bright); }
 
 .drc-info-bar {
     padding: 2px 6px;
@@ -2492,4 +2485,60 @@ html[data-theme="dark"] .schematic-widget svg {
 }
 .drc-flashing .leaflet-tile-pane {
     animation: drc-pulse 0.4s ease-in-out 3;
+}
+
+/* ─── Focus and motion ────────────────────────────────────────────────────── */
+
+/* :focus-visible rather than :focus, so the ring appears for keyboard
+ * navigation and not after a mouse click.  The offset is 1px: several of these
+ * sit in dense rows where 2px would overlap the neighbouring row. */
+:focus-visible {
+    outline: 2px solid var(--accent-tab);
+    outline-offset: 1px;
+}
+/* An input already marks focus by its border; a ring on top of that reads as
+ * a double border. */
+.modal-dialog input[type="text"]:focus-visible,
+.tcl-input:focus-visible,
+.sb-filter:focus-visible {
+    outline: none;
+}
+.tcl-input-row:focus-within {
+    border-top-color: var(--accent);
+    box-shadow: inset 0 1px 0 var(--accent);
+}
+
+/* Hover feedback on the dense list rows.  Backgrounds only -- these rows are
+ * built and torn down in bulk, so nothing here should animate layout. */
+.display-controls .vis-leaf,
+.display-controls .vis-group-header,
+.fb-entry,
+.drc-tree-header,
+.drc-marker-row,
+.sb-row,
+.cm-item,
+.context-menu-item,
+.tcl-complete-item,
+#menu-bar .menu-item,
+#menu-bar .menu-label {
+    transition: background-color 120ms ease, color 120ms ease;
+}
+
+/* Every animation in this file is decoration over a state the UI already
+ * shows some other way (a banner, a spinner, a highlighted shape), so all of
+ * them can stop for a viewer who asked for less motion. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+    #loading-overlay .spinner {
+        /* The spinner is the only one whose whole job is the motion; leave it
+         * turning, just slowly enough not to flicker. */
+        animation-duration: 2.4s !important;
+        animation-iteration-count: infinite !important;
+    }
 }

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -52,6 +52,19 @@
     --fg-hud-muted: #9fb0bc;
 
     --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    /* Bare `monospace` is whatever the UA picked, which on several systems is
+     * Courier -- wide, and thin at the 11-12px this UI uses.  Name the faces
+     * that ship with each platform first and keep `monospace` as the floor. */
+    --font-mono: ui-monospace, 'SF Mono', 'Cascadia Mono', 'Segoe UI Mono',
+                 'DejaVu Sans Mono', Menlo, Consolas, monospace;
+
+    /* Violated and met slack.  These are the Qt GUI's histogram colours
+     * (chartsWidget.cpp:1052-1062, lightgreen/lightcoral), which
+     * charts-widget.js also carries, so the slack bars in the timing table
+     * read as the same measure as the bars in the charts panel.  Not
+     * theme-dependent, for the same reason. */
+    --slack-neg: #f08080;
+    --slack-pos: #90ee90;
 }
 
 html[data-theme="dark"] {
@@ -266,7 +279,7 @@ html[data-theme="light"] {
     color: var(--fg-hud);
     padding: 2px 6px;
     border-radius: var(--radius-sm);
-    font: 12px monospace;
+    font: 12px var(--font-mono);
     white-space: nowrap;
     pointer-events: none;
     border: none;
@@ -595,7 +608,7 @@ body {
     box-shadow: 0 6px 20px var(--shadow-strong);
     backdrop-filter: blur(3px);
     color: var(--fg-hud);
-    font: 12px monospace;
+    font: 12px var(--font-mono);
     font-variant-numeric: tabular-nums;
     pointer-events: none;
 }
@@ -643,7 +656,7 @@ body {
     padding: 16px 20px;
     min-width: 400px;
     color: var(--fg-primary);
-    font: 13px monospace;
+    font: 13px var(--font-sans);
 }
 .modal-dialog .modal-close {
     position: absolute;
@@ -675,7 +688,7 @@ body {
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-sm);
     color: var(--fg-primary);
-    font: 13px monospace;
+    font: 13px var(--font-mono);
     box-sizing: border-box;
 }
 .modal-dialog input[type="text"]:focus {
@@ -967,7 +980,7 @@ body {
     border-radius: var(--radius-sm);
 }
 .leaflet-popup-content {
-    font-family: monospace;
+    font-family: var(--font-mono);
 }
 .leaflet-popup-content strong {
     color: var(--accent-text);
@@ -1036,7 +1049,7 @@ body {
 /* Tick/label text drawn inside the scale-bar SVG. */
 .scale-bar-text {
     fill: currentColor;
-    font: 11px monospace;
+    font: 11px var(--font-mono);
 }
 
 /* Background color control in the Display Controls panel. */
@@ -1078,7 +1091,7 @@ body {
     align-items: center;
     gap: 12px;
     color: var(--fg-primary);
-    font: 16px monospace;
+    font: 16px var(--font-sans);
 }
 #loading-overlay .spinner {
     width: 20px;
@@ -1350,7 +1363,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100%;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
 }
 .tcl-output {
@@ -1394,7 +1407,7 @@ body {
     border: none;
     outline: none;
     padding: 6px 8px 6px 0;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
 }
 
@@ -1409,7 +1422,7 @@ body {
     border: 1px solid var(--border-strong);
     box-shadow: 0 -4px 12px var(--shadow);
     z-index: 10003;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
     color: var(--fg-primary);
     min-width: 200px;
@@ -1456,7 +1469,7 @@ body {
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-sm);
     padding: 1px 6px;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: 12px;
     color: var(--fg-bright);
 }
@@ -1467,7 +1480,7 @@ body {
     overflow-y: auto;
     height: 100%;
     font-size: 13px;
-    font-family: monospace;
+    font-family: var(--font-sans);
 }
 .inspector-prop {
     display: flex;
@@ -1482,6 +1495,7 @@ body {
  * itself is draggable via .inspector-col-resizer. */
 .inspector-prop-name {
     color: var(--accent-text);
+    font-family: var(--font-mono);
     box-sizing: border-box;
     flex: 0 0 var(--inspector-name-w, 140px);
     padding-right: 8px;
@@ -1500,6 +1514,8 @@ body {
  * lets the cell shrink to the row instead of stretching it. */
 .inspector-prop-value {
     color: var(--fg-primary);
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
     flex: 1 1 auto;
     min-width: 0;
     overflow-x: auto;
@@ -1647,20 +1663,24 @@ body {
     position: sticky;
     top: 0;
     background: var(--bg-panel);
+    color: var(--fg-muted);
     text-align: left;
-    padding: 3px 6px;
-    border-bottom: 1px solid var(--border-strong);
+    padding: var(--space-sm);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    font-weight: 600;
 }
 .sb-table th.sb-sortable {
     cursor: pointer;
 }
 .sb-table td {
-    padding: 2px 6px;
-    border-bottom: 1px solid var(--border-subtle);
+    padding: 2px var(--space-sm);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 220px;
+    font-family: var(--font-mono);
 }
 .sb-row {
     cursor: pointer;
@@ -1819,6 +1839,8 @@ body {
 }
 .inspector-table {
     border-collapse: collapse;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
     font-size: 12px;
 }
 .inspector-table th,
@@ -1933,7 +1955,7 @@ body {
     flex-direction: column;
     height: 100%;
     font-size: 13px;
-    font-family: monospace;
+    font-family: var(--font-sans);
     overflow: hidden;
 }
 
@@ -2015,13 +2037,27 @@ body {
     position: sticky;
     top: 0;
     z-index: 1;
-    background: var(--bg-context);
-    color: var(--fg-secondary);
-    padding: 4px 8px;
+    background: var(--bg-panel);
+    color: var(--fg-muted);
+    padding: var(--space-sm) var(--space-md);
     text-align: left;
     border-bottom: 1px solid var(--border);
+    font-family: var(--font-sans);
+    font-size: 11px;
     font-weight: 600;
     white-space: nowrap;
+}
+/* The header is sticky, so once the body scrolls under it there is nothing but
+   this to separate the two. */
+.timing-table thead th::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -4px;
+    height: 4px;
+    background: linear-gradient(var(--shadow-strong), transparent);
+    pointer-events: none;
 }
 
 .timing-table thead th.sortable {
@@ -2034,10 +2070,10 @@ body {
 }
 
 .timing-table tbody td {
-    padding: 3px 8px;
-    border-bottom: 1px solid var(--bg-context);
+    padding: 3px var(--space-md);
     white-space: nowrap;
     color: var(--fg-primary);
+    font-family: var(--font-mono);
 }
 
 .timing-table tbody tr:hover {
@@ -2046,6 +2082,9 @@ body {
 
 .timing-table tbody tr.selected {
     background: var(--bg-selected-row);
+}
+.timing-table tbody tr.selected td:first-child {
+    box-shadow: inset 2px 0 0 var(--accent-tab);
 }
 
 .timing-table tbody tr.timing-selected-row {
@@ -2059,6 +2098,44 @@ body {
 
 .timing-table tbody td.slack-negative {
     color: var(--error-text);
+}
+
+/* --slack-frac is set per cell by the widget: |slack| over the largest
+   |slack| in the table, so the bar is relative to the worst path shown.  It
+   grows from the cell's midpoint, left for negative and right for positive,
+   which puts every zero crossing on the same vertical line. */
+.timing-table tbody td.slack-cell {
+    position: relative;
+}
+.timing-table tbody td.slack-cell::after {
+    content: '';
+    position: absolute;
+    bottom: 1px;
+    height: 3px;
+    border-radius: 1px;
+    /* min() rather than a bare calc: the widget normalizes --slack-frac to
+       0..1, and the clamp keeps a bar inside its own cell even if some future
+       caller does not. */
+    width: min(calc(var(--slack-frac, 0) * 50%), 50%);
+    pointer-events: none;
+}
+.timing-table tbody td.slack-cell.slack-under::after {
+    right: 50%;
+    background: var(--slack-neg);
+}
+.timing-table tbody td.slack-cell.slack-over::after {
+    left: 50%;
+    background: var(--slack-pos);
+}
+
+/* A numeric cell: right-aligned with tabular figures, so a column of values
+   lines up on the decimal point and does not jitter as digits change. */
+.timing-table th.num,
+.timing-table td.num,
+.sb-table th.num,
+.sb-table td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
 }
 
 .col-resize-grip {
@@ -2087,7 +2164,7 @@ body {
     flex-direction: column;
     height: 100%;
     font-size: 13px;
-    font-family: monospace;
+    font-family: var(--font-sans);
     overflow: hidden;
 }
 
@@ -2129,7 +2206,7 @@ body {
     flex-direction: column;
     height: 100%;
     font-size: 13px;
-    font-family: monospace;
+    font-family: var(--font-sans);
     overflow: hidden;
     position: relative;
 }
@@ -2193,7 +2270,7 @@ body {
     flex-direction: column;
     height: 100%;
     font-size: 13px;
-    font-family: monospace;
+    font-family: var(--font-sans);
     overflow: hidden;
     position: relative;
 }
@@ -2213,7 +2290,7 @@ body {
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-sm);
     padding: 3px 6px;
-    font-family: monospace;
+    font-family: var(--font-sans);
     font-size: 12px;
     cursor: pointer;
 }
@@ -2236,7 +2313,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    font-family: monospace;
+    font-family: var(--font-sans);
     font-size: 12px;
 }
 
@@ -2268,7 +2345,7 @@ body {
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-sm);
     padding: 2px 4px;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: 12px;
 }
 

--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -127,5 +127,9 @@ export function getThemeColors() {
         fgMuted:     v('--fg-muted'),
         bgPanel:     v('--bg-panel'),
         bgMap:       v('--bg-map'),
+        // Font stacks for ctx.font, so the canvas widgets draw in the same
+        // faces as the DOM ones: mono for values, sans for titles and labels.
+        fontMono:    v('--font-mono'),
+        fontSans:    v('--font-sans'),
     };
 }

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -33,7 +33,7 @@ export class TimingWidget {
         toolbar.className = 'timing-toolbar';
 
         this._updateBtn = document.createElement('button');
-        this._updateBtn.className = 'timing-btn';
+        this._updateBtn.className = 'or-btn';
         this._updateBtn.textContent = 'Update';
         if (isStaticMode(this._app)) {
             this._updateBtn.style.display = 'none';
@@ -87,7 +87,7 @@ export class TimingWidget {
         // Column-header tooltip (custom div, like the charts/clock-tree
         // tooltips, rather than the easy-to-miss native title tooltip).
         this._headerTooltip = document.createElement('div');
-        this._headerTooltip.className = 'timing-header-tooltip';
+        this._headerTooltip.className = 'or-tooltip or-tooltip-fixed';
         el.appendChild(this._headerTooltip);
 
         this.element = el;
@@ -245,11 +245,11 @@ export class TimingWidget {
         panel.append(sync.input, sync.lbl);
 
         this._coneApplyBtn = document.createElement('button');
-        this._coneApplyBtn.className = 'timing-btn';
+        this._coneApplyBtn.className = 'or-btn';
         this._coneApplyBtn.textContent = 'Cone';
         this._coneApplyBtn.title = 'Show the timing cone for the selected instance';
         this._coneClearBtn = document.createElement('button');
-        this._coneClearBtn.className = 'timing-btn';
+        this._coneClearBtn.className = 'or-btn';
         this._coneClearBtn.textContent = 'Clear';
         panel.append(this._coneApplyBtn, this._coneClearBtn);
 

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -493,6 +493,7 @@ export class TimingWidget {
         for (const col of TimingWidget.PATH_COLS) {
             const th = document.createElement('th');
             th.classList.add('sortable');
+            if (col.num) th.classList.add('num');
             th.textContent = col.label +
                 (col.key === this._sortCol ? (this._sortAscending ? ' ▲' : ' ▼') : '');
             if (col.tooltip) {
@@ -508,6 +509,11 @@ export class TimingWidget {
         this._pathTable.appendChild(thead);
 
         const tbody = document.createElement('tbody');
+        // Scale for the slack bars: the largest magnitude in the table, so a
+        // bar reads as "how bad relative to the worst path shown".  Guard the
+        // zero case so a table of exactly-zero slacks does not divide by it.
+        const worstSlack = paths.reduce(
+            (m, p) => Math.max(m, Math.abs(Number(p.slack) || 0)), 0);
         paths.forEach((p, idx) => {
             const tr = document.createElement('tr');
             if (idx === this._selectedPathIndex) tr.classList.add('selected');
@@ -515,7 +521,18 @@ export class TimingWidget {
                 const td = document.createElement('td');
                 const v = p[col.key];
                 td.textContent = col.time ? fmtTime(v) : v;
-                if (col.key === 'slack' && p.slack < 0) td.classList.add('slack-negative');
+                if (col.num) td.classList.add('num');
+                if (col.key === 'slack') {
+                    const slack = Number(p.slack);
+                    if (slack < 0) td.classList.add('slack-negative');
+                    if (Number.isFinite(slack) && worstSlack > 0) {
+                        td.classList.add('slack-cell',
+                                         slack < 0 ? 'slack-under' : 'slack-over');
+                        td.style.setProperty(
+                            '--slack-frac',
+                            String(Math.abs(slack) / worstSlack));
+                    }
+                }
                 tr.appendChild(td);
             }
             tr.style.cursor = 'pointer';
@@ -585,6 +602,7 @@ export class TimingWidget {
         const hr = document.createElement('tr');
         for (const col of TimingWidget.DETAIL_COLS) {
             const th = document.createElement('th');
+            if (TimingWidget.DETAIL_NUM_COLS.has(col)) th.classList.add('num');
             th.textContent = col;
             hr.appendChild(th);
         }
@@ -604,11 +622,14 @@ export class TimingWidget {
                 fmtTime(n.slew),
                 fmtTime(n.load),
             ];
-            for (const v of vals) {
+            vals.forEach((v, col) => {
                 const td = document.createElement('td');
+                if (TimingWidget.DETAIL_NUM_COLS.has(TimingWidget.DETAIL_COLS[col])) {
+                    td.classList.add('num');
+                }
                 td.textContent = v;
                 tr.appendChild(td);
-            }
+            });
             tr.style.cursor = 'pointer';
             tr.addEventListener('click', () => this._selectDetailRow(idx));
             tbody.appendChild(tr);
@@ -636,24 +657,31 @@ export function fmtTime(v) {
 
 // Path table columns: label, path field to display/sort by, time formatting,
 // and header tooltip (tooltips match the Qt GUI's TimingPathsModel).
+// `time` formats the value through fmtTime; `num` is the display hint -- a
+// numeric column is right-aligned with tabular figures so a column of values
+// lines up on the decimal point.  Every time column is numeric; the counts are
+// too, and the clock and pin names are not.
 TimingWidget.PATH_COLS = [
     { label: 'Clock', key: 'end_clk' },
-    { label: 'Required', key: 'required', time: true },
-    { label: 'Arrival', key: 'arrival', time: true },
-    { label: 'Slack', key: 'slack', time: true },
-    { label: 'Skew', key: 'skew', time: true,
+    { label: 'Required', key: 'required', time: true, num: true },
+    { label: 'Arrival', key: 'arrival', time: true, num: true },
+    { label: 'Slack', key: 'slack', time: true, num: true },
+    { label: 'Skew', key: 'skew', time: true, num: true,
       tooltip: 'The difference in arrival times between\n' +
                'source and destination clock pins of a macro/register,\n' +
                'adjusted for CRPR and subtracting a clock period.\n' +
                'Setup and hold times account for internal clock delays.' },
-    { label: 'Logic Delay', key: 'path_delay', time: true,
+    { label: 'Logic Delay', key: 'path_delay', time: true, num: true,
       tooltip: 'Path delay from instances (excluding buffers and consecutive '
                + 'inverter pairs)' },
-    { label: 'Logic Depth', key: 'logic_depth',
+    { label: 'Logic Depth', key: 'logic_depth', num: true,
       tooltip: 'Path instances (excluding buffers and consecutive inverter '
                + 'pairs)' },
-    { label: 'Fanout', key: 'fanout' },
+    { label: 'Fanout', key: 'fanout', num: true },
     { label: 'Start', key: 'start_pin' },
     { label: 'End', key: 'end_pin' },
 ];
 TimingWidget.DETAIL_COLS = ['Pin', 'Fanout', 'R/F', 'Time', 'Delay', 'Slew', 'Load'];
+// Which of the above hold numbers (see PATH_COLS' `num`).
+TimingWidget.DETAIL_NUM_COLS
+    = new Set(['Fanout', 'Time', 'Delay', 'Slew', 'Load']);

--- a/src/web/src/toolbar.js
+++ b/src/web/src/toolbar.js
@@ -36,7 +36,7 @@ export function createToolbar(app) {
 
         for (const btn of buttons) {
             const el = document.createElement('button');
-            el.className = 'toolbar-button';
+            el.className = 'or-btn or-btn-sm toolbar-button';
             el.dataset.key = btn.key;
             if (btn.tooltip) el.title = btn.tooltip;
 

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -505,3 +505,73 @@ export function makeResizableHeaders(table, widths) {
         });
     });
 }
+
+// ─── Panel tab icons ────────────────────────────────────────────────────────
+
+// A 16-viewBox stroke glyph per panel, keyed by the tab title in
+// defaultLayoutConfig (and in componentTitles, which must agree).  A stack can
+// hold six panels whose titles all read alike at tab width; the icon is what
+// makes one findable at a glance.
+const kPanelIconPaths = {
+    'Layout':           '<rect x="2.5" y="2.5" width="19" height="19" rx="2"/>'
+                        + '<path d="M2.5 9h19M9 2.5v19"/>',
+    'Schematic':        '<circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="6" r="2.5"/>'
+                        + '<path d="M6 15.5V8a2 2 0 012-2h7.5"/>',
+    '3D Viewer':        '<path d="M12 2.5l9 5v9l-9 5-9-5v-9z"/><path d="M12 12l9-4.5M12 12v9.5M12 12L3 7.5"/>',
+    'Display Controls': '<path d="M3 6h18M3 12h18M3 18h18"/><circle cx="8" cy="6" r="2"/>'
+                        + '<circle cx="15" cy="12" r="2"/><circle cx="10" cy="18" r="2"/>',
+    'Inspector':        '<path d="M4 6h16M4 12h16M4 18h10"/>',
+    'Hierarchy':        '<path d="M5 4v13a2 2 0 002 2h4M5 10h6"/>'
+                        + '<rect x="13" y="2" width="7" height="5" rx="1"/>'
+                        + '<rect x="13" y="15" width="7" height="5" rx="1"/>',
+    'Timing':           '<path d="M2 14h5l3-8 4 14 3-6h5"/>',
+    'DRC':              '<path d="M12 3l9 16H3z"/><path d="M12 10v4M12 17h.01"/>',
+    'Select Highlight': '<path d="M4 3l14 9-6 1 4 7-3 2-4-7-5 4z"/>',
+    'Clock Tree':       '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3.5 2"/>',
+    'Charts':           '<path d="M4 20V10M10 20V4M16 20v-7M22 20V7"/>',
+    'Tcl Console':      '<path d="M5 8l4 4-4 4M12 16h7"/>',
+    'Help':             '<circle cx="12" cy="12" r="9"/>'
+                        + '<path d="M9.5 9.5a2.5 2.5 0 115 .5c0 1.5-2.5 2-2.5 3.5M12 17h.01"/>',
+};
+
+// Build the icon element for a tab title, or null when the title has none --
+// a Tcl-added panel, say, which should get a plain tab rather than a wrong
+// icon.
+export function panelTabIcon(title) {
+    const path = kPanelIconPaths[title];
+    if (!path) return null;
+    const span = document.createElement('span');
+    span.className = 'or-tab-icon';
+    span.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"'
+        + ' stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"'
+        + ' aria-hidden="true">' + path + '</svg>';
+    return span;
+}
+
+// Prepend the icon to every tab that does not have one yet, and return how
+// many were added.  Idempotent, so it can be called again after any layout
+// change -- Golden Layout rebuilds tab elements when a stack is dragged, split
+// or reordered -- without accumulating icons.  Titles are read from .lm_title
+// rather than from the component, so the overflow dropdown's tabs are
+// decorated by the same pass.
+//
+// The return value matters: an icon widens its tab, and Golden Layout decides
+// which tabs fit in a header before these exist, so the caller has to make it
+// measure again.  Reporting zero when there was nothing to do is what keeps
+// that re-measure from looping through the layout event that triggered it.
+export function decorateTabIcons(root = document) {
+    let added = 0;
+    for (const tab of root.querySelectorAll('.lm_tab:not([data-or-icon])')) {
+        const titleEl = tab.querySelector('.lm_title');
+        if (!titleEl) continue;
+        // Mark before the lookup, so a title with no icon is not re-examined
+        // on every subsequent layout change.
+        tab.setAttribute('data-or-icon', '');
+        const icon = panelTabIcon(titleEl.textContent.trim());
+        if (icon) {
+            tab.insertBefore(icon, titleEl);
+            added++;
+        }
+    }
+    return added;
+}

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -564,10 +564,15 @@ export function decorateTabIcons(root = document) {
     for (const tab of root.querySelectorAll('.lm_tab:not([data-or-icon])')) {
         const titleEl = tab.querySelector('.lm_title');
         if (!titleEl) continue;
-        // Mark before the lookup, so a title with no icon is not re-examined
-        // on every subsequent layout change.
+        const title = titleEl.textContent.trim();
+        // An empty title means the tab is not built yet.  Marking it now would
+        // spend its one chance at an icon on a title we cannot match, so leave
+        // it for the next layout change.
+        if (!title) continue;
+        // Mark before the lookup, so a title with no icon of its own is not
+        // re-examined on every subsequent layout change.
         tab.setAttribute('data-or-icon', '');
-        const icon = panelTabIcon(titleEl.textContent.trim());
+        const icon = panelTabIcon(title);
         if (icon) {
             tab.insertBefore(icon, titleEl);
             added++;

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -73,11 +73,10 @@ export function showConfirmModal({ title, message, confirmLabel = 'OK',
         const buttons = document.createElement('div');
         buttons.className = 'or-modal-buttons';
         const cancelBtn = document.createElement('button');
-        cancelBtn.className = 'or-modal-btn';
+        cancelBtn.className = 'or-btn';
         cancelBtn.textContent = 'Cancel';
         const confirmBtn = document.createElement('button');
-        confirmBtn.className = 'or-modal-btn'
-            + (danger ? ' or-modal-btn-danger' : '');
+        confirmBtn.className = 'or-btn' + (danger ? ' or-btn-danger' : '');
         confirmBtn.textContent = confirmLabel;
 
         const close = (result) => {

--- a/src/web/test/js/test-drc-widget.js
+++ b/src/web/test/js/test-drc-widget.js
@@ -49,7 +49,7 @@ describe('DrcWidget', () => {
             const select = toolbar.querySelector('.drc-category-select');
             assert.ok(select, 'category select exists');
 
-            const buttons = toolbar.querySelectorAll('.drc-btn');
+            const buttons = toolbar.querySelectorAll('.or-btn');
             assert.ok(buttons.length >= 1, 'load button exists');
 
             // Should have info bar

--- a/src/web/test/js/test-inspector.js
+++ b/src/web/test/js/test-inspector.js
@@ -72,7 +72,7 @@ describe('Inspector focus nets', () => {
     describe('updateInspector toolbar buttons', () => {
         it('shows focus button for Net type', () => {
             panel.updateInspector(netData('clk'));
-            const btns = app.inspectorEl.querySelectorAll('.inspector-btn');
+            const btns = app.inspectorEl.querySelectorAll('.or-btn-icon');
             // Should have back + zoom + focus buttons
             assert.ok(btns.length >= 3, `expected >=3 buttons, got ${btns.length}`);
             const focusBtn = Array.from(btns).find(b => b.title === 'Focus net');
@@ -81,7 +81,7 @@ describe('Inspector focus nets', () => {
 
         it('does not show focus button for non-Net type', () => {
             panel.updateInspector(instData('buf1'));
-            const btns = app.inspectorEl.querySelectorAll('.inspector-btn');
+            const btns = app.inspectorEl.querySelectorAll('.or-btn-icon');
             // Should have back + zoom buttons, no focus button
             assert.equal(btns.length, 2);
             const focusBtn = Array.from(btns).find(b => b.title === 'Focus net');
@@ -91,7 +91,7 @@ describe('Inspector focus nets', () => {
         it('shows de-focus button when net is already focused', () => {
             app.focusNets.add('clk');
             panel.updateInspector(netData('clk'));
-            const btns = app.inspectorEl.querySelectorAll('.inspector-btn');
+            const btns = app.inspectorEl.querySelectorAll('.or-btn-icon');
             const defocusBtn = Array.from(btns).find(b => b.title === 'De-focus net');
             assert.ok(defocusBtn, 'de-focus button should be present');
         });
@@ -99,14 +99,14 @@ describe('Inspector focus nets', () => {
         it('shows clear button when any nets are focused', () => {
             app.focusNets.add('data');
             panel.updateInspector(netData('clk'));
-            const btns = app.inspectorEl.querySelectorAll('.inspector-btn');
+            const btns = app.inspectorEl.querySelectorAll('.or-btn-icon');
             const clearBtn = Array.from(btns).find(b => b.title === 'Clear focus nets');
             assert.ok(clearBtn, 'clear button should be present');
         });
 
         it('does not show clear button when no nets are focused', () => {
             panel.updateInspector(netData('clk'));
-            const btns = app.inspectorEl.querySelectorAll('.inspector-btn');
+            const btns = app.inspectorEl.querySelectorAll('.or-btn-icon');
             const clearBtn = Array.from(btns).find(b => b.title === 'Clear focus nets');
             assert.equal(clearBtn, undefined, 'clear button should not be present');
         });
@@ -115,7 +115,7 @@ describe('Inspector focus nets', () => {
     describe('toggleFocusNet via button click', () => {
         it('adds net to focusNets on focus click', async () => {
             panel.updateInspector(netData('clk'));
-            const focusBtn = Array.from(app.inspectorEl.querySelectorAll('.inspector-btn'))
+            const focusBtn = Array.from(app.inspectorEl.querySelectorAll('.or-btn-icon'))
                 .find(b => b.title === 'Focus net');
             focusBtn.click();
             // Let promises settle
@@ -132,7 +132,7 @@ describe('Inspector focus nets', () => {
         it('removes net from focusNets on de-focus click', async () => {
             app.focusNets.add('clk');
             panel.updateInspector(netData('clk'));
-            const defocusBtn = Array.from(app.inspectorEl.querySelectorAll('.inspector-btn'))
+            const defocusBtn = Array.from(app.inspectorEl.querySelectorAll('.or-btn-icon'))
                 .find(b => b.title === 'De-focus net');
             assert.ok(defocusBtn, 'de-focus button should be present');
             defocusBtn.click();
@@ -150,7 +150,7 @@ describe('Inspector focus nets', () => {
             app.focusNets.add('data');
             panel.updateInspector(netData('clk'));
             const clearBtn = Array.from(
-                app.inspectorEl.querySelectorAll('.inspector-btn')
+                app.inspectorEl.querySelectorAll('.or-btn-icon')
             ).find(b => b.title === 'Clear focus nets');
             assert.ok(clearBtn);
             clearBtn.click();
@@ -212,7 +212,7 @@ describe('Inspector focus nets', () => {
                 selection_index: 1,
             });
             const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
-            const prevBtn = nav.querySelectorAll('.inspector-btn')[0];
+            const prevBtn = nav.querySelectorAll('.or-btn-icon')[0];
             prevBtn.click();
             assert.equal(app._requests.length, 1);
             assert.equal(app._requests[0].type, 'select_prev');
@@ -225,7 +225,7 @@ describe('Inspector focus nets', () => {
                 selection_index: 0,
             });
             const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
-            const btns = nav.querySelectorAll('.inspector-btn');
+            const btns = nav.querySelectorAll('.or-btn-icon');
             const nextBtn = btns[btns.length - 1];
             nextBtn.click();
             assert.equal(app._requests.length, 1);
@@ -256,7 +256,7 @@ describe('Inspector focus nets', () => {
                 selection_index: 0,
             });
             const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
-            const btns = nav.querySelectorAll('.inspector-btn');
+            const btns = nav.querySelectorAll('.or-btn-icon');
             btns[btns.length - 1].click();
 
             await new Promise(r => setTimeout(r, 0));
@@ -512,7 +512,7 @@ describe('Inspector focus nets', () => {
             assert.ok(modal.textContent.includes('cannot be undone'));
             assert.equal(app._requests.length, 0, 'nothing sent before confirm');
 
-            const confirmBtn = modal.querySelector('.or-modal-btn-danger');
+            const confirmBtn = modal.querySelector('.or-btn-danger');
             confirmBtn.click();
             await new Promise(r => setTimeout(r, 0));
 
@@ -529,7 +529,7 @@ describe('Inspector focus nets', () => {
             await new Promise(r => setTimeout(r, 0));
 
             const modal = document.querySelector('.or-modal');
-            const cancelBtn = modal.querySelector('.or-modal-btn');
+            const cancelBtn = modal.querySelector('.or-btn');
             cancelBtn.click();
             await new Promise(r => setTimeout(r, 0));
 

--- a/src/web/test/js/test-status-indicator.js
+++ b/src/web/test/js/test-status-indicator.js
@@ -69,9 +69,10 @@ describe('Status Indicator (updateStatus)', () => {
                 if (pendingCount === 0) {
                     statusDiv.style.display = 'none';
                 } else {
-                    statusDiv.innerHTML = `<div class="pending-indicator">pending: ${pendingCount}</div>`;
+                    statusDiv.innerHTML = `<div class="or-hud or-hud-top-right pending-indicator">pending: ${pendingCount}</div>`;
                     statusDiv.style.display = 'block';
-                    const color = pendingCount > 20 ? 'var(--error)' : 'var(--fg-bright)';
+                    const color = pendingCount > 20
+                        ? 'var(--sem-error)' : 'var(--fg-hud)';
                     statusDiv.querySelector('.pending-indicator').style.color = color;
                 }
             }
@@ -129,7 +130,7 @@ describe('Status Indicator (updateStatus)', () => {
 
             const indicator = statusDiv.querySelector('.pending-indicator');
             assert.ok(indicator);
-            assert.equal(indicator.style.color, 'var(--fg-bright)');
+            assert.equal(indicator.style.color, 'var(--fg-hud)');
         });
 
         it('shows pending indicator with error color when count > 20', () => {
@@ -142,7 +143,7 @@ describe('Status Indicator (updateStatus)', () => {
 
             const indicator = statusDiv.querySelector('.pending-indicator');
             assert.ok(indicator);
-            assert.equal(indicator.style.color, 'var(--error)');
+            assert.equal(indicator.style.color, 'var(--sem-error)');
         });
 
         it('updates pending count on repeated calls', () => {

--- a/src/web/test/js/test-status-indicator.js
+++ b/src/web/test/js/test-status-indicator.js
@@ -11,7 +11,11 @@ describe('Status Indicator (updateStatus)', () => {
     let app;
     let updateStatus;
     let disconnectTimeout;
+    let progressEl;
     const DISCONNECT_DELAY_MS = 2000;
+    // Keep in step with main.js: past this many outstanding requests the count
+    // is shown as well as the progress line.
+    const PENDING_BACKLOG = 20;
 
     beforeEach(async () => {
         // Setup DOM
@@ -20,12 +24,14 @@ describe('Status Indicator (updateStatus)', () => {
             <html>
             <body>
                 <div id="websocket-status" style="display: none;"></div>
+                <div id="tile-progress" class="or-progress"></div>
             </body>
             </html>
         `);
         globalThis.document = dom.window.document;
 
         statusDiv = document.getElementById('websocket-status');
+        progressEl = document.getElementById('tile-progress');
 
         // Mock app object
         app = {
@@ -66,16 +72,18 @@ describe('Status Indicator (updateStatus)', () => {
                     disconnectTimeout = null;
                 }
                 
-                if (pendingCount === 0) {
-                    statusDiv.style.display = 'none';
-                } else {
-                    statusDiv.innerHTML = `<div class="or-hud or-hud-top-right pending-indicator">pending: ${pendingCount}</div>`;
+                if (pendingCount > PENDING_BACKLOG) {
+                    statusDiv.innerHTML = '<div class="or-hud or-hud-top-right '
+                        + `pending-indicator">pending: ${pendingCount}</div>`;
                     statusDiv.style.display = 'block';
-                    const color = pendingCount > 20
-                        ? 'var(--sem-error)' : 'var(--fg-hud)';
-                    statusDiv.querySelector('.pending-indicator').style.color = color;
+                } else {
+                    statusDiv.style.display = 'none';
                 }
             }
+            // setTileProgress
+            progressEl.classList.toggle('active', pendingCount > 0);
+            progressEl.title = pendingCount > 0
+                ? `${pendingCount} tile requests pending` : '';
         };
 
         // Expose helper to trigger scheduled callbacks
@@ -104,7 +112,7 @@ describe('Status Indicator (updateStatus)', () => {
             assert.equal(statusDiv.style.display, 'none');
         });
 
-        it('shows pending count when connected with pending requests', () => {
+        it('shows only the progress line for ordinary tile traffic', () => {
             app.websocketManager = {
                 isConnected: true,
                 pending: new Map([
@@ -116,24 +124,27 @@ describe('Status Indicator (updateStatus)', () => {
 
             updateStatus();
 
-            assert.equal(statusDiv.style.display, 'block');
-            assert.ok(statusDiv.innerHTML.includes('pending: 3'));
+            // A handful of outstanding requests is normal while panning: the
+            // line says the server is working, and no count takes up space.
+            assert.ok(progressEl.classList.contains('active'));
+            assert.equal(statusDiv.style.display, 'none');
+            assert.equal(statusDiv.querySelector('.pending-indicator'), null);
+            assert.equal(progressEl.title, '3 tile requests pending');
         });
 
-        it('shows pending indicator with normal color when count <= 20', () => {
+        it('shows no count at the backlog threshold', () => {
             app.websocketManager = {
                 isConnected: true,
-                pending: new Map(Array.from({ length: 15 }, (_, i) => [i + 1, {}])),
+                pending: new Map(Array.from({ length: 20 }, (_, i) => [i + 1, {}])),
             };
 
             updateStatus();
 
-            const indicator = statusDiv.querySelector('.pending-indicator');
-            assert.ok(indicator);
-            assert.equal(indicator.style.color, 'var(--fg-hud)');
+            assert.ok(progressEl.classList.contains('active'));
+            assert.equal(statusDiv.querySelector('.pending-indicator'), null);
         });
 
-        it('shows pending indicator with error color when count > 20', () => {
+        it('shows the count once the backlog threshold is passed', () => {
             app.websocketManager = {
                 isConnected: true,
                 pending: new Map(Array.from({ length: 25 }, (_, i) => [i + 1, {}])),
@@ -143,27 +154,33 @@ describe('Status Indicator (updateStatus)', () => {
 
             const indicator = statusDiv.querySelector('.pending-indicator');
             assert.ok(indicator);
-            assert.equal(indicator.style.color, 'var(--sem-error)');
+            assert.equal(indicator.textContent, 'pending: 25');
+            assert.equal(statusDiv.style.display, 'block');
         });
 
-        it('updates pending count on repeated calls', () => {
+        it('clears the progress line when the queue drains', () => {
             app.websocketManager = {
                 isConnected: true,
-                pending: new Map([[1, {}]]),
+                pending: new Map(Array.from({ length: 25 }, (_, i) => [i + 1, {}])),
             };
 
             updateStatus();
-            assert.ok(statusDiv.innerHTML.includes('pending: 1'));
+            assert.ok(statusDiv.innerHTML.includes('pending: 25'));
+            assert.ok(progressEl.classList.contains('active'));
 
             // Simulate request completion
             app.websocketManager.pending.clear();
             updateStatus();
             assert.equal(statusDiv.style.display, 'none');
+            assert.equal(progressEl.classList.contains('active'), false);
+            assert.equal(progressEl.title, '');
 
             // Add more requests
-            app.websocketManager.pending = new Map(Array.from({ length: 5 }, (_, i) => [i + 1, {}]));
+            app.websocketManager.pending
+                = new Map(Array.from({ length: 30 }, (_, i) => [i + 1, {}]));
             updateStatus();
-            assert.ok(statusDiv.innerHTML.includes('pending: 5'));
+            assert.ok(statusDiv.innerHTML.includes('pending: 30'));
+            assert.ok(progressEl.classList.contains('active'));
         });
     });
 
@@ -213,7 +230,7 @@ describe('Status Indicator (updateStatus)', () => {
             assert.equal(statusDiv.style.display, 'none');
         });
 
-        it('shows pending count after reconnecting with pending requests', () => {
+        it('shows a backlog count after reconnecting with a long queue', () => {
             app.websocketManager = {
                 isConnected: false,
                 pending: new Map(),
@@ -221,13 +238,14 @@ describe('Status Indicator (updateStatus)', () => {
 
             updateStatus();
 
-            // Reconnect with pending requests
+            // Reconnect with a queue long enough to be worth a number
             app.websocketManager.isConnected = true;
-            app.websocketManager.pending = new Map(Array.from({ length: 3 }, (_, i) => [i + 1, {}]));
+            app.websocketManager.pending
+                = new Map(Array.from({ length: 25 }, (_, i) => [i + 1, {}]));
             updateStatus();
 
             assert.equal(statusDiv.style.display, 'block');
-            assert.ok(statusDiv.innerHTML.includes('pending: 3'));
+            assert.ok(statusDiv.innerHTML.includes('pending: 25'));
         });
 
         it('does not schedule multiple timeouts on repeated disconnect calls', () => {
@@ -283,7 +301,7 @@ describe('Status Indicator (updateStatus)', () => {
         it('does not show stale banner content after state changes', () => {
             app.websocketManager = {
                 isConnected: true,
-                pending: new Map([[1, {}]]),
+                pending: new Map(Array.from({ length: 25 }, (_, i) => [i + 1, {}])),
             };
 
             updateStatus();
@@ -300,14 +318,14 @@ describe('Status Indicator (updateStatus)', () => {
         it('displays correct HTML structure for pending indicator', () => {
             app.websocketManager = {
                 isConnected: true,
-                pending: new Map([[1, {}], [2, {}]]),
+                pending: new Map(Array.from({ length: 22 }, (_, i) => [i + 1, {}])),
             };
 
             updateStatus();
 
             const indicator = statusDiv.querySelector('.pending-indicator');
             assert.ok(indicator);
-            assert.equal(indicator.textContent, 'pending: 2');
+            assert.equal(indicator.textContent, 'pending: 22');
         });
 
         it('displays correct HTML structure for disconnected banner', () => {


### PR DESCRIPTION
The web viewer's stylesheet had accreted rather than been designed: a VS Code
palette, eight near-identical button rules, four byte-identical tooltip blocks,
and nineteen rules setting bare `monospace`. Four commits put it on a token
scale and consolidate what the tokens made redundant. No behaviour changes
beyond the visual ones described below.

Best reviewed commit by commit — each one stands alone.

### 1. Colours and radii on a token scale

Each theme block defines the palette as scales (`--surface-*`, `--line-*`,
`--ink-*`, `--accent-*`, `--sem-*`) and every role name the component rules
already use becomes an alias for a scale step. No role name is added or
removed, so no component rule had to change and a palette edit is now a scale
edit.

- Three deliberate surface elevation steps, cool-biased, replacing four values
  that sat inside 8% lightness of each other.
- A saturated accent. `--bg-selected` and `--accent` stay a solid step dark
  enough to carry `--fg-white` at 4.5:1 in both themes; the row highlights
  that carry `--fg-primary` are the tints.
- Light mode picked against its own ground rather than derived from dark —
  `--bg-hover` and `--border` sharing `#d0d0d0` was a symptom of that.
- `--ink-3` chosen so `--fg-muted` clears 4.5:1 on every surface it appears
  over.
- Radii collapse to `--radius-xs/sm/md`, picked by what the element is.
- `color-scheme` per theme, so native scrollbars and `<select>` popups follow
  it, and `accent-color` so checkboxes follow the accent.

### 2. Buttons, tooltips and canvas overlays

- Eight button rules — `.toolbar-button`, `.timing-btn`, `.drc-btn`,
  `.inspector-btn`, `.sb-tool`, `.heatmap-rebuild`, `.or-modal-btn` and a bare
  `.modal-dialog button` — become `.or-btn` with size and emphasis variants.
  Eleven buttons had no class at all and were rendering as browser defaults
  (nine in the schematic toolbar, two in the 3D viewer overlay); they join the
  rest.
- Four identical tooltip blocks become `.or-tooltip`.
- The scale bar, coordinate readout, heat-map legend and pending indicator
  share `.or-hud`, and the scale bar and coordinate readout merge into one HUD
  instead of two stacked chips.
- A `:focus-visible` ring — the file had none, so keyboard navigation was
  invisible — a 120ms transition on buttons and list rows, and a
  `prefers-reduced-motion` block.

### 3. Type roles and data tables

- `--font-mono` with a real stack. Bare `monospace` resolves to Courier on
  several systems.
- Six panels were set entirely in mono, so their toolbars and headers were too
  and they read as log output. Mono is now for values; labels take
  `--font-sans`. The canvas widgets get both stacks from `getThemeColors()`,
  so canvas and DOM agree.
- `.timing-table` and `.sb-table` drop the border under every cell, headers go
  sans, and the sticky header gets a shadow.
- Numeric columns are right-aligned with tabular figures, declared in the
  column definition rather than inferred at render time.
- Slack cells carry a bar growing from the cell midpoint, scaled by the largest
  |slack| in the table.

### 4. Canvas frame, panel tabs, status chrome

- The layout canvas gets a hairline, drawn as an overlay: a border would change
  the size Leaflet measures, and an inset shadow would paint under the tile
  panes.
- Golden Layout's active tab gets the accent underline the timing widget
  already uses, and each tab gets its panel's icon.
- The disconnect banner pulsed forever; it settles after three beats. Tile
  requests in flight become a 2px line on the canvas rather than a grey chip.

### Things worth a reviewer's attention

**Qt parity was the deciding factor twice, against my own initial read.** I had
flagged the duplicate colours in `clock-tree-widget.js` as a collision to fix.
They mirror `clockWidget.h:168-174`, which deliberately uses `Qt::red` for both
the root and the leaf register and `Qt::darkCyan` for both the inverter and the
leaf macro. Same for the charts palette, which transcribes
`chartsWidget.cpp:1052-1062`. Both palettes are left alone, and the slack bars
reuse those Qt colours so the table reads as the same measure as the charts
panel.

**The canvas overlays cannot follow the theme.** They sit on `--bg-map`, which
is black in both themes for Qt parity, so a light-theme HUD was a bright block
on black with unreadable ink. `--bg-hud`, `--border-hud`, `--fg-hud` and
`--fg-hud-muted` are theme-independent for that reason; the ruler labels and
label handles come off them too. The toast is not on the canvas, so it stays on
the theme.

**The tab icons need a re-measure.** They widen every tab, and Golden Layout
decides which tabs fit before they exist, so without it the overflowing tabs
overlap the stack's controls instead of moving into the dropdown.
`decorateTabIcons` returns a count and the caller re-measures only when
something was added, which also keeps that call from looping through the layout
event that triggered it. Header height is a `dimensions.headerHeight` config
value because GL measures it in JS; a saved layout carries the dimensions it was
saved with, so the restored config is overridden rather than bumping
`LAYOUT_VERSION` and discarding everyone's panel arrangement.

**Two contrast bugs that predate this branch.** `.fb-entry.fb-selected` painted
`--bg-selected` but inherited `--fg-primary`, which was 2.6:1 in light mode.
And `.gc-invalid` marked an invalid field with an `outline`, which the new focus
ring would have replaced — so a field would stop looking invalid exactly while
being fixed. It is a ring now.

**`test-status-indicator.js` reimplements `updateStatus` instead of importing
it**, so it passes against its own copy regardless of what `main.js` does. I
synced it, but this is the third commit in a row that needed hand-syncing.
Extracting `updateStatus` would fix it properly; I left that alone because
`main.js` builds the whole app at import time.

### Not in this branch

`index.html` loads Leaflet, both Golden Layout themes and netlistsvg from three
CDNs, so on a locked-down network the viewer renders unstyled. Vendoring them is
a robustness fix rather than a design one and belongs in its own PR.

A density toggle is now cheap — the space and radius scales exist — but is not
here.

### Verification

695/695 JS tests pass. Every token pair carrying text audited to 4.5:1 or
better in both themes. Rendered in headless Chrome in both themes throughout,
including against a real Golden Layout loaded from its CDN, which is what caught
the `border-bottom: none` override, the stale tab measurement, and the
`box-sizing: content-box !important` the header forces on its children.

Not yet run against a real design in a browser: the scale bar reserves 22px of
horizontal padding for its end labels, and how that sits inside the merged HUD
is the one thing a harness cannot tell me.
