### PR TITLE
rsz: Preserve port-backed ModNet names during buffer removal

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -8838,6 +8838,18 @@ class dbModNet : public dbObject
   bool isConnected(const dbModNet* other) const;
 
   ///
+  /// Returns true if this dbModNet is connected to an INPUT, INOUT, or
+  /// FEEDTHRU dbBTerm or dbModBTerm.
+  ///
+  bool isConnectedToInputPort() const;
+
+  ///
+  /// Returns true if this dbModNet is connected to an OUTPUT, INOUT, or
+  /// FEEDTHRU dbBTerm or dbModBTerm.
+  ///
+  bool isConnectedToOutputPort() const;
+
+  ///
   /// Returns the next dbModNets in the fanin of this dbModNet.
   /// Traverses up to parent inputs or down to child outputs.
   ///

--- a/src/odb/src/db/dbModNet.cpp
+++ b/src/odb/src/db/dbModNet.cpp
@@ -475,6 +475,40 @@ dbSet<dbITerm> dbModNet::getITerms() const
   return dbSet<dbITerm>(_mod_net, _block->module_modnet_iterm_itr_);
 }
 
+bool dbModNet::isConnectedToInputPort() const
+{
+  for (dbBTerm* bterm : getBTerms()) {
+    if (bterm->getIoType() != dbIoType::OUTPUT) {
+      return true;
+    }
+  }
+
+  for (dbModBTerm* mod_bterm : getModBTerms()) {
+    if (mod_bterm->getIoType() != dbIoType::OUTPUT) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool dbModNet::isConnectedToOutputPort() const
+{
+  for (dbBTerm* bterm : getBTerms()) {
+    if (bterm->getIoType() != dbIoType::INPUT) {
+      return true;
+    }
+  }
+
+  for (dbModBTerm* mod_bterm : getModBTerms()) {
+    if (mod_bterm->getIoType() != dbIoType::INPUT) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 unsigned dbModNet::connectionCount() const
 {
   return (getITerms().size() + getBTerms().size() + getModITerms().size()

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -272,6 +272,58 @@ void equivCellPinsForSwapReport(utl::Logger* logger,
   }
 }
 
+bool isInputOrInoutPort(const odb::dbIoType& io_type)
+{
+  return io_type != odb::dbIoType::OUTPUT;
+}
+
+bool isOutputOrInoutPort(const odb::dbIoType& io_type)
+{
+  return io_type != odb::dbIoType::INPUT;
+}
+
+bool modNetHasInputOrInoutPort(odb::dbModNet* modnet)
+{
+  if (modnet == nullptr) {
+    return false;
+  }
+
+  for (odb::dbBTerm* bterm : modnet->getBTerms()) {
+    if (isInputOrInoutPort(bterm->getIoType())) {
+      return true;
+    }
+  }
+
+  for (odb::dbModBTerm* mod_bterm : modnet->getModBTerms()) {
+    if (isInputOrInoutPort(mod_bterm->getIoType())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool modNetHasOutputOrInoutPort(odb::dbModNet* modnet)
+{
+  if (modnet == nullptr) {
+    return false;
+  }
+
+  for (odb::dbBTerm* bterm : modnet->getBTerms()) {
+    if (isOutputOrInoutPort(bterm->getIoType())) {
+      return true;
+    }
+  }
+
+  for (odb::dbModBTerm* mod_bterm : modnet->getModBTerms()) {
+    if (isOutputOrInoutPort(mod_bterm->getIoType())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 bool bufferRemovalCreatesFeedthrough(odb::dbModNet* input_modnet,
                                      odb::dbModNet* output_modnet)
 {
@@ -280,17 +332,8 @@ bool bufferRemovalCreatesFeedthrough(odb::dbModNet* input_modnet,
     return false;
   }
 
-  const bool input_modnet_has_input_port = std::ranges::any_of(
-      input_modnet->getModBTerms(), [](odb::dbModBTerm* mod_bterm) {
-        return mod_bterm->getIoType() == odb::dbIoType::INPUT;
-      });
-
-  const bool output_modnet_has_output_port = std::ranges::any_of(
-      output_modnet->getModBTerms(), [](odb::dbModBTerm* mod_bterm) {
-        return mod_bterm->getIoType() == odb::dbIoType::OUTPUT;
-      });
-
-  return input_modnet_has_input_port && output_modnet_has_output_port;
+  return modNetHasInputOrInoutPort(input_modnet)
+         && modNetHasOutputOrInoutPort(output_modnet);
 }
 
 float inputPinCapacitance(sta::Network* network,
@@ -2982,14 +3025,23 @@ bool Resizer::removeBuffer(sta::Instance* buffer)
   std::optional<std::string> new_net_name;
   std::optional<std::string> new_modnet_name;
   if (db_survivor->isDeeperThan(db_removed)) {
-    new_net_name = db_removed->getName();
-    // The rename exists to keep the ModNet name in sync with the flat net
-    // name.  Feedthrough is the exception: removed_modnet is the output
-    // ModNet, so syncing would name the ModNet after the output port and
-    // write_verilog would then drop the assign statement.  On a feedthrough
-    // the ModNet name must always stay the input port name.
-    if (removed_modnet != nullptr && !creates_feedthrough) {
-      new_modnet_name = removed_modnet->getName();
+    const bool preserve_port_name = modNetHasInputOrInoutPort(survivor_modnet);
+    if (!preserve_port_name) {
+      // Normally both names follow the shallower removed net.
+      new_net_name = db_removed->getName();
+      if (removed_modnet != nullptr) {
+        new_modnet_name = removed_modnet->getName();
+      }
+    } else {
+      // Keep input/inout port names so write_verilog retains required
+      // feedthrough assigns. Use the shallower flat name only if it remains
+      // represented after the ModNet merge.
+      const bool shallower_name_survives
+          = removed_modnet == nullptr
+            || removed_modnet->getHierarchicalName() != db_removed->getName();
+      if (shallower_name_survives) {
+        new_net_name = db_removed->getName();
+      }
     }
   }
 

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -272,58 +272,6 @@ void equivCellPinsForSwapReport(utl::Logger* logger,
   }
 }
 
-bool isInputOrInoutPort(const odb::dbIoType& io_type)
-{
-  return io_type != odb::dbIoType::OUTPUT;
-}
-
-bool isOutputOrInoutPort(const odb::dbIoType& io_type)
-{
-  return io_type != odb::dbIoType::INPUT;
-}
-
-bool modNetHasInputOrInoutPort(odb::dbModNet* modnet)
-{
-  if (modnet == nullptr) {
-    return false;
-  }
-
-  for (odb::dbBTerm* bterm : modnet->getBTerms()) {
-    if (isInputOrInoutPort(bterm->getIoType())) {
-      return true;
-    }
-  }
-
-  for (odb::dbModBTerm* mod_bterm : modnet->getModBTerms()) {
-    if (isInputOrInoutPort(mod_bterm->getIoType())) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-bool modNetHasOutputOrInoutPort(odb::dbModNet* modnet)
-{
-  if (modnet == nullptr) {
-    return false;
-  }
-
-  for (odb::dbBTerm* bterm : modnet->getBTerms()) {
-    if (isOutputOrInoutPort(bterm->getIoType())) {
-      return true;
-    }
-  }
-
-  for (odb::dbModBTerm* mod_bterm : modnet->getModBTerms()) {
-    if (isOutputOrInoutPort(mod_bterm->getIoType())) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 bool bufferRemovalCreatesFeedthrough(odb::dbModNet* input_modnet,
                                      odb::dbModNet* output_modnet)
 {
@@ -332,8 +280,8 @@ bool bufferRemovalCreatesFeedthrough(odb::dbModNet* input_modnet,
     return false;
   }
 
-  return modNetHasInputOrInoutPort(input_modnet)
-         && modNetHasOutputOrInoutPort(output_modnet);
+  return input_modnet->isConnectedToInputPort()
+         && output_modnet->isConnectedToOutputPort();
 }
 
 float inputPinCapacitance(sta::Network* network,
@@ -3025,7 +2973,9 @@ bool Resizer::removeBuffer(sta::Instance* buffer)
   std::optional<std::string> new_net_name;
   std::optional<std::string> new_modnet_name;
   if (db_survivor->isDeeperThan(db_removed)) {
-    const bool preserve_port_name = modNetHasInputOrInoutPort(survivor_modnet);
+    const bool preserve_port_name
+        = survivor_modnet != nullptr
+          && survivor_modnet->isConnectedToInputPort();
     if (!preserve_port_name) {
       // Normally both names follow the shallower removed net.
       new_net_name = db_removed->getName();

--- a/src/rsz/test/cpp/TestBufferRemoval3.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval3.cc
@@ -995,4 +995,83 @@ TEST_F(BufRemTest3, HierFeedthroughAcrossLevels)
   writeAndCompareVerilogOutputFile(test_name, test_name + "_post.v");
 }
 
+// Insert a buffer across sibling hierarchies so the insertion API creates the
+// sink input port and a deeper source-side flat net before buffer removal.
+TEST_F(BufRemTest3, HierInputPortNamePreservedAfterBufferRemoval)
+{
+  const std::string test_name = "TestBufferRemoval3_hier_input_port";
+  readVerilogAndSetup(test_name + ".v", /*init_default_sdc=*/false);
+
+  odb::dbITerm* driver = block_->findITerm("source/driver/u_drv/ZN");
+  odb::dbITerm* load0 = block_->findITerm("sink/load0/u_inv/A");
+  odb::dbITerm* load1 = block_->findITerm("sink/load1/u_inv/A");
+  ASSERT_NE(driver, nullptr);
+  ASSERT_NE(load0, nullptr);
+  ASSERT_NE(load1, nullptr);
+  EXPECT_EQ(driver->getNet()->getName(), "signal");
+  EXPECT_EQ(load0->getNet()->getName(), "seed");
+  EXPECT_EQ(load1->getNet()->getName(), "seed");
+
+  odb::dbMaster* buffer_master = db_->findMaster("BUF_X2");
+  ASSERT_NE(buffer_master, nullptr);
+  odb::PtrSet<odb::dbObject> loads;
+  loads.insert(load0);
+  loads.insert(load1);
+  odb::dbInst* buffer
+      = resizer_.insertBufferBeforeLoads(driver->getNet(),
+                                         loads,
+                                         buffer_master,
+                                         nullptr,
+                                         "u_buf",
+                                         "load_net",
+                                         odb::dbNameUniquifyType::IF_NEEDED,
+                                         /*loads_on_diff_nets=*/true);
+  ASSERT_NE(buffer, nullptr);
+  EXPECT_EQ(buffer, block_->findInst("sink/u_buf"));
+
+  odb::dbITerm* buffer_input = buffer->findITerm("A");
+  odb::dbITerm* buffer_output = buffer->findITerm("Z");
+  ASSERT_NE(buffer_input, nullptr);
+  ASSERT_NE(buffer_output, nullptr);
+  odb::dbNet* input_net = buffer_input->getNet();
+  odb::dbNet* output_net = buffer_output->getNet();
+  ASSERT_NE(input_net, nullptr);
+  ASSERT_NE(output_net, nullptr);
+  EXPECT_EQ(input_net->getName(), "source/driver/out");
+  EXPECT_EQ(output_net->getName(), "sink/load_net");
+  EXPECT_TRUE(input_net->isDeeperThan(output_net));
+
+  odb::dbModule* sink = block_->findModule("Sink");
+  ASSERT_NE(sink, nullptr);
+  odb::dbModBTerm* input_port = sink->findModBTerm("net");
+  ASSERT_NE(input_port, nullptr);
+  odb::dbModNet* input_modnet = input_port->getModNet();
+  odb::dbModNet* output_modnet = buffer_output->getModNet();
+  ASSERT_NE(input_modnet, nullptr);
+  ASSERT_NE(output_modnet, nullptr);
+  EXPECT_NE(input_modnet, output_modnet);
+  EXPECT_TRUE(output_modnet->getModBTerms().empty());
+  EXPECT_FALSE(output_modnet->getModITerms().empty());
+  EXPECT_EQ(input_modnet->getName(), "net");
+  EXPECT_EQ(output_modnet->getName(), "load_net");
+
+  sta::Instance* sta_buffer = db_network_->dbToSta(buffer);
+  ASSERT_NE(sta_buffer, nullptr);
+  sta::InstanceSeq buffers;
+  buffers.push_back(sta_buffer);
+  resizer_.removeBuffers(buffers);
+  EXPECT_EQ(block_->findInst("sink/u_buf"), nullptr);
+
+  sta_->updateTiming(true);
+  EXPECT_EQ(db_network_->checkAxioms() + sta_->checkSanity(), 0);
+  EXPECT_EQ(load0->getNet(), driver->getNet());
+  EXPECT_EQ(load1->getNet(), driver->getNet());
+
+  ASSERT_NE(input_port->getModNet(), nullptr);
+  EXPECT_EQ(std::string(input_port->getModNet()->getName()), "net")
+      << "the surviving input-port ModNet must retain the port name";
+
+  writeAndCompareVerilogOutputFile(test_name, test_name + "_post.v");
+}
+
 }  // namespace rsz

--- a/src/rsz/test/cpp/TestBufferRemoval3_hier_input_port.v
+++ b/src/rsz/test/cpp/TestBufferRemoval3_hier_input_port.v
@@ -1,0 +1,65 @@
+module top (a,
+    seed,
+    out0,
+    out1);
+ input a;
+ input seed;
+ output out0;
+ output out1;
+
+ wire signal;
+
+ Source source (.in(a),
+    .out(signal));
+ Sink sink (.out0(out0),
+    .seed(seed),
+    .out1(out1));
+endmodule
+module Driver (in,
+    out);
+ input in;
+ output out;
+
+
+ INV_X2 u_drv (.A(in),
+    .ZN(out));
+endmodule
+module Load0 (i,
+    out);
+ input i;
+ output out;
+
+
+ INV_X1 u_inv (.A(i),
+    .ZN(out));
+endmodule
+module Load1 (i,
+    out);
+ input i;
+ output out;
+
+
+ INV_X1 u_inv (.A(i),
+    .ZN(out));
+endmodule
+module Source (in,
+    out);
+ input in;
+ output out;
+
+
+ Driver driver (.in(in),
+    .out(out));
+endmodule
+module Sink (seed,
+    out0,
+    out1);
+ input seed;
+ output out0;
+ output out1;
+
+ Load0 load0 (.i(seed),
+    .out(out0));
+ Load1 load1 (.i(seed),
+    .out(out1));
+endmodule

--- a/src/rsz/test/cpp/TestBufferRemoval3_hier_input_port_post.v
+++ b/src/rsz/test/cpp/TestBufferRemoval3_hier_input_port_post.v
@@ -1,0 +1,69 @@
+module top (a,
+    out0,
+    out1,
+    seed);
+ input a;
+ output out0;
+ output out1;
+ input seed;
+
+ wire signal;
+
+ Sink sink (.net(signal),
+    .seed(seed),
+    .out0(out0),
+    .out1(out1));
+ Source source (.in(a),
+    .out(signal));
+endmodule
+module Driver (in,
+    out);
+ input in;
+ output out;
+
+
+ INV_X2 u_drv (.A(in),
+    .ZN(out));
+endmodule
+module Load0 (i,
+    out);
+ input i;
+ output out;
+
+
+ INV_X1 u_inv (.A(i),
+    .ZN(out));
+endmodule
+module Load1 (i,
+    out);
+ input i;
+ output out;
+
+
+ INV_X1 u_inv (.A(i),
+    .ZN(out));
+endmodule
+module Sink (net,
+    seed,
+    out0,
+    out1);
+ input net;
+ input seed;
+ output out0;
+ output out1;
+
+
+ Load0 load0 (.i(net),
+    .out(out0));
+ Load1 load1 (.i(net),
+    .out(out1));
+endmodule
+module Source (in,
+    out);
+ input in;
+ output out;
+
+
+ Driver driver (.in(in),
+    .out(out));
+endmodule


### PR DESCRIPTION
## Summary

- Preserve input/inout port-backed hierarchical ModNet names when removing timing-repair buffers.
- Prevent `write_verilog` from emitting kept-module boundary loads without a driver.

## Problem

- `BufRemTest3.HierInputPortNamePreservedAfterBufferRemoval` reproduces the failure through the same insert/remove ECO APIs used by timing repair. The snippets below show the relevant Verilog at each operation.

1. Initial netlist

   ```verilog
   module top (a, seed, out0, out1);
     input a;
     input seed;
     output out0;
     output out1;
     wire signal;
     Source source (.in(a), .out(signal));
     Sink sink (.seed(seed), .out0(out0), .out1(out1));
   endmodule

   module Sink (seed, out0, out1);
     input seed;
     Load0 load0 (.i(seed), .out(out0));
     Load1 load1 (.i(seed), .out(out1));
   endmodule
   ```

2. `u_buf` is inserted by Rebuffer.

   ```verilog
   module top (a, seed, out0, out1);
     input a;
     input seed;
     output out0;
     output out1;
     wire signal;
     Source source (.in(a), .out(signal));
     Sink sink (.net(signal), .seed(seed), .out0(out0), .out1(out1));
   endmodule

   module Sink (net, seed, out0, out1);
     input net;
     input seed;
     wire load_net;
     BUF_X2 u_buf (.A(net), .Z(load_net));     // INSERTED BUFFER
     Load0 load0 (.i(load_net), .out(out0));   // Net name changes: seed -> load_net
     Load1 load1 (.i(load_net), .out(out1));
   endmodule
   ```

   - This intermediate netlist is correct: input port `net` drives `u_buf`, and `load_net` is driven by the buffer output.

3. `u_buf` is removed by remove_buffer. In the output verilog, the undriven net `load_net` remains.

   ```verilog
   module Sink (net, seed, out0, out1);
     input net;
     input seed;
     wire load_net;
     Load0 load0 (.i(load_net), .out(out0));    // BUFFER u_buf is removed. But net name "load_net" remains  --> UNDRIVEN
     Load1 load1 (.i(load_net), .out(out1));
     // Missing: assign load_net = net;
   endmodule
   ```

- The net name should be `seed` instead of `load_net`.


## Cause

- In the regression, when `u_buf` is removed, one of two nets (input net `net` and output net `load_net`) should survive.
- `net` is selected as the surviving net, but its corresponding ModNet name is renamed to `load_net`, which is wrong.
- `removeBuffer()` selects `source/driver/out` and its input-port ModNet `net` as the survivors, while `sink/load_net` and its ModNet `load_net` are removed.
- Because the surviving flat net is deeper, the old depth-based naming logic copies the shallower removed names to both survivors: `sink/load_net` to the flat net and `load_net` to the ModNet.
- After the ModNets are merged, the `Sink.net` ModBTerm remains connected but its surviving ModNet is renamed from `net` to `load_net`.
- `write_verilog` then declares input `net`, connects the loads to `load_net`, and emits no input-to-net assign, producing the undriven loads.


## Solution

- Add `dbModNet::isConnectedToInputPort()` and `isConnectedToOutputPort()` to detect top-level BTerms and hierarchical ModBTerms, including inout/feedthrough directions.
- In `Resizer::removeBuffer()`, detect when the deeper surviving ModNet is connected to an input-capable port before applying the depth-based rename.
- Preserve that ModNet name instead of copying the removed output ModNet name. In the regression, the surviving ModNet therefore remains `net` and continues to represent `Sink.net` correctly.
- Copy the shallower flat-net name only when it remains represented after the ModNet merge. Since the removed ModNet owns `sink/load_net` in the regression, neither survivor adopts that name.


## Related

- Fixes https://github.com/The-OpenROAD-Project-private/ascenium/issues/54

