### PR TITLE
grt/cugr: re-estimate slack per-net for rerouted nets

### DIFF
--- a/src/est/BUILD
+++ b/src/est/BUILD
@@ -44,6 +44,7 @@ cc_library(
     name = "parasitics_service",
     hdrs = ["include/est/ParasiticsService.h"],
     includes = ["include"],
+    deps = ["//src/grt:groute"],
 )
 
 cc_library(

--- a/src/est/include/est/EstimateParasitics.h
+++ b/src/est/include/est/EstimateParasitics.h
@@ -89,6 +89,8 @@ class EstimateParasitics : public sta::dbStaState, public ParasiticsService
   ~EstimateParasitics() override;
 
   void estimateAllGlobalRouteParasitics() override;
+  void updateGlobalRouteParasitics(odb::dbNet* net,
+                                   grt::GRoute& route) override;
   void initSteinerRenderer(
       std::unique_ptr<est::AbstractSteinerRenderer> steiner_renderer);
   void setLayerRC(odb::dbTechLayer* layer,

--- a/src/est/include/est/ParasiticsService.h
+++ b/src/est/include/est/ParasiticsService.h
@@ -23,9 +23,7 @@ class ParasiticsService
   // current global routing state (partial routes).
   virtual void estimateAllGlobalRouteParasitics() = 0;
 
-  // Re-estimate one net's parasitics from the given route, replacing its
-  // previous annotation, and invalidate the timer's cached delays around
-  // it. A no-op for an empty route.
+  // Re-estimate one net's parasitics from the given route; no-op if empty.
   virtual void updateGlobalRouteParasitics(odb::dbNet* net, grt::GRoute& route)
       = 0;
 };

--- a/src/est/include/est/ParasiticsService.h
+++ b/src/est/include/est/ParasiticsService.h
@@ -5,10 +5,6 @@
 
 #include "grt/GRoute.h"
 
-namespace odb {
-class dbNet;
-}
-
 namespace est {
 
 // Service interface published by the parasitics estimator. Consumers

--- a/src/est/include/est/ParasiticsService.h
+++ b/src/est/include/est/ParasiticsService.h
@@ -3,6 +3,12 @@
 
 #pragma once
 
+#include "grt/GRoute.h"
+
+namespace odb {
+class dbNet;
+}
+
 namespace est {
 
 // Service interface published by the parasitics estimator. Consumers
@@ -16,6 +22,12 @@ class ParasiticsService
   // Clear all existing parasitics and re-estimate them from the
   // current global routing state (partial routes).
   virtual void estimateAllGlobalRouteParasitics() = 0;
+
+  // Re-estimate one net's parasitics from the given route, replacing its
+  // previous annotation, and invalidate the timer's cached delays around
+  // it. A no-op for an empty route.
+  virtual void updateGlobalRouteParasitics(odb::dbNet* net, grt::GRoute& route)
+      = 0;
 };
 
 }  // namespace est

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -98,7 +98,7 @@ void EstimateParasitics::estimateAllGlobalRouteParasitics()
 void EstimateParasitics::updateGlobalRouteParasitics(odb::dbNet* db_net,
                                                      grt::GRoute& route)
 {
-  if (route.empty()) {
+  if (db_net == nullptr || route.empty()) {
     return;
   }
   estimateGlobalRouteParasitics(db_net, route);

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -103,9 +103,7 @@ void EstimateParasitics::updateGlobalRouteParasitics(odb::dbNet* db_net,
   }
   estimateGlobalRouteParasitics(db_net, route);
   // Annotating parasitics alone leaves stale cached delays in the timer.
-  if (const sta::Net* net = db_network_->dbToSta(db_net)) {
-    sta_->delaysInvalidFromFanin(net);
-  }
+  sta_->delaysInvalidFromFanin(db_network_->dbToSta(db_net));
 }
 
 void EstimateParasitics::initSteinerRenderer(
@@ -659,6 +657,9 @@ void EstimateParasitics::estimateGlobalRouteRC(odb::dbNet* db_net)
 void EstimateParasitics::estimateGlobalRouteParasitics(odb::dbNet* net,
                                                        grt::GRoute& route)
 {
+  if (route.empty()) {
+    return;
+  }
   initBlock();
   MakeWireParasitics builder(
       logger_, this, sta_, block_->getTech(), block_, global_router_);

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -95,6 +95,20 @@ void EstimateParasitics::estimateAllGlobalRouteParasitics()
   }
 }
 
+void EstimateParasitics::updateGlobalRouteParasitics(odb::dbNet* db_net,
+                                                     grt::GRoute& route)
+{
+  if (route.empty()) {
+    return;
+  }
+  estimateGlobalRouteParasitics(db_net, route);
+  // Annotating parasitics does not invalidate the timer's cached delays;
+  // without this, slack queries would keep returning pre-reroute values.
+  if (const sta::Net* net = db_network_->dbToSta(db_net)) {
+    sta_->delaysInvalidFromFanin(net);
+  }
+}
+
 void EstimateParasitics::initSteinerRenderer(
     std::unique_ptr<est::AbstractSteinerRenderer> steiner_renderer)
 {

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -102,8 +102,7 @@ void EstimateParasitics::updateGlobalRouteParasitics(odb::dbNet* db_net,
     return;
   }
   estimateGlobalRouteParasitics(db_net, route);
-  // Annotating parasitics does not invalidate the timer's cached delays;
-  // without this, slack queries would keep returning pre-reroute values.
+  // Annotating parasitics alone leaves stale cached delays in the timer.
   if (const sta::Net* net = db_network_->dbToSta(db_net)) {
     sta_->delaysInvalidFromFanin(net);
   }

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -173,14 +173,9 @@ class CUGR
   // Refresh net slacks, re-mark the res-aware/critical set, and demote
   // non-critical nets so the next stage routes critical nets first.
   void updateCriticalNets(const std::vector<int>& net_indices);
-  // Refresh net slacks for the next stage. The global parasitics re-estimate
-  // runs at most once per route(); later calls rely on the per-stage
-  // updateReroutedParasitics() below and only re-query slacks.
+  // Refresh every net's slack; re-extracts parasitics once per route().
   void updateNetSlacks(const std::vector<int>& net_indices);
-  // Re-estimate parasitics for nets whose route just changed, using the new
-  // route. Must be called *after* a stage's reroute loop: the critical-net
-  // update runs before it, so doing the estimate there would use the old
-  // route and permanently miss nets that leave the congested set.
+  // Re-estimate parasitics for nets a stage rerouted; call after its loop.
   void updateReroutedParasitics(const std::vector<int>& net_indices);
   // Refresh the slack of the given nets from STA, without re-extracting
   // parasitics (incremental scope).
@@ -331,8 +326,7 @@ class CUGR
 
   // Suppresses the global parasitics re-estimate during incremental routing.
   bool incremental_routing_ = false;
-  // Set once the per-route() full parasitics estimate has run; later calls
-  // rely on per-stage incremental updates instead.
+  // True once route() has done its one full parasitics estimate.
   bool full_slack_update_done_ = false;
   // Dirty-net set for the current incremental pass; scopes congestion checks.
   std::vector<int> incremental_candidates_;

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -178,12 +178,13 @@ class CUGR
   // non-critical nets so the next stage routes critical nets first.
   void updateCriticalNets(const std::vector<int>& net_indices);
   // Refresh every net's slack; runs the full parasitics estimate once per
-  // route(), then re-estimates only the marked rerouted nets.
+  // route(), then re-estimates only the collected rerouted nets.
   void updateNetSlacks(const std::vector<int>& net_indices);
-  // Record nets a stage rerouted so the next slack sweep re-estimates
+  // Collect nets a stage rerouted so the next slack sweep re-estimates
   // their parasitics; call after the stage's reroute loop.
-  void markReroutedNets(const std::vector<int>& net_indices);
-  // Re-estimate parasitics for the marked rerouted nets, then clear the set.
+  void collectReroutedNets(const std::vector<int>& net_indices);
+  // Re-estimate parasitics for the collected rerouted nets, then clear the
+  // set.
   void updateReroutedParasitics(est::ParasiticsService& estimator);
   // Refresh the slack of the given nets from STA, without re-extracting
   // parasitics (incremental scope).

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -173,11 +173,15 @@ class CUGR
   // Refresh net slacks, re-mark the res-aware/critical set, and demote
   // non-critical nets so the next stage routes critical nets first.
   void updateCriticalNets(const std::vector<int>& net_indices);
-  // Refresh net slacks for the next stage. The global parasitics
-  // re-estimate and full-design slack sweep run at most once per route();
-  // later calls re-estimate parasitics and refresh slacks only for the
-  // given (congested/rerouted) nets.
+  // Refresh net slacks for the next stage. The global parasitics re-estimate
+  // runs at most once per route(); later calls rely on the per-stage
+  // updateReroutedParasitics() below and only re-query slacks.
   void updateNetSlacks(const std::vector<int>& net_indices);
+  // Re-estimate parasitics for nets whose route just changed, using the new
+  // route. Must be called *after* a stage's reroute loop: the critical-net
+  // update runs before it, so doing the estimate there would use the old
+  // route and permanently miss nets that leave the congested set.
+  void updateReroutedParasitics(const std::vector<int>& net_indices);
   // Refresh the slack of the given nets from STA, without re-extracting
   // parasitics (incremental scope).
   void refreshNetSlacks(const std::vector<int>& net_indices);
@@ -327,8 +331,8 @@ class CUGR
 
   // Suppresses the global parasitics re-estimate during incremental routing.
   bool incremental_routing_ = false;
-  // Set once the per-route() full parasitics estimate + slack sweep has run;
-  // subsequent updateNetSlacks calls downgrade to a subset refresh.
+  // Set once the per-route() full parasitics estimate has run; later calls
+  // rely on per-stage incremental updates instead.
   bool full_slack_update_done_ = false;
   // Dirty-net set for the current incremental pass; scopes congestion checks.
   std::vector<int> incremental_candidates_;

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -173,7 +173,10 @@ class CUGR
   // Refresh net slacks, re-mark the res-aware/critical set, and demote
   // non-critical nets so the next stage routes critical nets first.
   void updateCriticalNets(const std::vector<int>& net_indices);
-  // Re-extract parasitics and refresh every net's slack from the routing.
+  // Refresh net slacks for the next stage. The global parasitics
+  // re-estimate and full-design slack sweep run at most once per route();
+  // later calls re-estimate parasitics and refresh slacks only for the
+  // given (congested/rerouted) nets.
   void updateNetSlacks(const std::vector<int>& net_indices);
   // Refresh the slack of the given nets from STA, without re-extracting
   // parasitics (incremental scope).
@@ -324,6 +327,9 @@ class CUGR
 
   // Suppresses the global parasitics re-estimate during incremental routing.
   bool incremental_routing_ = false;
+  // Set once the per-route() full parasitics estimate + slack sweep has run;
+  // subsequent updateNetSlacks calls downgrade to a subset refresh.
+  bool full_slack_update_done_ = false;
   // Dirty-net set for the current incremental pass; scopes congestion checks.
   std::vector<int> incremental_candidates_;
 

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -35,6 +35,10 @@ class Logger;
 class ServiceRegistry;
 }  // namespace utl
 
+namespace est {
+class ParasiticsService;
+}  // namespace est
+
 namespace grt {
 
 class Design;
@@ -173,10 +177,14 @@ class CUGR
   // Refresh net slacks, re-mark the res-aware/critical set, and demote
   // non-critical nets so the next stage routes critical nets first.
   void updateCriticalNets(const std::vector<int>& net_indices);
-  // Refresh every net's slack; re-extracts parasitics once per route().
+  // Refresh every net's slack; runs the full parasitics estimate once per
+  // route(), then re-estimates only the marked rerouted nets.
   void updateNetSlacks(const std::vector<int>& net_indices);
-  // Re-estimate parasitics for nets a stage rerouted; call after its loop.
-  void updateReroutedParasitics(const std::vector<int>& net_indices);
+  // Record nets a stage rerouted so the next slack sweep re-estimates
+  // their parasitics; call after the stage's reroute loop.
+  void markReroutedNets(const std::vector<int>& net_indices);
+  // Re-estimate parasitics for the marked rerouted nets, then clear the set.
+  void updateReroutedParasitics(est::ParasiticsService& estimator);
   // Refresh the slack of the given nets from STA, without re-extracting
   // parasitics (incremental scope).
   void refreshNetSlacks(const std::vector<int>& net_indices);
@@ -328,6 +336,8 @@ class CUGR
   bool incremental_routing_ = false;
   // True once route() has done its one full parasitics estimate.
   bool full_slack_update_done_ = false;
+  // Nets rerouted since the last slack sweep re-estimated their parasitics.
+  std::vector<int> parasitics_dirty_nets_;
   // Dirty-net set for the current incremental pass; scopes congestion checks.
   std::vector<int> incremental_candidates_;
 

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -178,7 +178,7 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
   }
 }
 
-void CUGR::markReroutedNets(const std::vector<int>& net_indices)
+void CUGR::collectReroutedNets(const std::vector<int>& net_indices)
 {
   // Incremental routing refreshes slacks without re-estimating parasitics.
   if (incremental_routing_) {
@@ -590,7 +590,7 @@ void CUGR::patternRouteResAware(std::vector<int>& net_indices)
     pattern_route.run();
     grid_graph_->addTreeUsage(net->getRoutingTree(), net->getNdrCosts());
   }
-  markReroutedNets(res_aware_nets);
+  collectReroutedNets(res_aware_nets);
 }
 
 void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
@@ -629,7 +629,7 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
     pattern_route.run();
     grid_graph_->addTreeUsage(net->getRoutingTree(), net->getNdrCosts());
   }
