### PR TITLE
gpl: report internal metrics for iterations and area

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -4450,11 +4450,13 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
     } else {
       log_->info(
           GPL, 1001, "Global placement finished at iteration {}", final_iter);
+      log_->metric("gpl__convergence__iteration", final_iter);
       if (npVars_->routability_driven_mode) {
         log_->info(GPL,
                    1017,
                    "Routability mode iteration count: {}",
                    routability_gpl_iter_count);
+        log_->metric("gpl__routability__iteration", routability_gpl_iter_count);
       }
     }
 
@@ -4465,6 +4467,7 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
                  1005,
                  "Routability final weighted congestion: {:.4f}",
                  rb->getRudyAverage());
+      log_->metric("gpl__routability__congestion", rb->getRudyAverage());
     }
 
     log_->info(GPL,

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -988,6 +988,7 @@ void NesterovPlace::reportResults(int nesterov_iter,
                1011,
                "Original area (um^2): {:.2f}",
                block->dbuAreaToMicrons(original_area));
+    log_->metric("gpl__area__original", block->dbuAreaToMicrons(original_area));
   }
 
   if (npVars_.routability_driven_mode) {
@@ -999,6 +1000,9 @@ void NesterovPlace::reportResults(int nesterov_iter,
                "Total routability artificial inflation: {:.2f} ({:+.2f}%)",
                block->dbuAreaToMicrons(routability_inflation_area),
                routability_diff);
+    log_->metric("gpl__area__routability_inflation",
+                 block->dbuAreaToMicrons(routability_inflation_area));
+    log_->metric("gpl__area__routability_inflation__percent", routability_diff);
   }
 
   if (npVars_.timingDrivenMode) {
@@ -1008,6 +1012,9 @@ void NesterovPlace::reportResults(int nesterov_iter,
                "Total timing-driven delta area: {:.2f} ({:+.2f}%)",
                block->dbuAreaToMicrons(td_accumulated_delta_area),
                td_diff);
+    log_->metric("gpl__area__timing_delta",
+                 block->dbuAreaToMicrons(td_accumulated_delta_area));
+    log_->metric("gpl__area__timing_delta__percent", td_diff);
   }
 
   int64_t new_area = 0;
@@ -1021,6 +1028,8 @@ void NesterovPlace::reportResults(int nesterov_iter,
              "Final placement area: {:.2f} ({:+.2f}%)",
              block->dbuAreaToMicrons(new_area),
              placement_diff);
+  log_->metric("gpl__area__final", block->dbuAreaToMicrons(new_area));
+  log_->metric("gpl__area__final__percent", placement_diff);
 }
 
 int NesterovPlace::doNesterovPlace(int start_iter)


### PR DESCRIPTION
## What

Adds `logger_->metric()` calls for the remaining log messages requested
in #11234, so these values land in the `-metrics` JSON output, not just
the log:

- `gpl__convergence__iteration` (GPL-1001)
- `gpl__routability__iteration` (GPL-1017)
- `gpl__routability__congestion` (GPL-1005)
- `gpl__area__original` (GPL-1011)
- `gpl__area__routability_inflation` / `__percent` (GPL-1012)
- `gpl__area__timing_delta` / `__percent` (GPL-1013)
- `gpl__area__final` / `__percent` (GPL-1014)

`GPL-1018` (Final HPWL) was already covered by #11201
(`route__wirelength__estimated`), so it's untouched here.

## Why these values and names

Each value is already computed as a local variable right at the
existing `log_->info(...)` call site (in `NesterovBase::checkConvergence`
and `NesterovPlace::reportResults`), so this just adds a `log_->metric(...)`
call immediately after each, matching the inline pattern used in
`Opendp.cpp` / `NegotiationLegalizerPass.cpp`, rather than introducing a
new wrapper method.

Naming follows the existing `<tool>__<category>__<detail>` convention
(e.g. `dpl__hpwl__delta`, `negotiation__converge__phase_1__iteration`).
For the two values reported with both an absolute number and a percent
delta (GPL-1012/1013/1014), I split them into a `_value` /
`_value__percent` pair, mirroring `dpl__hpwl__delta` /
`dpl__hpwl__delta__percent`. Open to renaming if a different convention
is preferred.

## Testing

These calls only write to the separate `-metrics <file>` JSON stream
(`Logger::log_metric`), not to the regular log/stdout that the existing
`src/gpl/test/*.ok` golden files diff against, so no existing regression
goldens change.

I verified the underlying mechanism directly: ran the project's existing
`src/utl/test/cpp/TestMetrics` unit test (passes), and compiled a small
standalone probe that calls `logger.metric(...)` with the same 10 keys
and value types (`int`/`float`/`double`) added here, confirming valid
JSON output with the expected keys and values.

I wasn't able to build the full `openroad` binary end-to-end on macOS to
run the `gpl` Tcl regression suite directly — hit a couple of unrelated,
pre-existing macOS/Homebrew toolchain issues along the way (CUDD not
packaged for the Darwin dependency-install path, a Boost.Stacktrace
`_GNU_SOURCE` gap, and an `fmt`/vendored-`slang` version mismatch in
`third-party/slang-elab`), none of which touch `gpl`. Per CONTRIBUTING.md,
Mac builds are best-effort/non-blocking, so deferring to CI here.

Fixes #11234