### PR TITLE
gha: fix quarterly tag drift between upstream and mirrors

### DIFF
--- a/.github/workflows/github-actions-cron-sync-fork-from-upstream-PII.yaml
+++ b/.github/workflows/github-actions-cron-sync-fork-from-upstream-PII.yaml
@@ -43,4 +43,10 @@ jobs:
         # You can also manually trigger a workflow dispatch with the force
         # value equal to 'true'.
         force: ${{ github.event.inputs.force || (secrets.UPSTREAM_SYNC == 'always overwrite master branch') }}
+        # Quarterly release tags are only created upstream (see
+        # github-actions-quarterly-tag.yml); mirror the exact tag object
+        # here instead of letting this repo mint its own, which is what
+        # caused tag drift (same commit, two different annotated tag
+        # objects, breaking plain `git fetch` between the two remotes).
+        syncTags: true
         deployKey: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/github-actions-cron-sync-fork-from-upstream.yml
+++ b/.github/workflows/github-actions-cron-sync-fork-from-upstream.yml
@@ -43,4 +43,10 @@ jobs:
         # You can also manually trigger a workflow dispatch with the force
         # value equal to 'true'.
         force: ${{ github.event.inputs.force || (secrets.UPSTREAM_SYNC == 'always overwrite master branch') }}
+        # Quarterly release tags are only created upstream (see
+        # github-actions-quarterly-tag.yml); mirror the exact tag object
+        # here instead of letting this repo mint its own, which is what
+        # caused tag drift (same commit, two different annotated tag
+        # objects, breaking plain `git fetch` between the two remotes).
+        syncTags: true
         deployKey: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/github-actions-quarterly-tag.yml
+++ b/.github/workflows/github-actions-quarterly-tag.yml
@@ -14,6 +14,10 @@ jobs:
   create-tag:
     name: Create quarterly tag
     runs-on: ubuntu-latest
+    # Only create the tag on the canonical repo; mirrors pick it up via
+    # github-actions-cron-sync-fork-from-upstream*.yml instead of minting
+    # their own independent tag object for the same commit.
+    if: github.repository == 'The-OpenROAD-Project/OpenROAD'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Gate tag creation to the canonical repo only, and sync the exact tag object to each mirror (main and PII) via the fork-sync cron's new syncTags option, instead of letting each mirror mint its own tag object for the same commit and break plain git fetch.
\