-  markReroutedNets(net_indices);
+  collectReroutedNets(net_indices);
 }
 
 void CUGR::mazeRoute(std::vector<int>& net_indices)
@@ -691,7 +691,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
     grid_graph_->updateWireCostView(wire_cost_view, net->getRoutingTree());
     grid.step();
   }
-  markReroutedNets(net_indices);
+  collectReroutedNets(net_indices);
 }
 
 void CUGR::route(bool incremental)

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -93,6 +93,8 @@ void CUGR::clear()
   nets_to_route_.clear();
   incremental_candidates_.clear();
   incremental_routing_ = false;
+  full_slack_update_done_ = false;
+  parasitics_dirty_nets_.clear();
 }
 
 void CUGR::init(const int min_routing_layer,

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -157,11 +157,15 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
     refreshNetSlacks(net_indices);
     return;
   }
-  if (!full_slack_update_done_) {
-    if (auto* estimator = service_registry_->find<est::ParasiticsService>()) {
+  if (auto* estimator = service_registry_->find<est::ParasiticsService>()) {
+    if (!full_slack_update_done_) {
       estimator->estimateAllGlobalRouteParasitics();
+      full_slack_update_done_ = true;
+      // The full estimate covers any nets marked before it ran.
+      parasitics_dirty_nets_.clear();
+    } else {
+      updateReroutedParasitics(*estimator);
     }
-    full_slack_update_done_ = true;
   }
   // Query every net: the critical threshold is a percentile over all nets.
   for (const auto& net : gr_nets_) {
@@ -172,23 +176,33 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
   }
 }
 
-void CUGR::updateReroutedParasitics(const std::vector<int>& net_indices)
+void CUGR::markReroutedNets(const std::vector<int>& net_indices)
 {
-  if (incremental_routing_ || !full_slack_update_done_) {
+  // Incremental routing refreshes slacks without re-estimating parasitics.
+  if (incremental_routing_) {
     return;
   }
-  auto* estimator = service_registry_->find<est::ParasiticsService>();
-  if (estimator == nullptr) {
-    return;
-  }
-  for (const int net_index : net_indices) {
-    GRNet* net = gr_nets_[net_index].get();
-    if (net == nullptr || net->getRoutingTree() == nullptr) {
+  parasitics_dirty_nets_.insert(
+      parasitics_dirty_nets_.end(), net_indices.begin(), net_indices.end());
+}
+
+void CUGR::updateReroutedParasitics(est::ParasiticsService& estimator)
+{
+  std::ranges::sort(parasitics_dirty_nets_);
+  const auto duplicates = std::ranges::unique(parasitics_dirty_nets_);
+  parasitics_dirty_nets_.erase(duplicates.begin(), duplicates.end());
+  // Hoisted so its capacity is reused across nets.
+  GRoute route;
+  for (const int net_index : parasitics_dirty_nets_) {
+    const GRNet* net = gr_nets_[net_index].get();
+    if (net == nullptr || net->getNumPins() < 2 || net->isLocal()) {
       continue;
     }
-    GRoute route = getNetRoute(net->getDbNet());
-    estimator->updateGlobalRouteParasitics(net->getDbNet(), route);
+    route.clear();
+    buildNetRoute(net, route);
+    estimator.updateGlobalRouteParasitics(net->getDbNet(), route);
   }
+  parasitics_dirty_nets_.clear();
 }
 
 float CUGR::criticalSlackThreshold() const
@@ -574,7 +588,7 @@ void CUGR::patternRouteResAware(std::vector<int>& net_indices)
     pattern_route.run();
     grid_graph_->addTreeUsage(net->getRoutingTree(), net->getNdrCosts());
   }
-  updateReroutedParasitics(res_aware_nets);
+  markReroutedNets(res_aware_nets);
 }
 
 void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
@@ -613,7 +627,7 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
     pattern_route.run();
     grid_graph_->addTreeUsage(net->getRoutingTree(), net->getNdrCosts());
   }
-  updateReroutedParasitics(net_indices);
+  markReroutedNets(net_indices);
 }
 
 void CUGR::mazeRoute(std::vector<int>& net_indices)
