### PR TITLE
web: Print stderr and a warning when opening the url with the default browser fails.

### DIFF
--- a/src/web/src/web_serve.cpp
+++ b/src/web/src/web_serve.cpp
@@ -329,14 +329,14 @@ void WebServer::serve(int port)
         ss << err.rdbuf();
         errout = "\n" + ss.str();
       }
-      if (fd != -1) {
-        std::remove(errfile.c_str());
-      }
       logger_->warn(utl::WEB,
                     3,
                     "Could not launch default browser (shell error {}){}",
                     ret,
                     errout);
+    }
+    if (fd != -1) {
+      std::remove(errfile.c_str());
     }
   } catch (std::exception const& e) {
     stop();

--- a/src/web/src/web_serve.cpp
+++ b/src/web/src/web_serve.cpp
@@ -293,10 +293,13 @@ void WebServer::serve(int port)
       threads_.emplace_back([this] { ioc_->run(); });
     }
 
+    logger_->info(utl::WEB, 1, "Server started on {}.", url);
+
+    // Open the url with the default browser
 #if defined(__APPLE__)
-    std::string open_cmd = "open " + url + " > /dev/null 2>&1";
+    std::string open_cmd = "open " + url + " > /dev/null";
 #elif defined(_WIN32)
-    std::string open_cmd = "start " + url + " > nul 2>&1";
+    std::string open_cmd = "start " + url + " > nul";
 #else
     // `setsid -f` forks the launcher into a new session, severing the
     // SIGHUP cascade from openroad's controlling pty.  Without this,
@@ -306,13 +309,15 @@ void WebServer::serve(int port)
     // redirect stdin from /dev/null so xdg-open never blocks on input
     // inherited from the pty.
     std::string open_cmd
-        = "setsid -f xdg-open " + url + " < /dev/null > /dev/null 2>&1";
+        = "setsid -f xdg-open " + url + " < /dev/null > /dev/null";
 #endif
     int ret = std::system(open_cmd.c_str());
-    (void) ret;
-
-    logger_->info(utl::WEB, 1, "Server started on {}.", url);
-
+    if (ret != 0) {
+      logger_->warn(utl::WEB,
+                    3,
+                    "Could not launch default browser (shell error {})",
+                    ret);
+    }
   } catch (std::exception const& e) {
     stop();
     logger_->error(utl::WEB, 2, "Server error : {}", e.what());

--- a/src/web/src/web_serve.cpp
+++ b/src/web/src/web_serve.cpp
@@ -296,10 +296,17 @@ void WebServer::serve(int port)
     logger_->info(utl::WEB, 1, "Server started on {}.", url);
 
     // Open the url with the default browser
+    char tmp_filename[] = "/tmp/openroad-XXXXXX";
+    int fd = mkstemp(tmp_filename);
+    std::string errfile = "/dev/null";
+    if (fd != -1) {
+      errfile = tmp_filename;
+      close(fd);
+    }
 #if defined(__APPLE__)
-    std::string open_cmd = "open " + url + " > /dev/null";
+    std::string open_cmd = "open " + url + " > /dev/null 2> " + errfile;
 #elif defined(_WIN32)
-    std::string open_cmd = "start " + url + " > nul";
+    std::string open_cmd = "start " + url + " > nul 2> " + errfile;
 #else
     // `setsid -f` forks the launcher into a new session, severing the
     // SIGHUP cascade from openroad's controlling pty.  Without this,
@@ -308,15 +315,28 @@ void WebServer::serve(int port)
     // the pty master and SIGHUPs every process in the session.  Also
     // redirect stdin from /dev/null so xdg-open never blocks on input
     // inherited from the pty.
-    std::string open_cmd
-        = "setsid -f xdg-open " + url + " < /dev/null > /dev/null";
+    // `setsid -w` waits for xdg-open to finish end so the return code
+    // can be forwarded to setsid
+    std::string open_cmd = "setsid -f -w xdg-open " + url
+                           + " < /dev/null > /dev/null 2> " + errfile;
 #endif
     int ret = std::system(open_cmd.c_str());
     if (ret != 0) {
+      std::ifstream err(errfile);
+      std::string errout = "";
+      if (err) {
+        std::ostringstream ss;
+        ss << err.rdbuf();
+        errout = "\n" + ss.str();
+      }
+      if (fd != -1) {
+        std::remove(errfile.c_str());
+      }
       logger_->warn(utl::WEB,
                     3,
-                    "Could not launch default browser (shell error {})",
-                    ret);
+                    "Could not launch default browser (shell error {}){}",
+                    ret,
+                    errout);
     }
   } catch (std::exception const& e) {
     stop();


### PR DESCRIPTION

## Summary
I had an issue in my environment and had to instrument the code to know why the browser was not launch.
This PR log the error messages and a warning in case of failure:
```
[INFO WEB-0001] Server started on http://localhost:43901.
sh: setsid: command not found
[WARNING WEB-0003] Could not launch default browser (shell error 32512)
```

## Type of Change
Improve error message

## Impact
The behaviour is the same. Just additional console output in case of error

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
  => I build with "bazelisk run --//:platform=gui //:install
        I'll try to use ./etc/Build.sh if necessary
- [*] I have run the relevant tests and they pass.
  => They are none
- [*] My code follows the repository's formatting guidelines.

## Related Issues
[Link issues here]
