### PR TITLE
etc: pass CMAKE_PACKAGE_ROOT_ARGS to Yosys CMake configure

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -192,7 +192,10 @@ _install_yosys() {
                 if [[ ! -f "${cmake_bin}" ]]; then
                     cmake_bin="cmake"
                 fi
-                _execute "Configuring Yosys..." "${cmake_bin}" -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${yosys_prefix}" .
+                # CMAKE_PACKAGE_ROOT_ARGS already has bison/swig/boost paths
+                # here; pass them to Yosys too, or its CMake may pick a
+                # system copy instead.
+                _execute "Configuring Yosys..." "${cmake_bin}" -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${yosys_prefix}" ${CMAKE_PACKAGE_ROOT_ARGS} .
                 _execute "Building Yosys..." "${cmake_bin}" --build build -j "${NUM_THREADS}"
                 _execute "Installing Yosys..." "${cmake_bin}" --build build --target install
             fi


### PR DESCRIPTION
## Summary
- Yosys's CMake configure step did not get the dependency root paths (bison, swig, boost, and the rest) that `DependencyInstaller.sh` already found for other packages, so its CMake build could pick up mismatched system copies instead.
- Pass `${CMAKE_PACKAGE_ROOT_ARGS}` into that command, the same way every other dependency in this script already does.