@@ -675,7 +689,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
     grid_graph_->updateWireCostView(wire_cost_view, net->getRoutingTree());
     grid.step();
   }
-  updateReroutedParasitics(net_indices);
+  markReroutedNets(net_indices);
 }
 
 void CUGR::route(bool incremental)
@@ -710,8 +724,10 @@ void CUGR::route(bool incremental)
     }
   }
 
-  // One full parasitics estimate + slack sweep per route().
+  // One full parasitics estimate per route(); stages then mark rerouted
+  // nets and the next slack sweep re-estimates only those.
   full_slack_update_done_ = false;
+  parasitics_dirty_nets_.clear();
 
   // Incremental re-optimizes every dirty net each stage: the congested-set
   // narrowing between the stages below is skipped, so net_indices stays the

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -157,6 +157,22 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
     refreshNetSlacks(net_indices);
     return;
   }
+  if (full_slack_update_done_) {
+    // Later stages: re-estimate parasitics only for the rerouted nets;
+    // untouched nets keep the RC from the initial full estimate.
+    if (auto* estimator = service_registry_->find<est::ParasiticsService>()) {
+      for (const int net_index : net_indices) {
+        GRNet* net = gr_nets_[net_index].get();
+        if (net == nullptr) {
+          continue;
+        }
+        GRoute route = getNetRoute(net->getDbNet());
+        estimator->updateGlobalRouteParasitics(net->getDbNet(), route);
+      }
+    }
+    refreshNetSlacks(net_indices);
+    return;
+  }
   if (auto* estimator = service_registry_->find<est::ParasiticsService>()) {
     estimator->estimateAllGlobalRouteParasitics();
   }
