### PR TITLE
ppl: avoid routing obstructions and via landing pads at the die boundary

### DIFF
--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -235,12 +235,11 @@ class IOPlacer
                                              const odb::Rect& box);
   int roundUpToEvenMfgGrid(int dim);
   PinSize computePinSize(int layer);
-  int computeLayerSpacing(int layer, int shape_width, int parallel_length);
-  int computeShapeSpacing(int layer,
+  int computeShapeSpacing(odb::dbTechLayer* tech_layer,
                           const odb::Rect& shape,
                           int pin_width,
                           int pin_length);
-  odb::Rect padShapeForPin(const odb::Rect& box, int layer);
+  odb::Rect padShapeForPin(const odb::Rect& box, odb::dbTechLayer* tech_layer);
   void forEachSpecialNetShape(
       const std::function<void(odb::dbTechLayer*, const odb::Rect&)>& callback);
   void excludeBoundaryShape(const odb::Rect& box,

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -233,6 +233,7 @@ class IOPlacer
   bool checkBlocked(Edge edge, odb::Line, const odb::Point& pos, int layer);
   std::vector<Interval> findBlockedIntervals(const odb::Rect& die_area,
                                              const odb::Rect& box);
+  int roundUpToMfgGrid(int dim);
   int roundUpToEvenMfgGrid(int dim);
   PinSize computePinSize(int layer);
   int computeShapeSpacing(odb::dbTechLayer* tech_layer,

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -56,6 +56,20 @@ struct PinSize
   int height = 0;
 };
 
+// the arguments that select a spacing value in a layer spacing table
+struct SpacingKey
+{
+  int layer = 0;
+  int shape_width = 0;
+  int parallel_length = 0;
+
+  bool operator<(const SpacingKey& other) const
+  {
+    return std::tie(layer, shape_width, parallel_length)
+           < std::tie(other.layer, other.shape_width, other.parallel_length);
+  }
+};
+
 struct FallbackPins
 {
   std::vector<std::pair<std::vector<int>, bool>> groups;
@@ -72,8 +86,7 @@ enum class Edge
   polygonEdge,
 };
 
-// the top and bottom edges hold vertical pins on the vertical layers
-inline bool isVerticalEdge(Edge edge)
+inline bool hasVerticalPins(Edge edge)
 {
   return edge == Edge::top || edge == Edge::bottom;
 }
@@ -240,7 +253,8 @@ class IOPlacer
                           const odb::Rect& shape,
                           int pin_width,
                           int pin_length);
-  odb::Rect padShapeForPin(const odb::Rect& box, odb::dbTechLayer* tech_layer);
+  odb::Rect computePinKeepout(const odb::Rect& box,
+                              odb::dbTechLayer* tech_layer);
   void forEachSpecialNetShape(
       const std::function<void(odb::dbTechLayer*, const odb::Rect&)>& callback);
   void excludeBoundaryShape(const odb::Rect& box,
@@ -296,7 +310,7 @@ class IOPlacer
   // a pin size only depends on its layer, wrong way pins are rejected
   std::map<int, PinSize> pin_size_cache_;
   // dbTechLayer::getSpacing(w, l) copies the whole spacing table per call
-  std::map<std::tuple<int, int, int>, int> spacing_cache_;
+  std::map<SpacingKey, int> spacing_cache_;
 
   utl::Logger* logger_ = nullptr;
   std::unique_ptr<utl::Validator> validator_;

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -227,6 +227,9 @@ class IOPlacer
                                              const odb::Rect& box);
   PinSize computePinSize(int layer);
   int computeLayerSpacing(int layer, int shape_width, int parallel_length);
+  void excludeBoundaryShape(const odb::Rect& box,
+                            odb::dbTechLayer* tech_layer,
+                            const odb::Rect& die_area);
   void getBlockedRegionsFromPDN();
   void getBlockedRegionsFromMacros();
   void getBlockedRegionsFromDbObstructions();

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -227,9 +228,11 @@ class IOPlacer
                                              const odb::Rect& box);
   PinSize computePinSize(int layer);
   int computeLayerSpacing(int layer, int shape_width, int parallel_length);
+  odb::Rect padShapeForPin(const odb::Rect& box, int layer, bool vertical_pin);
   void excludeBoundaryShape(const odb::Rect& box,
                             odb::dbTechLayer* tech_layer,
                             const odb::Rect& die_area);
+  void getBlockedRegions();
   void getBlockedRegionsFromPDN();
   void getBlockedRegionsFromMacros();
   void getBlockedRegionsFromDbObstructions();
@@ -274,9 +277,11 @@ class IOPlacer
   std::vector<Interval> excluded_intervals_;
   std::vector<Constraint> constraints_;
   FallbackPins fallback_pins_;
+  // fixed pin shapes padded by the pin size and spacing, per layer
   std::map<int, std::vector<odb::Rect>> layer_fixed_pins_shapes_;
   // a pin size only depends on its layer, wrong way pins are rejected
   std::map<int, PinSize> pin_size_cache_;
+  std::map<std::tuple<int, int, int>, int> spacing_cache_;
 
   utl::Logger* logger_ = nullptr;
   std::unique_ptr<utl::Validator> validator_;

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -233,6 +233,7 @@ class IOPlacer
   bool checkBlocked(Edge edge, odb::Line, const odb::Point& pos, int layer);
   std::vector<Interval> findBlockedIntervals(const odb::Rect& die_area,
                                              const odb::Rect& box);
+  int roundUpToEvenMfgGrid(int dim);
   PinSize computePinSize(int layer);
   int computeLayerSpacing(int layer, int shape_width, int parallel_length);
   int computeShapeSpacing(int layer,

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>
@@ -70,6 +71,12 @@ enum class Edge
   invalid,
   polygonEdge,
 };
+
+// the top and bottom edges hold vertical pins on the vertical layers
+inline bool isVerticalEdge(Edge edge)
+{
+  return edge == Edge::top || edge == Edge::bottom;
+}
 
 enum class Direction
 {
@@ -228,7 +235,13 @@ class IOPlacer
                                              const odb::Rect& box);
   PinSize computePinSize(int layer);
   int computeLayerSpacing(int layer, int shape_width, int parallel_length);
-  odb::Rect padShapeForPin(const odb::Rect& box, int layer, bool vertical_pin);
+  int computeShapeSpacing(int layer,
+                          const odb::Rect& shape,
+                          int pin_width,
+                          int pin_length);
+  odb::Rect padShapeForPin(const odb::Rect& box, int layer);
+  void forEachSpecialNetShape(
+      const std::function<void(odb::dbTechLayer*, const odb::Rect&)>& callback);
   void excludeBoundaryShape(const odb::Rect& box,
                             odb::dbTechLayer* tech_layer,
                             const odb::Rect& die_area);
@@ -278,9 +291,10 @@ class IOPlacer
   std::vector<Constraint> constraints_;
   FallbackPins fallback_pins_;
   // fixed pin shapes padded by the pin size and spacing, per layer
-  std::map<int, std::vector<odb::Rect>> layer_fixed_pins_shapes_;
+  std::map<int, std::vector<odb::Rect>> layer_fixed_pins_keepouts_;
   // a pin size only depends on its layer, wrong way pins are rejected
   std::map<int, PinSize> pin_size_cache_;
+  // dbTechLayer::getSpacing(w, l) copies the whole spacing table per call
   std::map<std::tuple<int, int, int>, int> spacing_cache_;
 
   utl::Logger* logger_ = nullptr;

