### PR TITLE
Fix: Web GUI wrong full view 

### DIFF
--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -3592,6 +3592,10 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             // solid object rather than an empty frame.  Painted over the
             // border, as Qt does.
             if (vis.placement_blockages) {
+              // Despite the name, getTransformedHalo() returns non-negative
+              // MARGINS -- setHalo()'s left/bottom/right/top, oriented -- and
+              // not a rect in world space, so they grow the bbox rather than
+              // replace it.  Same arithmetic as RenderThread::drawBlockages.
               const odb::Rect halo = inst->getTransformedHalo();
               hatch_box_in_tile(odb::Rect{xl - halo.xMin(),
                                           yl - halo.yMin(),

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -280,9 +280,7 @@ constexpr int kMinPinNameSizePixels = 20;
 constexpr int kPinLabelFontHeight = 14;  // pre-baked atlas size for pin labels
 constexpr int kItermLabelFontHeight = 10;  // atlas size for ITerm pin labels
 constexpr int kMinItermLabelBoxPx = 10;    // min pin-box pixel dim for labels
-constexpr int kMinInstNameFontPx = 10;     // minimum readable font size
-constexpr int kMaxInstNameFontPx = 40;     // cap font size for large macros
-constexpr int kMinInstNameBoxPx = 20;      // min instance pixel dim for names
+constexpr int kInstNameFontHeight = 12;    // atlas size for instance names
 // Minimum on-screen feature size (output CSS px) below which geometry is CULLED
 // at the search level instead of drawn.  A regular sub-pixel array (dense
 // bumps/vias) cannot be drawn both discretely (→ moiré) and band-limited (→ a
@@ -309,6 +307,10 @@ constexpr double kMinViewablePx = 5.0;
 // Die/core/region outline color: Qt pen Qt::gray width 0 (drawChip,
 // renderThread.cpp:1174).
 constexpr Color kOutlineGray{.r = 128, .g = 128, .b = 128, .a = 255};
+
+// Placement-blockage hatch, worn by dbBlockage shapes and by every instance's
+// own bbox+halo alike — Qt paints both in drawBlockages() with one brush.
+constexpr Color kBlockageHash{.r = 255, .g = 255, .b = 255, .a = 180};
 
 // DBU -> tile-pixel conversion shared by the drawing primitives, in double.
 // Unclamped: an oblique segment must be converted through these and clipped
@@ -1177,6 +1179,21 @@ static int patternAnchor(const double origin_dbu, const double scale)
   return latticeAnchor(origin_dbu, scale, kPatternLattice);
 }
 
+// The device-pixel ratio range the renderer works in.  Mirrors quantizeDpr()
+// in request_handler.cpp and tile-request.js, which already clamp whatever
+// arrives over the wire; this restates the guarantee where the value is USED,
+// so a caller reaching the generator by some other path cannot drive
+// super_per_css toward zero.  Several derived quantities have no meaning at
+// zero and some are outright unsafe: a zero font height, a zero hatch period,
+// and latticeAnchor()'s modulo by that period.
+static double effectiveDpr(const double dpr)
+{
+  if (!std::isfinite(dpr)) {
+    return 1.0;
+  }
+  return std::clamp(dpr, 1.0, 3.0);
+}
+
 // The frame of tile (x, y) on the grid that divides `bounds` into steps of
 // `tile_dbu_size`, drawn at `scale` pixels per DBU.  One definition shared by
 // the layer, overlay and heat-map tile paths: the browser stacks those three on
@@ -1396,15 +1413,15 @@ void TileGenerator::fillPolygon(std::vector<unsigned char>& image,
 
 odb::Rect TileGenerator::getBounds() const
 {
-  // Union of every reachable chiplet's bbox in world coordinates.
-  // Returned bbox drives both zoom-to-fit framing and `scale` in
-  // renderTileBuffer.  For single-chip designs we stick to the
-  // dbBlock BBox so existing per-instance pixel tests stay valid; for
-  // multi-die designs we merge each chiplet's die area as well, since
-  // (a) the chiplet outline overlay needs to land inside the viewport
-  // and (b) chiplets translated apart have no single "BBox" without
-  // the die-area inclusion.  Two bounds-semantics for two render
-  // modes is deliberate — see MultiDieBoundsIncludeChipletDieAreas.
+  // Union of every reachable chiplet's block bbox AND die area, in world
+  // coordinates.  Mirrors LayoutViewer::getBounds() in the Qt GUI.
+  //
+  // The die area must be in the union: dbBlock::getBBox() covers the placed
+  // SHAPES, not the die, so a design whose content sits in a corner of a much
+  // larger die (one macro in an empty floorplan) would frame on the content
+  // alone.  This rect is not just the zoom-to-fit box — it also georeferences
+  // the tile grid, whose indices are clamped to it, so anything outside is
+  // never rasterized at all and the die simply has no tiles (issue #11280).
   odb::dbChip* root = getChip();
   if (!root) {
     return {};
@@ -1413,13 +1430,6 @@ odb::Rect TileGenerator::getBounds() const
   bounds.mergeInit();
   bool any = false;
   const std::vector<ChipletNode>& nodes = chiplets();
-  // In single-chip designs the previous behavior used only the top
-  // block's bbox; expanding to the full die-area changes `scale` for
-  // every tile and breaks tests that depend on the marker/label
-  // pixel-size threshold.  Only multi-die designs (more than one
-  // chiplet) benefit from the die-area expansion needed by the
-  // chiplet outline overlay.
-  const bool is_multi_die = nodes.size() > 1;
   for (const ChipletNode& node : nodes) {
     if (!node.block) {
       continue;
@@ -1427,13 +1437,11 @@ odb::Rect TileGenerator::getBounds() const
     odb::Rect b = node.block->getBBox()->getBox();
     node.world_xfm.apply(b);
     bounds.merge(b);
-    if (is_multi_die) {
-      const odb::Rect die = node.block->getDieArea();
-      if (die.area() > 0) {
-        odb::Rect d = die;
-        node.world_xfm.apply(d);
-        bounds.merge(d);
-      }
+    const odb::Rect die = node.block->getDieArea();
+    if (die.area() > 0) {
+      odb::Rect d = die;
+      node.world_xfm.apply(d);
+      bounds.merge(d);
     }
     any = true;
   }
@@ -2238,7 +2246,7 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
   // square it will display this tile in, because an overlay drawn at a
   // different size than the layer tiles beneath it is both blurry and
   // misregistered against them.  0 falls back to the historical 256*dpr.
-  const double effective_dpr = dpr > 0.0 ? dpr : 1.0;
+  const double effective_dpr = effectiveDpr(dpr);
   const int dim
       = requested_tile_px > 0
             ? requested_tile_px
@@ -2429,6 +2437,37 @@ void TileGenerator::outlineRectInTile(std::vector<unsigned char>& image,
       }
     }
   }
+}
+
+/* static */
+void TileGenerator::drawOrientationTag(std::vector<unsigned char>& image,
+                                       odb::dbInst* inst,
+                                       const TileFrame& frame,
+                                       const int dim,
+                                       const int stroke)
+{
+  odb::Rect master_box;
+  inst->getMaster()->getPlacementBoundary(master_box);
+  const int tag_width = std::min(master_box.dx() / 4, master_box.dy() / 8);
+  if (tag_width <= 0) {
+    return;
+  }
+  // Built in master space and pushed through the instance transform: that is
+  // what moves the tag to the corner the orientation implies.
+  odb::Point p1{master_box.xMin() + tag_width, master_box.yMin()};
+  odb::Point p2{master_box.xMin(), master_box.yMin() + 2 * tag_width};
+  const odb::dbTransform xfm = inst->getTransform();
+  xfm.apply(p1);
+  xfm.apply(p2);
+  // Oblique segment, so it must go through the unclamped toPx*d (see drawLine).
+  drawLine(image,
+           toPxXd(p1.x(), frame),
+           toPxYd(p1.y(), frame, dim),
+           toPxXd(p2.x(), frame),
+           toPxYd(p2.y(), frame, dim),
+           kOutlineGray,
+           stroke,
+           dim);
 }
 
 // Special "_access_points" layer: dbAccessPoint markers (X).  Mirrors GUI
@@ -2807,6 +2846,11 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
     const int requested_tile_px) const
 {
   static_assert(sizeof(Color) == 4);
+  // Clamped BEFORE tile_px is derived from it: a dpr below the supported range
+  // rounds 256*dpr down to zero, and a zero-sided buffer then trips the clamps
+  // in the drawing primitives.  The other three tile entry points already
+  // derive their size from the clamped value.
+  const double effective_dpr = effectiveDpr(dpr);
   // Output tile size in physical pixels: exactly what the client will display
   // the tile in, so the image maps 1:1 onto the device grid (no browser
   // resampling → no re-aliased moiré).  The client sends the count rather than
@@ -2817,7 +2861,7 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
   const int tile_px
       = requested_tile_px > 0
             ? requested_tile_px
-            : static_cast<int>(std::lround(kTileSizeInPixel * dpr));
+            : static_cast<int>(std::lround(kTileSizeInPixel * effective_dpr));
   // Band-limit factor: the tile is rasterized at tile_px*kCoverageSupersample
   // and Lanczos-2 decimated back to tile_px, prefiltering the dense periodic
   // geometry (bump arrays) that otherwise aliases into a moiré beat.
@@ -2829,7 +2873,6 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
   // look identical across dpr after decimation.  Taken from dpr rather than
   // from tile_px/256: with a device-exact tile size those differ slightly, and
   // a CSS pixel is defined by the display, not by the tile's pixel count.
-  const double effective_dpr = dpr > 0.0 ? dpr : 1.0;
   const double super_per_css = kCoverageSupersample * effective_dpr;
   // The tile's CSS side length, which is 256 only while tile_px is 256*dpr.
   // Drives the sub-resolution cull below, whose threshold is authored in CSS
@@ -3109,6 +3152,54 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                              pat_oy,
                              super);
             };
+
+      // Diagonal white hash: the blockage look, shared by placement blockages,
+      // instance footprints and routing obstructions so one design cannot show
+      // three spacings of the same pattern.  Coarser and thinner than
+      // FillPattern::kDiagonal, whose lattice is sized for layer shapes.  The
+      // period is anchored in absolute pixel space so the hatch is seamless
+      // across tile boundaries.
+      const int hash_period = static_cast<int>(std::lround(20 * super_per_css));
+      const int hash_width = static_cast<int>(std::lround(2 * super_per_css));
+      const int hash_ox = latticeAnchor(dbu_x_min, scale, hash_period);
+      const int hash_oy = latticeAnchor(dbu_y_min, scale, hash_period);
+      // One CSS px in buffer pixels; invariant for the tile.
+      const int stroke = hairlineCss(frame);
+      // Walks only the lit pixels: from each row's starting phase, step to the
+      // first lit column and stride by the period.  Visiting every pixel and
+      // testing `(ix + iy) % period` instead costs a real idiv on 100% of the
+      // area to light 10% of it -- affordable when this only ran over the rare
+      // dbBlockage, not now that it runs over every instance footprint.
+      auto hatch_box_in_tile = [&](const odb::Rect& box) {
+        if (!box.overlaps(dbu_tile)) {
+          return;
+        }
+        const odb::Rect draw = toPixels(frame, box.intersect(dbu_tile));
+        const int x_lo = std::max(0, draw.xMin());
+        const int x_hi = std::min(super, draw.xMax());
+        const int y_lo = std::max(0, draw.yMin());
+        const int y_hi = std::min(super, draw.yMax());
+        for (int iy = y_lo; iy < y_hi; ++iy) {
+          const int draw_y = super - 1 - iy;
+          // Phase of x_lo on this row, in [0, hash_period).
+          int phase = (x_lo + hash_ox + iy + hash_oy) % hash_period;
+          if (phase < 0) {
+            phase += hash_period;
+          }
+          // Start of the band holding x_lo; if x_lo has already passed that
+          // band, start at the next one.  Bands run [start, start + width).
+          int start = x_lo - phase;
+          if (phase >= hash_width) {
+            start += hash_period;
+          }
+          for (; start < x_hi; start += hash_period) {
+            const int band_end = std::min(x_hi, start + hash_width);
+            for (int bx = std::max(start, x_lo); bx < band_end; ++bx) {
+              blendPixel(image_buffer, bx, draw_y, kBlockageHash, super);
+            }
+          }
+        }
+      };
 
       // Special "_modules" layer: draw filled module-colored rectangles
       const bool modules_layer
@@ -3496,101 +3587,116 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
               }
             }
 