@@ -166,6 +182,7 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
     }
     net->setSlack(getNetSlack(net->getDbNet()));
   }
+  full_slack_update_done_ = true;
 }
 
 float CUGR::criticalSlackThreshold() const
@@ -683,6 +700,10 @@ void CUGR::route(bool incremental)
       net_indices.push_back(net->getIndex());
     }
   }
+
+  // Each route() call gets one full parasitics estimate + slack sweep; the
+  // stages after it refresh only the nets they touch.
+  full_slack_update_done_ = false;
 
   // Incremental re-optimizes every dirty net each stage: the congested-set
   // narrowing between the stages below is skipped, so net_indices stays the

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -157,32 +157,42 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
     refreshNetSlacks(net_indices);
     return;
   }
-  if (full_slack_update_done_) {
-    // Later stages: re-estimate parasitics only for the rerouted nets;
-    // untouched nets keep the RC from the initial full estimate.
+  if (!full_slack_update_done_) {
     if (auto* estimator = service_registry_->find<est::ParasiticsService>()) {
-      for (const int net_index : net_indices) {
-        GRNet* net = gr_nets_[net_index].get();
-        if (net == nullptr) {
-          continue;
-        }
-        GRoute route = getNetRoute(net->getDbNet());
-        estimator->updateGlobalRouteParasitics(net->getDbNet(), route);
-      }
+      estimator->estimateAllGlobalRouteParasitics();
     }
-    refreshNetSlacks(net_indices);
-    return;
+    full_slack_update_done_ = true;
   }
-  if (auto* estimator = service_registry_->find<est::ParasiticsService>()) {
-    estimator->estimateAllGlobalRouteParasitics();
-  }
+  // Query every net, not just the rerouted ones: rerouting a net moves slack
+  // on every path it shares, and criticalSlackThreshold() takes a percentile
+  // over all nets. Parasitics are already current -- each stage refreshes the
+  // nets it rerouted via updateReroutedParasitics() -- so this is one lazy STA
+  // propagation plus cached reads, not a re-extraction.
   for (const auto& net : gr_nets_) {
     if (net == nullptr) {
       continue;
     }
     net->setSlack(getNetSlack(net->getDbNet()));
   }
-  full_slack_update_done_ = true;
+}
+
+void CUGR::updateReroutedParasitics(const std::vector<int>& net_indices)
+{
+  if (incremental_routing_ || !full_slack_update_done_) {
+    return;
+  }
+  auto* estimator = service_registry_->find<est::ParasiticsService>();
+  if (estimator == nullptr) {
+    return;
+  }
+  for (const int net_index : net_indices) {
+    GRNet* net = gr_nets_[net_index].get();
+    if (net == nullptr || net->getRoutingTree() == nullptr) {
+      continue;
+    }
+    GRoute route = getNetRoute(net->getDbNet());
+    estimator->updateGlobalRouteParasitics(net->getDbNet(), route);
+  }
 }
 
 float CUGR::criticalSlackThreshold() const
