### PR TITLE
drt: mark vias landing on dbBTerms as pin-connected

### DIFF
--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -482,43 +482,51 @@ void FlexDR::init()
     logger_->info(DRT, 194, "Start detail routing.");
   }
   for (const auto& net : getDesign()->getTopBlock()->getNets()) {
-    if (net->hasInitialRouting()) {
-      for (const auto& via : net->getVias()) {
-        auto bottomBox = via->getLayer1BBox();
-        auto topBox = via->getLayer2BBox();
-        for (auto term : net->getInstTerms()) {
-          if (term->getBBox().intersects(bottomBox)) {
-            std::vector<frRect> shapes;
-            term->getShapes(shapes);
-            for (const auto& shape : shapes) {
-              if (shape.getLayerNum() != via->getViaDef()->getLayer1Num()) {
-                continue;
-              }
-              if (!shape.intersects(bottomBox)) {
-                continue;
-              }
-              via->setBottomConnected(true);
-              break;
+    if (!net->hasInitialRouting()) {
+      continue;
+    }
+    for (const auto& via : net->getVias()) {
+      const odb::Rect bottomBox = via->getLayer1BBox();
+      const odb::Rect topBox = via->getLayer2BBox();
+      // A via can land on an instance pin or on an IO pin.
+      auto mark_via_connected = [&via, &bottomBox, &topBox](auto* term) {
+        if (term->getBBox().intersects(bottomBox)) {
+          std::vector<frRect> shapes;
+          term->getShapes(shapes);
+          for (const auto& shape : shapes) {
+            if (shape.getLayerNum() != via->getViaDef()->getLayer1Num()) {
+              continue;
             }
-          }
-          if (via->isBottomConnected()) {
-            continue;
-          }
-          if (term->getBBox().intersects(topBox)) {
-            std::vector<frRect> shapes;
-            term->getShapes(shapes);
-            for (const auto& shape : shapes) {
-              if (shape.getLayerNum() != via->getViaDef()->getLayer2Num()) {
-                continue;
-              }
-              if (!shape.intersects(topBox)) {
-                continue;
-              }
-              via->setTopConnected(true);
-              break;
+            if (!shape.intersects(bottomBox)) {
+              continue;
             }
+            via->setBottomConnected(true);
+            break;
           }
         }
+        if (via->isBottomConnected()) {
+          return;
+        }
+        if (term->getBBox().intersects(topBox)) {
+          std::vector<frRect> shapes;
+          term->getShapes(shapes);
+          for (const auto& shape : shapes) {
+            if (shape.getLayerNum() != via->getViaDef()->getLayer2Num()) {
+              continue;
+            }
+            if (!shape.intersects(topBox)) {
+              continue;
+            }
+            via->setTopConnected(true);
+            break;
+          }
+        }
+      };
+      for (auto term : net->getInstTerms()) {
+        mark_via_connected(term);
+      }
+      for (auto term : net->getBTerms()) {
+        mark_via_connected(term);
       }
     }
   }


### PR DESCRIPTION
## Summary
`FlexDR::init()` seeds the pin-connected flags of vias in pre-existing routing,
but only iterated `getInstTerms()`, so a via landing on a `dbBTerm` was never
flagged. Search-repair matches a terminal through a via only when that flag is
set, so a two-terminal net whose IO pin is reached by a bare via resolved to a
single pin in the worker. `routeNet()` reports success without geometry for a
one-pin net, and the empty result overwrote the routing the caller had already
cleared, leaving the net unrouted with no warning.

Fixed by applying the same per-terminal logic to `getBTerms()`.

## Type of Change
- Bug fix

## Impact
`detailed_route` on an already-routed design (for example the reroute after
`repair_antennas`) no longer discards the routing of such nets.

This also removes the trigger for the segfault in issue #11153: the dropped net
was the only one reaching the antenna checker's guide-to-wire fallback.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/11153
