### PR TITLE
rsz: keep rejected buffer checks side effect free

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2848,17 +2848,8 @@ bool Resizer::canRemoveBuffer(sta::Instance* buffer,
   getBufferPins(buffer, buffer_ip_pin, buffer_op_pin);
 
   odb::dbInst* db_inst = db_network_->staToDb(buffer);
-  if (db_inst->isDoNotTouch()) {
-    if (honor_dont_touch_fixed) {
-      return false;
-    }
-    db_inst->setDoNotTouch(false);
-  }
-  if (db_inst->isFixed()) {
-    if (honor_dont_touch_fixed) {
-      return false;
-    }
-    db_inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  if (db_inst == nullptr) {
+    return false;
   }
 
   sta::LibertyPort* input_port = nullptr;
@@ -2870,19 +2861,12 @@ bool Resizer::canRemoveBuffer(sta::Instance* buffer,
   sta::Net* output_net = db_network_->net(output_pin);
   odb::dbNet* input_db_net = db_network_->findFlatDbNet(input_net);
   odb::dbNet* output_db_net = db_network_->findFlatDbNet(output_net);
-  if ((input_db_net != nullptr && input_db_net->isDoNotTouch())
-      || (output_db_net != nullptr && output_db_net->isDoNotTouch())) {
-    if (honor_dont_touch_fixed) {
-      return false;
-    }
-    if (input_db_net != nullptr) {
-      input_db_net->setDoNotTouch(false);
-    }
-    if (output_db_net != nullptr) {
-      output_db_net->setDoNotTouch(false);
-    }
+  if (honor_dont_touch_fixed
+      && (db_inst == nullptr || db_inst->isDoNotTouch() || db_inst->isFixed()
+          || (input_db_net != nullptr && input_db_net->isDoNotTouch())
+          || (output_db_net != nullptr && output_db_net->isDoNotTouch()))) {
+    return false;
   }
-
   const bool out_net_ports = db_network_->hasPort(output_net);
   sta::Net* removed = nullptr;
   odb::dbNet* db_net_survivor = nullptr;
@@ -2901,9 +2885,39 @@ bool Resizer::canRemoveBuffer(sta::Instance* buffer,
   if (!sdc->isConstrained(input_pin) && !sdc->isConstrained(output_pin)
       && (removed == nullptr || !sdc->isConstrained(removed))
       && !sdc->isConstrained(buffer)) {
-    return db_net_removed == nullptr
-           || (db_net_survivor != nullptr
-               && db_net_survivor->canMergeNet(db_net_removed));
+    bool can_merge_nets = db_net_removed == nullptr;
+    if (!can_merge_nets && db_net_survivor != nullptr) {
+      if (honor_dont_touch_fixed) {
+        can_merge_nets = db_net_survivor->canMergeNet(db_net_removed);
+      } else {
+        // The legacy override clears the candidate nets and buffer instance
+        // before checking the remaining instances on the removed net.
+        can_merge_nets = true;
+        for (odb::dbITerm* iterm : db_net_removed->getITerms()) {
+          odb::dbInst* inst = iterm->getInst();
+          if (inst != nullptr && inst != db_inst && inst->isDoNotTouch()) {
+            can_merge_nets = false;
+            break;
+          }
+        }
+      }
+    }
+    if (!can_merge_nets) {
+      return false;
+    }
+    if (db_inst->isDoNotTouch()) {
+      db_inst->setDoNotTouch(false);
+    }
+    if (db_inst->isFixed()) {
+      db_inst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+    }
+    if (input_db_net != nullptr) {
+      input_db_net->setDoNotTouch(false);
+    }
+    if (output_db_net != nullptr) {
+      output_db_net->setDoNotTouch(false);
+    }
+    return true;
   }
 
   return false;

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -53,6 +53,7 @@ TESTS = [
     "remove_buffers1",
     "remove_buffers2",
     "remove_buffers3",
+    "remove_buffers_dont_touch_rejected",
     "remove_buffers4",
     "remove_buffers4_hier",
     "remove_buffers5",

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -44,6 +44,7 @@ or_integration_tests(
     remove_buffers1
     remove_buffers2
     remove_buffers3
+    remove_buffers_dont_touch_rejected
     remove_buffers4
     remove_buffers4_hier
     remove_buffers5

--- a/src/rsz/test/remove_buffers_dont_touch_rejected.ok
+++ b/src/rsz/test/remove_buffers_dont_touch_rejected.ok
@@ -1,0 +1,8 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: top
+[INFO ODB-0130]     Created 2 pins.
+[INFO ODB-0131]     Created 4 components and 16 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 8 connections.
+[INFO ODB-0133]     Created 5 nets and 8 connections.
+[WARNING RSZ-0097] Instance b2 cannot be removed because it is not a buffer, functions as a feedthrough port buffer, or is constrained
+[INFO RSZ-0026] Removed 0 buffers.

--- a/src/rsz/test/remove_buffers_dont_touch_rejected.tcl
+++ b/src/rsz/test/remove_buffers_dont_touch_rejected.tcl
@@ -1,0 +1,18 @@
+# A rejected user-selected buffer removal must not clear its dont_touch flag.
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def remove_buffers3.def
+
+# b3 prevents the merge when b2 is selected.  The override path may remove
+# dont_touch after a successful eligibility check, but b2 must remain intact
+# when the later merge check rejects it.
+set_dont_touch b2
+set_dont_touch b3
+remove_buffers b2
+
+set block [ord::get_db_block]
+set b2 [$block findInst b2]
+if {$b2 == "NULL" || ![$b2 isDoNotTouch]} {
+  error "b2 dont_touch changed after rejected remove_buffers"
+}


### PR DESCRIPTION
Fixes #11188.

`canRemoveBuffer` is used as a predicate, but it was changing the buffer, its adjacent nets, and sometimes placement status before all of the rejection checks had completed. A candidate that was later rejected could therefore leave the design modified.

The state changes now happen only after the existing constraint and net merge checks succeed. The override path keeps its previous eligibility behavior, while rejected candidates keep their original flags and placement.

Tested on the GCP VM:
- `bazel test --test_output=errors //src/rsz/test:all`
- 263 tests passed
- `git diff --check`