@@ -568,6 +578,7 @@ void CUGR::patternRouteResAware(std::vector<int>& net_indices)
     pattern_route.run();
     grid_graph_->addTreeUsage(net->getRoutingTree(), net->getNdrCosts());
   }
+  updateReroutedParasitics(res_aware_nets);
 }
 
 void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
@@ -606,6 +617,7 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
     pattern_route.run();
     grid_graph_->addTreeUsage(net->getRoutingTree(), net->getNdrCosts());
   }
+  updateReroutedParasitics(net_indices);
 }
 
 void CUGR::mazeRoute(std::vector<int>& net_indices)
@@ -667,6 +679,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
     grid_graph_->updateWireCostView(wire_cost_view, net->getRoutingTree());
     grid.step();
   }
+  updateReroutedParasitics(net_indices);
 }
 
 void CUGR::route(bool incremental)

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -163,11 +163,7 @@ void CUGR::updateNetSlacks(const std::vector<int>& net_indices)
     }
     full_slack_update_done_ = true;
   }
-  // Query every net, not just the rerouted ones: rerouting a net moves slack
-  // on every path it shares, and criticalSlackThreshold() takes a percentile
-  // over all nets. Parasitics are already current -- each stage refreshes the
-  // nets it rerouted via updateReroutedParasitics() -- so this is one lazy STA
-  // propagation plus cached reads, not a re-extraction.
+  // Query every net: the critical threshold is a percentile over all nets.
   for (const auto& net : gr_nets_) {
     if (net == nullptr) {
       continue;
@@ -714,8 +710,7 @@ void CUGR::route(bool incremental)
     }
   }
 
