### PR TITLE
Fix dielectric epsilon lookup in UniversalFormat2FasterCap_923.py

### DIFF
--- a/src/rcx/BUILD
+++ b/src/rcx/BUILD
@@ -12,6 +12,14 @@ package(
     features = ["layering_check"],
 )
 
+# rule_scripts/ and calibration/ have no BUILD file of their own, so
+# they're part of this package; exported here so test/BUILD can depend
+# on them.
+exports_files([
+    "rule_scripts/UniversalFormat2FasterCap_923.py",
+    "calibration/fasterCap/scripts/UniversalFormat2FasterCap_923.py",
+])
+
 cc_library(
     name = "rcx",
     srcs = [

--- a/src/rcx/calibration/fasterCap/scripts/UniversalFormat2FasterCap_923.py
+++ b/src/rcx/calibration/fasterCap/scripts/UniversalFormat2FasterCap_923.py
@@ -199,6 +199,15 @@ class Shapes:
 
 
 # TODO: Handle comment lines #
+
+def safeDielEpsilon(index):
+    # nothing is modeled above/below the top/bottom dielectric, so reuse
+    # its own epsilon rather than base_epsilon (the true open-air region,
+    # used only where a wire has no dielectric neighbor at all) #
+    idx = max(0, min(index, len(processDielectrics) - 1))
+    return float(processDielectrics[idx].epsilon)
+
+
 def processTechFile(filename: str):
 
     f = open(filename)
@@ -229,7 +238,10 @@ def processTechFile(filename: str):
         elif conductorblock == 1:
             linesplits = line.split()
 
-            if "distance" in line:
+            # process.out puts the conductor's name on its own line #
+            if len(linesplits) >= 2 and linesplits[0] == "name":
+                conductorname = linesplits[1]
+            elif "distance" in line:
                 conductordistance = linesplits[1]
             elif "thickness" in line:
                 conductorthickness = linesplits[1]
@@ -255,7 +267,10 @@ def processTechFile(filename: str):
         elif dielectricblock == 1:
             linesplits = line.split()
 
-            if "epsilon" in line:
+            # process.out puts the dielectric's name on its own line #
+            if len(linesplits) >= 2 and linesplits[0] == "name":
+                dielectricname = linesplits[1]
+            elif "epsilon" in line:
                 dielectricepsilon = linesplits[1]
             elif "thickness" in line:
                 dielectricthickness = linesplits[1]
@@ -290,6 +305,13 @@ def TranslateUniversalFile(Universalfilename: str, FasterCapfilename: str):
         tempuniversalfilename = Universalfilename + "/"
     else:
         tempuniversalfilename = Universalfilename
+
+    # shapeorder is each dielectric's index in processDielectrics, found by name #
+    dielNameToGlobalIndex = {}
+    for i, d in enumerate(processDielectrics):
+        if d.name in dielNameToGlobalIndex:
+            raise ValueError(f"duplicate dielectric name in process file: {d.name}")
+        dielNameToGlobalIndex[d.name] = i
 
     # walk each directory tree for specified Universalfilename #
     for root, dirs, files in os.walk(tempuniversalfilename):
@@ -460,11 +482,13 @@ def TranslateUniversalFile(Universalfilename: str, FasterCapfilename: str):
 
                 # map Universal Format Data Structures to Shapes #
                 # NOTE: height == length (y-axis) #
-                dielorder = 0
                 for dielectric in tempdielectrics:
                     shapetype = 0  # Dielectric
-                    shapeorder = dielorder
-                    dielorder += 1
+                    if dielectric.name not in dielNameToGlobalIndex:
+                        raise ValueError(
+                            f"dielectric {dielectric.name!r} not found in process file"
+                        )
+                    shapeorder = dielNameToGlobalIndex[dielectric.name]
                     shapename = dielectric.name
                     shapeheight = round(patternswindowheight, 6)
                     shapethickness = round(dielectric.thickness, 6)
@@ -1161,11 +1185,11 @@ def extractFasterCapfile(filename: str):
                         conductorfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[
                                         dielindexlist[intersection]
                                     ].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1199,9 +1223,9 @@ def extractFasterCapfile(filename: str):
                     conductorfile,
                     round(
                         float(
-                            processDielectrics[
+                            safeDielEpsilon(
                                 PatternShapes[dielindexlist[intersection]].shapeorder
-                            ].epsilon
+                            )
                         )
                         * float(1.0e-6),
                         8,
@@ -1242,12 +1266,12 @@ def extractFasterCapfile(filename: str):
                         conductorfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[
                                         dielindexlist[intersection]
                                     ].shapeorder
                                     + 1
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1307,11 +1331,11 @@ def extractFasterCapfile(filename: str):
                             float(1.0e-6),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1353,23 +1377,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         - 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1410,9 +1434,9 @@ def extractFasterCapfile(filename: str):
                     1.0e-6,
                     round(
                         float(
-                            processDielectrics[
+                            safeDielEpsilon(
                                 PatternShapes[dielindexlist[dielindex]].shapeorder
-                            ].epsilon
+                            )
                         )
                         * float(1.0e-6),
                         8,
@@ -1449,19 +1473,19 @@ def extractFasterCapfile(filename: str):
                         dielectricfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
                                     + 1
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
                         ),
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1599,23 +1623,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         - 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1652,9 +1676,9 @@ def extractFasterCapfile(filename: str):
                         1.0e-6,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1691,23 +1715,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         + 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,

--- a/src/rcx/rule_scripts/UniversalFormat2FasterCap_923.py
+++ b/src/rcx/rule_scripts/UniversalFormat2FasterCap_923.py
@@ -199,6 +199,15 @@ class Shapes:
 
 
 # TODO: Handle comment lines #
+
+def safeDielEpsilon(index):
+    # nothing is modeled above/below the top/bottom dielectric, so reuse
+    # its own epsilon rather than base_epsilon (the true open-air region,
+    # used only where a wire has no dielectric neighbor at all) #
+    idx = max(0, min(index, len(processDielectrics) - 1))
+    return float(processDielectrics[idx].epsilon)
+
+
 def processTechFile(filename: str):
 
     f = open(filename)
@@ -229,7 +238,10 @@ def processTechFile(filename: str):
         elif conductorblock == 1:
             linesplits = line.split()
 
-            if "distance" in line:
+            # process.out puts the conductor's name on its own line #
+            if len(linesplits) >= 2 and linesplits[0] == "name":
+                conductorname = linesplits[1]
+            elif "distance" in line:
                 conductordistance = linesplits[1]
             elif "thickness" in line:
                 conductorthickness = linesplits[1]
@@ -255,7 +267,10 @@ def processTechFile(filename: str):
         elif dielectricblock == 1:
             linesplits = line.split()
 
-            if "epsilon" in line:
+            # process.out puts the dielectric's name on its own line #
+            if len(linesplits) >= 2 and linesplits[0] == "name":
+                dielectricname = linesplits[1]
+            elif "epsilon" in line:
                 dielectricepsilon = linesplits[1]
             elif "thickness" in line:
                 dielectricthickness = linesplits[1]
@@ -290,6 +305,13 @@ def TranslateUniversalFile(Universalfilename: str, FasterCapfilename: str):
         tempuniversalfilename = Universalfilename + "/"
     else:
         tempuniversalfilename = Universalfilename
+
+    # shapeorder is each dielectric's index in processDielectrics, found by name #
+    dielNameToGlobalIndex = {}
+    for i, d in enumerate(processDielectrics):
+        if d.name in dielNameToGlobalIndex:
+            raise ValueError(f"duplicate dielectric name in process file: {d.name}")
+        dielNameToGlobalIndex[d.name] = i
 
     # walk each directory tree for specified Universalfilename #
     for root, dirs, files in os.walk(tempuniversalfilename):
@@ -460,11 +482,13 @@ def TranslateUniversalFile(Universalfilename: str, FasterCapfilename: str):
 
                 # map Universal Format Data Structures to Shapes #
                 # NOTE: height == length (y-axis) #
-                dielorder = 0
                 for dielectric in tempdielectrics:
                     shapetype = 0  # Dielectric
-                    shapeorder = dielorder
-                    dielorder += 1
+                    if dielectric.name not in dielNameToGlobalIndex:
+                        raise ValueError(
+                            f"dielectric {dielectric.name!r} not found in process file"
+                        )
+                    shapeorder = dielNameToGlobalIndex[dielectric.name]
                     shapename = dielectric.name
                     shapeheight = round(patternswindowheight, 6)
                     shapethickness = round(dielectric.thickness, 6)
@@ -1161,11 +1185,11 @@ def extractFasterCapfile(filename: str):
                         conductorfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[
                                         dielindexlist[intersection]
                                     ].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1199,9 +1223,9 @@ def extractFasterCapfile(filename: str):
                     conductorfile,
                     round(
                         float(
-                            processDielectrics[
+                            safeDielEpsilon(
                                 PatternShapes[dielindexlist[intersection]].shapeorder
-                            ].epsilon
+                            )
                         )
                         * float(1.0e-6),
                         8,
@@ -1242,12 +1266,12 @@ def extractFasterCapfile(filename: str):
                         conductorfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[
                                         dielindexlist[intersection]
                                     ].shapeorder
                                     + 1
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1307,11 +1331,11 @@ def extractFasterCapfile(filename: str):
                             float(1.0e-6),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1353,23 +1377,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         - 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1410,9 +1434,9 @@ def extractFasterCapfile(filename: str):
                     1.0e-6,
                     round(
                         float(
-                            processDielectrics[
+                            safeDielEpsilon(
                                 PatternShapes[dielindexlist[dielindex]].shapeorder
-                            ].epsilon
+                            )
                         )
                         * float(1.0e-6),
                         8,
@@ -1449,19 +1473,19 @@ def extractFasterCapfile(filename: str):
                         dielectricfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
                                     + 1
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
                         ),
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1599,23 +1623,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         - 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1652,9 +1676,9 @@ def extractFasterCapfile(filename: str):
                         1.0e-6,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1691,23 +1715,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         + 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -26,6 +26,7 @@ COMPULSORY_TESTS = [
 
 # From CMakeLists.txt or_integration_tests(PASSFAIL_TESTS
 PASSFAIL_TESTS = [
+    "test_dielectric_epsilon",
 ]
 
 ALL_TESTS = COMPULSORY_TESTS + PASSFAIL_TESTS
@@ -99,6 +100,11 @@ filegroup(
                 "gcd.def",
             ],
             "short_resover": ["gcd.def"],
+            "test_dielectric_epsilon": [
+                "//src/rcx:rule_scripts/UniversalFormat2FasterCap_923.py",
+                "//src/rcx:calibration/fasterCap/scripts/UniversalFormat2FasterCap_923.py",
+                "rcx_v2/FasterCapModel/scripts/UniversalFormat2FasterCap_923.py",
+            ],
         }.get(test_name, []),
     )
     for test_name in ALL_TESTS
@@ -107,6 +113,7 @@ filegroup(
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
         check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         visibility = ["//visibility:public"],

--- a/src/rcx/test/CMakeLists.txt
+++ b/src/rcx/test/CMakeLists.txt
@@ -13,6 +13,7 @@ or_integration_tests(
     short_resover
   PASSFAIL_TESTS
     rcx_unit_test
+    test_dielectric_epsilon
 )
 
 #generate_rules

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/UniversalFormat2FasterCap_923.py
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/UniversalFormat2FasterCap_923.py
@@ -229,6 +229,15 @@ class Shapes:
 
 
 # TODO: Handle comment lines #
+
+def safeDielEpsilon(index):
+    # nothing is modeled above/below the top/bottom dielectric, so reuse
+    # its own epsilon rather than base_epsilon (the true open-air region,
+    # used only where a wire has no dielectric neighbor at all) #
+    idx = max(0, min(index, len(processDielectrics) - 1))
+    return float(processDielectrics[idx].epsilon)
+
+
 def processTechFile(filename: str):
 
     f = open(filename)
@@ -259,7 +268,10 @@ def processTechFile(filename: str):
         elif conductorblock == 1:
             linesplits = line.split()
 
-            if "distance" in line:
+            # process.out puts the conductor's name on its own line #
+            if len(linesplits) >= 2 and linesplits[0] == "name":
+                conductorname = linesplits[1]
+            elif "distance" in line:
                 conductordistance = linesplits[1]
             elif "thickness" in line:
                 conductorthickness = linesplits[1]
@@ -285,7 +297,10 @@ def processTechFile(filename: str):
         elif dielectricblock == 1:
             linesplits = line.split()
 
-            if "epsilon" in line:
+            # process.out puts the dielectric's name on its own line #
+            if len(linesplits) >= 2 and linesplits[0] == "name":
+                dielectricname = linesplits[1]
+            elif "epsilon" in line:
                 dielectricepsilon = linesplits[1]
             elif "thickness" in line:
                 dielectricthickness = linesplits[1]
@@ -320,6 +335,13 @@ def TranslateUniversalFile(Universalfilename: str, FasterCapfilename: str):
         tempuniversalfilename = Universalfilename + "/"
     else:
         tempuniversalfilename = Universalfilename
+
+    # shapeorder is each dielectric's index in processDielectrics, found by name #
+    dielNameToGlobalIndex = {}
+    for i, d in enumerate(processDielectrics):
+        if d.name in dielNameToGlobalIndex:
+            raise ValueError(f"duplicate dielectric name in process file: {d.name}")
+        dielNameToGlobalIndex[d.name] = i
 
     # walk each directory tree for specified Universalfilename #
     for root, dirs, files in os.walk(tempuniversalfilename):
@@ -490,11 +512,13 @@ def TranslateUniversalFile(Universalfilename: str, FasterCapfilename: str):
 
                 # map Universal Format Data Structures to Shapes #
                 # NOTE: height == length (y-axis) #
-                dielorder = 0
                 for dielectric in tempdielectrics:
                     shapetype = 0  # Dielectric
-                    shapeorder = dielorder
-                    dielorder += 1
+                    if dielectric.name not in dielNameToGlobalIndex:
+                        raise ValueError(
+                            f"dielectric {dielectric.name!r} not found in process file"
+                        )
+                    shapeorder = dielNameToGlobalIndex[dielectric.name]
                     shapename = dielectric.name
                     shapeheight = round(patternswindowheight, 6)
                     shapethickness = round(dielectric.thickness, 6)
@@ -1191,11 +1215,11 @@ def extractFasterCapfile(filename: str):
                         conductorfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[
                                         dielindexlist[intersection]
                                     ].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1229,9 +1253,9 @@ def extractFasterCapfile(filename: str):
                     conductorfile,
                     round(
                         float(
-                            processDielectrics[
+                            safeDielEpsilon(
                                 PatternShapes[dielindexlist[intersection]].shapeorder
-                            ].epsilon
+                            )
                         )
                         * float(1.0e-6),
                         8,
@@ -1272,12 +1296,12 @@ def extractFasterCapfile(filename: str):
                         conductorfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[
                                         dielindexlist[intersection]
                                     ].shapeorder
                                     + 1
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1337,11 +1361,11 @@ def extractFasterCapfile(filename: str):
                             float(1.0e-6),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1383,23 +1407,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         - 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1440,9 +1464,9 @@ def extractFasterCapfile(filename: str):
                     1.0e-6,
                     round(
                         float(
-                            processDielectrics[
+                            safeDielEpsilon(
                                 PatternShapes[dielindexlist[dielindex]].shapeorder
-                            ].epsilon
+                            )
                         )
                         * float(1.0e-6),
                         8,
@@ -1479,19 +1503,19 @@ def extractFasterCapfile(filename: str):
                         dielectricfile,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
                                     + 1
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
                         ),
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1629,23 +1653,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         - 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
@@ -1682,9 +1706,9 @@ def extractFasterCapfile(filename: str):
                         1.0e-6,
                         round(
                             float(
-                                processDielectrics[
+                                safeDielEpsilon(
                                     PatternShapes[dielindexlist[dielindex]].shapeorder
-                                ].epsilon
+                                )
                             )
                             * float(1.0e-6),
                             8,
@@ -1721,23 +1745,23 @@ def extractFasterCapfile(filename: str):
                             dielectricfile,
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
                                         + 1
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,
                             ),
                             round(
                                 float(
-                                    processDielectrics[
+                                    safeDielEpsilon(
                                         PatternShapes[
                                             dielindexlist[dielindex]
                                         ].shapeorder
-                                    ].epsilon
+                                    )
                                 )
                                 * float(1.0e-6),
                                 8,

--- a/src/rcx/test/test_dielectric_epsilon.py
+++ b/src/rcx/test/test_dielectric_epsilon.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024-2026, The OpenROAD Authors
+
+# dielectric epsilon lookup in UniversalFormat2FasterCap_923.py
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CONVERTER = os.path.join(HERE, "..", "rule_scripts", "UniversalFormat2FasterCap_923.py")
+
+_spec = importlib.util.spec_from_file_location("converter_under_test", CONVERTER)
+converter_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(converter_module)
+
+# this script exists as three separate copies in the tree; run the
+# behavioral checks below against all of them #
+CONVERTERS = {
+    "rule_scripts": CONVERTER,
+    "calibration": os.path.join(
+        HERE,
+        "..",
+        "calibration",
+        "fasterCap",
+        "scripts",
+        "UniversalFormat2FasterCap_923.py",
+    ),
+    "fastercap_model": os.path.join(
+        HERE, "rcx_v2", "FasterCapModel", "scripts", "UniversalFormat2FasterCap_923.py"
+    ),
+}
+
+PROCESS_OUT = """\
+CONDUCTOR {
+	name M1
+	height 0.1
+	thickness 0.1
+	min_width 0.1
+	min_spacing 0.1
+	top_extension 0
+	bottom_extension 0
+	resistivity 0.1
+}
+DIELECTRIC {
+	name M1_diel
+	epsilon 2.0
+	non_conformal_metal
+	thickness 1.0
+	slope 0
+	next_met 1
+}
+DIELECTRIC {
+	name M2_diel
+	epsilon 3.0
+	non_conformal_metal
+	thickness 1.0
+	slope 0
+	next_met 2
+}
+DIELECTRIC {
+	name M3_diel
+	epsilon 4.0
+	non_conformal_metal
+	thickness 1.0
+	slope 0
+	next_met 3
+}
+"""
+
+# pattern window starting above the bottom of the process
+WIRES_BUG1 = """\
+PATTERN TYP/test_pattern
+GROUND_PLANE 2 M2_gnd HEIGHT 1.0 1.1 THICKNESS 0.1
+GROUND_PLANE 3 M3_gnd HEIGHT 2.9 3.0 THICKNESS 0.1
+DIELECTRIC M2_diel HEIGHT 1.0 2.0 EPSILON 3.0
+DIELECTRIC M3_diel HEIGHT 2.0 3.0 EPSILON 4.0
+WIRE 1 M3_w1 LL 0.0 1.9 LR 1.0 1.9 UR 1.0 2.1 UL 0.0 2.1 LENGTH 1.0 VOLTAGE 1
+WINDOW_BBOX  LL -1.0  0.0 UR  2.0  1.0 LENGTH  1.0
+"""
+
+# pattern whose only dielectric is the topmost layer in the process
+WIRES_BUG2 = """\
+PATTERN TYP/test_pattern_boundary
+GROUND_PLANE 3 M3_gnd HEIGHT 2.0 2.1 THICKNESS 0.1
+DIELECTRIC M3_diel HEIGHT 2.0 3.0 EPSILON 4.0
+WIRE 1 M3_w1 LL 0.0 2.5 LR 1.0 2.5 UR 1.0 2.7 UL 0.0 2.7 LENGTH 1.0 VOLTAGE 1
+WINDOW_BBOX  LL -1.0  0.0 UR  2.0  1.0 LENGTH  1.0
+"""
+
+# dielectric name absent from PROCESS_OUT
+WIRES_UNKNOWN_DIEL = """\
+PATTERN TYP/test_pattern_unknown
+GROUND_PLANE 2 M2_gnd HEIGHT 1.0 1.1 THICKNESS 0.1
+DIELECTRIC UnknownLayer_diel HEIGHT 1.0 2.0 EPSILON 3.0
+WIRE 1 M2_w1 LL 0.0 1.0 LR 1.0 1.0 UR 1.0 1.2 UL 0.0 1.2 LENGTH 1.0 VOLTAGE 1
+WINDOW_BBOX  LL -1.0  0.0 UR  2.0  1.0 LENGTH  1.0
+"""
+
+# a conductor at layer M0 so the dielectric fill-panel path also runs
+# (it's gated on the pattern's lowest conductor layer); M2_diel has no
+# conductor in its range, so it gets a synthetic fill panel referencing
+# both its neighbors' epsilon
+WIRES_DIEL_PANEL = """\
+PATTERN TYP/test_diel_panel
+GROUND_PLANE 0 M0_gnd HEIGHT 0.0 0.1 THICKNESS 0.1
+DIELECTRIC M1_diel HEIGHT 0.0 1.0 EPSILON 2.0
+DIELECTRIC M2_diel HEIGHT 1.0 2.0 EPSILON 3.0
+DIELECTRIC M3_diel HEIGHT 2.0 3.0 EPSILON 4.0
+WIRE 1 M3_w1 LL 0.0 2.0 LR 1.0 2.0 UR 1.0 2.2 UL 0.0 2.2 LENGTH 1.0 VOLTAGE 1
+WINDOW_BBOX  LL -1.0  0.0 UR  2.0  1.0 LENGTH  1.0
+"""
+
+
+def run_converter(wires_text, pattern_name, converter=CONVERTER):
+    workdir = tempfile.mkdtemp()
+    try:
+        pat_dir = os.path.join(workdir, "TYP", pattern_name)
+        os.makedirs(pat_dir)
+        with open(os.path.join(workdir, "TYP", "process.out"), "w") as f:
+            f.write(PROCESS_OUT)
+        with open(os.path.join(pat_dir, "wires"), "w") as f:
+            f.write(wires_text)
+        os.makedirs(os.path.join(workdir, "fcout"))
+        result = subprocess.run(
+            [
+                "python3",
+                converter,
+                "TYP/process.out",
+                f"TYP/{pattern_name}",
+                "fcout",
+                "standard",
+                "-sim_window_ext",
+                "-20",
+                "-20",
+                "-20",
+                "20",
+                "20",
+                "20",
+            ],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+        )
+        lst_path = os.path.join(workdir, "fcout", pattern_name, "wires.lst")
+        lst_text = None
+        if os.path.exists(lst_path):
+            with open(lst_path) as f:
+                lst_text = f.read()
+        return result.returncode, result.stderr, lst_text
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def epsilons_for(lst_text, wire_name):
+    # panel lines are "C <file> <epsilon*1e-6> ..."
+    values = []
+    for line in lst_text.splitlines():
+        if line.startswith("C ") and wire_name in line:
+            values.append(float(line.split()[2]))
+    return values
+
+
+class TestDielectricEpsilon(unittest.TestCase):
+    def test_shapeorder_uses_global_dielectric_index(self):
+        for label, converter in CONVERTERS.items():
+            with self.subTest(converter=label):
+                rc, stderr, lst_text = run_converter(
+                    WIRES_BUG1, "test_pattern", converter
+                )
+                self.assertEqual(rc, 0, stderr)
+                self.assertIsNotNone(lst_text)
+                values = epsilons_for(lst_text, "M3_w1")
+                self.assertTrue(values)
+                self.assertEqual(set(values), {4.0e-6})
+
+    def test_no_indexerror_at_topmost_dielectric(self):
+        for label, converter in CONVERTERS.items():
+            with self.subTest(converter=label):
+                rc, stderr, lst_text = run_converter(
+                    WIRES_BUG2, "test_pattern_boundary", converter
+                )
+                self.assertEqual(rc, 0, stderr)
+                self.assertIsNotNone(lst_text)
+                # nothing is modeled above the topmost dielectric, so the
+                # wire's top panel clamps to M3_diel's own epsilon #
+                top_line = next(
+                    l
+                    for l in lst_text.splitlines()
+                    if "wire_M3_w1" in l and "-top.txt" in l
+                )
+                self.assertEqual(float(top_line.split()[2]), 4.0e-6)
+
+    def test_dielectric_fill_panel_uses_correct_neighbor_epsilon(self):
+        for label, converter in CONVERTERS.items():
+            with self.subTest(converter=label):
+                rc, stderr, lst_text = run_converter(
+                    WIRES_DIEL_PANEL, "test_diel_panel", converter
+                )
+                self.assertEqual(rc, 0, stderr)
+                self.assertIsNotNone(lst_text)
+                lines = lst_text.splitlines()
+                top_line = next(
+                    l for l in lines if "dielectric_M1_diel" in l and "-top.txt" in l
+                )
+                bottom_line = next(
+                    l for l in lines if "dielectric_M2_diel" in l and "-bottom.txt" in l
+                )
+                # M1_diel's top borders M2_diel (shapeorder + 1); M2_diel's
+                # bottom borders M1_diel (shapeorder - 1) #
+                self.assertEqual(float(top_line.split()[2]), 3.0e-6)
+                self.assertEqual(float(bottom_line.split()[2]), 2.0e-6)
+
+    def test_unmatched_dielectric_name_raises(self):
+        for label, converter in CONVERTERS.items():
+            with self.subTest(converter=label):
+                rc, stderr, _ = run_converter(
+                    WIRES_UNKNOWN_DIEL, "test_pattern_unknown", converter
+                )
+                self.assertNotEqual(rc, 0)
+                self.assertIn("not found in process file", stderr)
+
+    def test_duplicate_dielectric_name_raises(self):
+        converter_module.processDielectrics = [
+            converter_module.Dielectrics("M1_diel", 1.0, 2.0),
+            converter_module.Dielectrics("M1_diel", 1.0, 3.0),
+        ]
+        with self.assertRaises(ValueError):
+            converter_module.TranslateUniversalFile("unused", "unused")
+
+    def test_safe_diel_epsilon_clamps_both_ends(self):
+        converter_module.processDielectrics = [
+            converter_module.Dielectrics("M1_diel", 1.0, 2.0),
+            converter_module.Dielectrics("M2_diel", 1.0, 3.0),
+            converter_module.Dielectrics("M3_diel", 1.0, 4.0),
+        ]
+        self.assertEqual(converter_module.safeDielEpsilon(-1), 2.0)
+        self.assertEqual(converter_module.safeDielEpsilon(3), 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #11250.

This script indexes the global dielectric list with a counter that
resets to 0 for every pattern instead of each dielectric's actual index
in the process stack, so lookups into the global dielectric list
grabbed the wrong layer's epsilon whenever a file's stack didn't start
at the bottom. Fixed by looking up each dielectric's index by name
instead. Raises if a name isn't found in the process file, or if two
dielectrics share a name, rather than silently falling back to the old
counter.

shapeorder+1/-1 also walked off the end of the list at the top/bottom
layer, crashing with IndexError. Clamped to the valid range instead,
reusing the boundary dielectric's own epsilon for the missing
neighbor.

processTechFile only read a dielectric's name off the "DIELECTRIC {"
line itself, but process.out puts the name on the next line. Added a
case to read it from there. CONDUCTOR blocks have the identical format
and the identical gap; fixed the same way, though nothing currently
reads a conductor's name so it was latent rather than active.

This exact script exists in three places in the tree
(rule_scripts/, calibration/fasterCap/scripts/,
test/rcx_v2/FasterCapModel/scripts/) -- independent copies from three
separate contributions in 2024, not sharing a source. All three had
the identical bug and are patched identically here. Deduplicating them
(e.g. via symlinks, as was done for the *_man_tcl_check.py copies in
#9900) seems worth doing but is left for a separate PR to keep this
one focused on the bug fix.

Adds test_dielectric_epsilon.py: shapeorder resolving to the right
global index, the boundary crash, an unmatched dielectric name
raising, and the dielectric-fill-panel code path (only reachable for
patterns anchored at conductor layer M0, due to a separate
pre-existing case-sensitivity gate elsewhere in the file that this PR
does not touch) -- run against all three copies of the script so a fix
applied to only one of them wouldn't go unnoticed. Also tests a
duplicate dielectric name raising and the clamp helper directly,
against the rule_scripts copy (identical logic in all three).

src/rcx/test/BUILD's regression_test() call never set check_log=False
for PASSFAIL_TESTS entries, so bazel test tried to diff this test's
output against a golden file that doesn't exist for a passfail test.
Added the missing check_log = False, matching the pattern already
used for PASSFAIL tests elsewhere (e.g. src/grt/test/BUILD).

The built openroad binary doesn't compile in -python support at all
(ENABLE_PYTHON3 is a CMake-only define), so regression_test.sh's
existing fallback to plain python3 is what actually runs this test
under bazel test.
