### PR TITLE
pad/pdn: move to use odb::geom

### DIFF
--- a/src/odb/include/odb/geom_boost.h
+++ b/src/odb/include/odb/geom_boost.h
@@ -431,31 +431,29 @@ BoostPolygon90 toPolygon90(const T& shape)
   return polygon;
 }
 
-// Collect the shape into a polygon set
+// Collect the shape into a polygon set.  insert() adds the shape without
+// running a boolean op; the set unions and normalizes lazily on first read.
 template <AreaShape T>
 BoostPolygonSet toPolygonSet(const T& shape)
 {
-  using boost::polygon::operators::operator+=;
-
   const std::vector<Point> points = shape.getPoints();
 
   BoostPolygonSet polygon_set;
-  polygon_set += BoostPolygon(points.begin(), points.end());
+  polygon_set.insert(BoostPolygon(points.begin(), points.end()));
 
   return polygon_set;
 }
 
 // Collect the shapes into a single polygon set, which unions overlapping
-// shapes together
+// shapes together.  insert() keeps this linear in the shape count; operator+=
+// would run a scanline boolean op per shape, making the build quadratic.
 template <AreaShape T>
 BoostPolygonSet toPolygonSet(const std::vector<T>& shapes)
 {
-  using boost::polygon::operators::operator+=;
-
   BoostPolygonSet polygon_set;
   for (const T& shape : shapes) {
     const std::vector<Point> points = shape.getPoints();
-    polygon_set += BoostPolygon(points.begin(), points.end());
+    polygon_set.insert(BoostPolygon(points.begin(), points.end()));
   }
 
   return polygon_set;

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1888,8 +1888,13 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
     const odb::dbTransform xform = inst->getTransform();
 
     auto* master = inst->getMaster();
-    auto& master_obs = master_obstruction_map[master];
-    if (master_obs.empty()) {
+    // Keyed on presence, not emptiness: a master with no obstructions on this
+    // layer yields an empty vector, and rechecking emptiness would recompute
+    // it for every instance of that master.
+    const auto [master_it, is_new_master]
+        = master_obstruction_map.try_emplace(master);
+    auto& master_obs = master_it->second;
+    if (is_new_master) {
       // Collect all polygons to add (obstructions).  Each shape is bloated on
       // its own, since bloating the union would miter the merged outline
       // instead.  get() appends, so everything lands in one vector that is
@@ -1918,7 +1923,9 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
       odb::geom::BoostPolygonSet master_obstruction(polys_to_add.begin(),
                                                     polys_to_add.end());
 
-      // Collect all polygons to subtract (iterm shapes)
+      // Collect all polygons to subtract (iterm shapes).  As above, get()
+      // appends to the vector rather than overwriting it, so every pin
+      // accumulates here and the whole set is normalized once below.
       std::vector<odb::geom::BoostPolygon> polys_to_subtract;
       for (auto* mterm : master->getMTerms()) {
         for (auto* mpin : mterm->getMPins()) {

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1958,16 +1958,7 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
             polys_to_subtract.begin(), polys_to_subtract.end());
       }
 
-      std::vector<odb::geom::BoostPolygon> output_polygons;
-      master_obstruction.get(output_polygons);
-      for (const auto& polygon_out : output_polygons) {
-        std::vector<odb::Point> new_coord;
-        new_coord.reserve(polygon_out.coords_.size());
-        for (const auto& pt : polygon_out.coords_) {
-          new_coord.emplace_back(pt.x(), pt.y());
-        }
-        master_obs.emplace_back(new_coord);
-      }
+      master_obs = odb::geom::extractPolygons(master_obstruction);
     }
     for (const auto& poly : master_obs) {
       if (poly.isRect()) {

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -23,7 +23,6 @@
 #include "RDLNet.h"
 #include "RDLSegment.h"
 #include "Utilities.h"
-#include "boost/geometry/geometries/point_xy.hpp"
 #include "boost/geometry/geometry.hpp"
 #include "boost/graph/astar_search.hpp"
 #include "boost/graph/lookup_edge.hpp"

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1891,20 +1891,19 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
     auto* master = inst->getMaster();
     auto& master_obs = master_obstruction_map[master];
     if (master_obs.empty()) {
-      odb::geom::BoostPolygonSet master_obstruction;
-
-      // Collect all polygons to add (obstructions)
+      // Collect all polygons to add (obstructions).  Each shape is bloated on
+      // its own, since bloating the union would miter the merged outline
+      // instead.  get() appends, so everything lands in one vector that is
+      // normalized once below.
       std::vector<odb::geom::BoostPolygon> polys_to_add;
       for (auto* obs : master->getPolygonObstructions()) {
         if (obs->getTechLayer() != layer_) {
           continue;
         }
 
-        for (const auto& bloat_poly : odb::geom::extractPolygons(
-                 odb::geom::toPolygonSet(obs->getPolygon()) + bloat)) {
-          const auto pts = bloat_poly.getPoints();
-          polys_to_add.emplace_back(pts.begin(), pts.end());
-        }
+        const odb::geom::BoostPolygonSet bloated_obs
+            = odb::geom::toPolygonSet(obs->getPolygon()) + bloat;
+        bloated_obs.get(polys_to_add);
       }
       for (auto* obs : master->getObstructions(false)) {
         if (obs->getTechLayer() != layer_) {
@@ -1917,12 +1916,8 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
         polys_to_add.emplace_back(pts.begin(), pts.end());
       }
 
-      // Build temporary set for all additions, then assign to
-      // master_obstruction
-      if (!polys_to_add.empty()) {
-        master_obstruction = odb::geom::BoostPolygonSet(polys_to_add.begin(),
-                                                        polys_to_add.end());
-      }
+      odb::geom::BoostPolygonSet master_obstruction(polys_to_add.begin(),
+                                                    polys_to_add.end());
 
       // Collect all polygons to subtract (iterm shapes)
       std::vector<odb::geom::BoostPolygon> polys_to_subtract;
@@ -1933,11 +1928,9 @@ void RDLRouter::populateObstructions(const std::vector<odb::dbNet*>& nets)
               continue;
             }
 
-            for (const auto& bloat_poly : odb::geom::extractPolygons(
-                     odb::geom::toPolygonSet(geom->getPolygon()) + bloat)) {
-              const auto pts = bloat_poly.getPoints();
-              polys_to_subtract.emplace_back(pts.begin(), pts.end());
-            }
+            const odb::geom::BoostPolygonSet bloated_pin
+                = odb::geom::toPolygonSet(geom->getPolygon()) + bloat;
+            bloated_pin.get(polys_to_subtract);
           }
           for (auto* geom : mpin->getGeometry(false)) {
             if (geom->getTechLayer() != layer_) {

--- a/src/pad/src/RDLSegment.cpp
+++ b/src/pad/src/RDLSegment.cpp
@@ -4,7 +4,6 @@
 #include "RDLSegment.h"
 
 #include <algorithm>
-#include <array>
 #include <map>
 #include <memory>
 #include <set>
@@ -16,9 +15,6 @@
 #include "RDLRouter.h"
 #include "boost/geometry/geometry.hpp"
 #include "boost/polygon/polygon_90_set_data.hpp"
-#include "boost/polygon/polygon_90_with_holes_data.hpp"
-#include "boost/polygon/rectangle_concept.hpp"
-#include "boost/polygon/rectangle_data.hpp"
 #include "odb/PtrSetMap.h"
 #include "odb/db.h"
 #include "odb/geom.h"
@@ -316,36 +312,20 @@ void RDLSegment::preprocess(odb::dbTechLayer* layer, utl::Logger* logger)
   using boost::polygon::operators::operator+=;
   using boost::polygon::operators::operator-=;
 
-  using Rectangle = boost::polygon::rectangle_data<int>;
-  using Polygon90 = boost::polygon::polygon_90_with_holes_data<int>;
-  using Polygon90Set = boost::polygon::polygon_90_set_data<int>;
-  using Pt = Polygon90::point_type;
-
-  auto rect_to_poly = [](const odb::Rect& rect) -> Polygon90 {
-    std::array<Pt, 4> pts = {Pt(rect.xMin(), rect.yMin()),
-                             Pt(rect.xMax(), rect.yMin()),
-                             Pt(rect.xMax(), rect.yMax()),
-                             Pt(rect.xMin(), rect.yMax())};
-
-    Polygon90 poly;
-    poly.set(pts.begin(), pts.end());
-    return poly;
-  };
-
-  Polygon90Set source_iterms;
+  odb::geom::BoostPolygon90Set source_iterms;
 
   bool has_layer = false;
   for (const auto& [iterm_layer, iterm_rect] : iterm_->getGeometries()) {
     if (iterm_layer == layer) {
       has_layer = true;
-      source_iterms += rect_to_poly(iterm_rect);
+      source_iterms += odb::geom::toPolygon90(iterm_rect);
     }
   }
   if (!has_layer) {
     return;
   }
 
-  odb::PtrMap<odb::dbITerm, Polygon90Set> iterms_geoms;
+  odb::PtrMap<odb::dbITerm, odb::geom::BoostPolygon90Set> iterms_geoms;
 
   // Create geom of all shapes
   for (odb::dbITerm* iterm : terminals_) {
@@ -353,7 +333,7 @@ void RDLSegment::preprocess(odb::dbTechLayer* layer, utl::Logger* logger)
     for (const auto& [iterm_layer, iterm_rect] : iterm->getGeometries()) {
       if (iterm_layer == layer) {
         iterm_has_layer = true;
-        iterms_geoms[iterm] += rect_to_poly(iterm_rect);
+        iterms_geoms[iterm] += odb::geom::toPolygon90(iterm_rect);
       }
     }
     if (!iterm_has_layer) {
@@ -363,7 +343,7 @@ void RDLSegment::preprocess(odb::dbTechLayer* layer, utl::Logger* logger)
 
   // check if route is even needed, ie, shapes overlap
   for (const auto& [iterm, polys] : iterms_geoms) {
-    Polygon90Set check = polys;
+    odb::geom::BoostPolygon90Set check = polys;
     check.interact(source_iterms);
     if (!check.empty()) {
       // There is nothing to do
@@ -381,20 +361,18 @@ void RDLSegment::preprocess(odb::dbTechLayer* layer, utl::Logger* logger)
   const int min_dist = layer->getSpacing();
 
   for (const auto& [iterm, polys] : iterms_geoms) {
-    Polygon90Set check = polys;
+    odb::geom::BoostPolygon90Set check = polys;
     check.bloat(min_dist, min_dist, min_dist, min_dist);
     check.interact(source_iterms);
     if (!check.empty()) {
-      Polygon90Set source_bloat = source_iterms;
+      odb::geom::BoostPolygon90Set source_bloat = source_iterms;
       source_bloat.bloat(min_dist, min_dist, min_dist, min_dist);
       check += source_bloat;
       check.shrink(min_dist, min_dist, min_dist, min_dist);
       check -= source_iterms;
 
-      std::vector<Rectangle> combined_rects;
-      check.get_rectangles(combined_rects);
-      for (const auto& rect : combined_rects) {
-        stubs_.emplace(xl(rect), yl(rect), xh(rect), yh(rect));
+      for (const odb::Rect& rect : odb::geom::extractRectangles(check)) {
+        stubs_.insert(rect);
       }
       // There is nothing to do
       locked_ = true;

--- a/src/pad/src/RDLSegment.cpp
+++ b/src/pad/src/RDLSegment.cpp
@@ -318,7 +318,7 @@ void RDLSegment::preprocess(odb::dbTechLayer* layer, utl::Logger* logger)
   for (const auto& [iterm_layer, iterm_rect] : iterm_->getGeometries()) {
     if (iterm_layer == layer) {
       has_layer = true;
-      source_iterms += odb::geom::toPolygon90(iterm_rect);
+      source_iterms.insert(odb::geom::toPolygon90(iterm_rect));
     }
   }
   if (!has_layer) {
@@ -333,7 +333,7 @@ void RDLSegment::preprocess(odb::dbTechLayer* layer, utl::Logger* logger)
     for (const auto& [iterm_layer, iterm_rect] : iterm->getGeometries()) {
       if (iterm_layer == layer) {
         iterm_has_layer = true;
-        iterms_geoms[iterm] += odb::geom::toPolygon90(iterm_rect);
+        iterms_geoms[iterm].insert(odb::geom::toPolygon90(iterm_rect));
       }
     }
     if (!iterm_has_layer) {

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -4,7 +4,6 @@
 #include "shape.h"
 
 #include <algorithm>
-#include <array>
 #include <functional>
 #include <memory>
 #include <set>
@@ -231,7 +230,7 @@ bool Shape::cut(const ObstructionTree& obstructions,
 
   const ObstructionHalo obs_halo = getObstructionHalo();
 
-  std::vector<odb::geom::BoostPolygon90WithHoles> shape_violations;
+  std::vector<odb::geom::BoostPolygon90> shape_violations;
   for (auto it = obstructions.qbegin(bgi::intersects(getObstruction())
                                      && bgi::satisfies([&](const auto& other) {
                                           return layer_ == other->getLayer()
@@ -270,17 +269,8 @@ bool Shape::cut(const ObstructionTree& obstructions,
       vio_rect.set_xlo(std::min(obs_.xMin(), vio_rect.xMin()));
       vio_rect.set_xhi(std::max(obs_.xMax(), vio_rect.xMax()));
     }
-    std::array<odb::Point, 4> pts
-        = {odb::Point(vio_rect.xMin(), vio_rect.yMin()),
-           odb::Point(vio_rect.xMax(), vio_rect.yMin()),
-           odb::Point(vio_rect.xMax(), vio_rect.yMax()),
-           odb::Point(vio_rect.xMin(), vio_rect.yMax())};
-
-    odb::geom::BoostPolygon90WithHoles poly;
-    poly.set(pts.begin(), pts.end());
-
     // save violating polygon
-    shape_violations.push_back(poly);
+    shape_violations.push_back(odb::geom::toPolygon90(vio_rect));
   }
 
   // check if violations is empty and return no new shapes
@@ -288,28 +278,15 @@ bool Shape::cut(const ObstructionTree& obstructions,
     return false;
   }
 
-  const std::array<odb::Point, 4> pts = {odb::Point(obs_.xMin(), obs_.yMin()),
-                                         odb::Point(obs_.xMax(), obs_.yMin()),
-                                         odb::Point(obs_.xMax(), obs_.yMax()),
-                                         odb::Point(obs_.xMin(), obs_.yMax())};
-
-  odb::geom::BoostPolygon90WithHoles poly;
-  poly.set(pts.begin(), pts.end());
-  std::array<odb::geom::BoostPolygon90WithHoles, 1> arr{poly};
-
-  odb::geom::BoostPolygon90Set new_shape(
-      boost::polygon::HORIZONTAL, arr.begin(), arr.end());
+  odb::geom::BoostPolygon90Set new_shape = odb::geom::toPolygonSet90(obs_);
 
   // remove all violations from the shape
   for (const auto& violation : shape_violations) {
     new_shape -= violation;
   }
 
-  std::vector<odb::geom::BoostRectangle> rects;
-  new_shape.get_rectangles(rects);
-
-  for (auto& r : rects) {
-    const odb::Rect new_obs_rect(xl(r), yl(r), xh(r), yh(r));
+  for (const odb::Rect& new_obs_rect :
+       odb::geom::extractRectangles(new_shape)) {
     if (!new_obs_rect.overlaps(rect_)) {
       // New shape will exceed original
       continue;

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -278,12 +278,17 @@ bool Shape::cut(const ObstructionTree& obstructions,
     return false;
   }
 
-  odb::geom::BoostPolygon90Set new_shape = odb::geom::toPolygonSet90(obs_);
+  // Gather the violations with insert(), which defers normalization, and
+  // remove them in a single boolean op.  Subtracting one at a time would run
+  // a scanline pass per violation.
+  odb::geom::BoostPolygon90Set violations;
+  for (const auto& violation : shape_violations) {
+    violations.insert(violation);
+  }
 
   // remove all violations from the shape
-  for (const auto& violation : shape_violations) {
-    new_shape -= violation;
-  }
+  odb::geom::BoostPolygon90Set new_shape = odb::geom::toPolygonSet90(obs_);
+  new_shape -= violations;
 
   for (const odb::Rect& new_obs_rect :
        odb::geom::extractRectangles(new_shape)) {

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -22,6 +22,7 @@
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "odb/geom_boost.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
 #include "via.h"
@@ -225,16 +226,12 @@ bool Shape::cut(const ObstructionTree& obstructions,
                 const std::function<bool(const ShapePtr&)>& obs_filter) const
 {
   using boost::polygon::operators::operator-=;
-  using Rectangle = boost::polygon::rectangle_data<int>;
-  using Polygon90 = boost::polygon::polygon_90_with_holes_data<int>;
-  using Polygon90Set = boost::polygon::polygon_90_set_data<int>;
-  using Pt = Polygon90::point_type;
 
   const bool is_horizontal = isHorizontal();
 
   const ObstructionHalo obs_halo = getObstructionHalo();
 
-  std::vector<Polygon90> shape_violations;
+  std::vector<odb::geom::BoostPolygon90WithHoles> shape_violations;
   for (auto it = obstructions.qbegin(bgi::intersects(getObstruction())
                                      && bgi::satisfies([&](const auto& other) {
                                           return layer_ == other->getLayer()
@@ -273,12 +270,13 @@ bool Shape::cut(const ObstructionTree& obstructions,
       vio_rect.set_xlo(std::min(obs_.xMin(), vio_rect.xMin()));
       vio_rect.set_xhi(std::max(obs_.xMax(), vio_rect.xMax()));
     }
-    std::array<Pt, 4> pts = {Pt(vio_rect.xMin(), vio_rect.yMin()),
-                             Pt(vio_rect.xMax(), vio_rect.yMin()),
-                             Pt(vio_rect.xMax(), vio_rect.yMax()),
-                             Pt(vio_rect.xMin(), vio_rect.yMax())};
+    std::array<odb::Point, 4> pts
+        = {odb::Point(vio_rect.xMin(), vio_rect.yMin()),
+           odb::Point(vio_rect.xMax(), vio_rect.yMin()),
+           odb::Point(vio_rect.xMax(), vio_rect.yMax()),
+           odb::Point(vio_rect.xMin(), vio_rect.yMax())};
 
-    Polygon90 poly;
+    odb::geom::BoostPolygon90WithHoles poly;
     poly.set(pts.begin(), pts.end());
 
     // save violating polygon
@@ -290,23 +288,24 @@ bool Shape::cut(const ObstructionTree& obstructions,
     return false;
   }
 
-  const std::array<Pt, 4> pts = {Pt(obs_.xMin(), obs_.yMin()),
-                                 Pt(obs_.xMax(), obs_.yMin()),
-                                 Pt(obs_.xMax(), obs_.yMax()),
-                                 Pt(obs_.xMin(), obs_.yMax())};
+  const std::array<odb::Point, 4> pts = {odb::Point(obs_.xMin(), obs_.yMin()),
+                                         odb::Point(obs_.xMax(), obs_.yMin()),
+                                         odb::Point(obs_.xMax(), obs_.yMax()),
+                                         odb::Point(obs_.xMin(), obs_.yMax())};
 
-  Polygon90 poly;
+  odb::geom::BoostPolygon90WithHoles poly;
   poly.set(pts.begin(), pts.end());
-  std::array<Polygon90, 1> arr{poly};
+  std::array<odb::geom::BoostPolygon90WithHoles, 1> arr{poly};
 
-  Polygon90Set new_shape(boost::polygon::HORIZONTAL, arr.begin(), arr.end());
+  odb::geom::BoostPolygon90Set new_shape(
+      boost::polygon::HORIZONTAL, arr.begin(), arr.end());
 
   // remove all violations from the shape
   for (const auto& violation : shape_violations) {
     new_shape -= violation;
   }
 
-  std::vector<Rectangle> rects;
+  std::vector<odb::geom::BoostRectangle> rects;
   new_shape.get_rectangles(rects);
 
   for (auto& r : rects) {

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -4,7 +4,6 @@
 #include "straps.h"
 
 #include <algorithm>
-#include <array>
 #include <cstdlib>
 #include <functional>
 #include <iterator>
@@ -17,7 +16,6 @@
 #include <vector>
 
 #include "boost/geometry/geometry.hpp"
-#include "boost/polygon/polygon.hpp"
 #include "connect.h"
 #include "domain.h"
 #include "grid.h"
@@ -2558,32 +2556,19 @@ RepairChannelStraps::findRepairChannels(Grid* grid,
       continue;
     }
 
-    // determine bloat factor
-    const int bloat = grid_strap->getPitch();
-    const int bloat_x = grid_strap->isHorizontal() ? 0 : bloat;
-    const int bloat_y = grid_strap->isHorizontal() ? bloat : 0;
-
-    const auto& min_corner = shape->getRect().ll();
-    const auto& max_corner = shape->getRect().ur();
-    std::array<odb::Point, 4> pts
-        = {odb::Point(min_corner.x() - bloat_x, min_corner.y() - bloat_y),
-           odb::Point(max_corner.x() + bloat_x, min_corner.y() - bloat_y),
-           odb::Point(max_corner.x() + bloat_x, max_corner.y() + bloat_y),
-           odb::Point(min_corner.x() - bloat_x, max_corner.y() + bloat_y)};
-    odb::geom::BoostPolygon90WithHoles poly;
-    poly.set(pts.begin(), pts.end());
+    // bloat by the strap pitch across the strap, so neighboring straps merge
+    // and the gaps left between them are the channels
+    const odb::Rect bloated_shape = shape->getRect().bloat(
+        grid_strap->getPitch(),
+        grid_strap->isHorizontal() ? odb::vertical : odb::horizontal);
 
     shapes_used.push_back(shape.get());
-    shape_set.insert(poly);
+    shape_set.insert(odb::geom::toPolygon90(bloated_shape));
   }
 
   // get all possible channel rects
   std::set<odb::Rect> channels_rects;
-  std::vector<odb::geom::BoostRectangle> channel_set;
-  shape_set.get_rectangles(channel_set);
-  for (const auto& channel : channel_set) {
-    const odb::Rect area(xl(channel), yl(channel), xh(channel), yh(channel));
-
+  for (const odb::Rect& area : odb::geom::extractRectangles(shape_set)) {
     if (area.intersects(grid_core)) {
       channels_rects.insert(area.intersect(grid_core));
     }

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -25,6 +25,7 @@
 #include "odb/db.h"
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
+#include "odb/geom_boost.h"
 #include "pdn/PdnGen.hh"
 #include "renderer.h"
 #include "shape.h"
@@ -2528,15 +2529,10 @@ RepairChannelStraps::findRepairChannels(Grid* grid,
     return {};
   }
 
-  using Rectangle = boost::polygon::rectangle_data<int>;
-  using Polygon90 = boost::polygon::polygon_90_with_holes_data<int>;
-  using Polygon90Set = boost::polygon::polygon_90_set_data<int>;
-  using Pt = Polygon90::point_type;
-
   const auto grid_core = grid->getDomainBoundary();
 
   std::vector<Shape*> shapes_used;
-  Polygon90Set shape_set;
+  odb::geom::BoostPolygon90Set shape_set;
   for (const auto& shape : shapes) {
     if (shape->getNumberOfConnectionsAbove() != 0) {
       // shape already connected to something
@@ -2569,12 +2565,12 @@ RepairChannelStraps::findRepairChannels(Grid* grid,
 
     const auto& min_corner = shape->getRect().ll();
     const auto& max_corner = shape->getRect().ur();
-    std::array<Pt, 4> pts
-        = {Pt(min_corner.x() - bloat_x, min_corner.y() - bloat_y),
-           Pt(max_corner.x() + bloat_x, min_corner.y() - bloat_y),
-           Pt(max_corner.x() + bloat_x, max_corner.y() + bloat_y),
-           Pt(min_corner.x() - bloat_x, max_corner.y() + bloat_y)};
-    Polygon90 poly;
+    std::array<odb::Point, 4> pts
+        = {odb::Point(min_corner.x() - bloat_x, min_corner.y() - bloat_y),
+           odb::Point(max_corner.x() + bloat_x, min_corner.y() - bloat_y),
+           odb::Point(max_corner.x() + bloat_x, max_corner.y() + bloat_y),
+           odb::Point(min_corner.x() - bloat_x, max_corner.y() + bloat_y)};
+    odb::geom::BoostPolygon90WithHoles poly;
     poly.set(pts.begin(), pts.end());
 
     shapes_used.push_back(shape.get());
@@ -2583,7 +2579,7 @@ RepairChannelStraps::findRepairChannels(Grid* grid,
 
   // get all possible channel rects
   std::set<odb::Rect> channels_rects;
-  std::vector<Rectangle> channel_set;
+  std::vector<odb::geom::BoostRectangle> channel_set;
   shape_set.get_rectangles(channel_set);
   for (const auto& channel : channel_set) {
     const odb::Rect area(xl(channel), yl(channel), xh(channel), yh(channel));

--- a/src/pdn/src/via.cpp
+++ b/src/pdn/src/via.cpp
@@ -27,6 +27,7 @@
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "odb/geom_boost.h"
 #include "shape.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
@@ -946,18 +947,15 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
   using boost::polygon::operators::operator+=;
   using boost::polygon::operators::operator+;
   using boost::polygon::operators::operator^;
-  using Rectangle = boost::polygon::rectangle_data<int>;
-  using Polygon90 = boost::polygon::polygon_90_with_holes_data<int>;
-  using Polygon90Set = boost::polygon::polygon_90_set_data<int>;
-  using Pt = Polygon90::point_type;
 
-  auto rect_to_poly = [](const odb::Rect& rect) -> Polygon90 {
-    std::array<Pt, 4> pts = {Pt(rect.xMin(), rect.yMin()),
-                             Pt(rect.xMax(), rect.yMin()),
-                             Pt(rect.xMax(), rect.yMax()),
-                             Pt(rect.xMin(), rect.yMax())};
+  auto rect_to_poly
+      = [](const odb::Rect& rect) -> odb::geom::BoostPolygon90WithHoles {
+    std::array<odb::Point, 4> pts = {odb::Point(rect.xMin(), rect.yMin()),
+                                     odb::Point(rect.xMax(), rect.yMin()),
+                                     odb::Point(rect.xMax(), rect.yMax()),
+                                     odb::Point(rect.xMin(), rect.yMax())};
 
-    Polygon90 poly;
+    odb::geom::BoostPolygon90WithHoles poly;
     poly.set(pts.begin(), pts.end());
     return poly;
   };
@@ -965,7 +963,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
   ViaLayerShape via_shapes;
 
   DbVia* prev_via = nullptr;
-  Polygon90Set top_of_previous;
+  odb::geom::BoostPolygon90Set top_of_previous;
   for (size_t i = 0; i < vias_.size(); i++) {
     const auto& via = vias_[i];
     const auto& layer_lower = layers_[i];
@@ -991,20 +989,21 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
     via_shapes.middle.insert(via_shapes.top.begin(), via_shapes.top.end());
     via_shapes.top = shapes.top;
 
-    Polygon90Set patch_shapes;
-    Polygon90Set total_shape;
+    odb::geom::BoostPolygon90Set patch_shapes;
+    odb::geom::BoostPolygon90Set total_shape;
     odb::dbTechLayer* add_to_layer = layer_lower->getLayer();
     if (prev_via != nullptr) {
-      Polygon90Set bottom_of_current;
+      odb::geom::BoostPolygon90Set bottom_of_current;
       for (const auto& [shape, box] : shapes.bottom) {
         bottom_of_current += rect_to_poly(shape);
       }
 
       // create a single set of shapes for the layer
-      Polygon90Set combine_layer = top_of_previous + bottom_of_current;
+      odb::geom::BoostPolygon90Set combine_layer
+          = top_of_previous + bottom_of_current;
 
       if (prev_via->requiresPatch() || via->requiresPatch()) {
-        Rectangle patch_shape;
+        odb::geom::BoostRectangle patch_shape;
         combine_layer.extents(patch_shape);
         patch_shapes.clear();
         patch_shapes += patch_shape;
@@ -1012,19 +1011,19 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
         patch_shapes = combine_layer;
       }
 
-      std::vector<Polygon90> patches;
+      std::vector<odb::geom::BoostPolygon90WithHoles> patches;
       combine_layer.get_polygons(patches);
 
       // extract the rectangles that will patch the layer
       for (const auto& patch : patches) {
-        Rectangle patch_shape;
+        odb::geom::BoostRectangle patch_shape;
         extents(patch_shape, patch);
 
         patch_shapes += patch_shape;
       }
 
       // ensure patches are minimum area
-      std::vector<Rectangle> patch_rects;
+      std::vector<odb::geom::BoostRectangle> patch_rects;
       patch_shapes.get_rectangles(patch_rects);
       patch_shapes.clear();
       for (const auto& patch : patch_rects) {
@@ -1040,7 +1039,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
 
     if (!patch_shapes.empty()) {
       if (via->hasGenerator()) {
-        Rectangle complete_shape;
+        odb::geom::BoostRectangle complete_shape;
         extents(complete_shape, total_shape);
         const odb::Rect patch_shape_rect(xl(complete_shape),
                                          yl(complete_shape),
@@ -1078,7 +1077,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
         }
       }
 
-      std::vector<Rectangle> patches;
+      std::vector<odb::geom::BoostRectangle> patches;
       patch_shapes.get_rectangles(patches);
       for (const auto& patch : patches) {
         // add patch metal on layers between the bottom and top of the via stack

--- a/src/pdn/src/via.cpp
+++ b/src/pdn/src/via.cpp
@@ -982,7 +982,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
     if (prev_via != nullptr) {
       odb::geom::BoostPolygon90Set bottom_of_current;
       for (const auto& [shape, box] : shapes.bottom) {
-        bottom_of_current += odb::geom::toPolygon90(shape);
+        bottom_of_current.insert(odb::geom::toPolygon90(shape));
       }
 
       // create a single set of shapes for the layer
@@ -1001,7 +1001,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
 
       // extract the rectangles that will patch the layer
       for (const auto& patch : patches) {
-        patch_shapes += odb::geom::getEnclosingRect(patch);
+        patch_shapes.insert(odb::geom::getEnclosingRect(patch));
       }
 
       // ensure patches are minimum area
@@ -1009,8 +1009,8 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
           = odb::geom::extractRectangles(patch_shapes);
       patch_shapes.clear();
       for (const odb::Rect& patch_rect : patch_rects) {
-        patch_shapes += odb::geom::toPolygon90(
-            adjustToMinArea(add_to_layer, patch_rect));
+        patch_shapes.insert(
+            odb::geom::toPolygon90(adjustToMinArea(add_to_layer, patch_rect)));
       }
 
       // find shapes that touch "left-over" shapes from the xor
@@ -1071,7 +1071,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
     prev_via = via.get();
     top_of_previous.clear();
     for (const auto& [shape, box] : shapes.top) {
-      top_of_previous += odb::geom::toPolygon90(shape);
+      top_of_previous.insert(odb::geom::toPolygon90(shape));
     }
   }
 

--- a/src/pdn/src/via.cpp
+++ b/src/pdn/src/via.cpp
@@ -4,7 +4,6 @@
 #include "via.h"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -948,18 +947,6 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
   using boost::polygon::operators::operator+;
   using boost::polygon::operators::operator^;
 
-  auto rect_to_poly
-      = [](const odb::Rect& rect) -> odb::geom::BoostPolygon90WithHoles {
-    std::array<odb::Point, 4> pts = {odb::Point(rect.xMin(), rect.yMin()),
-                                     odb::Point(rect.xMax(), rect.yMin()),
-                                     odb::Point(rect.xMax(), rect.yMax()),
-                                     odb::Point(rect.xMin(), rect.yMax())};
-
-    odb::geom::BoostPolygon90WithHoles poly;
-    poly.set(pts.begin(), pts.end());
-    return poly;
-  };
-
   ViaLayerShape via_shapes;
 
   DbVia* prev_via = nullptr;
@@ -995,7 +982,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
     if (prev_via != nullptr) {
       odb::geom::BoostPolygon90Set bottom_of_current;
       for (const auto& [shape, box] : shapes.bottom) {
-        bottom_of_current += rect_to_poly(shape);
+        bottom_of_current += odb::geom::toPolygon90(shape);
       }
 
       // create a single set of shapes for the layer
@@ -1003,10 +990,8 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
           = top_of_previous + bottom_of_current;
 
       if (prev_via->requiresPatch() || via->requiresPatch()) {
-        odb::geom::BoostRectangle patch_shape;
-        combine_layer.extents(patch_shape);
         patch_shapes.clear();
-        patch_shapes += patch_shape;
+        patch_shapes += odb::geom::getEnclosingRect(combine_layer);
       } else {
         patch_shapes = combine_layer;
       }
@@ -1016,20 +1001,16 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
 
       // extract the rectangles that will patch the layer
       for (const auto& patch : patches) {
-        odb::geom::BoostRectangle patch_shape;
-        extents(patch_shape, patch);
-
-        patch_shapes += patch_shape;
+        patch_shapes += odb::geom::getEnclosingRect(patch);
       }
 
       // ensure patches are minimum area
-      std::vector<odb::geom::BoostRectangle> patch_rects;
-      patch_shapes.get_rectangles(patch_rects);
+      const std::vector<odb::Rect> patch_rects
+          = odb::geom::extractRectangles(patch_shapes);
       patch_shapes.clear();
-      for (const auto& patch : patch_rects) {
-        const odb::Rect patch_rect(xl(patch), yl(patch), xh(patch), yh(patch));
-        odb::Rect min_area_shape = adjustToMinArea(add_to_layer, patch_rect);
-        patch_shapes += rect_to_poly(min_area_shape);
+      for (const odb::Rect& patch_rect : patch_rects) {
+        patch_shapes += odb::geom::toPolygon90(
+            adjustToMinArea(add_to_layer, patch_rect));
       }
 
       // find shapes that touch "left-over" shapes from the xor
@@ -1039,12 +1020,8 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
 
     if (!patch_shapes.empty()) {
       if (via->hasGenerator()) {
-        odb::geom::BoostRectangle complete_shape;
-        extents(complete_shape, total_shape);
-        const odb::Rect patch_shape_rect(xl(complete_shape),
-                                         yl(complete_shape),
-                                         xh(complete_shape),
-                                         yh(complete_shape));
+        const odb::Rect patch_shape_rect
+            = odb::geom::getEnclosingRect(total_shape);
 
         auto* generator = via->getGenerator();
         if (!generator->recheckConstraints(patch_shape_rect, true)) {
@@ -1077,11 +1054,9 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
         }
       }
 
-      std::vector<odb::geom::BoostRectangle> patches;
-      patch_shapes.get_rectangles(patches);
-      for (const auto& patch : patches) {
+      for (const odb::Rect& patch_rect :
+           odb::geom::extractRectangles(patch_shapes)) {
         // add patch metal on layers between the bottom and top of the via stack
-        const odb::Rect patch_rect(xl(patch), yl(patch), xh(patch), yh(patch));
         auto* patch_box = odb::dbSBox::create(wire,
                                               add_to_layer,
                                               patch_rect.xMin(),
@@ -1096,7 +1071,7 @@ DbVia::ViaLayerShape DbGenerateStackedVia::generate(
     prev_via = via.get();
     top_of_previous.clear();
     for (const auto& [shape, box] : shapes.top) {
-      top_of_previous += rect_to_poly(shape);
+      top_of_previous += odb::geom::toPolygon90(shape);
     }
   }
 

--- a/src/pdn/src/via.h
+++ b/src/pdn/src/via.h
@@ -13,7 +13,6 @@
 #include <utility>
 #include <vector>
 
-#include "boost/geometry/geometries/point_xy.hpp"
 #include "boost/geometry/geometry.hpp"
 #include "boost/geometry/index/rtree.hpp"
 #include "odb/PtrSetMap.h"

--- a/src/pdn/src/via_repair.cpp
+++ b/src/pdn/src/via_repair.cpp
@@ -17,6 +17,7 @@
 #include "odb/dbShape.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "odb/geom_boost.h"
 #include "utl/Logger.h"
 #include "via.h"
 
@@ -53,27 +54,22 @@ void ViaRepair::repair()
   }
 
   // find via violations
-  using Rectangle = boost::polygon::rectangle_data<int>;
-  using Polygon90 = boost::polygon::polygon_90_with_holes_data<int>;
-  using Polygon90Set = boost::polygon::polygon_90_set_data<int>;
-  using Pt = Polygon90::point_type;
-
   odb::PtrMap<odb::dbTechLayer, odb::PtrSet<odb::dbSBox>> tech_vias_to_remove;
   odb::PtrMap<odb::dbTechLayer, odb::PtrSet<odb::dbSBox>> block_vias_to_remove;
   for (const auto& [layer, layer_obs] : combined_obs) {
-    Polygon90Set layer_obstructions;
+    odb::geom::BoostPolygon90Set layer_obstructions;
     for (const auto& obs : layer_obs) {
-      std::array<Pt, 4> pts = {Pt(obs.xMin(), obs.yMin()),
-                               Pt(obs.xMax(), obs.yMin()),
-                               Pt(obs.xMax(), obs.yMax()),
-                               Pt(obs.xMin(), obs.yMax())};
+      std::array<odb::Point, 4> pts = {odb::Point(obs.xMin(), obs.yMin()),
+                                       odb::Point(obs.xMax(), obs.yMin()),
+                                       odb::Point(obs.xMax(), obs.yMax()),
+                                       odb::Point(obs.xMin(), obs.yMax())};
 
-      Polygon90 poly;
+      odb::geom::BoostPolygon90WithHoles poly;
       poly.set(pts.begin(), pts.end());
       layer_obstructions.insert(poly);
     }
 
-    std::vector<Rectangle> layer_obstructions_rect;
+    std::vector<odb::geom::BoostRectangle> layer_obstructions_rect;
     layer_obstructions.get_rectangles(layer_obstructions_rect);
 
     const auto& layer_vias = vias[layer];

--- a/src/pdn/src/via_repair.cpp
+++ b/src/pdn/src/via_repair.cpp
@@ -3,14 +3,12 @@
 
 #include "via_repair.h"
 
-#include <array>
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
 
 #include "boost/geometry/geometry.hpp"
-#include "boost/polygon/polygon.hpp"
 #include "grid.h"
 #include "odb/PtrSetMap.h"
 #include "odb/db.h"
@@ -58,26 +56,16 @@ void ViaRepair::repair()
   odb::PtrMap<odb::dbTechLayer, odb::PtrSet<odb::dbSBox>> block_vias_to_remove;
   for (const auto& [layer, layer_obs] : combined_obs) {
     odb::geom::BoostPolygon90Set layer_obstructions;
-    for (const auto& obs : layer_obs) {
-      std::array<odb::Point, 4> pts = {odb::Point(obs.xMin(), obs.yMin()),
-                                       odb::Point(obs.xMax(), obs.yMin()),
-                                       odb::Point(obs.xMax(), obs.yMax()),
-                                       odb::Point(obs.xMin(), obs.yMax())};
-
-      odb::geom::BoostPolygon90WithHoles poly;
-      poly.set(pts.begin(), pts.end());
-      layer_obstructions.insert(poly);
+    for (const odb::Rect& obs : layer_obs) {
+      layer_obstructions.insert(odb::geom::toPolygon90(obs));
     }
-
-    std::vector<odb::geom::BoostRectangle> layer_obstructions_rect;
-    layer_obstructions.get_rectangles(layer_obstructions_rect);
 
     const auto& layer_vias = vias[layer];
     auto& tech_vias = tech_vias_to_remove[layer];
     auto& block_vias = block_vias_to_remove[layer];
 
-    for (const auto& obs : layer_obstructions_rect) {
-      const odb::Rect obs_rect(xl(obs), yl(obs), xh(obs), yh(obs));
+    for (const odb::Rect& obs_rect :
+         odb::geom::extractRectangles(layer_obstructions)) {
       for (auto itr = layer_vias.qbegin(bgi::intersects(obs_rect));
            itr != layer_vias.qend();
            itr++) {


### PR DESCRIPTION
## Summary
Cleanup pdn and pad code to avoid custom converters. Plus I found a speedup in the toPolygon code which provided a good speedup.

## Type of Change
- Refactoring

## Impact
No changes.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**
