### PR TITLE
mpl: reset state before repeated macro placement runs

### DIFF
--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -306,6 +306,11 @@ void HierRTLMP::blockMacroChannels()
 
 void HierRTLMP::init()
 {
+  tree_ = std::make_unique<PhysicalHierarchy>();
+  skip_macro_placement_ = false;
+  placement_blockages_.clear();
+  io_blockages_.clear();
+
   block_ = db_->getChip()->getBlock();
   clustering_engine_ = std::make_unique<ClusteringEngine>(
       block_, logger_, tritonpart_, graphics_.get());

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -47,6 +47,7 @@ COMPULSORY_TESTS = [
     "orientation_improve2",
     "orientation_improve3",
     "place_macro_right_angle_rotation",
+    "second_invocation",
     "placement_blockages1",
     "unfixed_cells_dont_fit_in_core",
 ]
@@ -243,6 +244,10 @@ filegroup(
                     "testcases/macro_only.lef",
                     "testcases/placement_blockages1.def",
                 ],
+                "second_invocation": [
+                    "testcases/halos1.def",
+                    "testcases/orientation_improve1.lef",
+                ],
                 "unfixed_cells_dont_fit_in_core": [
                     "testcases/macro_only.lef",
                     "testcases/unfixed_cells_dont_fit_in_core.def",
@@ -257,6 +262,7 @@ filegroup(
     regression_test(
         name = test_name,
         data = [":" + test_name + "_resources"],
+        check_log = False if test_name == "second_invocation" else True,
         tags = [] if test_name in COMPULSORY_TESTS else ["manual"],
         visibility = ["//visibility:public"],
     )

--- a/src/mpl/test/CMakeLists.txt
+++ b/src/mpl/test/CMakeLists.txt
@@ -32,6 +32,7 @@ or_integration_tests(
     macros_without_pins1
     unfixed_cells_dont_fit_in_core
     place_macro_right_angle_rotation
+    second_invocation
     placement_blockages1
     halos1
     halos2

--- a/src/mpl/test/second_invocation.tcl
+++ b/src/mpl/test/second_invocation.tcl
@@ -1,0 +1,16 @@
+# Exercise rtl_macro_placer twice in one OpenROAD process.
+# The first run locks the macros. The second run must not dereference the
+# hierarchy tree cleared by the first run.
+
+source "helpers.tcl"
+
+read_lef Nangate45/Nangate45.lef
+read_lef testcases/orientation_improve1.lef
+read_def testcases/halos1.def
+
+set_thread_count 0
+set first_report [make_result_dir]
+set second_report [make_result_dir]
+
+rtl_macro_placer -report_directory $first_report
+rtl_macro_placer -report_directory $second_report


### PR DESCRIPTION
Fixes #11277.

`rtl_macro_placer` keeps its `HierRTLMP` object alive across commands. The first run clears the physical hierarchy tree, but the next `init()` reused the null tree and the previous `skip_macro_placement_` value. That made a second invocation crash instead of starting a fresh placement run.

`init()` now creates a new hierarchy and resets the per-run skip state before configuring the clustering engine. I also added a regression that invokes `rtl_macro_placer` twice in the same process using the existing macro-placement fixtures.

Tested on the GCP VM:
- `bazel test --test_output=errors //src/mpl/test:all`
- 43 tests passed
- `git diff --check`