+            // Instances wear the blockage hatch too, over their own footprint
+            // grown by the halo -- which is what makes a lone macro read as a
+            // solid object rather than an empty frame.  Painted over the
+            // border, as Qt does.
+            if (vis.placement_blockages) {
+              const odb::Rect halo = inst->getTransformedHalo();
+              hatch_box_in_tile(odb::Rect{xl - halo.xMin(),
+                                          yl - halo.yMin(),
+                                          xh + halo.xMax(),
+                                          yh + halo.yMax()});
+            }
+
+            // Qt gates the tag on the MASTER's height in DBU against
+            // nominalViewableResolution(), which size_limit_dbu already is.
+            if (master->getHeight() >= size_limit_dbu) {
+              drawOrientationTag(image_buffer, inst, frame, super, stroke);
+            }
+
             // Draw instance name label when zoomed in enough.
-            // Font scales to ~40% of the smaller box dimension, clamped
-            // to [kMinInstNameFontPx, kMaxInstNameFontPx].  Text is
+            // The font is a FIXED size, as in the Qt GUI, which renders every
+            // instance name in options_->instanceNameFont() and only decides
+            // whether the name fits (drawTextInBBox).  Scaling it with the box
+            // instead made a large macro's name fill the macro.  Text is
             // elided from the left ("...suffix") to fit 90% of the
             // available dimension, matching the Qt GUI's behavior.
             if (vis.inst_names) {
               const int box_px_w = (int) (pixel_xh - pixel_xl);
               const int box_px_h = (int) (pixel_yh - pixel_yl);
               const int box_px_min = std::min(box_px_w, box_px_h);
-              if (std::max(box_px_w, box_px_h)
-                  >= kMinInstNameBoxPx * super_per_css) {
-                const int font_px = std::clamp(
-                    static_cast<int>(box_px_min * 0.4),
-                    static_cast<int>(
-                        std::lround(kMinInstNameFontPx * super_per_css)),
-                    static_cast<int>(
-                        std::lround(kMaxInstNameFontPx * super_per_css)));
-                const auto inst_font = fontAtlasGetFont(font_px);
-                const int font_h = getTextHeight(inst_font);
+              const auto inst_font = fontAtlasGetFont(static_cast<int>(
+                  std::lround(kInstNameFontHeight * super_per_css)));
+              const int font_h = getTextHeight(inst_font);
 
-                // Skip if font would dominate the cell (> 50% of cross
-                // dimension), matching GUI's kNonCoreScaleLimit = 2.0.
-                if (2 * font_h <= box_px_min) {
-                  constexpr Color name_color{
-                      .r = 255, .g = 255, .b = 0, .a = 220};
-                  const std::string full_name = inst->getName();
-                  const int full_w = getTextWidth(full_name, inst_font);
+              // The only size gate, as in Qt's drawTextInBBox: skip when the
+              // font would dominate the cell (> 50% of the cross dimension),
+              // matching its kNonCoreScaleLimit = 2.0.  A separate minimum
+              // box test would be dead weight -- with a fixed font this one
+              // already implies box_px_min >= 2 * kInstNameFontHeight.
+              if (2 * font_h <= box_px_min) {
+                constexpr Color name_color{
+                    .r = 255, .g = 255, .b = 0, .a = 220};
+                const std::string full_name = inst->getName();
+                const int full_w = getTextWidth(full_name, inst_font);
 
-                  // Rotate if taller than wide and text overflows (85%).
-                  const bool rotate
-                      = (box_px_h > box_px_w) && (full_w > box_px_w * 85 / 100);
+                // Rotate if taller than wide and text overflows (85%).
+                const bool rotate
+                    = (box_px_h > box_px_w) && (full_w > box_px_w * 85 / 100);
 
-                  // Available width for text (90% of relevant dim).
-                  const int avail
-                      = rotate ? (box_px_h * 9 / 10) : (box_px_w * 9 / 10);
+                // Available width for text (90% of relevant dim).
+                const int avail
+                    = rotate ? (box_px_h * 9 / 10) : (box_px_w * 9 / 10);
 
-                  // Elide from the left if text is too wide.  Maintain a
-                  // running prefix width so each candidate "..." +
-                  // name.substr(skip) is evaluated in O(1) using
-                  //   textWidth(name.substr(skip))
-                  //     = full_w - prefix_w - kern(name[skip-1], name[skip])
-                  // giving O(N) total instead of O(N^2).
-                  std::string name = full_name;
-                  int text_w = full_w;
-                  if (text_w > avail && name.size() > 4) {
-                    const int dots_w = getTextWidth("...", inst_font);
-                    const size_t n = name.size();
-                    int prefix_w = 0;
-                    for (size_t skip = 1; skip < n - 1; ++skip) {
-                      prefix_w += inst_font.glyph(name[skip - 1]).advance;
-                      if (skip >= 2) {
-                        prefix_w
-                            += inst_font.kern(name[skip - 2], name[skip - 1]);
-                      }
-                      const int suffix_w
-                          = full_w - prefix_w
-                            - inst_font.kern(name[skip - 1], name[skip]);
-                      const int w
-                          = dots_w + inst_font.kern('.', name[skip]) + suffix_w;
-                      if (w <= avail) {
-                        name = "..." + name.substr(skip);
-                        text_w = w;
-                        break;
-                      }
+                // Elide from the left if text is too wide.  Maintain a
+                // running prefix width so each candidate "..." +
+                // name.substr(skip) is evaluated in O(1) using
+                //   textWidth(name.substr(skip))
+                //     = full_w - prefix_w - kern(name[skip-1], name[skip])
+                // giving O(N) total instead of O(N^2).
+                std::string name = full_name;
+                int text_w = full_w;
+                if (text_w > avail && name.size() > 4) {
+                  const int dots_w = getTextWidth("...", inst_font);
+                  const size_t n = name.size();
+                  int prefix_w = 0;
+                  for (size_t skip = 1; skip < n - 1; ++skip) {
+                    prefix_w += inst_font.glyph(name[skip - 1]).advance;
+                    if (skip >= 2) {
+                      prefix_w
+                          += inst_font.kern(name[skip - 2], name[skip - 1]);
+                    }
+                    const int suffix_w
+                        = full_w - prefix_w
+                          - inst_font.kern(name[skip - 1], name[skip]);
+                    const int w
+                        = dots_w + inst_font.kern('.', name[skip]) + suffix_w;
+                    if (w <= avail) {
+                      name = "..." + name.substr(skip);
+                      text_w = w;
+                      break;
                     }
                   }
+                }
 
-                  // Center of instance bbox in pixel coords.
-                  const int64_t cx = (pixel_xl + pixel_xh) / 2;
-                  const int64_t cy = super - 1 - (pixel_yl + pixel_yh) / 2;
+                // Center of instance bbox in pixel coords.
+                const int64_t cx = (pixel_xl + pixel_xh) / 2;
+                const int64_t cy = super - 1 - (pixel_yl + pixel_yh) / 2;
 
-                  if (rotate) {
-                    const int64_t px = cx - font_h / 2;
-                    const int64_t py = cy - text_w / 2;
-                    if (px > -font_h && px < super && py > -text_w
-                        && py < super) {
-                      drawTextRotated(image_buffer,
-                                      (int) px,
-                                      (int) py,
-                                      name,
-                                      inst_font,
-                                      name_color);
-                    }
-                  } else {
-                    const int64_t px = cx - text_w / 2;
-                    const int64_t py = cy - font_h / 2;
-                    if (px > -text_w && px < super && py > -font_h
-                        && py < super) {
-                      drawText(image_buffer,
-                               (int) px,
-                               (int) py,
-                               name,
-                               inst_font,
-                               name_color);
-                    }
+                if (rotate) {
+                  const int64_t px = cx - font_h / 2;
+                  const int64_t py = cy - text_w / 2;
+                  if (px > -font_h && px < super && py > -text_w
+                      && py < super) {
+                    drawTextRotated(image_buffer,
+                                    (int) px,
+                                    (int) py,
+                                    name,
+                                    inst_font,
+                                    name_color);
+                  }
+                } else {
+                  const int64_t px = cx - text_w / 2;
+                  const int64_t py = cy - font_h / 2;
+                  if (px > -text_w && px < super && py > -font_h
+                      && py < super) {
+                    drawText(image_buffer,
+                             (int) px,
+                             (int) py,
+                             name,
+                             inst_font,
+                             name_color);
                   }
                 }
               }
@@ -3995,16 +4101,9 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
           }
         }
 
-        // Draw placement blockages (dbBlockage) on the _instances layer.
-        // Diagonal white hash lines in pixel space, with period anchored in dbu
-        // coordinates so the pattern is seamless across tile boundaries.
+        // Draw placement blockages (dbBlockage) on the _instances layer; the
+        // instance footprints above wear the same hatch.
         if (instances_only && vis.placement_blockages) {
-          const Color hash_color{.r = 255, .g = 255, .b = 255, .a = 180};
-          // In output pixels; scaled to the supersampled raster grid.
-          const int kPixelPeriod
-              = static_cast<int>(std::lround(20 * super_per_css));
-          const int kLineWidth
-              = static_cast<int>(std::lround(2 * super_per_css));
           for (odb::dbBlockage* blk :
                search_->searchBlockages(block,
                                         dbu_tile.xMin(),
@@ -4012,33 +4111,12 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                                         dbu_tile.xMax(),
                                         dbu_tile.yMax(),
                                         shape_size_limit_dbu)) {
-            odb::Rect box = blk->getBBox()->getBox();
-            if (!box.overlaps(dbu_tile)) {
-              continue;
-            }
-            const odb::Rect overlap = box.intersect(dbu_tile);
-            const odb::Rect draw = toPixels(frame, overlap);
-            // Offset in absolute pixel coordinates for seamless tiling
-            const int ox = latticeAnchor(dbu_x_min, scale, kPixelPeriod);
-            const int oy = latticeAnchor(dbu_y_min, scale, kPixelPeriod);
-            for (int iy = draw.yMin(); iy < draw.yMax(); ++iy) {
-              for (int ix = draw.xMin(); ix < draw.xMax(); ++ix) {
-                if (((ix + ox) + (iy + oy)) % kPixelPeriod < kLineWidth) {
-                  blendPixel(image_buffer, ix, super - 1 - iy, hash_color);
-                }
-              }
-            }
+            hatch_box_in_tile(blk->getBBox()->getBox());
           }
         }
 
         // Draw routing obstructions (dbObstruction) on per-layer tiles.
-        // Same diagonal white hash lines.
         if (!instances_only && tech_layer && vis.routing_obstructions) {
-          const Color hash_color{.r = 255, .g = 255, .b = 255, .a = 180};
-          const int kPixelPeriod
-              = static_cast<int>(std::lround(20 * super_per_css));
-          const int kLineWidth
-              = static_cast<int>(std::lround(2 * super_per_css));
           for (odb::dbObstruction* obs :
                search_->searchObstructions(block,
                                            tech_layer,
@@ -4047,21 +4125,7 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                                            dbu_tile.xMax(),
                                            dbu_tile.yMax(),
                                            shape_size_limit_dbu)) {
-            odb::Rect box = obs->getBBox()->getBox();
-            if (!box.overlaps(dbu_tile)) {
-              continue;
-            }
-            const odb::Rect overlap = box.intersect(dbu_tile);
-            const odb::Rect draw = toPixels(frame, overlap);
-            const int ox = latticeAnchor(dbu_x_min, scale, kPixelPeriod);
-            const int oy = latticeAnchor(dbu_y_min, scale, kPixelPeriod);
-            for (int iy = draw.yMin(); iy < draw.yMax(); ++iy) {
-              for (int ix = draw.xMin(); ix < draw.xMax(); ++ix) {
-                if (((ix + ox) + (iy + oy)) % kPixelPeriod < kLineWidth) {
-                  blendPixel(image_buffer, ix, super - 1 - iy, hash_color);
-                }
-              }
-            }
+            hatch_box_in_tile(obs->getBBox()->getBox());
           }
         }
 
@@ -4092,19 +4156,13 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
           const Color row_color{
               .r = 60, .g = 180, .b = 60, .a = 180};  // green outlines
 
-          // Lambda to draw a rectangle outline.
-          auto draw_outline = [&](const odb::Rect& rect) {
-            const odb::Rect draw = toPixels(frame, rect);
-            for (int ix = draw.xMin(); ix <= draw.xMax(); ++ix) {
-              blendPixel(image_buffer, ix, super - 1 - draw.yMin(), row_color);
-              blendPixel(image_buffer, ix, super - 1 - draw.yMax(), row_color);
-            }
-            for (int iy = draw.yMin(); iy <= draw.yMax(); ++iy) {
-              blendPixel(image_buffer, draw.xMin(), super - 1 - iy, row_color);
-              blendPixel(image_buffer, draw.xMax(), super - 1 - iy, row_color);
-            }
-          };
-
+          // outlineRectInTile, not a local pixel loop: a row spans the core, so
+          // converting its rect whole and walking that span costs one iteration
+          // per pixel of the row's full width on EVERY tile it crosses -- tens
+          // of millions at deep zoom, nearly all of them rejected -- and feeds
+          // unclamped doubles to odb::Rect's int constructor on the way.  It
+          // also strokes hairlineCss rather than a single buffer pixel, which
+          // is what stops the row fading out under the supersampled decimation.
           for (const auto& [row_rect, row] :
                search_->searchRows(block,
                                    dbu_tile.xMin(),
@@ -4121,7 +4179,7 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             }
 
             // Always draw the row outline.
-            draw_outline(row_rect);
+            outlineRectInTile(image_buffer, row_rect, row_color, frame);
 
             // Draw individual sites when zoomed in enough (site >= 5px).
             // Matches GUI nominalViewableResolution threshold.
@@ -4143,17 +4201,50 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
 
               const int site_w_px = static_cast<int>(site_w * scale);
               if (site_w_px >= 5 * super_per_css) {
-                odb::Point pt = row->getOrigin();
+                const odb::Point origin = row->getOrigin();
                 const int spacing = row->getSpacing();
                 const int count = row->getSiteCount();
                 const bool horizontal
                     = (row->getDirection() == odb::dbRowDir::HORIZONTAL);
 
-                for (int i = 0; i < count; ++i) {
+                // Sites are evenly spaced along one axis, so seek to the first
+                // one the tile can see instead of walking all of them: a row
+                // holds thousands, and this runs once per tile, at a zoom where
+                // the tile spans a handful.  Qt walks the whole row, but does
+                // it once per repaint rather than once per tile.
+                const int64_t lo
+                    = horizontal
+                          ? (int64_t) dbu_tile.xMin() - origin.x() - site_w
+                          : (int64_t) dbu_tile.yMin() - origin.y() - site_h;
+                const int64_t hi = horizontal
+                                       ? (int64_t) dbu_tile.xMax() - origin.x()
+                                       : (int64_t) dbu_tile.yMax() - origin.y();
+                int64_t i_begin = 0;
+                int64_t i_end = count;
+                if (spacing > 0) {
+                  // Numerators are forced non-negative, so C++ truncation
+                  // toward zero coincides with floor.
+                  i_begin = std::min<int64_t>(
+                      std::max<int64_t>(lo, 0) / spacing, count);
+                  i_end
+                      = hi < 0 ? 0 : std::min<int64_t>(hi / spacing + 1, count);
+                } else {
+                  // Every site sits on the origin; one rect covers them all.
+                  i_end = std::min<int64_t>(1, count);
+                }
+
+                odb::Point pt = origin;
+                if (horizontal) {
+                  pt.addX(static_cast<int>(i_begin * spacing));
+                } else {
+                  pt.addY(static_cast<int>(i_begin * spacing));
+                }
+                for (int64_t i = i_begin; i < i_end; ++i) {
                   const odb::Rect site_rect(
                       pt.x(), pt.y(), pt.x() + site_w, pt.y() + site_h);
                   if (site_rect.overlaps(dbu_tile)) {
-                    draw_outline(site_rect);
+                    outlineRectInTile(
+                        image_buffer, site_rect, row_color, frame);
                   }
                   if (horizontal) {
                     pt.addX(spacing);
@@ -4515,7 +4606,7 @@ std::vector<unsigned char> TileGenerator::generateHeatMapTile(
   // device-pixel square, so the heat map is as crisp as the layers under it
   // instead of being a 256 px image stretched over them.  0 falls back to the
   // historical 256*dpr.
-  const double effective_dpr = dpr > 0.0 ? dpr : 1.0;
+  const double effective_dpr = effectiveDpr(dpr);
   const int dim
       = requested_tile_px > 0
             ? requested_tile_px
@@ -5769,8 +5860,12 @@ void TileGenerator::drawLine(std::vector<unsigned char>& image,
                              const double fx1,
                              const double fy1,
                              const Color& c,
-                             const int width)
+                             const int width,
+                             int dim)
 {
+  if (dim < 0) {
+    dim = bufferDim(image);
+  }
   const int r = (width - 1) / 2;
   int x0 = 0;
   int y0 = 0;
@@ -5791,7 +5886,7 @@ void TileGenerator::drawLine(std::vector<unsigned char>& image,
   // the tile the endpoints started.
   {
     const double lo = -r - 1.0;
-    const double hi = bufferDim(image) + r;
+    const double hi = dim + r;
     const double dxf = fx1 - fx0;
     const double dyf = fy1 - fy0;
     double t0 = 0.0;
@@ -5834,11 +5929,11 @@ void TileGenerator::drawLine(std::vector<unsigned char>& image,
 
   while (true) {
     if (r <= 0) {
-      blendPixel(image, x0, y0, c);
+      blendPixel(image, x0, y0, c, dim);
     } else {
       for (int dy2 = -r; dy2 <= r; dy2++) {
         for (int dx2 = -r; dx2 <= r; dx2++) {
-          blendPixel(image, x0 + dx2, y0 + dy2, c);
+          blendPixel(image, x0 + dx2, y0 + dy2, c, dim);
         }
       }
     }
@@ -6026,7 +6121,7 @@ std::vector<unsigned char> TileGenerator::renderLabelTile(
   // Same contract as generateOverlayTile: the caller states the device-pixel
   // square it will composite this tile into, so the glyphs land at the same
   // size and registration as the tiles beneath.
-  const double effective_dpr = dpr > 0.0 ? dpr : 1.0;
+  const double effective_dpr = effectiveDpr(dpr);
   const int dim
       = requested_tile_px > 0
             ? requested_tile_px

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -850,13 +850,16 @@ class TileGenerator
   // as given and only its (in-bounds) result is rounded.  Converting an oblique
   // DBU segment through the clamped toPxX/toPxY instead would saturate each
   // axis on its own and rotate the segment — use toPxXd/toPxYd here.
+  // `dim` is the side of the buffer, as in setPixel/drawFilledRect; pass it on
+  // the hot paths so the clip bound and every step skip bufferDim()'s sqrt.
   static void drawLine(std::vector<unsigned char>& image,
                        double x0,
                        double y0,
                        double x1,
                        double y1,
                        const Color& c,
-                       int width = 3);
+                       int width = 3,
+                       int dim = -1);
 
   void computePinLabelMargin();
 
@@ -1003,6 +1006,14 @@ class TileGenerator
                          const odb::Rect& r,
                          const Color& c,
                          const TileFrame& frame) const;
+  // Diagonal across the master's origin corner, so a flipped or rotated
+  // instance reads as such.  Mirrors RenderThread::drawInstanceOutlines();
+  // callers gate on the master height, as Qt does.
+  static void drawOrientationTag(std::vector<unsigned char>& image,
+                                 odb::dbInst* inst,
+                                 const TileFrame& frame,
+                                 int dim,
+                                 int stroke);
   mutable std::mutex heatmap_mutex_;
   mutable std::map<std::string, std::shared_ptr<gui::HeatMapDataSource>>
       heatmaps_;

--- a/src/web/test/cpp/TestSaveImage.cpp
+++ b/src/web/test/cpp/TestSaveImage.cpp
@@ -111,6 +111,27 @@ class SaveImageTest : public tst::Nangate45Fixture
     return false;
   }
 
+  // True if any visible pixel isn't part of the always-on die/core outline,
+  // which getBounds() now guarantees is in every saved image.  Matches
+  // TileGeneratorTest::hasNonOutlinePixel: the outline is neutral gray
+  // (kOutlineGray) and alpha is NOT checked, because tiles are rasterized
+  // supersampled and decimated, so its edge pixels come back at partial
+  // coverage while the RGB stays 128,128,128.  Testing by colour rather than
+  // by carving out a border keeps the die edge itself in scope — that is
+  // where pin markers are drawn.
+  static bool hasNonOutlinePixel(const std::vector<unsigned char>& rgba)
+  {
+    for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+      if (rgba[i + 3] == 0) {
+        continue;
+      }
+      if (rgba[i] != 128 || rgba[i + 1] != 128 || rgba[i + 2] != 128) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   static size_t countNonTransparentPixels(
       const std::vector<unsigned char>& rgba)
   {
@@ -190,12 +211,13 @@ TEST_F(SaveImageTest, VisibilityStdcellsOff)
   const std::string path = tempPng("vis_off");
   TileVisibility vis;
   vis.stdcells = false;
-  // With stdcells hidden and no routing, the _instances layer should be empty.
+  // With stdcells hidden and no routing, the _instances layer holds nothing
+  // but the die outline, which Qt draws regardless of instance visibility.
   tile_gen_->saveImage(path, odb::Rect(0, 0, 0, 0), 256, 0, vis);
 
   unsigned w = 0, h = 0;
   auto pixels = decodePngFile(path, w, h);
-  EXPECT_FALSE(hasNonTransparentPixel(pixels));
+  EXPECT_FALSE(hasNonOutlinePixel(pixels));
 }
 
 TEST_F(SaveImageTest, VisibilityPinsOff_Markers)
@@ -278,8 +300,11 @@ TEST_F(SaveImageTest, EmptyDesign)
   unsigned w = 0, h = 0;
   auto pixels = decodePngFile(path, w, h);
   EXPECT_EQ(w, 256u);
-  // Empty design should produce a transparent image.
-  EXPECT_FALSE(hasNonTransparentPixel(pixels));
+  // A design with no shapes still has a floorplan: the die outline is drawn
+  // and nothing else.
+  EXPECT_FALSE(hasNonOutlinePixel(pixels));
+  EXPECT_TRUE(hasNonTransparentPixel(pixels))
+      << "the die outline should still be drawn";
 }
 
 TEST_F(SaveImageTest, LargeWidthClamped)

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -361,6 +361,12 @@ class TileGeneratorTest : public tst::Nangate45Fixture
         getDb(), /*sta=*/nullptr, getLogger());
   }
 
+  // Shrink the die onto the placed content.  getBounds() covers the die area
+  // too, so a test whose shapes sit in one corner of the fixture's 50 um die
+  // would otherwise frame the whole die and render those shapes sub-pixel.
+  // Call after placing content and before makeTileGen().
+  void fitDieToContent() { block_->setDieArea(block_->getBBox()->getBox()); }
+
   // Decode a PNG byte vector into raw RGBA pixels.
   std::vector<unsigned char> decodePng(
       const std::vector<unsigned char>& png_data,
@@ -414,6 +420,43 @@ class TileGeneratorTest : public tst::Nangate45Fixture
       }
     }
     return false;
+  }
+
+  // True if any pixel carries the green of a row/site outline (row_color in
+  // renderTileBuffer).  Distinguishes them from the neutral gray die/core
+  // outline, which a plain "is anything drawn" check cannot: the outline is
+  // always painted on the _instances pass, so it satisfies that check on its
+  // own.  Tested by dominance rather than equality because decimation blends
+  // the green with whatever it crosses.
+  static bool hasRowColorPixel(const std::vector<unsigned char>& rgba)
+  {
+    for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+      if (rgba[i + 3] == 0) {
+        continue;
+      }
+      if (rgba[i + 1] > rgba[i] + 10 && rgba[i + 1] > rgba[i + 2] + 10) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // DBU -> tile pixel, for the tile the generator produced at some zoom.  The
+  // scale (bounds.maxDXDY() spread over the tile's width) and the Y flip are
+  // the tile georeference; keeping one copy means a change to it breaks the
+  // tests loudly instead of leaving them measuring the wrong pixel.
+  // Unclamped: callers that inset or window around the result need to see
+  // out-of-range values before they clamp.
+  static int colOf(const odb::Rect& bounds, unsigned w, int dbu)
+  {
+    const double dbu_per_px = static_cast<double>(bounds.maxDXDY()) / w;
+    return static_cast<int>((dbu - bounds.xMin()) / dbu_per_px);
+  }
+
+  static int rowOf(const odb::Rect& bounds, unsigned w, unsigned h, int dbu)
+  {
+    const double dbu_per_px = static_cast<double>(bounds.maxDXDY()) / w;
+    return static_cast<int>((h - 1) - (dbu - bounds.yMin()) / dbu_per_px);
   }
 
   odb::dbInst* placeInst(const char* master_name,
@@ -588,6 +631,214 @@ TEST_F(TileGeneratorTest, BoundsIncludeLabelMargin)
   const int pin_max = tile_gen_->getPinMaxSize();
   const int margin = bounds.xMax() - die.xMax();
   EXPECT_GT(margin, pin_max);
+}
+
+// The request path quantizes dpr into [1, 3] before it ever reaches the
+// generator, but generateTile() takes it as a plain argument, and several
+// derived quantities are unsafe at zero -- a zero font height, a zero hatch
+// period, and latticeAnchor()'s modulo by that period.  So the generator
+// clamps too, and a caller that skips the request path still gets a tile
+// rendered at the nearest supported ratio instead of a crash.
+TEST_F(TileGeneratorTest, OutOfRangeDprIsClampedNotHonored)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  const auto tile_at = [&](double dpr) {
+    return tile_gen_->generateTile("_instances",
+                                   0,
+                                   0,
+                                   0,
+                                   vis,
+                                   {},
+                                   {},
+                                   {},
+                                   {},
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   dpr);
+  };
+
+  unsigned w = 0, h = 0;
+  auto baseline = decodePng(tile_at(1.0), w, h);
+  ASSERT_GT(w, 0u);
+  const unsigned baseline_px = w;
+
+  // Below the range, and degenerate values, all render as dpr 1.
+  for (const double dpr : {0.001, 0.5, 0.0, -1.0}) {
+    SCOPED_TRACE(dpr);
+    unsigned dw = 0, dh = 0;
+    auto pixels = decodePng(tile_at(dpr), dw, dh);
+    EXPECT_EQ(dw, baseline_px);
+    EXPECT_EQ(pixels, baseline);
+  }
+
+  // Above the range it saturates rather than scaling without bound.
+  unsigned hw = 0, hh = 0;
+  decodePng(tile_at(1000.0), hw, hh);
+  EXPECT_EQ(hw, baseline_px * 3);
+}
+
+// Issue #11280: a floorplan holding one macro in a corner of a much larger die
+// framed on the macro, because dbBlock::getBBox() covers the placed SHAPES and
+// not the die.  Qt's LayoutViewer::getBounds() merges the die area; so must
+// this one.
+TEST_F(TileGeneratorTest, BoundsCoverDieAreaWhenContentIsSmaller)
+{
+  placeInst("BUF_X16", "lone", 90000, 90000);
+  makeTileGen();
+
+  const odb::Rect die = block_->getDieArea();
+  const odb::Rect bbox = block_->getBBox()->getBox();
+  ASSERT_LT(bbox.dx(), die.dx()) << "precondition: content smaller than die";
+
+  const odb::Rect bounds = tile_gen_->getBounds();
+  EXPECT_LE(bounds.xMin(), die.xMin());
+  EXPECT_LE(bounds.yMin(), die.yMin());
+  EXPECT_GE(bounds.xMax(), die.xMax());
+  EXPECT_GE(bounds.yMax(), die.yMax());
+}
+
+// The consequence of the bug above, and the one the reporter saw: the tile
+// grid is georeferenced on getBounds() and its indices are clamped to it, so
+// die area outside those bounds had no tiles at all and simply went missing.
+TEST_F(TileGeneratorTest, DieOutlineFarFromContentIsRasterized)
+{
+  // One instance in the upper-right corner; the die's lower-left corner is as
+  // far from it as this fixture allows.
+  placeInst("BUF_X16", "lone", 90000, 90000);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  auto png = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  // Both dimensions: they bound the std::clamp ranges below, which need
+  // lo <= hi.
+  ASSERT_GT(w, 0u);
+  ASSERT_GT(h, 0u);
+
+  // Sample where the die's lower-left corner lands at z=0.
+  const odb::Rect bounds = tile_gen_->getBounds();
+  const odb::Rect die = block_->getDieArea();
+  const auto col_of = [&](int dbu) {
+    return static_cast<unsigned>(
+        std::clamp(colOf(bounds, w, dbu), 0, static_cast<int>(w) - 1));
+  };
+  const auto row_of = [&](int dbu) {
+    return static_cast<unsigned>(
+        std::clamp(rowOf(bounds, w, h, dbu), 0, static_cast<int>(h) - 1));
+  };
+
+  // The outline is a hairline that antialiasing spreads a pixel or two, so
+  // accept a hit anywhere in a small window around the corner.
+  const auto drawn_near = [&](unsigned cx, unsigned cy) {
+    for (unsigned y = (cy > 2 ? cy - 2 : 0); y <= std::min(cy + 2, h - 1);
+         ++y) {
+      for (unsigned x = (cx > 2 ? cx - 2 : 0); x <= std::min(cx + 2, w - 1);
+           ++x) {
+        if (pixels[4UL * (y * w + x) + 3] > 0) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  EXPECT_TRUE(drawn_near(col_of(die.xMin()), row_of(die.yMin() + die.dy() / 2)))
+      << "the die's left edge must be rasterized, not clipped away";
+  EXPECT_TRUE(drawn_near(col_of(die.xMin() + die.dx() / 2), row_of(die.yMin())))
+      << "the die's bottom edge must be rasterized, not clipped away";
+}
+
+// Qt draws a diagonal across the master's origin corner
+// (drawInstanceOutlines), which is what tells a flipped instance from an
+// unflipped one.  The tag rides the instance transform, so R0 puts it at the
+// bottom-left of the footprint and MX at the top-left.
+//
+// Renders the instance alone: the hatch and the name would both put ink in the
+// interior, and the tag is the only thing left that can.
+TEST_F(TileGeneratorTest, OrientationTagMarksTheMasterOrigin)
+{
+  odb::dbInst* inst = placeInst("BUF_X16", "buf1", 0, 0);
+
+  TileVisibility vis;
+  vis.placement_blockages = false;
+  vis.inst_names = false;
+
+  // Counts interior ink per half of the footprint, ignoring a 3 px frame so
+  // the instance outline itself is never sampled.
+  const std::pair<odb::dbOrientType, bool> cases[]
+      = {{odb::dbOrientType::R0, true}, {odb::dbOrientType::MX, false}};
+  for (const auto& [orient, expect_bottom] : cases) {
+    SCOPED_TRACE(odb::dbOrientType(orient).getString());
+    inst->setOrient(orient);
+    fitDieToContent();
+    makeTileGen();
+    tile_gen_->eagerInit();
+
+    auto png = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
+    unsigned w = 0, h = 0;
+    auto pixels = decodePng(png, w, h);
+    ASSERT_GT(w, 16u);
+
+    const odb::Rect bounds = tile_gen_->getBounds();
+    const odb::Rect box = inst->getBBox()->getBox();
+    // Rows grow downwards, so the footprint's yMin is the LAST row.
+    const int top = rowOf(bounds, w, h, box.yMax()) + 3;
+    const int bottom = rowOf(bounds, w, h, box.yMin()) - 3;
+    const int left = colOf(bounds, w, box.xMin()) + 3;
+    const int right = colOf(bounds, w, box.xMax()) - 3;
+    ASSERT_LT(top, bottom) << "footprint too small to sample";
+    const int mid = (top + bottom) / 2;
+
+    int ink_top = 0, ink_bottom = 0;
+    for (int y = std::max(top, 0); y <= std::min<int>(bottom, h - 1); ++y) {
+      for (int x = std::max(left, 0); x <= std::min<int>(right, w - 1); ++x) {
+        if (pixels[4UL * (y * w + x) + 3] > 0) {
+          if (y < mid) {
+            ++ink_top;
+          } else {
+            ++ink_bottom;
+          }
+        }
+      }
+    }
+    ASSERT_GT(ink_top + ink_bottom, 0) << "no orientation tag was drawn";
+    EXPECT_EQ(ink_bottom > ink_top, expect_bottom);
+  }
+}
+
+// Qt fills every visible instance with the placement-blockage hatch, in
+// drawBlockages(), whether or not the design has a real dbBlockage — that is
+// what makes a lone macro read as a solid object rather than an empty frame.
+TEST_F(TileGeneratorTest, InstanceFootprintIsHatched)
+{
+  placeInst("BUF_X16", "buf1", 0, 0);
+  fitDieToContent();
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.inst_names = false;
+
+  vis.placement_blockages = true;
+  auto png_on = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
+  unsigned w = 0, h = 0;
+  auto pixels_on = decodePng(png_on, w, h);
+
+  vis.placement_blockages = false;
+  auto png_off = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
+  auto pixels_off = decodePng(png_off, w, h);
+
+  // The hatch is many pixels; the outline and the tag under it are a handful.
+  EXPECT_GT(countNonTransparentPixels(pixels_on),
+            2 * countNonTransparentPixels(pixels_off))
+      << "the instance footprint should be hatched when blockages are shown";
 }
 
 TEST_F(TileGeneratorTest, GetLayers)
@@ -1070,8 +1321,9 @@ TEST_F(TileGeneratorTest, TileContentRegistersWithIdealGrid)
   constexpr int kZoom = 10;
   const int num_tiles = 1 << kZoom;
 
-  // Pin the block bbox to a known square: getBounds() follows the bbox (the
-  // die area alone does not move it), and the tile grid is derived from it.
+  // Pin the block bbox to the same known square as the die, so getBounds()
+  // (their union, plus the label margin) is that square, and with it the
+  // tile grid derived from it.
   odb::dbMaster* master = lib_->findMaster("BUF_X16");
   ASSERT_NE(master, nullptr);
   block_->setDieArea(odb::Rect(0, 0, kSeamDieSide, kSeamDieSide));
@@ -1911,11 +2163,14 @@ TEST_F(TileGeneratorTest, PinMarkersRespectNetVisibility)
 
 TEST_F(TileGeneratorTest, PinNamesGatesBTermLabels)
 {
-  // Use a tiny die so that pin markers are large enough for labels.
-  // die_pin_size = max(0.02 * 100, 8) = 8; scale = 256/100 = 2.56;
-  // 8 * 2.56 = 20.48 >= kMinPinNameSizePixels (20) → labels render.
-  block_->setDieArea(odb::Rect(0, 0, 100, 100));
-  makeBTermAtEdge("label_test_pin", "metal1", 0, 40, 10, 10);
+  // Use a tiny die so that pin markers are large enough for labels:
+  // die_pin_size = max(0.02 * 64, 8) = 8, and getBounds() spans the die plus
+  // a symmetric pin-label margin, so scale = 256 / (64 + 2 * margin).  The
+  // margin grows with the pin NAME, hence the one-character name here — it
+  // keeps 8 * scale above kMinPinNameSizePixels (20), which is what makes the
+  // renderer emit labels at all.
+  block_->setDieArea(odb::Rect(0, 0, 64, 64));
+  makeBTermAtEdge("p", "metal1", 0, 40, 10, 10);
   makeTileGen();
   tile_gen_->eagerInit();
 
@@ -2129,7 +2384,6 @@ TEST_F(TileGeneratorTest, AccessPointsRespectLayerVisibility)
 TEST_F(TileGeneratorTest, RegionsOverlayGatedByFlag)
 {
   block_->setDieArea(odb::Rect(0, 0, 4000, 4000));
-  // Anchor the block bbox (getBounds uses content, not the die area).
   placeInst("BUF_X16", "buf1", 0, 0);
 
   odb::dbRegion* region = odb::dbRegion::create(block_, "test_dom");
@@ -2521,11 +2775,10 @@ TileVisibility trackOnlyVisibility()
 TEST_F(TileGeneratorTest, TracksAreClippedToTheDieArea)
 {
   block_->setDieArea(odb::Rect(0, 0, kTrackDieSide, kTrackDieSide));
-  // getBounds() follows the block bbox, and dbBlock::getBBox() covers the
-  // SHAPES, not the die area: an instance at the origin anchors the viewport
-  // to the die, and a second one beyond the die stretches the bbox past it.
-  // That gap outside the die is where the tracks used to run on, drawn to the
-  // tile edge instead of stopping at the die boundary.
+  // getBounds() is the union of the die area and the block bbox, so an
+  // instance placed beyond the die stretches the viewport past it.  That gap
+  // outside the die is where the tracks used to run on, drawn to the tile edge
+  // instead of stopping at the die boundary.
   placeInst("BUF_X16", "inside", 0, 0);
   placeInst("BUF_X16", "outside", kTrackDieSide + 20000, kTrackDieSide + 20000);
 
@@ -2612,7 +2865,10 @@ TEST_F(TileGeneratorTest, TracksSpanTheWholeTileWhenTheDieCoversIt)
   auto png = tile_gen_->generateTile("metal1", 0, 0, 0, trackOnlyVisibility());
   unsigned w = 0, h = 0;
   auto pixels = decodePng(png, w, h);
+  // Both dimensions: they bound the std::clamp ranges below, which need
+  // lo <= hi.
   ASSERT_GT(w, 0u);
+  ASSERT_GT(h, 0u);
 
   // Rows reuse the fixture's coveredColumns(); columns have no equivalent.
   const auto row_has_pixel
@@ -2629,14 +2885,13 @@ TEST_F(TileGeneratorTest, TracksSpanTheWholeTileWhenTheDieCoversIt)
   // getBounds() adds a symmetric pin-label margin, so the die does not reach
   // the tile edge; sample just inside each die border instead of at pixel 0.
   const odb::Rect bounds = tile_gen_->getBounds();
-  const double dbu_per_px = static_cast<double>(bounds.maxDXDY()) / w;
   const auto col_of = [&](int dbu) {
-    const double px = (dbu - bounds.xMin()) / dbu_per_px;
-    return static_cast<unsigned>(std::clamp(px, 0.0, w - 1.0));
+    return static_cast<unsigned>(
+        std::clamp(colOf(bounds, w, dbu), 0, static_cast<int>(w) - 1));
   };
   const auto row_of = [&](int dbu) {
-    const double py = (h - 1) - (dbu - bounds.yMin()) / dbu_per_px;
-    return static_cast<unsigned>(std::clamp(py, 0.0, h - 1.0));
+    return static_cast<unsigned>(
+        std::clamp(rowOf(bounds, w, h, dbu), 0, static_cast<int>(h) - 1));
   };
 
   EXPECT_TRUE(row_has_pixel(row_of(2000)) && row_has_pixel(row_of(98000)))
@@ -2834,8 +3089,7 @@ TEST_F(TileGeneratorTest, FlywireSlopePreservedAtExtremeZoom)
   const odb::Rect bounds = tile_gen_->getBounds();
   const int num_tiles = 1 << kZoom;
   const double tile_dbu = bounds.maxDXDY() / static_cast<double>(num_tiles);
-  // Offsets are relative to the bounds, which follow the block BBox (and so the
-  // instance above), not the die area.
+  // Offsets are relative to the bounds, not to the die area.
   const int diag_offset = bounds.maxDXDY() / 4;
   const int far = 100 * bounds.maxDXDY();
   const odb::Point on_diagonal(bounds.xMin() + diag_offset,
@@ -3122,6 +3376,7 @@ TEST_F(TileGeneratorTest, SpecialNetViaEnclosureDrawnOnMetalLayer)
       swire, via_def, 500, 500, odb::dbWireShapeType::IOWIRE);
   ASSERT_NE(sbox, nullptr);
 
+  fitDieToContent();
   makeTileGen();
   tile_gen_->eagerInit();
 
@@ -3200,7 +3455,10 @@ TEST_F(RowRenderingTest, RowOutlineDrawnWhenVisible)
   auto png = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
   unsigned w = 0, h = 0;
   auto pixels = decodePng(png, w, h);
-  EXPECT_TRUE(hasNonTransparentPixel(pixels))
+  // By colour, not by "anything drawn": the gray die/core outline is painted
+  // on every _instances tile, so a plain non-transparent test passes even with
+  // row drawing removed entirely.
+  EXPECT_TRUE(hasRowColorPixel(pixels))
       << "Row outline should be drawn when rows are visible";
 }
 
@@ -3222,6 +3480,10 @@ TEST_F(RowRenderingTest, RowHiddenWhenSiteNotVisible)
       << "Row should be hidden when its site is not in the visibility list";
 }
 
+// Samples a tile lying STRICTLY inside the row, so neither the row's own
+// edges nor the die outline reach it and the only thing that can ink it is a
+// site edge.  A tile at the row origin would be inked by the row corner and by
+// the die corner alike, and so would pass with site drawing removed.
 TEST_F(RowRenderingTest, IndividualSitesDrawnWhenZoomedIn)
 {
   makeTileGen();
@@ -3230,45 +3492,46 @@ TEST_F(RowRenderingTest, IndividualSitesDrawnWhenZoomedIn)
   vis.parseFromJson(parseObj(
       R"({"rows":true,"stdcells":false,"site_FreePDK45_38x28_10R_NP_162NW_34O":true})"));
 
-  // At zoom 0, tile covers the full design. Site is 380 DBU wide.
-  // site_px = 380 * (256 / ~104000) ≈ 0.9 → no individual sites.
-  auto png_z0 = tile_gen_->generateTile("_instances", 0, 0, 0, vis);
-  unsigned w0 = 0, h0 = 0;
-  auto pixels_z0 = decodePng(png_z0, w0, h0);
-  EXPECT_TRUE(hasNonTransparentPixel(pixels_z0))
-      << "Row outline should be visible at zoom 0";
-
-  // At a high zoom, site_px should exceed the 5px threshold and
-  // individual sites should be drawn.  Use renderTileBuffer to scan
-  // for the tile that contains our row at y=[0, 2800].
-  const int zoom = 8;  // 256 tiles, ~400 DBU per tile → site_px ≈ 240
+  // 256 tiles → ~400 DBU per tile, so the 380 DBU site clears the 5 px gate
+  // and a whole tile still fits inside the row's 2800 DBU height.
+  const int zoom = 8;
   const int num_tiles = 1 << zoom;
   const odb::Rect bounds = tile_gen_->getBounds();
   const double tile_dbu = static_cast<double>(bounds.maxDXDY()) / num_tiles;
+  const odb::Rect row_box = row_->getBBox();
 
-  // Find the tile column/row containing the row origin (0,0).
-  const int tx = static_cast<int>((0 - bounds.xMin()) / tile_dbu);
+  // First tile index whose whole DBU span sits between `lo` and `hi`.
+  const auto index_inside = [&](int origin, int lo, int hi) {
+    for (int i = 0; i < num_tiles; ++i) {
+      const double a = origin + i * tile_dbu;
+      if (a > lo && a + tile_dbu < hi) {
+        return i;
+      }
+    }
+    return -1;
+  };
+  const int tx = index_inside(bounds.xMin(), row_box.xMin(), row_box.xMax());
+  const int dbu_y_idx
+      = index_inside(bounds.yMin(), row_box.yMin(), row_box.yMax());
+  ASSERT_GE(tx, 0) << "no tile column falls strictly inside the row";
+  ASSERT_GE(dbu_y_idx, 0) << "no tile row falls strictly inside the row";
   // Leaflet y is flipped: dbu_y_index = num_tiles - 1 - leaflet_y.
-  const int dbu_y_idx = static_cast<int>((0 - bounds.yMin()) / tile_dbu);
   const int ly = num_tiles - 1 - dbu_y_idx;
 
-  ASSERT_GE(tx, 0);
-  ASSERT_LT(tx, num_tiles);
-  ASSERT_GE(ly, 0);
-  ASSERT_LT(ly, num_tiles);
+  auto png = tile_gen_->generateTile("_instances", zoom, tx, ly, vis);
+  unsigned w = 0, h = 0;
+  auto pixels = decodePng(png, w, h);
+  EXPECT_TRUE(hasRowColorPixel(pixels))
+      << "site outlines should ink a tile inside the row";
 
-  auto png_hi = tile_gen_->generateTile("_instances", zoom, tx, ly, vis);
-  unsigned wh = 0, hh = 0;
-  auto pixels_hi = decodePng(png_hi, wh, hh);
-
-  int count_hi = 0;
-  for (size_t i = 3; i < pixels_hi.size(); i += 4) {
-    if (pixels_hi[i] > 0) {
-      ++count_hi;
-    }
-  }
-  EXPECT_GT(count_hi, 0)
-      << "Zoomed-in tile at row origin should have site outlines";
+  // Control: with rows off the same tile is empty, which is what proves the
+  // ink above came from the sites and not from something always drawn.
+  TileVisibility vis_off;
+  vis_off.parseFromJson(parseObj(R"({"rows":false,"stdcells":false})"));
+  auto png_off = tile_gen_->generateTile("_instances", zoom, tx, ly, vis_off);
+  auto pixels_off = decodePng(png_off, w, h);
+  EXPECT_FALSE(hasNonTransparentPixel(pixels_off))
+      << "nothing but rows should reach a tile inside the row";
 }
 
 TEST_F(RowRenderingTest, RowsDefaultOff)


### PR DESCRIPTION
Fix #[11280](https://github.com/The-OpenROAD-Project/OpenROAD/issues/11280)

<img width="1018" height="571" alt="image" src="https://github.com/user-attachments/assets/a06e1227-6922-4879-a2ef-31195345036d" />

Fixes in the Web GUI:

- Filling 

- Font size is bigger

- Macro orientation marker