-  // Each route() call gets one full parasitics estimate + slack sweep; the
-  // stages after it refresh only the nets they touch.
+  // One full parasitics estimate + slack sweep per route().
   full_slack_update_done_ = false;
 
   // Incremental re-optimizes every dirty net each stage: the congested-set


### PR DESCRIPTION
## Summary

CUGR previously ran a full parasitics re-estimate (`clearParasitics()` + estimate of every net in the design) on every slack sweep, once per routing stage and per RRR iteration. This PR reduces that to **one** full estimate per `route()` call; afterwards each stage marks the nets it actually rerouted in a dirty set, and the next slack sweep re-estimates only those nets through a new `ParasiticsService::updateGlobalRouteParasitics(dbNet*, GRoute&)` entry point (which also invalidates the affected fanin delays so the timer never serves stale values). The flush is pull-based — it runs right before slacks are queried — so rerouted nets that are never re-queried (e.g. after the final RRR iteration) cost nothing, and a net rerouted in consecutive stages is estimated once.

## Type of Change
- Refactoring

## Impact

Runtime only; no QoR change. Every slack query sees parasitics computed from the same routes as before, and CUGR routing results are identical (log-compare regressions pass unchanged). CI runtime comparison showed a median 0.47× global-route runtime, faster on all 26 comparable designs.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues

N/A