--- a/src/ppl/src/HungarianMatching.cpp
+++ b/src/ppl/src/HungarianMatching.cpp
@@ -59,6 +59,7 @@ void HungarianMatching::createMatrix()
   for (int idx : pin_indices_) {
     IOPin& io_pin = netlist_->getIoPin(idx);
     if (!io_pin.isInGroup()) {
+      const bool has_mirror = io_pin.getBTerm()->hasMirroredBTerm();
       bool is_mirrored = false;
       std::vector<int> larger_costs;
       int slot_index = 0;
@@ -75,7 +76,7 @@ void HungarianMatching::createMatrix()
         larger_costs.push_back(std::max(io_net_hpwl, mirrored_cost));
         // avoid slots whose mirrored slot cannot receive the mirrored pin
         hungarian_matrix_[slot_index][pin_index]
-            = isMirroredSlotBlocked(io_pin, slot_pos, slots_[i].layer)
+            = has_mirror && isMirroredSlotBlocked(slot_pos, slots_[i].layer)
                   ? hungarian_fail_
                   : hpwl;
         is_mirrored = is_mirrored || mirrored_cost != 0;
@@ -355,13 +356,9 @@ void HungarianMatching::getAssignmentForGroups(std::vector<IOPin>& assignment,
   assignment_.clear();
 }
 
-bool HungarianMatching::isMirroredSlotBlocked(IOPin& io_pin,
-                                              const odb::Point& pos,
+bool HungarianMatching::isMirroredSlotBlocked(const odb::Point& pos,
                                               int layer) const
 {
-  if (!io_pin.getBTerm()->hasMirroredBTerm()) {
-    return false;
-  }
   const int slot_index
       = getSlotIdxByPosition(core_->getMirroredPosition(pos), layer);
   return slot_index < 0 || !slots_[slot_index].isAvailable();

--- a/src/ppl/src/HungarianMatching.h
+++ b/src/ppl/src/HungarianMatching.h
@@ -60,9 +60,7 @@ class HungarianMatching
   void createMatrixForGroups();
   void assignMirroredPins(IOPin& io_pin, std::vector<IOPin>& assignment);
   int getSlotIdxByPosition(const odb::Point& position, int layer) const;
-  bool isMirroredSlotBlocked(IOPin& io_pin,
-                             const odb::Point& pos,
-                             int layer) const;
+  bool isMirroredSlotBlocked(const odb::Point& pos, int layer) const;
   bool groupHasMirroredPin(const std::vector<int>& group);
   int getMirroredPinCost(IOPin& io_pin, const odb::Point& position);
   Edge getMirroredEdge(const Edge& edge);

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -483,17 +483,22 @@ std::vector<Interval> IOPlacer::findBlockedIntervals(const odb::Rect& die_area,
   return intervals;
 }
 
-int IOPlacer::roundUpToEvenMfgGrid(const int dim)
+int IOPlacer::roundUpToMfgGrid(const int dim)
 {
   const int mfg_grid = getTech()->getManufacturingGrid();
-  int rounded = dim;
-  if (mfg_grid > 0 && rounded % mfg_grid != 0) {
-    rounded = mfg_grid * std::ceil(static_cast<float>(rounded) / mfg_grid);
+  if (mfg_grid > 0 && dim % mfg_grid != 0) {
+    return mfg_grid * std::ceil(static_cast<float>(dim) / mfg_grid);
   }
+  return dim;
+}
+
+int IOPlacer::roundUpToEvenMfgGrid(const int dim)
+{
+  int rounded = roundUpToMfgGrid(dim);
   // ensure the dimension is an even multiple of the manufacturing grid,
   // since it is divided by 2 when the pin shape is created
   if (rounded % 2 != 0) {
-    rounded += mfg_grid;
+    rounded += getTech()->getManufacturingGrid();
   }
   return rounded;
 }
@@ -529,11 +534,7 @@ PinSize IOPlacer::computePinSize(const int layer)
   if (user_length != -1) {
     height = user_length;
   }
-  // round up to the manufacturing grid
-  const int mfg_grid = getTech()->getManufacturingGrid();
-  if (mfg_grid > 0 && height % mfg_grid != 0) {
-    height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
-  }
+  height = roundUpToMfgGrid(height);
   const PinSize pin_size{half_width, height};
   pin_size_cache_[layer] = pin_size;
   return pin_size;
@@ -587,10 +588,7 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
   if (layer == 0) {
     return;
   }
-  // the layer sets only filter which layers have slots: the Tcl/Python
-  // wrappers reject layers whose preferred direction disagrees with the set
-  // (PPL-45/46). Empty sets mean standalone place_pin, where every layer
-  // participates
+
   const bool vertical_pin
       = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
   if (!ver_layers_.empty() || !hor_layers_.empty()) {
@@ -636,7 +634,7 @@ void IOPlacer::forEachSpecialNetShape(
           sbox->getViaBoxes(via_shapes);
           for (const odb::dbShape& via_shape : via_shapes) {
             odb::dbTechLayer* tech_layer = via_shape.getTechLayer();
-            if (tech_layer != nullptr && tech_layer->getRoutingLevel() != 0) {
+            if (tech_layer != nullptr) {
               callback(tech_layer, via_shape.getBox());
             }
           }
@@ -1895,8 +1893,8 @@ void IOPlacer::updatePinArea(IOPin& pin)
                      getBlock()->dbuAreaToMicrons(required_min_area));
     }
   } else {
-    const int pin_width = roundUpToEvenMfgGrid(top_grid_->pin_width);
-    const int pin_height = roundUpToEvenMfgGrid(top_grid_->pin_height);
+    const int pin_width = top_grid_->pin_width;
+    const int pin_height = top_grid_->pin_height;
 
     pin.setLowerBound(pin.getX() - pin_width / 2, pin.getY() - pin_height / 2);
     pin.setUpperBound(pin.getX() + pin_width / 2, pin.getY() + pin_height / 2);
@@ -2729,22 +2727,8 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
           = int(std::max(static_cast<double>(height), ceil(min_area / height)));
     }
   }
-  const int mfg_grid = getTech()->getManufacturingGrid();
-  if (width % mfg_grid != 0) {
-    width = mfg_grid * std::ceil(static_cast<float>(width) / mfg_grid);
-  }
-  if (width % 2 != 0) {
-    // ensure width is a even multiple of mfg_grid since its divided by 2 later
-    width += mfg_grid;
-  }
-
-  if (height % mfg_grid != 0) {
-    height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
-  }
-  if (height % 2 != 0) {
-    // ensure height is a even multiple of mfg_grid since its divided by 2 later
-    height += mfg_grid;
-  }
+  width = roundUpToEvenMfgGrid(width);
+  height = roundUpToEvenMfgGrid(height);
 
   odb::Point pos = odb::Point(x, y);
 
@@ -3092,6 +3076,9 @@ void IOPlacer::initTopLayerGrid()
   if (top_layer_grid) {
     top_grid_ = std::make_unique<odb::dbBlock::dbBTermTopLayerGrid>(
         top_layer_grid.value());
+    // commit the rounded pin size, so every consumer sees the placed shape
+    top_grid_->pin_width = roundUpToEvenMfgGrid(top_grid_->pin_width);
+    top_grid_->pin_height = roundUpToEvenMfgGrid(top_grid_->pin_height);
   }
 }
 
@@ -3146,6 +3133,10 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   // Get routing obstructions. The system reserved ones are not skipped here,
   // since they are the only filter for slots outside of polygon dies
   for (odb::dbObstruction* obstruction : getBlock()->getObstructions()) {
+    // fill and slot only blockages still allow routing metal over them
+    if (obstruction->isFillObstruction() || obstruction->isSlotObstruction()) {
+      continue;
+    }
     odb::dbBox* box = obstruction->getBBox();
     if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
       obstructions.push_back(box->getBox());
@@ -3173,9 +3164,8 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
     }
   }
 
-  // use the committed pin size, which is rounded up to the mfg grid
-  const int pin_width = roundUpToEvenMfgGrid(top_grid_->pin_width);
-  const int pin_height = roundUpToEvenMfgGrid(top_grid_->pin_height);
+  const int pin_width = top_grid_->pin_width;
+  const int pin_height = top_grid_->pin_height;
 
   // check for slots that go beyond the die boundary
   odb::Rect die_area = getBlock()->getDieArea();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -443,7 +443,8 @@ bool IOPlacer::checkBlocked(Edge edge,
     // the layer of the position
     if (blocked_interval.getLayer() == -1
         || blocked_interval.getLayer() == layer) {
-      // polygon slots match intervals of any edge with the same orientation
+      // polygon slots match intervals of any edge with the same orientation,
+      // over-blocking parallel edges until intervals carry their source edge
       if ((blocked_interval.getEdge() == edge
            || (edge == Edge::polygonEdge
                && isVerticalEdge(blocked_interval.getEdge()) == vertical_pin))
@@ -528,6 +529,7 @@ PinSize IOPlacer::computePinSize(const int layer)
   if (user_length != -1) {
     height = user_length;
   }
+  // round up to the manufacturing grid
   const int mfg_grid = getTech()->getManufacturingGrid();
   if (mfg_grid > 0 && height % mfg_grid != 0) {
     height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
@@ -537,18 +539,22 @@ PinSize IOPlacer::computePinSize(const int layer)
   return pin_size;
 }
 
-int IOPlacer::computeLayerSpacing(const int layer,
-                                  const int shape_width,
-                                  const int parallel_length)
+int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
+                                  const odb::Rect& shape,
+                                  const int pin_width,
+                                  const int pin_length)
 {
-  const auto cache_key = std::make_tuple(layer, shape_width, parallel_length);
+  // the spacing rules use the width of the widest shape and the parallel
+  // run length between the shapes
+  const int shape_width = std::max(std::min(shape.dx(), shape.dy()), pin_width);
+  const auto cache_key
+      = std::make_tuple(tech_layer->getRoutingLevel(), shape_width, pin_length);
   const auto cached = spacing_cache_.find(cache_key);
   if (cached != spacing_cache_.end()) {
     return cached->second;
   }
-  odb::dbTechLayer* tech_layer = getTech()->findRoutingLayer(layer);
   // width-dependent rules require larger clearance to wide PDN shapes
-  int spacing = tech_layer->getSpacing(shape_width, parallel_length);
+  int spacing = tech_layer->getSpacing(shape_width, pin_length);
   if (spacing == 0) {
     spacing = tech_layer->getWidth();
   }
@@ -556,26 +562,14 @@ int IOPlacer::computeLayerSpacing(const int layer,
   return spacing;
 }
 
-int IOPlacer::computeShapeSpacing(const int layer,
-                                  const odb::Rect& shape,
-                                  const int pin_width,
-                                  const int pin_length)
+odb::Rect IOPlacer::padShapeForPin(const odb::Rect& box,
+                                   odb::dbTechLayer* tech_layer)
 {
-  // the spacing rules use the width of the widest shape and the parallel
-  // run length between the shapes
-  const int shape_width = std::min(shape.dx(), shape.dy());
-  return computeLayerSpacing(
-      layer, std::max(shape_width, pin_width), pin_length);
-}
-
-odb::Rect IOPlacer::padShapeForPin(const odb::Rect& box, const int layer)
-{
-  const PinSize pin_size = computePinSize(layer);
+  const PinSize pin_size = computePinSize(tech_layer->getRoutingLevel());
   const int spacing = computeShapeSpacing(
-      layer, box, 2 * pin_size.half_width, pin_size.height);
+      tech_layer, box, 2 * pin_size.half_width, pin_size.height);
   // pad by the pin footprint plus spacing: half width along the edge, the pin
   // extension into the die on the other axis
-  odb::dbTechLayer* tech_layer = getTech()->findRoutingLayer(layer);
   const odb::Orientation2D edge_dir
       = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL
             ? odb::Orientation2D::Horizontal
@@ -605,7 +599,7 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
       return;
     }
   }
-  const odb::Rect padded_box = padShapeForPin(box, layer);
+  const odb::Rect padded_box = padShapeForPin(box, tech_layer);
   if (!die_area.intersects(padded_box)) {
     return;
   }
@@ -793,8 +787,7 @@ void IOPlacer::computeRegionIncrease(const Interval& interval,
                                      int& new_begin,
                                      int& new_end)
 {
-  const bool vertical_pin
-      = interval.getEdge() == Edge::top || interval.getEdge() == Edge::bottom;
+  const bool vertical_pin = isVerticalEdge(interval.getEdge());
 
   int interval_length = std::abs(interval.getEnd() - interval.getBegin());
   int interval_begin = std::min(interval.getBegin(), interval.getEnd());
@@ -827,8 +820,7 @@ void IOPlacer::computeRegionIncrease(const Interval& interval,
 
 int IOPlacer::getMinDistanceForInterval(const Interval& interval)
 {
-  const bool vertical_pin
-      = interval.getEdge() == Edge::top || interval.getEdge() == Edge::bottom;
+  const bool vertical_pin = isVerticalEdge(interval.getEdge());
   int min_dist = std::numeric_limits<int>::min();
 
   if (interval.getLayer() != -1) {
@@ -965,7 +957,7 @@ std::vector<odb::Point> IOPlacer::findLayerSlots(const int layer,
     max = vertical_pin ? std::max(edge_start.getX(), edge_end.getX())
                        : std::max(edge_start.getY(), edge_end.getY());
   } else {
-    vertical_pin = (edge == Edge::top || edge == Edge::bottom);
+    vertical_pin = isVerticalEdge(edge);
     min = vertical_pin ? lb_x : lb_y;
     max = vertical_pin ? ub_x : ub_y;
   }
@@ -2645,11 +2637,9 @@ bool IOPlacer::checkPinConstraints()
       if (constraint_interval.getEdge() != Edge::invalid) {
         const int constraint_begin = constraint_interval.getBegin();
         const int constraint_end = constraint_interval.getEnd();
-        const int pin_coord
-            = constraint_interval.getEdge() == Edge::bottom
-                      || constraint_interval.getEdge() == Edge::top
-                  ? pin.getPosition().getX()
-                  : pin.getPosition().getY();
+        const int pin_coord = isVerticalEdge(constraint_interval.getEdge())
+                                  ? pin.getPosition().getX()
+                                  : pin.getPosition().getY();
         if (pin_coord < constraint_begin || pin_coord > constraint_end) {
           logger_->warn(PPL,
                         102,
@@ -3201,7 +3191,7 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   for (odb::Rect& rect : obstructions) {
     // floor the keepout at the layer spacing required by the obstruction
     const int spacing
-        = computeShapeSpacing(top_layer_level, rect, pin_min_dim, pin_max_dim);
+        = computeShapeSpacing(top_grid_->layer, rect, pin_min_dim, pin_max_dim);
     const int keepout = std::max(top_grid_->keepout, spacing);
     // pad the obstruction by the pin footprint instead of one rect per slot
     const odb::Rect keepout_rect
@@ -3292,11 +3282,11 @@ void IOPlacer::initNetlist()
     if (bterm->getFirstPinPlacementStatus().isFixed()) {
       for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
         for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
-          const int layer = bpin_box->getTechLayer()->getRoutingLevel();
+          odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
           // store the shapes padded, so the pins created near them keep the
           // min spacing
-          layer_fixed_pins_keepouts_[layer].push_back(
-              padShapeForPin(bpin_box->getBox(), layer));
+          layer_fixed_pins_keepouts_[tech_layer->getRoutingLevel()].push_back(
+              padShapeForPin(bpin_box->getBox(), tech_layer));
         }
       }
       continue;

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -623,6 +623,7 @@ void IOPlacer::getBlockedRegions()
 void IOPlacer::forEachSpecialNetShape(
     const std::function<void(odb::dbTechLayer*, const odb::Rect&)>& callback)
 {
+  // reused across all vias, getViaBoxes clears it on every call
   std::vector<odb::dbShape> via_shapes;
   for (odb::dbNet* net : getBlock()->getNets()) {
     if (!net->isSpecial()) {
@@ -3188,7 +3189,7 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   // check for slots that overlap with obstructions
   const int pin_min_dim = std::min(pin_width, pin_height);
   const int pin_max_dim = std::max(pin_width, pin_height);
-  for (odb::Rect& rect : obstructions) {
+  for (const odb::Rect& rect : obstructions) {
     // floor the keepout at the layer spacing required by the obstruction
     const int spacing
         = computeShapeSpacing(top_grid_->layer, rect, pin_min_dim, pin_max_dim);

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -436,7 +436,7 @@ bool IOPlacer::checkBlocked(Edge edge,
   }
   bool vertical_pin = (edge == Edge::polygonEdge)
                           ? line.pt0().getY() == line.pt1().getY()
-                          : isVerticalEdge(edge);
+                          : hasVerticalPins(edge);
   int coord = vertical_pin ? pos.getX() : pos.getY();
   for (const Interval& blocked_interval : excluded_intervals_) {
     // check if the blocked interval blocks all layers (== -1) or if it blocks
@@ -447,7 +447,7 @@ bool IOPlacer::checkBlocked(Edge edge,
       // over-blocking parallel edges until intervals carry their source edge
       if ((blocked_interval.getEdge() == edge
            || (edge == Edge::polygonEdge
-               && isVerticalEdge(blocked_interval.getEdge()) == vertical_pin))
+               && hasVerticalPins(blocked_interval.getEdge()) == vertical_pin))
           && coord > blocked_interval.getBegin()
           && coord < blocked_interval.getEnd()) {
         return true;
@@ -548,8 +548,8 @@ int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
   // the spacing rules use the width of the widest shape and the parallel
   // run length between the shapes
   const int shape_width = std::max(std::min(shape.dx(), shape.dy()), pin_width);
-  const auto cache_key
-      = std::make_tuple(tech_layer->getRoutingLevel(), shape_width, pin_length);
+  const SpacingKey cache_key{
+      tech_layer->getRoutingLevel(), shape_width, pin_length};
   const auto cached = spacing_cache_.find(cache_key);
   if (cached != spacing_cache_.end()) {
     return cached->second;
@@ -563,8 +563,8 @@ int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
   return spacing;
 }
 
-odb::Rect IOPlacer::padShapeForPin(const odb::Rect& box,
-                                   odb::dbTechLayer* tech_layer)
+odb::Rect IOPlacer::computePinKeepout(const odb::Rect& box,
+                                      odb::dbTechLayer* tech_layer)
 {
   const PinSize pin_size = computePinSize(tech_layer->getRoutingLevel());
   const int spacing = computeShapeSpacing(
@@ -597,13 +597,13 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
       return;
     }
   }
-  const odb::Rect padded_box = padShapeForPin(box, tech_layer);
+  const odb::Rect padded_box = computePinKeepout(box, tech_layer);
   if (!die_area.intersects(padded_box)) {
     return;
   }
   const odb::Rect intersect = die_area.intersect(padded_box);
   for (const Interval& interval : findBlockedIntervals(die_area, intersect)) {
-    if (isVerticalEdge(interval.getEdge()) != vertical_pin) {
+    if (hasVerticalPins(interval.getEdge()) != vertical_pin) {
       continue;
     }
     excludeInterval(Interval(
@@ -790,7 +790,7 @@ void IOPlacer::computeRegionIncrease(const Interval& interval,
                                      int& new_begin,
                                      int& new_end)
 {
-  const bool vertical_pin = isVerticalEdge(interval.getEdge());
+  const bool vertical_pin = hasVerticalPins(interval.getEdge());
 
   int interval_length = std::abs(interval.getEnd() - interval.getBegin());
   int interval_begin = std::min(interval.getBegin(), interval.getEnd());
@@ -823,7 +823,7 @@ void IOPlacer::computeRegionIncrease(const Interval& interval,
 
 int IOPlacer::getMinDistanceForInterval(const Interval& interval)
 {
-  const bool vertical_pin = isVerticalEdge(interval.getEdge());
+  const bool vertical_pin = hasVerticalPins(interval.getEdge());
   int min_dist = std::numeric_limits<int>::min();
 
   if (interval.getLayer() != -1) {
@@ -960,7 +960,7 @@ std::vector<odb::Point> IOPlacer::findLayerSlots(const int layer,
     max = vertical_pin ? std::max(edge_start.getX(), edge_end.getX())
                        : std::max(edge_start.getY(), edge_end.getY());
   } else {
-    vertical_pin = isVerticalEdge(edge);
+    vertical_pin = hasVerticalPins(edge);
     min = vertical_pin ? lb_x : lb_y;
     max = vertical_pin ? ub_x : ub_y;
   }
@@ -2640,7 +2640,7 @@ bool IOPlacer::checkPinConstraints()
       if (constraint_interval.getEdge() != Edge::invalid) {
         const int constraint_begin = constraint_interval.getBegin();
         const int constraint_end = constraint_interval.getEnd();
-        const int pin_coord = isVerticalEdge(constraint_interval.getEdge())
+        const int pin_coord = hasVerticalPins(constraint_interval.getEdge())
                                   ? pin.getPosition().getX()
                                   : pin.getPosition().getY();
         if (pin_coord < constraint_begin || pin_coord > constraint_end) {
@@ -3281,7 +3281,7 @@ void IOPlacer::initNetlist()
           // store the shapes padded, so the pins created near them keep the
           // min spacing
           layer_fixed_pins_keepouts_[tech_layer->getRoutingLevel()].push_back(
-              padShapeForPin(bpin_box->getBox(), tech_layer));
+              computePinKeepout(bpin_box->getBox(), tech_layer));
         }
       }
       continue;

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -685,6 +685,10 @@ void IOPlacer::getBlockedRegionsFromDbObstructions()
     if (obstruction->isSystemReserved()) {
       continue;
     }
+    // fill and slot only blockages still allow routing metal over them
+    if (obstruction->isFillObstruction() || obstruction->isSlotObstruction()) {
+      continue;
+    }
     odb::dbBox* obstruct_box = obstruction->getBBox();
     odb::dbTechLayer* tech_layer = obstruct_box->getTechLayer();
     if (tech_layer == nullptr) {

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -72,6 +72,7 @@ void IOPlacer::clear()
   top_layer_slots_.clear();
   assignment_.clear();
   excluded_intervals_.clear();
+  layer_fixed_pins_keepouts_.clear();
   pin_size_cache_.clear();
   spacing_cache_.clear();
   *parms_ = Parameters();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -481,6 +481,21 @@ std::vector<Interval> IOPlacer::findBlockedIntervals(const odb::Rect& die_area,
   return intervals;
 }
 
+int IOPlacer::roundUpToEvenMfgGrid(const int dim)
+{
+  const int mfg_grid = getTech()->getManufacturingGrid();
+  int rounded = dim;
+  if (mfg_grid > 0 && rounded % mfg_grid != 0) {
+    rounded = mfg_grid * std::ceil(static_cast<float>(rounded) / mfg_grid);
+  }
+  // ensure the dimension is an even multiple of the manufacturing grid,
+  // since it is divided by 2 when the pin shape is created
+  if (rounded % 2 != 0) {
+    rounded += mfg_grid;
+  }
+  return rounded;
+}
+
 PinSize IOPlacer::computePinSize(const int layer)
 {
   const auto cached = pin_size_cache_.find(layer);
@@ -1878,28 +1893,8 @@ void IOPlacer::updatePinArea(IOPin& pin)
                      getBlock()->dbuAreaToMicrons(required_min_area));
     }
   } else {
-    int pin_width = top_grid_->pin_width;
-    int pin_height = top_grid_->pin_height;
-
-    if (pin_width % mfg_grid != 0) {
-      pin_width
-          = mfg_grid * std::ceil(static_cast<float>(pin_width) / mfg_grid);
-    }
-    if (pin_width % 2 != 0) {
-      // ensure pin_width is a even multiple of mfg_grid since its divided by 2
-      // later
-      pin_width += mfg_grid;
-    }
-
-    if (pin_height % mfg_grid != 0) {
-      pin_height
-          = mfg_grid * std::ceil(static_cast<float>(pin_height) / mfg_grid);
-    }
-    if (pin_height % 2 != 0) {
-      // ensure pin_height is a even multiple of mfg_grid since its divided by 2
-      // later
-      pin_height += mfg_grid;
-    }
+    const int pin_width = roundUpToEvenMfgGrid(top_grid_->pin_width);
+    const int pin_height = roundUpToEvenMfgGrid(top_grid_->pin_height);
 
     pin.setLowerBound(pin.getX() - pin_width / 2, pin.getY() - pin_height / 2);
     pin.setUpperBound(pin.getX() + pin_width / 2, pin.getY() + pin_height / 2);
@@ -3178,35 +3173,37 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
     }
   }
 
+  // use the committed pin size, which is rounded up to the mfg grid
+  const int pin_width = roundUpToEvenMfgGrid(top_grid_->pin_width);
+  const int pin_height = roundUpToEvenMfgGrid(top_grid_->pin_height);
+
   // check for slots that go beyond the die boundary
   odb::Rect die_area = getBlock()->getDieArea();
   for (auto& slot : top_layer_slots_) {
     odb::Point& point = slot.pos;
-    if (point.x() - top_grid_->pin_width / 2 < die_area.xMin()
-        || point.y() - top_grid_->pin_height / 2 < die_area.yMin()
-        || point.x() + top_grid_->pin_width / 2 > die_area.xMax()
-        || point.y() + top_grid_->pin_height / 2 > die_area.yMax()) {
+    if (point.x() - pin_width / 2 < die_area.xMin()
+        || point.y() - pin_height / 2 < die_area.yMin()
+        || point.x() + pin_width / 2 > die_area.xMax()
+        || point.y() + pin_height / 2 > die_area.yMax()) {
       // mark slot as blocked since it extends beyond the die area
       slot.blocked = true;
     }
   }
 
   // check for slots that overlap with obstructions
-  const int pin_min_dim = std::min(top_grid_->pin_width, top_grid_->pin_height);
-  const int pin_max_dim = std::max(top_grid_->pin_width, top_grid_->pin_height);
+  const int pin_min_dim = std::min(pin_width, pin_height);
+  const int pin_max_dim = std::max(pin_width, pin_height);
   for (odb::Rect& rect : obstructions) {
     // floor the keepout at the layer spacing required by the obstruction
     const int spacing
         = computeShapeSpacing(top_layer_level, rect, pin_min_dim, pin_max_dim);
     const int keepout = std::max(top_grid_->keepout, spacing);
+    // pad the obstruction by the pin footprint instead of one rect per slot
+    const odb::Rect keepout_rect
+        = rect.bloat(pin_width / 2 + keepout, odb::Orientation2D::Horizontal)
+              .bloat(pin_height / 2 + keepout, odb::Orientation2D::Vertical);
     for (auto& slot : top_layer_slots_) {
-      odb::Point& point = slot.pos;
-      // mock slot with keepout
-      odb::Rect pin_rect(point.x() - top_grid_->pin_width / 2 - keepout,
-                         point.y() - top_grid_->pin_height / 2 - keepout,
-                         point.x() + top_grid_->pin_width / 2 + keepout,
-                         point.y() + top_grid_->pin_height / 2 + keepout);
-      if (rect.intersects(pin_rect)) {  // mark slot as blocked
+      if (keepout_rect.intersects(slot.pos)) {
         slot.blocked = true;
       }
     }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -3228,15 +3228,22 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   }
 
   // check for slots that overlap with obstructions
+  const int layer_level = top_grid_->layer->getRoutingLevel();
+  const int pin_min_dim = std::min(top_grid_->pin_width, top_grid_->pin_height);
+  const int pin_max_dim = std::max(top_grid_->pin_width, top_grid_->pin_height);
   for (odb::Rect& rect : obstructions) {
+    // floor the keepout at the layer spacing required by the obstruction
+    const int shape_width = std::min(rect.dx(), rect.dy());
+    const int spacing = computeLayerSpacing(
+        layer_level, std::max(shape_width, pin_min_dim), pin_max_dim);
+    const int keepout = std::max(top_grid_->keepout, spacing);
     for (auto& slot : top_layer_slots_) {
       odb::Point& point = slot.pos;
       // mock slot with keepout
-      odb::Rect pin_rect(
-          point.x() - top_grid_->pin_width / 2 - top_grid_->keepout,
-          point.y() - top_grid_->pin_height / 2 - top_grid_->keepout,
-          point.x() + top_grid_->pin_width / 2 + top_grid_->keepout,
-          point.y() + top_grid_->pin_height / 2 + top_grid_->keepout);
+      odb::Rect pin_rect(point.x() - top_grid_->pin_width / 2 - keepout,
+                         point.y() - top_grid_->pin_height / 2 - keepout,
+                         point.x() + top_grid_->pin_width / 2 + keepout,
+                         point.y() + top_grid_->pin_height / 2 + keepout);
       if (rect.intersects(pin_rect)) {  // mark slot as blocked
         slot.blocked = true;
       }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -24,6 +24,7 @@
 #include "Slots.h"
 #include "odb/db.h"
 #include "odb/dbSet.h"
+#include "odb/dbShape.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 #include "ppl/Parameters.h"
@@ -609,6 +610,16 @@ void IOPlacer::getBlockedRegionsFromPDN()
     for (odb::dbSWire* swire : net->getSWires()) {
       for (odb::dbSBox* sbox : swire->getWires()) {
         if (sbox->isVia()) {
+          // via landing pads can also reach the die boundary
+          std::vector<odb::dbShape> via_shapes;
+          sbox->getViaBoxes(via_shapes);
+          for (const odb::dbShape& via_shape : via_shapes) {
+            odb::dbTechLayer* tech_layer = via_shape.getTechLayer();
+            if (tech_layer == nullptr || tech_layer->getRoutingLevel() == 0) {
+              continue;
+            }
+            excludeBoundaryShape(via_shape.getBox(), tech_layer, die_area);
+          }
           continue;
         }
         odb::dbTechLayer* tech_layer = sbox->getTechLayer();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -589,6 +589,10 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
                                     const odb::Rect& die_area)
 {
   const int layer = tech_layer->getRoutingLevel();
+  // cut and masterslice shapes never conflict with routing layer pins
+  if (layer == 0) {
+    return;
+  }
   // the layer sets only filter which layers have slots: the Tcl/Python
   // wrappers reject layers whose preferred direction disagrees with the set
   // (PPL-45/46). Empty sets mean standalone place_pin, where every layer

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -71,6 +71,7 @@ void IOPlacer::clear()
   assignment_.clear();
   excluded_intervals_.clear();
   pin_size_cache_.clear();
+  spacing_cache_.clear();
   *parms_ = Parameters();
 }
 
@@ -422,42 +423,28 @@ bool IOPlacer::checkBlocked(Edge edge,
                             const odb::Point& pos,
                             int layer)
 {
-  bool vertical_pin = (edge == Edge::polygonEdge)
-                          ? line.pt0().getY() == line.pt1().getY()
-                          : (edge == Edge::top || edge == Edge::bottom);
   const auto fixed_shapes = layer_fixed_pins_shapes_.find(layer);
   if (fixed_shapes != layer_fixed_pins_shapes_.end()) {
-    // pad fixed shapes so the new pin geometry keeps min spacing to them
-    const PinSize pin_size = computePinSize(layer);
-    for (const odb::Rect& fixed_pin_shape : fixed_shapes->second) {
-      const int shape_width
-          = std::min(fixed_pin_shape.dx(), fixed_pin_shape.dy());
-      const int spacing
-          = computeLayerSpacing(layer,
-                                std::max(shape_width, 2 * pin_size.half_width),
-                                pin_size.height);
-      const int edge_pad = pin_size.half_width + spacing;
-      const int depth_pad = pin_size.height + spacing;
-      const odb::Rect padded_shape
-          = vertical_pin
-                ? fixed_pin_shape
-                      .bloat(edge_pad, odb::Orientation2D::Horizontal)
-                      .bloat(depth_pad, odb::Orientation2D::Vertical)
-                : fixed_pin_shape.bloat(edge_pad, odb::Orientation2D::Vertical)
-                      .bloat(depth_pad, odb::Orientation2D::Horizontal);
+    for (const odb::Rect& padded_shape : fixed_shapes->second) {
       if (padded_shape.intersects(pos)) {
         return true;
       }
     }
   }
+  bool vertical_pin = (edge == Edge::polygonEdge)
+                          ? line.pt0().getY() == line.pt1().getY()
+                          : (edge == Edge::top || edge == Edge::bottom);
   int coord = vertical_pin ? pos.getX() : pos.getY();
   for (Interval blocked_interval : excluded_intervals_) {
     // check if the blocked interval blocks all layers (== -1) or if it blocks
     // the layer of the position
     if (blocked_interval.getLayer() == -1
         || blocked_interval.getLayer() == layer) {
-      if ((blocked_interval.getEdge() == edge || edge == Edge::polygonEdge)
-          // Polygons need to be dealt with properly later
+      // polygon slots match intervals of any edge with the same orientation
+      const bool vertical_edge = blocked_interval.getEdge() == Edge::top
+                                 || blocked_interval.getEdge() == Edge::bottom;
+      if ((blocked_interval.getEdge() == edge
+           || (edge == Edge::polygonEdge && vertical_edge == vertical_pin))
           && coord > blocked_interval.getBegin()
           && coord < blocked_interval.getEnd()) {
         return true;
@@ -499,7 +486,6 @@ PinSize IOPlacer::computePinSize(const int layer)
   if (cached != pin_size_cache_.end()) {
     return cached->second;
   }
-  int half_width, height;
   odb::dbTechLayer* tech_layer = getTech()->findRoutingLayer(layer);
   const bool vertical_pin
       = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
@@ -517,19 +503,20 @@ PinSize IOPlacer::computePinSize(const int layer)
   const int min_area = min_areas.find(layer) != min_areas.end()
                            ? min_areas.at(layer)
                            : tech_layer->getArea();
-  half_width = int(ceil(min_width / 2.0)) * thickness_multiplier;
-  height = int(std::max(2.0 * half_width, ceil(min_area / (2.0 * half_width))));
+  PinSize pin_size;
+  pin_size.half_width = int(ceil(min_width / 2.0)) * thickness_multiplier;
+  pin_size.height = int(std::max(2.0 * pin_size.half_width,
+                                 ceil(min_area / (2.0 * pin_size.half_width))));
   const int user_length = vertical_pin ? parms_->getVerticalLength()
                                        : parms_->getHorizontalLength();
   if (user_length != -1) {
-    height = user_length;
+    pin_size.height = user_length;
   }
-  // round up to the manufacturing grid like updatePinArea does
   const int mfg_grid = getTech()->getManufacturingGrid();
-  if (mfg_grid > 0 && height % mfg_grid != 0) {
-    height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
+  if (mfg_grid > 0 && pin_size.height % mfg_grid != 0) {
+    pin_size.height
+        = mfg_grid * std::ceil(static_cast<float>(pin_size.height) / mfg_grid);
   }
-  const PinSize pin_size{half_width, height};
   pin_size_cache_[layer] = pin_size;
   return pin_size;
 }
@@ -538,16 +525,36 @@ int IOPlacer::computeLayerSpacing(const int layer,
                                   const int shape_width,
                                   const int parallel_length)
 {
+  const auto cache_key = std::make_tuple(layer, shape_width, parallel_length);
+  const auto cached = spacing_cache_.find(cache_key);
+  if (cached != spacing_cache_.end()) {
+    return cached->second;
+  }
   odb::dbTechLayer* tech_layer = getTech()->findRoutingLayer(layer);
   // width-dependent rules require larger clearance to wide PDN shapes
   int spacing = tech_layer->getSpacing(shape_width, parallel_length);
   if (spacing == 0) {
-    spacing = tech_layer->getSpacing();
-  }
-  if (spacing == 0) {
     spacing = tech_layer->getWidth();
   }
+  spacing_cache_[cache_key] = spacing;
   return spacing;
+}
+
+odb::Rect IOPlacer::padShapeForPin(const odb::Rect& box,
+                                   const int layer,
+                                   const bool vertical_pin)
+{
+  const PinSize pin_size = computePinSize(layer);
+  const int shape_width = std::min(box.dx(), box.dy());
+  const int spacing = computeLayerSpacing(
+      layer, std::max(shape_width, 2 * pin_size.half_width), pin_size.height);
+  // pad by the pin footprint plus spacing: half width along the edge, the pin
+  // extension into the die on the other axis
+  const odb::Orientation2D edge_dir = vertical_pin
+                                          ? odb::Orientation2D::Horizontal
+                                          : odb::Orientation2D::Vertical;
+  return box.bloat(pin_size.half_width + spacing, edge_dir)
+      .bloat(pin_size.height + spacing, edge_dir.turn_90());
 }
 
 void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
@@ -555,48 +562,38 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
                                     const odb::Rect& die_area)
 {
   const int layer = tech_layer->getRoutingLevel();
-  bool vertical = ver_layers_.find(layer) != ver_layers_.end();
-  bool horizontal = hor_layers_.find(layer) != hor_layers_.end();
-  if (ver_layers_.empty() && hor_layers_.empty()) {
-    // standalone place_pin: use the layer preferred direction
-    vertical = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
-    horizontal = !vertical;
+  // PPL-45/46 guarantee the layer sets agree with the preferred direction, so
+  // they only filter which layers have slots; empty sets mean standalone
+  // place_pin, where every layer participates
+  const bool vertical_pin
+      = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
+  if (!ver_layers_.empty() || !hor_layers_.empty()) {
+    const std::set<int>& layers = vertical_pin ? ver_layers_ : hor_layers_;
+    if (layers.find(layer) == layers.end()) {
+      return;
+    }
   }
-  if (!vertical && !horizontal) {
+  const odb::Rect padded_box = padShapeForPin(box, layer, vertical_pin);
+  if (!die_area.intersects(padded_box)) {
     return;
   }
-  for (const bool vertical_pin : {true, false}) {
-    // skip orientations whose pins are placed on other layers
-    if (vertical_pin ? !vertical : !horizontal) {
+  const odb::Rect intersect = die_area.intersect(padded_box);
+  for (const Interval& interval : findBlockedIntervals(die_area, intersect)) {
+    const bool vertical_edge
+        = interval.getEdge() == Edge::top || interval.getEdge() == Edge::bottom;
+    if (vertical_edge != vertical_pin) {
       continue;
     }
-    const PinSize pin_size = computePinSize(layer);
-    const int shape_width = std::min(box.dx(), box.dy());
-    const int spacing = computeLayerSpacing(
-        layer, std::max(shape_width, 2 * pin_size.half_width), pin_size.height);
-    // extend the shape by the pin reach into the die, so shapes close
-    // to the boundary also block the nearby slots
-    const odb::Rect reach_box
-        = box.bloat(pin_size.height + spacing,
-                    vertical_pin ? odb::Orientation2D::Vertical
-                                 : odb::Orientation2D::Horizontal);
-    if (!die_area.intersects(reach_box)) {
-      continue;
-    }
-    const odb::Rect intersect = die_area.intersect(reach_box);
-    const int pad = pin_size.half_width + spacing;
-    for (const Interval& interval : findBlockedIntervals(die_area, intersect)) {
-      const bool vertical_edge = interval.getEdge() == Edge::top
-                                 || interval.getEdge() == Edge::bottom;
-      if (vertical_edge != vertical_pin) {
-        continue;
-      }
-      excludeInterval(Interval(interval.getEdge(),
-                               interval.getBegin() - pad,
-                               interval.getEnd() + pad,
-                               layer));
-    }
+    excludeInterval(Interval(
+        interval.getEdge(), interval.getBegin(), interval.getEnd(), layer));
   }
+}
+
+void IOPlacer::getBlockedRegions()
+{
+  getBlockedRegionsFromMacros();
+  getBlockedRegionsFromDbObstructions();
+  getBlockedRegionsFromPDN();
 }
 
 void IOPlacer::getBlockedRegionsFromPDN()
@@ -975,15 +972,7 @@ std::vector<odb::Point> IOPlacer::findLayerSlots(const int layer,
     int init_tracks = layer_init_tracks[l];
     int num_tracks = layer_num_tracks[l];
 
-    float thickness_multiplier
-        = vertical_pin ? parms_->getVerticalThicknessMultiplier()
-                       : parms_->getHorizontalThicknessMultiplier();
-
-    int half_width = vertical_pin
-                         ? int(ceil(core_->getMinWidthX().at(layer) / 2.0))
-                         : int(ceil(core_->getMinWidthY().at(layer) / 2.0));
-
-    half_width *= thickness_multiplier;
+    const int half_width = computePinSize(layer).half_width;
 
     int num_tracks_offset
         = std::ceil(static_cast<double>(corner_avoidance_) / min_dst_pins);
@@ -1826,25 +1815,14 @@ void IOPlacer::updatePinArea(IOPin& pin)
 
     if (pin.getOrientation() == Orientation::north
         || pin.getOrientation() == Orientation::south) {
-      float thickness_multiplier = parms_->getVerticalThicknessMultiplier();
-      int half_width = int(ceil(core_->getMinWidthX().at(pin.getLayer()) / 2.0))
-                       * thickness_multiplier;
-      int height = int(std::max(
-          2.0 * half_width,
-          ceil(core_->getMinAreaX().at(pin.getLayer()) / (2.0 * half_width))));
+      const PinSize pin_size = computePinSize(pin.getLayer());
+      const int half_width = pin_size.half_width;
+      const int height = pin_size.height;
       required_min_area = core_->getMinAreaX().at(pin.getLayer());
 
       int ext = 0;
-      if (parms_->getVerticalLength() != -1) {
-        height = parms_->getVerticalLength();
-      }
-
       if (parms_->getVerticalLengthExtend() != -1) {
         ext = parms_->getVerticalLengthExtend();
-      }
-
-      if (height % mfg_grid != 0) {
-        height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
       }
 
       if (pin.getOrientation() == Orientation::north) {
@@ -1858,24 +1836,14 @@ void IOPlacer::updatePinArea(IOPin& pin)
 
     if (pin.getOrientation() == Orientation::west
         || pin.getOrientation() == Orientation::east) {
-      float thickness_multiplier = parms_->getHorizontalThicknessMultiplier();
-      int half_width = int(ceil(core_->getMinWidthY().at(pin.getLayer()) / 2.0))
-                       * thickness_multiplier;
-      int height = int(std::max(
-          2.0 * half_width,
-          ceil(core_->getMinAreaY().at(pin.getLayer()) / (2.0 * half_width))));
+      const PinSize pin_size = computePinSize(pin.getLayer());
+      const int half_width = pin_size.half_width;
+      const int height = pin_size.height;
       required_min_area = core_->getMinAreaY().at(pin.getLayer());
 
       int ext = 0;
       if (parms_->getHorizontalLengthExtend() != -1) {
         ext = parms_->getHorizontalLengthExtend();
-      }
-      if (parms_->getHorizontalLength() != -1) {
-        height = parms_->getHorizontalLength();
-      }
-
-      if (height % mfg_grid != 0) {
-        height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
       }
 
       if (pin.getOrientation() == Orientation::east) {
@@ -2431,9 +2399,7 @@ void IOPlacer::runHungarianMatching()
   slots_per_section_ = parms_->getSlotsPerSection();
   initExcludedIntervals();
   initNetlistAndCore(hor_layers_, ver_layers_);
-  getBlockedRegionsFromMacros();
-  getBlockedRegionsFromDbObstructions();
-  getBlockedRegionsFromPDN();
+  getBlockedRegions();
 
   defineSlots();
 
@@ -2575,9 +2541,7 @@ void IOPlacer::runAnnealing()
   slots_per_section_ = parms_->getSlotsPerSection();
   initExcludedIntervals();
   initNetlistAndCore(hor_layers_, ver_layers_);
-  getBlockedRegionsFromMacros();
-  getBlockedRegionsFromDbObstructions();
-  getBlockedRegionsFromPDN();
+  getBlockedRegions();
 
   defineSlots();
 
@@ -3185,13 +3149,24 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
     if (net->isSpecial()) {
       for (odb::dbSWire* swire : net->getSWires()) {
         for (odb::dbSBox* wire : swire->getWires()) {
-          if (!wire->isVia()) {
-            if (top_grid_->layer != nullptr
-                && wire->getTechLayer()->getRoutingLevel()
-                       == top_grid_->layer->getRoutingLevel()) {
-              odb::Rect obstruction_rect = wire->getBox();
-              obstructions.push_back(obstruction_rect);
+          if (top_grid_ == nullptr || top_grid_->layer == nullptr) {
+            continue;
+          }
+          const int top_layer_level = top_grid_->layer->getRoutingLevel();
+          if (wire->isVia()) {
+            // via landing pads also obstruct the top layer pins
+            std::vector<odb::dbShape> via_shapes;
+            wire->getViaBoxes(via_shapes);
+            for (const odb::dbShape& via_shape : via_shapes) {
+              odb::dbTechLayer* tech_layer = via_shape.getTechLayer();
+              if (tech_layer != nullptr
+                  && tech_layer->getRoutingLevel() == top_layer_level) {
+                obstructions.push_back(via_shape.getBox());
+              }
             }
+          } else if (wire->getTechLayer()->getRoutingLevel()
+                     == top_layer_level) {
+            obstructions.push_back(wire->getBox());
           }
         }
       }
@@ -3314,6 +3289,7 @@ void IOPlacer::initNetlist()
   netlist_->reset();
   layer_fixed_pins_shapes_.clear();
   pin_size_cache_.clear();
+  spacing_cache_.clear();
   const odb::Rect& coreBoundary = core_->getBoundary();
   int x_center = (coreBoundary.xMin() + coreBoundary.xMax()) / 2;
   int y_center = (coreBoundary.yMin() + coreBoundary.yMax()) / 2;
@@ -3327,8 +3303,14 @@ void IOPlacer::initNetlist()
     if (bterm->getFirstPinPlacementStatus().isFixed()) {
       for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
         for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
-          int layer = bpin_box->getTechLayer()->getRoutingLevel();
-          layer_fixed_pins_shapes_[layer].push_back(bpin_box->getBox());
+          odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
+          const int layer = tech_layer->getRoutingLevel();
+          // store the shapes padded, so the pins created near them keep the
+          // min spacing
+          const bool vertical_pin
+              = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
+          layer_fixed_pins_shapes_[layer].push_back(
+              padShapeForPin(bpin_box->getBox(), layer, vertical_pin));
         }
       }
       continue;

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -8,11 +8,13 @@
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <functional>
 #include <limits>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -423,8 +425,8 @@ bool IOPlacer::checkBlocked(Edge edge,
                             const odb::Point& pos,
                             int layer)
 {
-  const auto fixed_shapes = layer_fixed_pins_shapes_.find(layer);
-  if (fixed_shapes != layer_fixed_pins_shapes_.end()) {
+  const auto fixed_shapes = layer_fixed_pins_keepouts_.find(layer);
+  if (fixed_shapes != layer_fixed_pins_keepouts_.end()) {
     for (const odb::Rect& padded_shape : fixed_shapes->second) {
       if (padded_shape.intersects(pos)) {
         return true;
@@ -433,18 +435,17 @@ bool IOPlacer::checkBlocked(Edge edge,
   }
   bool vertical_pin = (edge == Edge::polygonEdge)
                           ? line.pt0().getY() == line.pt1().getY()
-                          : (edge == Edge::top || edge == Edge::bottom);
+                          : isVerticalEdge(edge);
   int coord = vertical_pin ? pos.getX() : pos.getY();
-  for (Interval blocked_interval : excluded_intervals_) {
+  for (const Interval& blocked_interval : excluded_intervals_) {
     // check if the blocked interval blocks all layers (== -1) or if it blocks
     // the layer of the position
     if (blocked_interval.getLayer() == -1
         || blocked_interval.getLayer() == layer) {
       // polygon slots match intervals of any edge with the same orientation
-      const bool vertical_edge = blocked_interval.getEdge() == Edge::top
-                                 || blocked_interval.getEdge() == Edge::bottom;
       if ((blocked_interval.getEdge() == edge
-           || (edge == Edge::polygonEdge && vertical_edge == vertical_pin))
+           || (edge == Edge::polygonEdge
+               && isVerticalEdge(blocked_interval.getEdge()) == vertical_pin))
           && coord > blocked_interval.getBegin()
           && coord < blocked_interval.getEnd()) {
         return true;
@@ -503,20 +504,19 @@ PinSize IOPlacer::computePinSize(const int layer)
   const int min_area = min_areas.find(layer) != min_areas.end()
                            ? min_areas.at(layer)
                            : tech_layer->getArea();
-  PinSize pin_size;
-  pin_size.half_width = int(ceil(min_width / 2.0)) * thickness_multiplier;
-  pin_size.height = int(std::max(2.0 * pin_size.half_width,
-                                 ceil(min_area / (2.0 * pin_size.half_width))));
+  const int half_width = int(ceil(min_width / 2.0)) * thickness_multiplier;
+  int height
+      = int(std::max(2.0 * half_width, ceil(min_area / (2.0 * half_width))));
   const int user_length = vertical_pin ? parms_->getVerticalLength()
                                        : parms_->getHorizontalLength();
   if (user_length != -1) {
-    pin_size.height = user_length;
+    height = user_length;
   }
   const int mfg_grid = getTech()->getManufacturingGrid();
-  if (mfg_grid > 0 && pin_size.height % mfg_grid != 0) {
-    pin_size.height
-        = mfg_grid * std::ceil(static_cast<float>(pin_size.height) / mfg_grid);
+  if (mfg_grid > 0 && height % mfg_grid != 0) {
+    height = mfg_grid * std::ceil(static_cast<float>(height) / mfg_grid);
   }
+  const PinSize pin_size{half_width, height};
   pin_size_cache_[layer] = pin_size;
   return pin_size;
 }
@@ -540,19 +540,30 @@ int IOPlacer::computeLayerSpacing(const int layer,
   return spacing;
 }
 
-odb::Rect IOPlacer::padShapeForPin(const odb::Rect& box,
-                                   const int layer,
-                                   const bool vertical_pin)
+int IOPlacer::computeShapeSpacing(const int layer,
+                                  const odb::Rect& shape,
+                                  const int pin_width,
+                                  const int pin_length)
+{
+  // the spacing rules use the width of the widest shape and the parallel
+  // run length between the shapes
+  const int shape_width = std::min(shape.dx(), shape.dy());
+  return computeLayerSpacing(
+      layer, std::max(shape_width, pin_width), pin_length);
+}
+
+odb::Rect IOPlacer::padShapeForPin(const odb::Rect& box, const int layer)
 {
   const PinSize pin_size = computePinSize(layer);
-  const int shape_width = std::min(box.dx(), box.dy());
-  const int spacing = computeLayerSpacing(
-      layer, std::max(shape_width, 2 * pin_size.half_width), pin_size.height);
+  const int spacing = computeShapeSpacing(
+      layer, box, 2 * pin_size.half_width, pin_size.height);
   // pad by the pin footprint plus spacing: half width along the edge, the pin
   // extension into the die on the other axis
-  const odb::Orientation2D edge_dir = vertical_pin
-                                          ? odb::Orientation2D::Horizontal
-                                          : odb::Orientation2D::Vertical;
+  odb::dbTechLayer* tech_layer = getTech()->findRoutingLayer(layer);
+  const odb::Orientation2D edge_dir
+      = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL
+            ? odb::Orientation2D::Horizontal
+            : odb::Orientation2D::Vertical;
   return box.bloat(pin_size.half_width + spacing, edge_dir)
       .bloat(pin_size.height + spacing, edge_dir.turn_90());
 }
@@ -562,9 +573,10 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
                                     const odb::Rect& die_area)
 {
   const int layer = tech_layer->getRoutingLevel();
-  // PPL-45/46 guarantee the layer sets agree with the preferred direction, so
-  // they only filter which layers have slots; empty sets mean standalone
-  // place_pin, where every layer participates
+  // the layer sets only filter which layers have slots: the Tcl/Python
+  // wrappers reject layers whose preferred direction disagrees with the set
+  // (PPL-45/46). Empty sets mean standalone place_pin, where every layer
+  // participates
   const bool vertical_pin
       = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
   if (!ver_layers_.empty() || !hor_layers_.empty()) {
@@ -573,15 +585,13 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
       return;
     }
   }
-  const odb::Rect padded_box = padShapeForPin(box, layer, vertical_pin);
+  const odb::Rect padded_box = padShapeForPin(box, layer);
   if (!die_area.intersects(padded_box)) {
     return;
   }
   const odb::Rect intersect = die_area.intersect(padded_box);
   for (const Interval& interval : findBlockedIntervals(die_area, intersect)) {
-    const bool vertical_edge
-        = interval.getEdge() == Edge::top || interval.getEdge() == Edge::bottom;
-    if (vertical_edge != vertical_pin) {
+    if (isVerticalEdge(interval.getEdge()) != vertical_pin) {
       continue;
     }
     excludeInterval(Interval(
@@ -596,10 +606,10 @@ void IOPlacer::getBlockedRegions()
   getBlockedRegionsFromPDN();
 }
 
-void IOPlacer::getBlockedRegionsFromPDN()
+void IOPlacer::forEachSpecialNetShape(
+    const std::function<void(odb::dbTechLayer*, const odb::Rect&)>& callback)
 {
-  const odb::Rect die_area = getBlock()->getDieArea();
-
+  std::vector<odb::dbShape> via_shapes;
   for (odb::dbNet* net : getBlock()->getNets()) {
     if (!net->isSpecial()) {
       continue;
@@ -607,26 +617,29 @@ void IOPlacer::getBlockedRegionsFromPDN()
     for (odb::dbSWire* swire : net->getSWires()) {
       for (odb::dbSBox* sbox : swire->getWires()) {
         if (sbox->isVia()) {
-          // via landing pads can also reach the die boundary
-          std::vector<odb::dbShape> via_shapes;
+          // via landing pads can also block pins
           sbox->getViaBoxes(via_shapes);
           for (const odb::dbShape& via_shape : via_shapes) {
             odb::dbTechLayer* tech_layer = via_shape.getTechLayer();
-            if (tech_layer == nullptr || tech_layer->getRoutingLevel() == 0) {
-              continue;
+            if (tech_layer != nullptr && tech_layer->getRoutingLevel() != 0) {
+              callback(tech_layer, via_shape.getBox());
             }
-            excludeBoundaryShape(via_shape.getBox(), tech_layer, die_area);
           }
-          continue;
+        } else if (sbox->getTechLayer() != nullptr) {
+          callback(sbox->getTechLayer(), sbox->getBox());
         }
-        odb::dbTechLayer* tech_layer = sbox->getTechLayer();
-        if (tech_layer == nullptr) {
-          continue;
-        }
-        excludeBoundaryShape(sbox->getBox(), tech_layer, die_area);
       }
     }
   }
+}
+
+void IOPlacer::getBlockedRegionsFromPDN()
+{
+  const odb::Rect die_area = getBlock()->getDieArea();
+  forEachSpecialNetShape(
+      [&](odb::dbTechLayer* tech_layer, const odb::Rect& rect) {
+        excludeBoundaryShape(rect, tech_layer, die_area);
+      });
 }
 
 void IOPlacer::getBlockedRegionsFromMacros()
@@ -2760,7 +2773,8 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
   const int layer_level = layer->getRoutingLevel();
   if (force_to_die_bound) {
     // block boundary PDN shapes for the checks below, without persisting the
-    // intervals beyond this placement
+    // intervals beyond this placement. Macros are not included, since their
+    // intervals block all layers and the pin position is an explicit request
     const size_t num_excluded_intervals = excluded_intervals_.size();
     getBlockedRegionsFromDbObstructions();
     getBlockedRegionsFromPDN();
@@ -3126,63 +3140,38 @@ void IOPlacer::findSlotsForTopLayer()
 
 void IOPlacer::filterObstructedSlotsForTopLayer()
 {
-  if (top_grid_ == nullptr) {
+  if (top_grid_ == nullptr || top_grid_->layer == nullptr) {
     return;
   }
+  const int top_layer_level = top_grid_->layer->getRoutingLevel();
 
   // Collect top_grid obstructions
   std::vector<odb::Rect> obstructions;
 
-  // Get routing obstructions
+  // Get routing obstructions. The system reserved ones are not skipped here,
+  // since they are the only filter for slots outside of polygon dies
   for (odb::dbObstruction* obstruction : getBlock()->getObstructions()) {
     odb::dbBox* box = obstruction->getBBox();
-    if (top_grid_->layer != nullptr
-        && box->getTechLayer()->getRoutingLevel()
-               == top_grid_->layer->getRoutingLevel()) {
-      odb::Rect obstruction_rect = box->getBox();
-      obstructions.push_back(obstruction_rect);
+    if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
+      obstructions.push_back(box->getBox());
     }
   }
 
   // Get already routed special nets
-  for (odb::dbNet* net : getBlock()->getNets()) {
-    if (net->isSpecial()) {
-      for (odb::dbSWire* swire : net->getSWires()) {
-        for (odb::dbSBox* wire : swire->getWires()) {
-          if (top_grid_ == nullptr || top_grid_->layer == nullptr) {
-            continue;
-          }
-          const int top_layer_level = top_grid_->layer->getRoutingLevel();
-          if (wire->isVia()) {
-            // via landing pads also obstruct the top layer pins
-            std::vector<odb::dbShape> via_shapes;
-            wire->getViaBoxes(via_shapes);
-            for (const odb::dbShape& via_shape : via_shapes) {
-              odb::dbTechLayer* tech_layer = via_shape.getTechLayer();
-              if (tech_layer != nullptr
-                  && tech_layer->getRoutingLevel() == top_layer_level) {
-                obstructions.push_back(via_shape.getBox());
-              }
-            }
-          } else if (wire->getTechLayer()->getRoutingLevel()
-                     == top_layer_level) {
-            obstructions.push_back(wire->getBox());
-          }
+  forEachSpecialNetShape(
+      [&](odb::dbTechLayer* tech_layer, const odb::Rect& rect) {
+        if (tech_layer->getRoutingLevel() == top_layer_level) {
+          obstructions.push_back(rect);
         }
-      }
-    }
-  }
+      });
 
   // Get already placed pins
   for (odb::dbBTerm* term : getBlock()->getBTerms()) {
     for (odb::dbBPin* pin : term->getBPins()) {
       if (pin->getPlacementStatus().isFixed()) {
         for (odb::dbBox* box : pin->getBoxes()) {
-          if (top_grid_->layer != nullptr
-              && box->getTechLayer()->getRoutingLevel()
-                     == top_grid_->layer->getRoutingLevel()) {
-            odb::Rect obstruction_rect = box->getBox();
-            obstructions.push_back(obstruction_rect);
+          if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
+            obstructions.push_back(box->getBox());
           }
         }
       }
@@ -3203,14 +3192,12 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   }
 
   // check for slots that overlap with obstructions
-  const int layer_level = top_grid_->layer->getRoutingLevel();
   const int pin_min_dim = std::min(top_grid_->pin_width, top_grid_->pin_height);
   const int pin_max_dim = std::max(top_grid_->pin_width, top_grid_->pin_height);
   for (odb::Rect& rect : obstructions) {
     // floor the keepout at the layer spacing required by the obstruction
-    const int shape_width = std::min(rect.dx(), rect.dy());
-    const int spacing = computeLayerSpacing(
-        layer_level, std::max(shape_width, pin_min_dim), pin_max_dim);
+    const int spacing
+        = computeShapeSpacing(top_layer_level, rect, pin_min_dim, pin_max_dim);
     const int keepout = std::max(top_grid_->keepout, spacing);
     for (auto& slot : top_layer_slots_) {
       odb::Point& point = slot.pos;
@@ -3287,7 +3274,7 @@ std::vector<Section> IOPlacer::findSectionsForTopLayer(const odb::Rect& region)
 void IOPlacer::initNetlist()
 {
   netlist_->reset();
-  layer_fixed_pins_shapes_.clear();
+  layer_fixed_pins_keepouts_.clear();
   pin_size_cache_.clear();
   spacing_cache_.clear();
   const odb::Rect& coreBoundary = core_->getBoundary();
@@ -3303,14 +3290,11 @@ void IOPlacer::initNetlist()
     if (bterm->getFirstPinPlacementStatus().isFixed()) {
       for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
         for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
-          odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
-          const int layer = tech_layer->getRoutingLevel();
+          const int layer = bpin_box->getTechLayer()->getRoutingLevel();
           // store the shapes padded, so the pins created near them keep the
           // min spacing
-          const bool vertical_pin
-              = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
-          layer_fixed_pins_shapes_[layer].push_back(
-              padShapeForPin(bpin_box->getBox(), layer, vertical_pin));
+          layer_fixed_pins_keepouts_[layer].push_back(
+              padShapeForPin(bpin_box->getBox(), layer));
         }
       }
       continue;

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -645,6 +645,10 @@ void IOPlacer::getBlockedRegionsFromDbObstructions()
   const odb::Rect die_area = getBlock()->getDieArea();
 
   for (odb::dbObstruction* obstruction : getBlock()->getObstructions()) {
+    // system reserved obstructions only mark the outside of polygon dies
+    if (obstruction->isSystemReserved()) {
+      continue;
+    }
     odb::dbBox* obstruct_box = obstruction->getBBox();
     odb::dbTechLayer* tech_layer = obstruct_box->getTechLayer();
     if (tech_layer == nullptr) {

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -549,6 +549,55 @@ int IOPlacer::computeLayerSpacing(const int layer,
   return spacing;
 }
 
+void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
+                                    odb::dbTechLayer* tech_layer,
+                                    const odb::Rect& die_area)
+{
+  const int layer = tech_layer->getRoutingLevel();
+  bool vertical = ver_layers_.find(layer) != ver_layers_.end();
+  bool horizontal = hor_layers_.find(layer) != hor_layers_.end();
+  if (ver_layers_.empty() && hor_layers_.empty()) {
+    // standalone place_pin: use the layer preferred direction
+    vertical = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
+    horizontal = !vertical;
+  }
+  if (!vertical && !horizontal) {
+    return;
+  }
+  for (const bool vertical_pin : {true, false}) {
+    // skip orientations whose pins are placed on other layers
+    if (vertical_pin ? !vertical : !horizontal) {
+      continue;
+    }
+    const PinSize pin_size = computePinSize(layer);
+    const int shape_width = std::min(box.dx(), box.dy());
+    const int spacing = computeLayerSpacing(
+        layer, std::max(shape_width, 2 * pin_size.half_width), pin_size.height);
+    // extend the shape by the pin reach into the die, so shapes close
+    // to the boundary also block the nearby slots
+    const odb::Rect reach_box
+        = box.bloat(pin_size.height + spacing,
+                    vertical_pin ? odb::Orientation2D::Vertical
+                                 : odb::Orientation2D::Horizontal);
+    if (!die_area.intersects(reach_box)) {
+      continue;
+    }
+    const odb::Rect intersect = die_area.intersect(reach_box);
+    const int pad = pin_size.half_width + spacing;
+    for (const Interval& interval : findBlockedIntervals(die_area, intersect)) {
+      const bool vertical_edge = interval.getEdge() == Edge::top
+                                 || interval.getEdge() == Edge::bottom;
+      if (vertical_edge != vertical_pin) {
+        continue;
+      }
+      excludeInterval(Interval(interval.getEdge(),
+                               interval.getBegin() - pad,
+                               interval.getEnd() + pad,
+                               layer));
+    }
+  }
+}
+
 void IOPlacer::getBlockedRegionsFromPDN()
 {
   const odb::Rect die_area = getBlock()->getDieArea();
@@ -566,54 +615,7 @@ void IOPlacer::getBlockedRegionsFromPDN()
         if (tech_layer == nullptr) {
           continue;
         }
-        const int layer = tech_layer->getRoutingLevel();
-        bool vertical = ver_layers_.find(layer) != ver_layers_.end();
-        bool horizontal = hor_layers_.find(layer) != hor_layers_.end();
-        if (ver_layers_.empty() && hor_layers_.empty()) {
-          // standalone place_pin: use the layer preferred direction
-          vertical
-              = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
-          horizontal = !vertical;
-        }
-        if (!vertical && !horizontal) {
-          continue;
-        }
-        const odb::Rect box = sbox->getBox();
-        for (const bool vertical_pin : {true, false}) {
-          // skip orientations whose pins are placed on other layers
-          if (vertical_pin ? !vertical : !horizontal) {
-            continue;
-          }
-          const PinSize pin_size = computePinSize(layer);
-          const int shape_width = std::min(box.dx(), box.dy());
-          const int spacing = computeLayerSpacing(
-              layer,
-              std::max(shape_width, 2 * pin_size.half_width),
-              pin_size.height);
-          // extend the shape by the pin reach into the die, so shapes close
-          // to the boundary also block the nearby slots
-          const odb::Rect reach_box
-              = box.bloat(pin_size.height + spacing,
-                          vertical_pin ? odb::Orientation2D::Vertical
-                                       : odb::Orientation2D::Horizontal);
-          if (!die_area.intersects(reach_box)) {
-            continue;
-          }
-          const odb::Rect intersect = die_area.intersect(reach_box);
-          const int pad = pin_size.half_width + spacing;
-          for (const Interval& interval :
-               findBlockedIntervals(die_area, intersect)) {
-            const bool vertical_edge = interval.getEdge() == Edge::top
-                                       || interval.getEdge() == Edge::bottom;
-            if (vertical_edge != vertical_pin) {
-              continue;
-            }
-            excludeInterval(Interval(interval.getEdge(),
-                                     interval.getBegin() - pad,
-                                     interval.getEnd() + pad,
-                                     layer));
-          }
-        }
+        excludeBoundaryShape(sbox->getBox(), tech_layer, die_area);
       }
     }
   }
@@ -640,17 +642,15 @@ void IOPlacer::getBlockedRegionsFromMacros()
 
 void IOPlacer::getBlockedRegionsFromDbObstructions()
 {
-  odb::Rect die_area = getBlock()->getDieArea();
+  const odb::Rect die_area = getBlock()->getDieArea();
 
   for (odb::dbObstruction* obstruction : getBlock()->getObstructions()) {
-    odb::dbBox* obstructBox = obstruction->getBBox();
-    odb::Rect obstructArea = obstructBox->getBox();
-    odb::Rect intersect = die_area.intersect(obstructArea);
-
-    std::vector<Interval> intervals = findBlockedIntervals(die_area, intersect);
-    for (Interval interval : intervals) {
-      excludeInterval(interval);
+    odb::dbBox* obstruct_box = obstruction->getBBox();
+    odb::dbTechLayer* tech_layer = obstruct_box->getTechLayer();
+    if (tech_layer == nullptr) {
+      continue;
     }
+    excludeBoundaryShape(obstruct_box->getBox(), tech_layer, die_area);
   }
 }
 
@@ -2417,6 +2417,7 @@ void IOPlacer::runHungarianMatching()
   initExcludedIntervals();
   initNetlistAndCore(hor_layers_, ver_layers_);
   getBlockedRegionsFromMacros();
+  getBlockedRegionsFromDbObstructions();
   getBlockedRegionsFromPDN();
 
   defineSlots();
@@ -2560,6 +2561,7 @@ void IOPlacer::runAnnealing()
   initExcludedIntervals();
   initNetlistAndCore(hor_layers_, ver_layers_);
   getBlockedRegionsFromMacros();
+  getBlockedRegionsFromDbObstructions();
   getBlockedRegionsFromPDN();
 
   defineSlots();
@@ -2781,6 +2783,7 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
     // block boundary PDN shapes for the checks below, without persisting the
     // intervals beyond this placement
     const size_t num_excluded_intervals = excluded_intervals_.size();
+    getBlockedRegionsFromDbObstructions();
     getBlockedRegionsFromPDN();
     movePinToTrack(pos, layer_level, width, height, die_boundary);
     Edge edge;

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -139,6 +139,7 @@ COMPULSORY_TESTS = [
     "top_layer7",
     "top_layer_error",
     "top_layer_error2",
+    "top_layer_pdn_spacing",
     "write_pin_placement1",
     "write_pin_placement2",
     "write_pin_placement3",

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -99,6 +99,7 @@ COMPULSORY_TESTS = [
     "no_instance_pins",
     "no_pins",
     "no_tracks",
+    "obstruction_boundary",
     "on_grid",
     "partial_tracks",
     "partial_tracks_error",

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -110,6 +110,7 @@ COMPULSORY_TESTS = [
     "pdn_boundary_stripes_length",
     "pdn_boundary_stripes_no_pins",
     "pdn_boundary_stripes_polygon",
+    "pdn_boundary_vias",
     "pdn_near_boundary_stripes",
     "pdn_near_boundary_stripes_length",
     "pin_extension",

--- a/src/ppl/test/CMakeLists.txt
+++ b/src/ppl/test/CMakeLists.txt
@@ -132,6 +132,7 @@ or_integration_tests(
     top_layer7
     top_layer_error
     top_layer_error2
+    top_layer_pdn_spacing
     write_pin_placement1
     write_pin_placement2
     write_pin_placement3

--- a/src/ppl/test/CMakeLists.txt
+++ b/src/ppl/test/CMakeLists.txt
@@ -92,6 +92,7 @@ or_integration_tests(
     no_instance_pins
     no_pins
     no_tracks
+    obstruction_boundary
     on_grid
     partial_tracks
     partial_tracks_error

--- a/src/ppl/test/CMakeLists.txt
+++ b/src/ppl/test/CMakeLists.txt
@@ -103,6 +103,7 @@ or_integration_tests(
     pdn_boundary_stripes_length
     pdn_boundary_stripes_no_pins
     pdn_boundary_stripes_polygon
+    pdn_boundary_vias
     pdn_near_boundary_stripes
     pdn_near_boundary_stripes_length
     pin_extension

--- a/src/ppl/test/annealing_pdn_boundary.tcl
+++ b/src/ppl/test/annealing_pdn_boundary.tcl
@@ -1,5 +1,6 @@
 # the annealing placer must also keep pins away from boundary PDN stripes
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -27,46 +28,4 @@ pdngen
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12 -annealing
 
-# count signal pin shapes overlapping special net wires on the same layer
-proc count_pin_stripe_overlaps { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        foreach net [$block getNets] {
-          if { ![$net isSpecial] } {
-            continue
-          }
-          foreach swire [$net getSWires] {
-            foreach sbox [$swire getWires] {
-              set slayer [$sbox getTechLayer]
-              if { $slayer == "NULL" || $slayer != $layer } {
-                continue
-              }
-              if {
-                [$box xMin] < [$sbox xMax] && [$sbox xMin] < [$box xMax]
-                && [$box yMin] < [$sbox yMax] && [$sbox yMin] < [$box yMax]
-              } {
-                puts "pin [$bterm getName] on layer [$layer getName] at\
-                  ([ord::dbu_to_microns [$box xMin]]\
-                  [ord::dbu_to_microns [$box yMin]])\
-                  ([ord::dbu_to_microns [$box xMax]]\
-                  [ord::dbu_to_microns [$box yMax]]) overlaps\
-                  [$net getName] stripe"
-                incr violations
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to boundary stripe violations: [count_pin_stripe_overlaps]"
+puts "pin to boundary stripe violations: [count_pdn_shape_violations overlap]"

--- a/src/ppl/test/obstruction_boundary.ok
+++ b/src/ppl/test/obstruction_boundary.ok
@@ -10,3 +10,5 @@ Found 0 macro blocks.
 [INFO PPL-0005] Slots per section         200
 [INFO PPL-0008] Successfully assigned pins to sections.
 pin to obstruction violations: 0
+pins over fill blockage: 19
+pins over slot blockage: 19

--- a/src/ppl/test/obstruction_boundary.ok
+++ b/src/ppl/test/obstruction_boundary.ok
@@ -10,5 +10,4 @@ Found 0 macro blocks.
 [INFO PPL-0005] Slots per section         200
 [INFO PPL-0008] Successfully assigned pins to sections.
 pin to obstruction violations: 0
-pins over fill blockage: 19
-pins over slot blockage: 19
+pins over the fill and slot blockages: 19

--- a/src/ppl/test/obstruction_boundary.ok
+++ b/src/ppl/test/obstruction_boundary.ok
@@ -1,0 +1,12 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 53 components and 333 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 54 connections.
+Found 0 macro blocks.
+[INFO PPL-0002] Number of I/O             54
+[INFO PPL-0003] Number of I/O w/sink      54
+[INFO PPL-0004] Number of I/O w/o sink    0
+[INFO PPL-0005] Slots per section         200
+[INFO PPL-0008] Successfully assigned pins to sections.
+pin to obstruction violations: 0

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -17,11 +17,10 @@ set obstruction_rect {100000 292000 104000 296000}
 odb::dbObstruction_create $block $metal2 {*}$obstruction_rect
 
 # fill and slot only blockages allow routing metal, so pins may use them
-set fill_rect {110000 292000 200000 296000}
-set fill_obs [odb::dbObstruction_create $block $metal2 {*}$fill_rect]
+set blockage_rect {110000 292000 200000 296000}
+set fill_obs [odb::dbObstruction_create $block $metal2 {*}$blockage_rect]
 $fill_obs setFillObstruction
-set slot_rect {110000 292000 200000 296000}
-set slot_obs [odb::dbObstruction_create $block $metal2 {*}$slot_rect]
+set slot_obs [odb::dbObstruction_create $block $metal2 {*}$blockage_rect]
 $slot_obs setSlotObstruction
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
@@ -46,5 +45,5 @@ proc count_pins_in_rect { llx lly urx ury } {
 
 puts "pin to obstruction violations:\
   [count_rect_violations metal2 [list $obstruction_rect] spacing]"
-puts "pins over fill blockage: [count_pins_in_rect {*}$fill_rect]"
-puts "pins over slot blockage: [count_pins_in_rect {*}$slot_rect]"
+puts "pins over the fill and slot blockages:\
+  [count_pins_in_rect {*}$blockage_rect]"

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -16,8 +16,35 @@ set metal2 [[ord::get_db_tech] findLayer metal2]
 set obstruction_rect {100000 292000 104000 296000}
 odb::dbObstruction_create $block $metal2 {*}$obstruction_rect
 
+# fill and slot only blockages allow routing metal, so pins may use them
+set fill_rect {110000 292000 200000 296000}
+set fill_obs [odb::dbObstruction_create $block $metal2 {*}$fill_rect]
+$fill_obs setFillObstruction
+set slot_rect {110000 292000 200000 296000}
+set slot_obs [odb::dbObstruction_create $block $metal2 {*}$slot_rect]
+$slot_obs setSlotObstruction
+
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
+proc count_pins_in_rect { llx lly urx ury } {
+  set count 0
+  foreach bterm [[ord::get_db_block] getBTerms] {
+    foreach bpin [$bterm getBPins] {
+      foreach box [$bpin getBoxes] {
+        if {
+          [$box xMin] < $urx && $llx < [$box xMax]
+          && [$box yMin] < $ury && $lly < [$box yMax]
+        } {
+          incr count
+        }
+      }
+    }
+  }
+  return $count
+}
+
 puts "pin to obstruction violations:\
   [count_rect_violations metal2 [list $obstruction_rect] spacing]"
+puts "pins over fill blockage: [count_pins_in_rect {*}$fill_rect]"
+puts "pins over slot blockage: [count_pins_in_rect {*}$slot_rect]"

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -13,10 +13,11 @@ set block [ord::get_db_block]
 set metal2 [[ord::get_db_tech] findLayer metal2]
 
 # routing obstruction touching the top edge
-odb::dbObstruction_create $block $metal2 100000 292000 104000 296000
+set obstruction_rect {100000 292000 104000 296000}
+odb::dbObstruction_create $block $metal2 {*}$obstruction_rect
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-set obstruction_rect [list [list 100000 292000 104000 296000]]
-puts "pin to obstruction violations: [count_rect_violations metal2 $obstruction_rect spacing]"
+puts "pin to obstruction violations:\
+  [count_rect_violations metal2 [list $obstruction_rect] spacing]"

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -1,5 +1,6 @@
 # place_pins must keep min spacing from routing obstructions at the die edges
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary shapes block slots
 suppress_message PPL 1
@@ -17,37 +18,5 @@ odb::dbObstruction_create $block $metal2 100000 292000 104000 296000
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping or too close to the obstruction
-proc count_obstruction_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        if { [$layer getName] != "metal2" } {
-          continue
-        }
-        set dx [expr {
-          max(0, max(100000 - [$box xMax], [$box xMin] - 104000))
-        }]
-        set dy [expr {
-          max(0, max(292000 - [$box yMax], [$box yMin] - 296000))
-        }]
-        if { $dx < $spacing && $dy < $spacing } {
-          puts "pin [$bterm getName] at\
-            ([ord::dbu_to_microns [$box xMin]]\
-            [ord::dbu_to_microns [$box yMin]])\
-            ([ord::dbu_to_microns [$box xMax]]\
-            [ord::dbu_to_microns [$box yMax]]) within\
-            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the obstruction"
-          incr violations
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to obstruction violations: [count_obstruction_violations]"
+set obstruction_rect [list [list 100000 292000 104000 296000]]
+puts "pin to obstruction violations: [count_rect_violations metal2 $obstruction_rect spacing]"

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -1,0 +1,53 @@
+# place_pins must keep min spacing from routing obstructions at the die edges
+source "helpers.tcl"
+
+# slot count and HPWL change once boundary shapes block slots
+suppress_message PPL 1
+suppress_message PPL 12
+
+read_lef Nangate45/Nangate45.lef
+read_def gcd_placed.def
+
+set block [ord::get_db_block]
+set metal2 [[ord::get_db_tech] findLayer metal2]
+
+# routing obstruction touching the top edge
+odb::dbObstruction_create $block $metal2 100000 292000 104000 296000
+
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
+  -min_distance 0.12
+
+# count signal pin shapes overlapping or too close to the obstruction
+proc count_obstruction_violations { } {
+  set block [ord::get_db_block]
+  set violations 0
+  foreach bterm [$block getBTerms] {
+    foreach bpin [$bterm getBPins] {
+      foreach box [$bpin getBoxes] {
+        set layer [$box getTechLayer]
+        set spacing [$layer getSpacing]
+        if { [$layer getName] != "metal2" } {
+          continue
+        }
+        set dx [expr {
+          max(0, max(100000 - [$box xMax], [$box xMin] - 104000))
+        }]
+        set dy [expr {
+          max(0, max(292000 - [$box yMax], [$box yMin] - 296000))
+        }]
+        if { $dx < $spacing && $dy < $spacing } {
+          puts "pin [$bterm getName] at\
+            ([ord::dbu_to_microns [$box xMin]]\
+            [ord::dbu_to_microns [$box yMin]])\
+            ([ord::dbu_to_microns [$box xMax]]\
+            [ord::dbu_to_microns [$box yMax]]) within\
+            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the obstruction"
+          incr violations
+        }
+      }
+    }
+  }
+  return $violations
+}
+
+puts "pin to obstruction violations: [count_obstruction_violations]"

--- a/src/ppl/test/pdn_boundary_mirrored_pins.tcl
+++ b/src/ppl/test/pdn_boundary_mirrored_pins.tcl
@@ -1,6 +1,7 @@
 # mirrored pins must not land on slots blocked by boundary PDN shapes:
 # the matcher avoids them when possible and errors out when not
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -25,32 +26,7 @@ set_io_pin_constraint -region bottom:40-60 -pin_names {req_msg\[0\]}
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count mirrored pin shapes overlapping the strap
-proc count_strap_overlaps { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach name [list {req_msg\[0\]} {req_msg\[1\]}] {
-    set bterm [$block findBTerm $name]
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        if { [$layer getName] != "metal2" } {
-          continue
-        }
-        if {
-          [$box xMin] < 104000 && 100000 < [$box xMax] && [$box yMin] < 296000
-          && 292000 < [$box yMax]
-        } {
-          puts "pin [$bterm getName] overlaps the VDD strap"
-          incr violations
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "mirrored pin overlaps with strap: [count_strap_overlaps]"
+puts "mirrored pin overlaps with strap: [count_pdn_shape_violations overlap]"
 
 # a region whose mirrored slots are all blocked must error, not overlap
 clear_io_pin_constraints

--- a/src/ppl/test/pdn_boundary_pg_pins.tcl
+++ b/src/ppl/test/pdn_boundary_pg_pins.tcl
@@ -1,5 +1,6 @@
 # place_pins must keep min spacing from fixed power/ground pins on the die edge
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -25,54 +26,5 @@ $pin setPlacementStatus FIRM
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12 -exclude left:* -exclude right:* -exclude bottom:*
 
-# count signal pin shapes overlapping or too close to fixed PG pins
-proc count_pg_pin_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  set pg_boxes {}
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] != "POWER" && [$bterm getSigType] != "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        lappend pg_boxes [list [$bterm getName] $box]
-      }
-    }
-  }
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        foreach pg_box_pair $pg_boxes {
-          lassign $pg_box_pair pg_name pg_box
-          if { [$pg_box getTechLayer] != $layer } {
-            continue
-          }
-          set dx [expr {
-            max(0, max([$pg_box xMin] - [$box xMax], [$box xMin] - [$pg_box xMax]))
-          }]
-          set dy [expr {
-            max(0, max([$pg_box yMin] - [$box yMax], [$box yMin] - [$pg_box yMax]))
-          }]
-          if { $dx < $spacing && $dy < $spacing } {
-            puts "pin [$bterm getName] on layer [$layer getName] at\
-              ([ord::dbu_to_microns [$box xMin]]\
-              [ord::dbu_to_microns [$box yMin]])\
-              ([ord::dbu_to_microns [$box xMax]]\
-              [ord::dbu_to_microns [$box yMax]]) within\
-              [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of $pg_name pin"
-            incr violations
-          }
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin violations against PG pins: [count_pg_pin_violations]"
+set pg_rect [list [list 22140 295440 273640 296000]]
+puts "pin violations against PG pins: [count_rect_violations metal2 $pg_rect spacing]"

--- a/src/ppl/test/pdn_boundary_pg_pins.tcl
+++ b/src/ppl/test/pdn_boundary_pg_pins.tcl
@@ -26,5 +26,4 @@ $pin setPlacementStatus FIRM
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12 -exclude left:* -exclude right:* -exclude bottom:*
 
-set pg_rect [list [list 22140 295440 273640 296000]]
-puts "pin violations against PG pins: [count_rect_violations metal2 $pg_rect spacing]"
+puts "pin violations against PG pins: [count_pg_pin_violations spacing]"

--- a/src/ppl/test/pdn_boundary_place_pin.tcl
+++ b/src/ppl/test/pdn_boundary_place_pin.tcl
@@ -1,6 +1,7 @@
 # place_pin -force_to_die_boundary must move pins away from boundary PDN
 # stripes instead of placing them on top
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 read_lef Nangate45/Nangate45.lef
 read_def gcd_placed.def
@@ -20,35 +21,4 @@ place_pin -pin_name req_msg\[0\] -layer metal2 -location {51 148} \
 place_pin -pin_name req_msg\[1\] -layer metal2 -location {50.5 148} \
   -force_to_die_boundary
 
-# count pin shapes overlapping or too close to the stripe
-proc count_stripe_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach name [list {req_msg\[0\]} {req_msg\[1\]}] {
-    set bterm [$block findBTerm $name]
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        set dx [expr {
-          max(0, max(100000 - [$box xMax], [$box xMin] - 104000))
-        }]
-        set dy [expr {
-          max(0, max(292000 - [$box yMax], [$box yMin] - 296000))
-        }]
-        if { $dx < $spacing && $dy < $spacing } {
-          puts "pin [$bterm getName] at\
-            ([ord::dbu_to_microns [$box xMin]]\
-            [ord::dbu_to_microns [$box yMin]])\
-            ([ord::dbu_to_microns [$box xMax]]\
-            [ord::dbu_to_microns [$box yMax]]) within\
-            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the stripe"
-          incr violations
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to stripe violations: [count_stripe_violations]"
+puts "pin to stripe violations: [count_pdn_shape_violations spacing]"

--- a/src/ppl/test/pdn_boundary_stripes.tcl
+++ b/src/ppl/test/pdn_boundary_stripes.tcl
@@ -1,5 +1,6 @@
 # place_pins must not place pins over PDN stripes extended to the die boundary
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -27,46 +28,4 @@ pdngen
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping special net wires on the same layer
-proc count_pin_stripe_overlaps { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        foreach net [$block getNets] {
-          if { ![$net isSpecial] } {
-            continue
-          }
-          foreach swire [$net getSWires] {
-            foreach sbox [$swire getWires] {
-              set slayer [$sbox getTechLayer]
-              if { $slayer == "NULL" || $slayer != $layer } {
-                continue
-              }
-              if {
-                [$box xMin] < [$sbox xMax] && [$sbox xMin] < [$box xMax]
-                && [$box yMin] < [$sbox yMax] && [$sbox yMin] < [$box yMax]
-              } {
-                puts "pin [$bterm getName] on layer [$layer getName] at\
-                  ([ord::dbu_to_microns [$box xMin]]\
-                  [ord::dbu_to_microns [$box yMin]])\
-                  ([ord::dbu_to_microns [$box xMax]]\
-                  [ord::dbu_to_microns [$box yMax]]) overlaps\
-                  [$net getName] stripe"
-                incr violations
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to boundary stripe violations: [count_pin_stripe_overlaps]"
+puts "pin to boundary stripe violations: [count_pdn_shape_violations overlap]"

--- a/src/ppl/test/pdn_boundary_stripes_length.tcl
+++ b/src/ppl/test/pdn_boundary_stripes_length.tcl
@@ -1,6 +1,7 @@
 # place_pins must honor the width-dependent spacing rules to wide boundary
 # PDN stripes when long pins have enough parallel run length to trigger them
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -30,57 +31,4 @@ set_pin_length -ver_length 1.0 -hor_length 1.0
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes closer to a stripe than the wide-shape spacing rule
-proc count_stripe_spacing_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        foreach net [$block getNets] {
-          if { ![$net isSpecial] } {
-            continue
-          }
-          foreach swire [$net getSWires] {
-            foreach sbox [$swire getWires] {
-              set slayer [$sbox getTechLayer]
-              if { $slayer == "NULL" || $slayer != $layer } {
-                continue
-              }
-              set stripe_width [expr {
-                min([$sbox xMax] - [$sbox xMin], [$sbox yMax] - [$sbox yMin])
-              }]
-              set pin_length [expr {
-                max([$box xMax] - [$box xMin], [$box yMax] - [$box yMin])
-              }]
-              set spacing [$layer getSpacing $stripe_width $pin_length]
-              set dx [expr {
-                max(0, max([$sbox xMin] - [$box xMax], [$box xMin] - [$sbox xMax]))
-              }]
-              set dy [expr {
-                max(0, max([$sbox yMin] - [$box yMax], [$box yMin] - [$sbox yMax]))
-              }]
-              if { $dx < $spacing && $dy < $spacing } {
-                puts "pin [$bterm getName] on layer [$layer getName] at\
-                  ([ord::dbu_to_microns [$box xMin]]\
-                  [ord::dbu_to_microns [$box yMin]])\
-                  ([ord::dbu_to_microns [$box xMax]]\
-                  [ord::dbu_to_microns [$box yMax]]) within\
-                  [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of\
-                  [$net getName] stripe, needs [ord::dbu_to_microns $spacing]um"
-                incr violations
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to wide stripe spacing violations: [count_stripe_spacing_violations]"
+puts "pin to wide stripe spacing violations: [count_pdn_shape_violations table]"

--- a/src/ppl/test/pdn_boundary_stripes_no_pins.tcl
+++ b/src/ppl/test/pdn_boundary_stripes_no_pins.tcl
@@ -2,6 +2,7 @@
 # -dont_add_pins leaves the straps without BPins, so avoiding them depends
 # entirely on place_pins checking the special net wires (dbSBox)
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # the available slot count is kept in the log, since it is the main observable
 # of the shapes blocking slots; HPWL changes with the pin assignment
@@ -29,46 +30,4 @@ pdngen -dont_add_pins
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping special net wires on the same layer
-proc count_pin_stripe_overlaps { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        foreach net [$block getNets] {
-          if { ![$net isSpecial] } {
-            continue
-          }
-          foreach swire [$net getSWires] {
-            foreach sbox [$swire getWires] {
-              set slayer [$sbox getTechLayer]
-              if { $slayer == "NULL" || $slayer != $layer } {
-                continue
-              }
-              if {
-                [$box xMin] < [$sbox xMax] && [$sbox xMin] < [$box xMax]
-                && [$box yMin] < [$sbox yMax] && [$sbox yMin] < [$box yMax]
-              } {
-                puts "pin [$bterm getName] on layer [$layer getName] at\
-                  ([ord::dbu_to_microns [$box xMin]]\
-                  [ord::dbu_to_microns [$box yMin]])\
-                  ([ord::dbu_to_microns [$box xMax]]\
-                  [ord::dbu_to_microns [$box yMax]]) overlaps\
-                  [$net getName] stripe"
-                incr violations
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to boundary stripe violations: [count_pin_stripe_overlaps]"
+puts "pin to boundary stripe violations: [count_pdn_shape_violations overlap]"

--- a/src/ppl/test/pdn_boundary_stripes_polygon.tcl
+++ b/src/ppl/test/pdn_boundary_stripes_polygon.tcl
@@ -1,5 +1,6 @@
 # place_pins must not place pins over boundary PDN stripes on polygon dies
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -19,40 +20,4 @@ odb::dbSBox_create $swire $metal2 70000 0 74000 20000 "STRIPE"
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping or too close to the stripe
-proc count_stripe_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        if { [$layer getName] != "metal2" } {
-          continue
-        }
-        set dx [expr {
-          max(0, max(70000 - [$box xMax], [$box xMin] - 74000))
-        }]
-        set dy [expr {
-          max(0, max(0 - [$box yMax], [$box yMin] - 20000))
-        }]
-        if { $dx < $spacing && $dy < $spacing } {
-          puts "pin [$bterm getName] at\
-            ([ord::dbu_to_microns [$box xMin]]\
-            [ord::dbu_to_microns [$box yMin]])\
-            ([ord::dbu_to_microns [$box xMax]]\
-            [ord::dbu_to_microns [$box yMax]]) within\
-            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the stripe"
-          incr violations
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to stripe violations: [count_stripe_violations]"
+puts "pin to stripe violations: [count_pdn_shape_violations spacing]"

--- a/src/ppl/test/pdn_boundary_vias.ok
+++ b/src/ppl/test/pdn_boundary_vias.ok
@@ -1,0 +1,12 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 53 components and 333 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 54 connections.
+Found 0 macro blocks.
+[INFO PPL-0002] Number of I/O             54
+[INFO PPL-0003] Number of I/O w/sink      54
+[INFO PPL-0004] Number of I/O w/o sink    0
+[INFO PPL-0005] Slots per section         200
+[INFO PPL-0008] Successfully assigned pins to sections.
+pin to via pad violations: 0

--- a/src/ppl/test/pdn_boundary_vias.tcl
+++ b/src/ppl/test/pdn_boundary_vias.tcl
@@ -1,0 +1,68 @@
+# place_pins must keep min spacing from special net via landing pads close to
+# the die boundary, even when no wire shape covers them
+source "helpers.tcl"
+
+# slot count and HPWL change once boundary PDN shapes block slots
+suppress_message PPL 1
+suppress_message PPL 12
+
+read_lef Nangate45/Nangate45.lef
+read_def gcd_placed.def
+
+set block [ord::get_db_block]
+set tech [ord::get_db_tech]
+set via [$tech findVia "via1_0"]
+
+# naked vias near the top edge; via1_0 metal2 enclosure is 0.07um around the
+# origin, so the pads span y 295650-295930, within reach of the pins
+set net [odb::dbNet_create $block "VDD"]
+$net setSpecial
+$net setSigType POWER
+set swire [odb::dbSWire_create $net "ROUTED"]
+for { set x 98000 } { $x <= 106000 } { incr x 380 } {
+  odb::dbSBox_create $swire $via $x 295790 "STRIPE"
+}
+
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
+  -min_distance 0.12
+
+# count signal pin shapes overlapping or too close to the via pads
+proc count_via_pad_violations { } {
+  set block [ord::get_db_block]
+  set violations 0
+  foreach bterm [$block getBTerms] {
+    if { [$bterm getSigType] == "POWER" } {
+      continue
+    }
+    foreach bpin [$bterm getBPins] {
+      foreach box [$bpin getBoxes] {
+        set layer [$box getTechLayer]
+        set spacing [$layer getSpacing]
+        if { [$layer getName] != "metal2" } {
+          continue
+        }
+        for { set x 98000 } { $x <= 106000 } { incr x 380 } {
+          set dx [expr {
+            max(0, max($x - 140 - [$box xMax], [$box xMin] - ($x + 140)))
+          }]
+          set dy [expr {
+            max(0, max(295650 - [$box yMax], [$box yMin] - 295930))
+          }]
+          if { $dx < $spacing && $dy < $spacing } {
+            puts "pin [$bterm getName] at\
+              ([ord::dbu_to_microns [$box xMin]]\
+              [ord::dbu_to_microns [$box yMin]])\
+              ([ord::dbu_to_microns [$box xMax]]\
+              [ord::dbu_to_microns [$box yMax]]) within\
+              [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of via pad at\
+              [ord::dbu_to_microns $x]um"
+            incr violations
+          }
+        }
+      }
+    }
+  }
+  return $violations
+}
+
+puts "pin to via pad violations: [count_via_pad_violations]"

--- a/src/ppl/test/pdn_boundary_vias.tcl
+++ b/src/ppl/test/pdn_boundary_vias.tcl
@@ -20,15 +20,17 @@ set net [odb::dbNet_create $block "VDD"]
 $net setSpecial
 $net setSigType POWER
 set swire [odb::dbSWire_create $net "ROUTED"]
+set via_xs {}
 for { set x 98000 } { $x <= 106000 } { incr x 380 } {
   odb::dbSBox_create $swire $via $x 295790 "STRIPE"
+  lappend via_xs $x
 }
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
 set via_rects {}
-for { set x 98000 } { $x <= 106000 } { incr x 380 } {
+foreach x $via_xs {
   lappend via_rects [list [expr { $x - 140 }] 295650 [expr { $x + 140 }] 295930]
 }
 puts "pin to via pad violations: [count_rect_violations metal2 $via_rects spacing]"

--- a/src/ppl/test/pdn_boundary_vias.tcl
+++ b/src/ppl/test/pdn_boundary_vias.tcl
@@ -1,6 +1,7 @@
 # place_pins must keep min spacing from special net via landing pads close to
 # the die boundary, even when no wire shape covers them
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -26,43 +27,8 @@ for { set x 98000 } { $x <= 106000 } { incr x 380 } {
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping or too close to the via pads
-proc count_via_pad_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        if { [$layer getName] != "metal2" } {
-          continue
-        }
-        for { set x 98000 } { $x <= 106000 } { incr x 380 } {
-          set dx [expr {
-            max(0, max($x - 140 - [$box xMax], [$box xMin] - ($x + 140)))
-          }]
-          set dy [expr {
-            max(0, max(295650 - [$box yMax], [$box yMin] - 295930))
-          }]
-          if { $dx < $spacing && $dy < $spacing } {
-            puts "pin [$bterm getName] at\
-              ([ord::dbu_to_microns [$box xMin]]\
-              [ord::dbu_to_microns [$box yMin]])\
-              ([ord::dbu_to_microns [$box xMax]]\
-              [ord::dbu_to_microns [$box yMax]]) within\
-              [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of via pad at\
-              [ord::dbu_to_microns $x]um"
-            incr violations
-          }
-        }
-      }
-    }
-  }
-  return $violations
+set via_rects {}
+for { set x 98000 } { $x <= 106000 } { incr x 380 } {
+  lappend via_rects [list [expr { $x - 140 }] 295650 [expr { $x + 140 }] 295930]
 }
-
-puts "pin to via pad violations: [count_via_pad_violations]"
+puts "pin to via pad violations: [count_rect_violations metal2 $via_rects spacing]"

--- a/src/ppl/test/pdn_helpers.tcl
+++ b/src/ppl/test/pdn_helpers.tcl
@@ -8,14 +8,12 @@ proc get_required_spacing { layer pin_box llx lly urx ury mode } {
     return 0
   }
   if { $mode == "table" } {
+    set pin_dx [expr { [$pin_box xMax] - [$pin_box xMin] }]
+    set pin_dy [expr { [$pin_box yMax] - [$pin_box yMin] }]
     # like the placer, use the width of the widest shape, pin included
-    set pin_width [expr {
-      min([$pin_box xMax] - [$pin_box xMin], [$pin_box yMax] - [$pin_box yMin])
-    }]
-    set shape_width [expr { max(min($urx - $llx, $ury - $lly), $pin_width) }]
-    set pin_length [expr {
-      max([$pin_box xMax] - [$pin_box xMin], [$pin_box yMax] - [$pin_box yMin])
-    }]
+    set shape_width \
+      [expr { max(min($urx - $llx, $ury - $lly), min($pin_dx, $pin_dy)) }]
+    set pin_length [expr { max($pin_dx, $pin_dy) }]
     return [$layer getSpacing $shape_width $pin_length]
   }
   return [$layer getSpacing]

--- a/src/ppl/test/pdn_helpers.tcl
+++ b/src/ppl/test/pdn_helpers.tcl
@@ -8,7 +8,11 @@ proc get_required_spacing { layer pin_box llx lly urx ury mode } {
     return 0
   }
   if { $mode == "table" } {
-    set shape_width [expr { min($urx - $llx, $ury - $lly) }]
+    # like the placer, use the width of the widest shape, pin included
+    set pin_width [expr {
+      min([$pin_box xMax] - [$pin_box xMin], [$pin_box yMax] - [$pin_box yMin])
+    }]
+    set shape_width [expr { max(min($urx - $llx, $ury - $lly), $pin_width) }]
     set pin_length [expr {
       max([$pin_box xMax] - [$pin_box xMin], [$pin_box yMax] - [$pin_box yMin])
     }]

--- a/src/ppl/test/pdn_helpers.tcl
+++ b/src/ppl/test/pdn_helpers.tcl
@@ -1,0 +1,102 @@
+# Helper procs for the boundary PDN tests. A violation is a signal pin shape
+# closer to a blocking shape than the required spacing: "overlap" requires
+# plain intersection, "spacing" uses the layer default spacing and "table"
+# the width-dependent spacing for wide shapes.
+
+proc get_required_spacing { layer pin_box llx lly urx ury mode } {
+  if { $mode == "overlap" } {
+    return 0
+  }
+  if { $mode == "table" } {
+    set shape_width [expr { min($urx - $llx, $ury - $lly) }]
+    set pin_length [expr {
+      max([$pin_box xMax] - [$pin_box xMin], [$pin_box yMax] - [$pin_box yMin])
+    }]
+    return [$layer getSpacing $shape_width $pin_length]
+  }
+  return [$layer getSpacing]
+}
+
+proc is_pin_shape_violation { pin_box llx lly urx ury required } {
+  set dx [expr { max($llx - [$pin_box xMax], [$pin_box xMin] - $urx) }]
+  set dy [expr { max($lly - [$pin_box yMax], [$pin_box yMin] - $ury) }]
+  if { $dx < 0 && $dy < 0 } {
+    return 1
+  }
+  return [expr { max($dx, 0) < $required && max($dy, 0) < $required }]
+}
+
+proc report_pin_violation { bterm box what } {
+  puts "pin [$bterm getName] on layer [[$box getTechLayer] getName] at\
+    ([ord::dbu_to_microns [$box xMin]] [ord::dbu_to_microns [$box yMin]])\
+    ([ord::dbu_to_microns [$box xMax]] [ord::dbu_to_microns [$box yMax]])\
+    too close to $what"
+}
+
+# count signal pin shapes too close to same layer special net wires
+proc count_pdn_shape_violations { mode } {
+  set block [ord::get_db_block]
+  set violations 0
+  foreach bterm [$block getBTerms] {
+    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
+      continue
+    }
+    foreach bpin [$bterm getBPins] {
+      foreach box [$bpin getBoxes] {
+        set layer [$box getTechLayer]
+        foreach net [$block getNets] {
+          if { ![$net isSpecial] } {
+            continue
+          }
+          foreach swire [$net getSWires] {
+            foreach sbox [$swire getWires] {
+              set slayer [$sbox getTechLayer]
+              if { $slayer == "NULL" || $slayer != $layer } {
+                continue
+              }
+              set required [get_required_spacing $layer $box [$sbox xMin] \
+                [$sbox yMin] [$sbox xMax] [$sbox yMax] $mode]
+              if {
+                [is_pin_shape_violation $box [$sbox xMin] [$sbox yMin] \
+                  [$sbox xMax] [$sbox yMax] $required]
+              } {
+                report_pin_violation $bterm $box "[$net getName] wire"
+                incr violations
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return $violations
+}
+
+# count signal pin shapes on the given layer too close to the given rects
+proc count_rect_violations { layer_name rects mode } {
+  set block [ord::get_db_block]
+  set violations 0
+  foreach bterm [$block getBTerms] {
+    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
+      continue
+    }
+    foreach bpin [$bterm getBPins] {
+      foreach box [$bpin getBoxes] {
+        set layer [$box getTechLayer]
+        if { [$layer getName] != $layer_name } {
+          continue
+        }
+        foreach rect $rects {
+          lassign $rect llx lly urx ury
+          set required \
+            [get_required_spacing $layer $box $llx $lly $urx $ury $mode]
+          if { [is_pin_shape_violation $box $llx $lly $urx $ury $required] } {
+            report_pin_violation $bterm $box "shape ($llx $lly) ($urx $ury)"
+            incr violations
+          }
+        }
+      }
+    }
+  }
+  return $violations
+}

--- a/src/ppl/test/pdn_helpers.tcl
+++ b/src/ppl/test/pdn_helpers.tcl
@@ -33,8 +33,9 @@ proc report_pin_violation { bterm box what } {
     too close to $what"
 }
 
-# count signal pin shapes too close to same layer special net wires
-proc count_pdn_shape_violations { mode } {
+# count signal pin shapes too close to the given shapes, a list of
+# {layer_name llx lly urx ury label} entries
+proc count_violations_against { shapes mode } {
   set block [ord::get_db_block]
   set violations 0
   foreach bterm [$block getBTerms] {
@@ -44,26 +45,16 @@ proc count_pdn_shape_violations { mode } {
     foreach bpin [$bterm getBPins] {
       foreach box [$bpin getBoxes] {
         set layer [$box getTechLayer]
-        foreach net [$block getNets] {
-          if { ![$net isSpecial] } {
+        foreach shape $shapes {
+          lassign $shape layer_name llx lly urx ury label
+          if { [$layer getName] != $layer_name } {
             continue
           }
-          foreach swire [$net getSWires] {
-            foreach sbox [$swire getWires] {
-              set slayer [$sbox getTechLayer]
-              if { $slayer == "NULL" || $slayer != $layer } {
-                continue
-              }
-              set required [get_required_spacing $layer $box [$sbox xMin] \
-                [$sbox yMin] [$sbox xMax] [$sbox yMax] $mode]
-              if {
-                [is_pin_shape_violation $box [$sbox xMin] [$sbox yMin] \
-                  [$sbox xMax] [$sbox yMax] $required]
-              } {
-                report_pin_violation $bterm $box "[$net getName] wire"
-                incr violations
-              }
-            }
+          set required \
+            [get_required_spacing $layer $box $llx $lly $urx $ury $mode]
+          if { [is_pin_shape_violation $box $llx $lly $urx $ury $required] } {
+            report_pin_violation $bterm $box $label
+            incr violations
           }
         }
       }
@@ -72,31 +63,53 @@ proc count_pdn_shape_violations { mode } {
   return $violations
 }
 
+# count signal pin shapes too close to same layer special net wires
+proc count_pdn_shape_violations { mode } {
+  set block [ord::get_db_block]
+  set shapes {}
+  foreach net [$block getNets] {
+    if { ![$net isSpecial] } {
+      continue
+    }
+    foreach swire [$net getSWires] {
+      foreach sbox [$swire getWires] {
+        set slayer [$sbox getTechLayer]
+        if { $slayer == "NULL" } {
+          continue
+        }
+        lappend shapes [list [$slayer getName] [$sbox xMin] [$sbox yMin] \
+          [$sbox xMax] [$sbox yMax] "[$net getName] wire"]
+      }
+    }
+  }
+  return [count_violations_against $shapes $mode]
+}
+
 # count signal pin shapes on the given layer too close to the given rects
 proc count_rect_violations { layer_name rects mode } {
+  set shapes {}
+  foreach rect $rects {
+    lassign $rect llx lly urx ury
+    lappend shapes \
+      [list $layer_name $llx $lly $urx $ury "shape ($llx $lly) ($urx $ury)"]
+  }
+  return [count_violations_against $shapes $mode]
+}
+
+# count signal pin shapes too close to fixed power/ground pins
+proc count_pg_pin_violations { mode } {
   set block [ord::get_db_block]
-  set violations 0
+  set shapes {}
   foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
+    if { [$bterm getSigType] != "POWER" && [$bterm getSigType] != "GROUND" } {
       continue
     }
     foreach bpin [$bterm getBPins] {
       foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        if { [$layer getName] != $layer_name } {
-          continue
-        }
-        foreach rect $rects {
-          lassign $rect llx lly urx ury
-          set required \
-            [get_required_spacing $layer $box $llx $lly $urx $ury $mode]
-          if { [is_pin_shape_violation $box $llx $lly $urx $ury $required] } {
-            report_pin_violation $bterm $box "shape ($llx $lly) ($urx $ury)"
-            incr violations
-          }
-        }
+        lappend shapes [list [[$box getTechLayer] getName] [$box xMin] \
+          [$box yMin] [$box xMax] [$box yMax] "[$bterm getName] pin"]
       }
     }
   }
-  return $violations
+  return [count_violations_against $shapes $mode]
 }

--- a/src/ppl/test/pdn_near_boundary_stripes.tcl
+++ b/src/ppl/test/pdn_near_boundary_stripes.tcl
@@ -1,6 +1,7 @@
 # place_pins must keep min spacing from PDN stripes close to the die boundary,
 # even when they do not touch it, since pin shapes extend into the die
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -22,51 +23,4 @@ odb::dbSBox_create $swire $metal2 22140 295340 273640 295900 "STRIPE"
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping or too close to special net wires
-proc count_pin_stripe_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        foreach net [$block getNets] {
-          if { ![$net isSpecial] } {
-            continue
-          }
-          foreach swire [$net getSWires] {
-            foreach sbox [$swire getWires] {
-              set slayer [$sbox getTechLayer]
-              if { $slayer == "NULL" || $slayer != $layer } {
-                continue
-              }
-              set dx [expr {
-                max(0, max([$sbox xMin] - [$box xMax], [$box xMin] - [$sbox xMax]))
-              }]
-              set dy [expr {
-                max(0, max([$sbox yMin] - [$box yMax], [$box yMin] - [$sbox yMax]))
-              }]
-              if { $dx < $spacing && $dy < $spacing } {
-                puts "pin [$bterm getName] on layer [$layer getName] at\
-                  ([ord::dbu_to_microns [$box xMin]]\
-                  [ord::dbu_to_microns [$box yMin]])\
-                  ([ord::dbu_to_microns [$box xMax]]\
-                  [ord::dbu_to_microns [$box yMax]]) within\
-                  [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of\
-                  [$net getName] stripe"
-                incr violations
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to near boundary stripe violations: [count_pin_stripe_violations]"
+puts "pin to near boundary stripe violations: [count_pdn_shape_violations spacing]"

--- a/src/ppl/test/pdn_near_boundary_stripes_length.tcl
+++ b/src/ppl/test/pdn_near_boundary_stripes_length.tcl
@@ -2,6 +2,7 @@
 # length is not aligned to the manufacturing grid, since the created pins are
 # rounded up to it
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 # slot count and HPWL change once boundary PDN shapes block slots
 suppress_message PPL 1
@@ -26,40 +27,4 @@ set_pin_length -ver_length 1.001 -hor_length 1.001
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12
 
-# count signal pin shapes overlapping or too close to the stripe
-proc count_stripe_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" || [$bterm getSigType] == "GROUND" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        set spacing [$layer getSpacing]
-        if { [$layer getName] != "metal2" } {
-          continue
-        }
-        set dx [expr {
-          max(0, max(20000 - [$box xMax], [$box xMin] - 280000))
-        }]
-        set dy [expr {
-          max(0, max(291857 - [$box yMax], [$box yMin] - 293857))
-        }]
-        if { $dx < $spacing && $dy < $spacing } {
-          puts "pin [$bterm getName] at\
-            ([ord::dbu_to_microns [$box xMin]]\
-            [ord::dbu_to_microns [$box yMin]])\
-            ([ord::dbu_to_microns [$box xMax]]\
-            [ord::dbu_to_microns [$box yMax]]) within\
-            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the stripe"
-          incr violations
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to stripe violations: [count_stripe_violations]"
+puts "pin to stripe violations: [count_pdn_shape_violations spacing]"

--- a/src/ppl/test/top_layer_pdn_spacing.ok
+++ b/src/ppl/test/top_layer_pdn_spacing.ok
@@ -1,0 +1,19 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+[INFO ODB-0227] LEF file: blocked_region.lef, created 1 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 253 components and 1357 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 155 connections.
+Found 1 macro blocks.
+Using 2 tracks default min distance between IO pins.
+[INFO PPL-0060] Restrict pins [ clk req_rdy req_val reset resp_rdy ... ] to region (50.00u, 122.95u)-(250.00u, 143.00u) at routing layer met5.
+[INFO PPL-0001] Number of available slots 866
+[INFO PPL-0062] Number of top layer slots 90
+[INFO PPL-0002] Number of I/O             54
+[INFO PPL-0003] Number of I/O w/sink      54
+[INFO PPL-0004] Number of I/O w/o sink    0
+[INFO PPL-0005] Slots per section         200
+[INFO PPL-0008] Successfully assigned pins to sections.
+[INFO PPL-0012] I/O nets HPWL: 7584.69 um.
+pin to strap spacing violations: 0

--- a/src/ppl/test/top_layer_pdn_spacing.tcl
+++ b/src/ppl/test/top_layer_pdn_spacing.tcl
@@ -1,6 +1,7 @@
 # top layer pin placement must keep at least the layer min spacing from PDN
 # shapes when the user keepout is smaller than it
 source "helpers.tcl"
+source "pdn_helpers.tcl"
 
 read_lef sky130hd/sky130hd.tlef
 read_lef sky130hd/sky130_fd_sc_hd_merged.lef
@@ -27,44 +28,4 @@ set_io_pin_constraint \
 
 place_pins -hor_layer met3 -ver_layer met2
 
-# count top layer pin shapes closer to the strap than the required spacing
-proc count_strap_spacing_violations { } {
-  set block [ord::get_db_block]
-  set violations 0
-  foreach bterm [$block getBTerms] {
-    if { [$bterm getSigType] == "POWER" } {
-      continue
-    }
-    foreach bpin [$bterm getBPins] {
-      foreach box [$bpin getBoxes] {
-        set layer [$box getTechLayer]
-        if { [$layer getName] != "met5" } {
-          continue
-        }
-        set pin_length [expr {
-          max([$box xMax] - [$box xMin], [$box yMax] - [$box yMin])
-        }]
-        set spacing [$layer getSpacing 10000 $pin_length]
-        set dx [expr {
-          max(0, max(50000 - [$box xMax], [$box xMin] - 250000))
-        }]
-        set dy [expr {
-          max(0, max(125000 - [$box yMax], [$box yMin] - 130000))
-        }]
-        if { $dx < $spacing && $dy < $spacing } {
-          puts "pin [$bterm getName] at\
-            ([ord::dbu_to_microns [$box xMin]]\
-            [ord::dbu_to_microns [$box yMin]])\
-            ([ord::dbu_to_microns [$box xMax]]\
-            [ord::dbu_to_microns [$box yMax]]) within\
-            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the strap,\
-            needs [ord::dbu_to_microns $spacing]um"
-          incr violations
-        }
-      }
-    }
-  }
-  return $violations
-}
-
-puts "pin to strap spacing violations: [count_strap_spacing_violations]"
+puts "pin to strap spacing violations: [count_pdn_shape_violations table]"

--- a/src/ppl/test/top_layer_pdn_spacing.tcl
+++ b/src/ppl/test/top_layer_pdn_spacing.tcl
@@ -1,0 +1,70 @@
+# top layer pin placement must keep at least the layer min spacing from PDN
+# shapes when the user keepout is smaller than it
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_lef blocked_region.lef
+
+read_def blocked_region.def
+
+set block [ord::get_db_block]
+set met5 [[ord::get_db_tech] findLayer met5]
+
+# wide strap crossing the pin pattern region
+set net [odb::dbNet_create $block "VDD"]
+$net setSpecial
+$net setSigType POWER
+set swire [odb::dbSWire_create $net "ROUTED"]
+odb::dbSBox_create $swire $met5 50000 125000 250000 130000 "STRIPE"
+
+# the first slot row ends 0.8um below the strap: allowed by the 0.3um user
+# keepout, but closer than the layer min spacing
+define_pin_shape_pattern -layer met5 -x_step 6.8 -y_step 6.8 \
+  -region { 50 122.95 250 143 } -size { 1.6 2.5 } -pin_keepout 0.3
+set_io_pin_constraint \
+  -pin_names {clk resp_val req_val resp_rdy reset req_rdy} -region "up:*"
+
+place_pins -hor_layer met3 -ver_layer met2
+
+# count top layer pin shapes closer to the strap than the required spacing
+proc count_strap_spacing_violations { } {
+  set block [ord::get_db_block]
+  set violations 0
+  foreach bterm [$block getBTerms] {
+    if { [$bterm getSigType] == "POWER" } {
+      continue
+    }
+    foreach bpin [$bterm getBPins] {
+      foreach box [$bpin getBoxes] {
+        set layer [$box getTechLayer]
+        if { [$layer getName] != "met5" } {
+          continue
+        }
+        set pin_length [expr {
+          max([$box xMax] - [$box xMin], [$box yMax] - [$box yMin])
+        }]
+        set spacing [$layer getSpacing 10000 $pin_length]
+        set dx [expr {
+          max(0, max(50000 - [$box xMax], [$box xMin] - 250000))
+        }]
+        set dy [expr {
+          max(0, max(125000 - [$box yMax], [$box yMin] - 130000))
+        }]
+        if { $dx < $spacing && $dy < $spacing } {
+          puts "pin [$bterm getName] at\
+            ([ord::dbu_to_microns [$box xMin]]\
+            [ord::dbu_to_microns [$box yMin]])\
+            ([ord::dbu_to_microns [$box xMax]]\
+            [ord::dbu_to_microns [$box yMax]]) within\
+            [ord::dbu_to_microns [expr { max($dx, $dy) }]]um of the strap,\
+            needs [ord::dbu_to_microns $spacing]um"
+          incr violations
+        }
+      }
+    }
+  }
+  return $violations
+}
+
+puts "pin to strap spacing violations: [count_strap_spacing_violations]"


### PR DESCRIPTION
## Summary
Second part of the boundary PDN series (follow-up to #11102). Pin placement
now also blocks slots against routing obstructions (dbObstruction) and the
landing pads of special net vias, padded by the pin footprint plus the layer
spacing. Shapes on cut/masterslice layers are ignored. The top layer keepout
is floored at the layer min spacing and checked against the final pin size
(rounded up to the manufacturing grid), so define_pin_shape_pattern with a
small -pin_keepout can no longer place pins within min spacing of a PDN
strap. System reserved obstructions (synthesized by odb over polygon die
notches) are skipped in the interval path, where they would blank whole
edges. Also consolidates the pin geometry and shape padding helpers and
shares the checker procs used by the boundary PDN tests.

## Type of Change
- Bug fix
- Refactoring

## Impact
place_pins, place_pin -force_to_die_boundary, and top layer placement no
longer create shorts or min spacing violations against routing obstructions,
PDN via landing pads, or boundary straps. No user interface changes.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Follow-up to #11102.
