### PR TITLE
ppl: honor spacing rules, polygon edges and fixed PG pins in boundary blocking

### DIFF
--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -316,6 +316,8 @@ class IOPlacer
   FallbackPins fallback_pins_;
   // fixed pin shapes padded by the pin size and spacing, per layer
   std::map<int, std::vector<odb::Rect>> layer_fixed_pins_keepouts_;
+  // padded boundary shapes blocking polygon die slots, per layer
+  std::map<int, std::vector<odb::Rect>> layer_blocked_shapes_;
   // a pin size only depends on its layer, wrong way pins are rejected
   std::map<int, PinSize> pin_size_cache_;
   // dbTechLayer::getSpacing(w, l) copies the whole spacing table per call

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -323,6 +323,8 @@ class IOPlacer
   std::map<int, PinSize> pin_size_cache_;
   // parameter revision the pin size cache was computed against
   int cached_pin_size_revision_ = 0;
+  // width of the pin being placed by place_pin, for the spacing rules
+  int manual_pin_width_ = 0;
   // dbTechLayer::getSpacing(w, l) copies the whole spacing table per call
   std::map<SpacingKey, int> spacing_cache_;
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -256,6 +256,7 @@ class IOPlacer
                                              const odb::Rect& box);
   int roundUpToMfgGrid(int dim);
   int roundUpToEvenMfgGrid(int dim);
+  void refreshPinSizeCache();
   PinSize computePinSize(int layer);
   int computeShapeSpacing(odb::dbTechLayer* tech_layer,
                           const BlockingShape& shape,
@@ -320,6 +321,8 @@ class IOPlacer
   std::map<int, std::vector<odb::Rect>> layer_blocked_shapes_;
   // a pin size only depends on its layer, wrong way pins are rejected
   std::map<int, PinSize> pin_size_cache_;
+  // parameter revision the pin size cache was computed against
+  int cached_pin_size_revision_ = 0;
   // dbTechLayer::getSpacing(w, l) copies the whole spacing table per call
   std::map<SpacingKey, int> spacing_cache_;
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -56,6 +56,14 @@ struct PinSize
   int height = 0;
 };
 
+// a shape blocking pins, with the spacing rules it carries
+struct BlockingShape
+{
+  odb::Rect rect;
+  int min_spacing = 0;
+  int effective_width = 0;
+};
+
 // the arguments that select a spacing value in a layer spacing table
 struct SpacingKey
 {
@@ -250,14 +258,15 @@ class IOPlacer
   int roundUpToEvenMfgGrid(int dim);
   PinSize computePinSize(int layer);
   int computeShapeSpacing(odb::dbTechLayer* tech_layer,
-                          const odb::Rect& shape,
+                          const BlockingShape& shape,
                           int pin_width,
                           int pin_length);
-  odb::Rect computePinKeepout(const odb::Rect& box,
+  odb::Rect computePinKeepout(const BlockingShape& shape,
                               odb::dbTechLayer* tech_layer);
+  void addFixedPinKeepouts(odb::dbBTerm* bterm);
   void forEachSpecialNetShape(
       const std::function<void(odb::dbTechLayer*, const odb::Rect&)>& callback);
-  void excludeBoundaryShape(const odb::Rect& box,
+  void excludeBoundaryShape(const BlockingShape& shape,
                             odb::dbTechLayer* tech_layer,
                             const odb::Rect& die_area);
   void getBlockedRegions();

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -154,6 +154,9 @@ class IOPlacer
   static Edge getEdge(const std::string& edge);
 
  private:
+  // temporary blocking state used by one place_pin call
+  struct ManualPinBlocking;
+
   void checkPinPlacement();
   bool checkPinConstraints();
   bool checkMirroredPins();
@@ -256,7 +259,6 @@ class IOPlacer
                                              const odb::Rect& box);
   int roundUpToMfgGrid(int dim);
   int roundUpToEvenMfgGrid(int dim);
-  void refreshPinSizeCache();
   PinSize computePinSize(int layer);
   int computeShapeSpacing(odb::dbTechLayer* tech_layer,
                           const BlockingShape& shape,
@@ -321,10 +323,6 @@ class IOPlacer
   std::map<int, std::vector<odb::Rect>> layer_blocked_shapes_;
   // a pin size only depends on its layer, wrong way pins are rejected
   std::map<int, PinSize> pin_size_cache_;
-  // parameter revision the pin size cache was computed against
-  int cached_pin_size_revision_ = 0;
-  // width of the pin being placed by place_pin, for the spacing rules
-  int manual_pin_width_ = 0;
   // dbTechLayer::getSpacing(w, l) copies the whole spacing table per call
   std::map<SpacingKey, int> spacing_cache_;
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -56,12 +56,13 @@ struct PinSize
   int height = 0;
 };
 
-// a shape blocking pins, with the spacing rules it carries
+// a shape blocking pins, with the DEF SPACING and DESIGNRULEWIDTH overrides
+// it carries; -1 when the shape has none
 struct BlockingShape
 {
   odb::Rect rect;
-  int min_spacing = 0;
-  int effective_width = 0;
+  int min_spacing = -1;
+  int effective_width = -1;
 };
 
 // the arguments that select a spacing value in a layer spacing table

--- a/src/ppl/include/ppl/Parameters.h
+++ b/src/ppl/include/ppl/Parameters.h
@@ -28,22 +28,11 @@ class Parameters
   void setVerticalLengthExtend(int length) { vertical_length_extend_ = length; }
   int getVerticalLengthExtend() const { return vertical_length_extend_; }
 
-  void setHorizontalLength(int length)
-  {
-    horizontal_length_ = length;
-    pin_size_revision_++;
-  }
+  void setHorizontalLength(int length) { horizontal_length_ = length; }
   int getHorizontalLength() const { return horizontal_length_; }
 
-  void setVerticalLength(int length)
-  {
-    vertical_length_ = length;
-    pin_size_revision_++;
-  }
+  void setVerticalLength(int length) { vertical_length_ = length; }
   int getVerticalLength() const { return vertical_length_; }
-
-  // bumped by the setters the cached pin sizes depend on
-  int getPinSizeRevision() const { return pin_size_revision_; }
 
   void setRandSeed(unsigned int seed) { rand_seed_ = seed; }
   unsigned int getRandSeed() const { return rand_seed_; }
@@ -51,7 +40,6 @@ class Parameters
   void setHorizontalThicknessMultiplier(float length)
   {
     horizontal_thickness_multiplier_ = length;
-    pin_size_revision_++;
   }
 
   float getHorizontalThicknessMultiplier() const
@@ -62,7 +50,6 @@ class Parameters
   void setVerticalThicknessMultiplier(float length)
   {
     vertical_thickness_multiplier_ = length;
-    pin_size_revision_++;
   }
   float getVerticalThicknessMultiplier() const
   {
@@ -100,7 +87,6 @@ class Parameters
   int corner_avoidance_ = -1;
   int min_dist_ = 0;
   bool distance_in_tracks_ = false;
-  int pin_size_revision_ = 0;
   std::string pin_placement_file_;
 };
 

--- a/src/ppl/include/ppl/Parameters.h
+++ b/src/ppl/include/ppl/Parameters.h
@@ -28,11 +28,22 @@ class Parameters
   void setVerticalLengthExtend(int length) { vertical_length_extend_ = length; }
   int getVerticalLengthExtend() const { return vertical_length_extend_; }
 
-  void setHorizontalLength(int length) { horizontal_length_ = length; }
+  void setHorizontalLength(int length)
+  {
+    horizontal_length_ = length;
+    pin_size_revision_++;
+  }
   int getHorizontalLength() const { return horizontal_length_; }
 
-  void setVerticalLength(int length) { vertical_length_ = length; }
+  void setVerticalLength(int length)
+  {
+    vertical_length_ = length;
+    pin_size_revision_++;
+  }
   int getVerticalLength() const { return vertical_length_; }
+
+  // bumped by the setters the cached pin sizes depend on
+  int getPinSizeRevision() const { return pin_size_revision_; }
 
   void setRandSeed(unsigned int seed) { rand_seed_ = seed; }
   unsigned int getRandSeed() const { return rand_seed_; }
@@ -40,6 +51,7 @@ class Parameters
   void setHorizontalThicknessMultiplier(float length)
   {
     horizontal_thickness_multiplier_ = length;
+    pin_size_revision_++;
   }
 
   float getHorizontalThicknessMultiplier() const
@@ -50,6 +62,7 @@ class Parameters
   void setVerticalThicknessMultiplier(float length)
   {
     vertical_thickness_multiplier_ = length;
+    pin_size_revision_++;
   }
   float getVerticalThicknessMultiplier() const
   {
@@ -87,6 +100,7 @@ class Parameters
   int corner_avoidance_ = -1;
   int min_dist_ = 0;
   bool distance_in_tracks_ = false;
+  int pin_size_revision_ = 0;
   std::string pin_placement_file_;
 };
 

--- a/src/ppl/src/Core.cpp
+++ b/src/ppl/src/Core.cpp
@@ -22,7 +22,7 @@ int Core::getPerimeter() const
   return (x + y) * 2;
 }
 
-std::vector<odb::Line> Core::getDieAreaEdges()
+const std::vector<odb::Line>& Core::getDieAreaEdges() const
 {
   return die_area_edges_;
 }

--- a/src/ppl/src/Core.h
+++ b/src/ppl/src/Core.h
@@ -59,7 +59,7 @@ class Core
   int getDatabaseUnit() const { return database_unit_; }
   int getPerimeter() const;
   odb::Point getMirroredPosition(const odb::Point& position) const;
-  std::vector<odb::Line> getDieAreaEdges();
+  const std::vector<odb::Line>& getDieAreaEdges() const;
 
  private:
   odb::Rect boundary_;

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -29,6 +29,7 @@
 #include "odb/dbShape.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "odb/geom_boost.h"
 #include "ppl/Parameters.h"
 #include "utl/Logger.h"
 #include "utl/validation.h"
@@ -422,28 +423,33 @@ void IOPlacer::placeFallbackGroup(
                 group.first.size());
 }
 
+namespace {
+bool pointInLayerShapes(const std::map<int, std::vector<odb::Rect>>& shapes,
+                        const int layer,
+                        const odb::Point& pos)
+{
+  const auto layer_shapes = shapes.find(layer);
+  if (layer_shapes == shapes.end()) {
+    return false;
+  }
+  for (const odb::Rect& padded_shape : layer_shapes->second) {
+    if (padded_shape.intersects(pos)) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
+
 bool IOPlacer::checkBlocked(Edge edge,
                             odb::Line line,
                             const odb::Point& pos,
                             int layer)
 {
-  const auto fixed_shapes = layer_fixed_pins_keepouts_.find(layer);
-  if (fixed_shapes != layer_fixed_pins_keepouts_.end()) {
-    for (const odb::Rect& padded_shape : fixed_shapes->second) {
-      if (padded_shape.intersects(pos)) {
-        return true;
-      }
-    }
-  }
-  if (edge == Edge::polygonEdge) {
-    const auto blocked_shapes = layer_blocked_shapes_.find(layer);
-    if (blocked_shapes != layer_blocked_shapes_.end()) {
-      for (const odb::Rect& padded_shape : blocked_shapes->second) {
-        if (padded_shape.intersects(pos)) {
-          return true;
-        }
-      }
-    }
+  if (pointInLayerShapes(layer_fixed_pins_keepouts_, layer, pos)
+      || (edge == Edge::polygonEdge
+          && pointInLayerShapes(layer_blocked_shapes_, layer, pos))) {
+    return true;
   }
   bool vertical_pin = (edge == Edge::polygonEdge)
                           ? line.pt0().getY() == line.pt1().getY()
@@ -514,18 +520,8 @@ int IOPlacer::roundUpToEvenMfgGrid(const int dim)
   return rounded;
 }
 
-void IOPlacer::refreshPinSizeCache()
-{
-  // parameter changes invalidate the cached pin sizes
-  if (cached_pin_size_revision_ != parms_->getPinSizeRevision()) {
-    pin_size_cache_.clear();
-    cached_pin_size_revision_ = parms_->getPinSizeRevision();
-  }
-}
-
 PinSize IOPlacer::computePinSize(const int layer)
 {
-  refreshPinSizeCache();
   const auto cached = pin_size_cache_.find(layer);
   if (cached != pin_size_cache_.end()) {
     return cached->second;
@@ -573,19 +569,17 @@ int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
                                     pin_width});
   const SpacingKey cache_key{
       tech_layer->getRoutingLevel(), shape_width, pin_length};
-  int spacing = 0;
+  // shapes can require more than the layer rules (DEF SPACING attribute)
   const auto cached = spacing_cache_.find(cache_key);
   if (cached != spacing_cache_.end()) {
-    spacing = cached->second;
-  } else {
-    // width-dependent rules require larger clearance to wide PDN shapes
-    spacing = tech_layer->getSpacing(shape_width, pin_length);
-    if (spacing == 0) {
-      spacing = tech_layer->getWidth();
-    }
-    spacing_cache_[cache_key] = spacing;
+    return std::max(cached->second, shape.min_spacing);
   }
-  // shapes can require more than the layer rules (DEF SPACING attribute)
+  // width-dependent rules require larger clearance to wide PDN shapes
+  int spacing = tech_layer->getSpacing(shape_width, pin_length);
+  if (spacing == 0) {
+    spacing = tech_layer->getWidth();
+  }
+  spacing_cache_[cache_key] = spacing;
   return std::max(spacing, shape.min_spacing);
 }
 
@@ -593,10 +587,8 @@ odb::Rect IOPlacer::computePinKeepout(const BlockingShape& shape,
                                       odb::dbTechLayer* tech_layer)
 {
   const PinSize pin_size = computePinSize(tech_layer->getRoutingLevel());
-  // place_pin can request a pin wider than the technology derived size
-  const int pin_width = std::max(2 * pin_size.half_width, manual_pin_width_);
-  const int spacing
-      = computeShapeSpacing(tech_layer, shape, pin_width, pin_size.height);
+  const int spacing = computeShapeSpacing(
+      tech_layer, shape, 2 * pin_size.half_width, pin_size.height);
   // pad by the pin footprint plus spacing: half width along the edge, the pin
   // extension into the die on the other axis
   const odb::Orientation2D edge_dir
@@ -606,22 +598,6 @@ odb::Rect IOPlacer::computePinKeepout(const BlockingShape& shape,
   return shape.rect.bloat(pin_size.half_width + spacing, edge_dir)
       .bloat(pin_size.height + spacing, edge_dir.turn_90());
 }
-
-namespace {
-bool touchesLine(const odb::Rect& rect, const odb::Line& line)
-{
-  const odb::Point pt0 = line.pt0();
-  const odb::Point pt1 = line.pt1();
-  if (pt0.getY() == pt1.getY()) {
-    return rect.yMin() <= pt0.getY() && pt0.getY() <= rect.yMax()
-           && rect.xMin() <= std::max(pt0.getX(), pt1.getX())
-           && std::min(pt0.getX(), pt1.getX()) <= rect.xMax();
-  }
-  return rect.xMin() <= pt0.getX() && pt0.getX() <= rect.xMax()
-         && rect.yMin() <= std::max(pt0.getY(), pt1.getY())
-         && std::min(pt0.getY(), pt1.getY()) <= rect.yMax();
-}
-}  // namespace
 
 void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
                                     odb::dbTechLayer* tech_layer,
@@ -645,13 +621,18 @@ void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
   if (!die_area.intersects(padded_box)) {
     return;
   }
+  // polygon dies have slots on edges the bounding box cannot represent, so
+  // also block their slots with the padded shape itself. Empty layer sets
+  // mean standalone place_pin, which never tests polygon slots
   const std::vector<odb::Line>& die_edges = core_->getDieAreaEdges();
-  if (die_edges.size() > 4) {
-    // polygon dies have slots on edges the bounding box cannot represent, so
-    // also block their slots with the padded shape itself
+  if (die_edges.size() > 4 && (!ver_layers_.empty() || !hor_layers_.empty())) {
     for (const odb::Line& die_edge : die_edges) {
-      if (touchesLine(padded_box, die_edge)) {
-        layer_blocked_shapes_[layer].push_back(padded_box);
+      if (boost::geometry::intersects(padded_box, die_edge)) {
+        std::vector<odb::Rect>& shapes = layer_blocked_shapes_[layer];
+        // boundary via arrays produce near duplicate keepouts, skip them
+        if (shapes.empty() || !shapes.back().contains(padded_box)) {
+          shapes.push_back(padded_box);
+        }
         break;
       }
     }
@@ -748,11 +729,9 @@ void IOPlacer::getBlockedRegionsFromDbObstructions()
       continue;
     }
     // obstructions can carry their own DEF spacing rules
-    const BlockingShape shape{
-        obstruct_box->getBox(),
-        obstruction->hasMinSpacing() ? obstruction->getMinSpacing() : 0,
-        obstruction->hasEffectiveWidth() ? obstruction->getEffectiveWidth()
-                                         : 0};
+    const BlockingShape shape{obstruct_box->getBox(),
+                              obstruction->getMinSpacing(),
+                              obstruction->getEffectiveWidth()};
     excludeBoundaryShape(shape, tech_layer, die_area);
   }
 }
@@ -2767,6 +2746,40 @@ void IOPlacer::reportHPWL()
                 static_cast<float>(getBlock()->dbuToMicrons(total_hpwl)));
 }
 
+// seeds the pin size caches with the size requested for one place_pin call
+// and drops every temporary blocking state on destruction, so an error
+// thrown during the placement search leaves nothing stale behind
+struct IOPlacer::ManualPinBlocking
+{
+  ManualPinBlocking(IOPlacer* placer,
+                    odb::dbTechLayer* layer,
+                    const int width,
+                    const int height)
+      : placer_(placer), num_intervals_(placer->excluded_intervals_.size())
+  {
+    placer_->pin_size_cache_.clear();
+    const bool vertical_pin
+        = layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
+    PinSize pin_size;
+    pin_size.half_width = (vertical_pin ? width : height) / 2;
+    pin_size.height = vertical_pin ? height : width;
+    placer_->pin_size_cache_[layer->getRoutingLevel()] = pin_size;
+  }
+
+  ~ManualPinBlocking()
+  {
+    placer_->excluded_intervals_.erase(
+        placer_->excluded_intervals_.begin() + num_intervals_,
+        placer_->excluded_intervals_.end());
+    placer_->layer_fixed_pins_keepouts_.clear();
+    placer_->layer_blocked_shapes_.clear();
+    placer_->pin_size_cache_.clear();
+  }
+
+  IOPlacer* placer_;
+  size_t num_intervals_;
+};
+
 void IOPlacer::placePin(odb::dbBTerm* bterm,
                         odb::dbTechLayer* layer,
                         int x,
@@ -2812,15 +2825,8 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
 
   const int layer_level = layer->getRoutingLevel();
   if (force_to_die_bound) {
-    // pad the blocking shapes with the size requested for this pin
-    refreshPinSizeCache();
-    const bool vertical_pin
-        = layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
-    PinSize pin_size;
-    pin_size.half_width = (vertical_pin ? width : height) / 2;
-    pin_size.height = vertical_pin ? height : width;
-    pin_size_cache_[layer_level] = pin_size;
-    manual_pin_width_ = std::min(width, height);
+    // the scope drops all the temporary blocking state, even on an error
+    ManualPinBlocking blocking(this, layer, width, height);
     // block the fixed supply pins; fixed signal pin positions are explicit
     // user requests, like the position being placed now
     for (odb::dbBTerm* fixed_bterm : getBlock()->getBTerms()) {
@@ -2829,10 +2835,9 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
         addFixedPinKeepouts(fixed_bterm);
       }
     }
-    // block boundary PDN shapes for the checks below, without persisting the
-    // intervals beyond this placement. Macros are not included, since their
-    // intervals block all layers and the pin position is an explicit request
-    const size_t num_excluded_intervals = excluded_intervals_.size();
+    // block boundary PDN shapes for the checks below. Macros are not
+    // included, since their intervals block all layers and the pin position
+    // is an explicit request
     getBlockedRegionsFromDbObstructions();
     getBlockedRegionsFromPDN();
     movePinToTrack(pos, layer_level, width, height, die_boundary);
@@ -2857,27 +2862,19 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
     // not straddle a blocked region
     // empty line created to comply with definition
     odb::Line empty_line;
-    bool placed_at_blocked
-        = checkBlocked(edge, empty_line, pos, layer_level)
-          || (horizontal
-                  ? checkBlocked(edge,
-                                 empty_line,
-                                 odb::Point(pos.x(), pos.y() - height / 2),
-                                 layer_level)
-                        || checkBlocked(
-                            edge,
-                            empty_line,
-                            odb::Point(pos.x(), pos.y() + height / 2),
-                            layer_level)
-                  : checkBlocked(edge,
-                                 empty_line,
-                                 odb::Point(pos.x() - width / 2, pos.y()),
-                                 layer_level)
-                        || checkBlocked(
-                            edge,
-                            empty_line,
-                            odb::Point(pos.x() + width / 2, pos.y()),
-                            layer_level));
+    const int half_span = (horizontal ? height : width) / 2;
+    auto is_blocked_at = [&](const int offset) {
+      for (const int delta : {offset - half_span, offset, offset + half_span}) {
+        const odb::Point probe = horizontal
+                                     ? odb::Point(pos.x(), pos.y() + delta)
+                                     : odb::Point(pos.x() + delta, pos.y());
+        if (checkBlocked(edge, empty_line, probe, layer_level)) {
+          return true;
+        }
+      }
+      return false;
+    };
+    bool placed_at_blocked = is_blocked_at(0);
     // keep the search inside the die area, so the pin is never pushed out of it
     const int max_offset = horizontal
                                ? die_boundary.yMax() - height / 2 - pos.y()
@@ -2919,46 +2916,10 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
         offset_sub++;
       }
 
-      // check the center and the extremities of the pin shape, so wide pins
-      // do not straddle a blocked region
-      const odb::Point offset_pos = horizontal
-                                        ? odb::Point(pos.x(), pos.y() + offset)
-                                        : odb::Point(pos.x() + offset, pos.y());
-      placed_at_blocked
-          = checkBlocked(edge, empty_line, offset_pos, layer_level)
-            || (horizontal
-                    ? checkBlocked(
-                          edge,
-                          empty_line,
-                          odb::Point(pos.x(), pos.y() - height / 2 + offset),
-                          layer_level)
-                          || checkBlocked(
-                              edge,
-                              empty_line,
-                              odb::Point(pos.x(),
-                                         pos.y() + height / 2 + offset),
-                              layer_level)
-                    : checkBlocked(
-                          edge,
-                          empty_line,
-                          odb::Point(pos.x() - width / 2 + offset, pos.y()),
-                          layer_level)
-                          || checkBlocked(
-                              edge,
-                              empty_line,
-                              odb::Point(pos.x() + width / 2 + offset, pos.y()),
-                              layer_level));
+      placed_at_blocked = is_blocked_at(offset);
     }
     pos.addX(horizontal ? 0 : offset);
     pos.addY(horizontal ? offset : 0);
-    excluded_intervals_.erase(
-        excluded_intervals_.begin() + num_excluded_intervals,
-        excluded_intervals_.end());
-    // drop the request-sized paddings along with the temporary keepouts
-    layer_fixed_pins_keepouts_.clear();
-    layer_blocked_shapes_.clear();
-    pin_size_cache_.clear();
-    manual_pin_width_ = 0;
   }
 
   odb::Point ll = odb::Point(pos.x() - width / 2, pos.y() - height / 2);
@@ -3230,11 +3191,9 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
     }
     odb::dbBox* box = obstruction->getBBox();
     if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
-      obstructions.push_back(
-          {box->getBox(),
-           obstruction->hasMinSpacing() ? obstruction->getMinSpacing() : 0,
-           obstruction->hasEffectiveWidth() ? obstruction->getEffectiveWidth()
-                                            : 0});
+      obstructions.push_back({box->getBox(),
+                              obstruction->getMinSpacing(),
+                              obstruction->getEffectiveWidth()});
     }
   }
 
@@ -3250,13 +3209,11 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   for (odb::dbBTerm* term : getBlock()->getBTerms()) {
     for (odb::dbBPin* pin : term->getBPins()) {
       if (pin->getPlacementStatus().isFixed()) {
-        const int min_spacing = pin->hasMinSpacing() ? pin->getMinSpacing() : 0;
-        const int effective_width
-            = pin->hasEffectiveWidth() ? pin->getEffectiveWidth() : 0;
         for (odb::dbBox* box : pin->getBoxes()) {
           if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
-            obstructions.push_back(
-                {box->getBox(), min_spacing, effective_width});
+            obstructions.push_back({box->getBox(),
+                                    pin->getMinSpacing(),
+                                    pin->getEffectiveWidth()});
           }
         }
       }
@@ -3361,20 +3318,17 @@ std::vector<Section> IOPlacer::findSectionsForTopLayer(const odb::Rect& region)
 void IOPlacer::addFixedPinKeepouts(odb::dbBTerm* bterm)
 {
   for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
-    // fixed pins can carry their own DEF spacing rules
-    const int min_spacing
-        = bterm_pin->hasMinSpacing() ? bterm_pin->getMinSpacing() : 0;
-    const int effective_width
-        = bterm_pin->hasEffectiveWidth() ? bterm_pin->getEffectiveWidth() : 0;
     for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
       odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
       if (tech_layer == nullptr || tech_layer->getRoutingLevel() == 0) {
         continue;
       }
       // store the shapes padded, so the pins created near them keep the
-      // min spacing
+      // min spacing carried by their own DEF rules
       layer_fixed_pins_keepouts_[tech_layer->getRoutingLevel()].push_back(
-          computePinKeepout({bpin_box->getBox(), min_spacing, effective_width},
+          computePinKeepout({bpin_box->getBox(),
+                             bterm_pin->getMinSpacing(),
+                             bterm_pin->getEffectiveWidth()},
                             tech_layer));
     }
   }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -541,45 +541,50 @@ PinSize IOPlacer::computePinSize(const int layer)
 }
 
 int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
-                                  const odb::Rect& shape,
+                                  const BlockingShape& shape,
                                   const int pin_width,
                                   const int pin_length)
 {
   // the spacing rules use the width of the widest shape and the parallel
   // run length between the shapes
-  const int shape_width = std::max(std::min(shape.dx(), shape.dy()), pin_width);
+  const int shape_width = std::max({std::min(shape.rect.dx(), shape.rect.dy()),
+                                    shape.effective_width,
+                                    pin_width});
   const SpacingKey cache_key{
       tech_layer->getRoutingLevel(), shape_width, pin_length};
+  int spacing = 0;
   const auto cached = spacing_cache_.find(cache_key);
   if (cached != spacing_cache_.end()) {
-    return cached->second;
+    spacing = cached->second;
+  } else {
+    // width-dependent rules require larger clearance to wide PDN shapes
+    spacing = tech_layer->getSpacing(shape_width, pin_length);
+    if (spacing == 0) {
+      spacing = tech_layer->getWidth();
+    }
+    spacing_cache_[cache_key] = spacing;
   }
-  // width-dependent rules require larger clearance to wide PDN shapes
-  int spacing = tech_layer->getSpacing(shape_width, pin_length);
-  if (spacing == 0) {
-    spacing = tech_layer->getWidth();
-  }
-  spacing_cache_[cache_key] = spacing;
-  return spacing;
+  // shapes can require more than the layer rules (DEF SPACING attribute)
+  return std::max(spacing, shape.min_spacing);
 }
 
-odb::Rect IOPlacer::computePinKeepout(const odb::Rect& box,
+odb::Rect IOPlacer::computePinKeepout(const BlockingShape& shape,
                                       odb::dbTechLayer* tech_layer)
 {
   const PinSize pin_size = computePinSize(tech_layer->getRoutingLevel());
   const int spacing = computeShapeSpacing(
-      tech_layer, box, 2 * pin_size.half_width, pin_size.height);
+      tech_layer, shape, 2 * pin_size.half_width, pin_size.height);
   // pad by the pin footprint plus spacing: half width along the edge, the pin
   // extension into the die on the other axis
   const odb::Orientation2D edge_dir
       = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL
             ? odb::Orientation2D::Horizontal
             : odb::Orientation2D::Vertical;
-  return box.bloat(pin_size.half_width + spacing, edge_dir)
+  return shape.rect.bloat(pin_size.half_width + spacing, edge_dir)
       .bloat(pin_size.height + spacing, edge_dir.turn_90());
 }
 
-void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
+void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
                                     odb::dbTechLayer* tech_layer,
                                     const odb::Rect& die_area)
 {
@@ -597,7 +602,7 @@ void IOPlacer::excludeBoundaryShape(const odb::Rect& box,
       return;
     }
   }
-  const odb::Rect padded_box = computePinKeepout(box, tech_layer);
+  const odb::Rect padded_box = computePinKeepout(shape, tech_layer);
   if (!die_area.intersects(padded_box)) {
     return;
   }
@@ -651,7 +656,7 @@ void IOPlacer::getBlockedRegionsFromPDN()
   const odb::Rect die_area = getBlock()->getDieArea();
   forEachSpecialNetShape(
       [&](odb::dbTechLayer* tech_layer, const odb::Rect& rect) {
-        excludeBoundaryShape(rect, tech_layer, die_area);
+        excludeBoundaryShape({rect}, tech_layer, die_area);
       });
 }
 
@@ -692,7 +697,13 @@ void IOPlacer::getBlockedRegionsFromDbObstructions()
     if (tech_layer == nullptr) {
       continue;
     }
-    excludeBoundaryShape(obstruct_box->getBox(), tech_layer, die_area);
+    // obstructions can carry their own DEF spacing rules
+    const BlockingShape shape{
+        obstruct_box->getBox(),
+        obstruction->hasMinSpacing() ? obstruction->getMinSpacing() : 0,
+        obstruction->hasEffectiveWidth() ? obstruction->getEffectiveWidth()
+                                         : 0};
+    excludeBoundaryShape(shape, tech_layer, die_area);
   }
 }
 
@@ -3127,8 +3138,8 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   }
   const int top_layer_level = top_grid_->layer->getRoutingLevel();
 
-  // Collect top_grid obstructions
-  std::vector<odb::Rect> obstructions;
+  // Collect top_grid obstructions, with the spacing rules they carry
+  std::vector<BlockingShape> obstructions;
 
   // Get routing obstructions. The system reserved ones are not skipped here,
   // since they are the only filter for slots outside of polygon dies
@@ -3139,7 +3150,11 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
     }
     odb::dbBox* box = obstruction->getBBox();
     if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
-      obstructions.push_back(box->getBox());
+      obstructions.push_back(
+          {box->getBox(),
+           obstruction->hasMinSpacing() ? obstruction->getMinSpacing() : 0,
+           obstruction->hasEffectiveWidth() ? obstruction->getEffectiveWidth()
+                                            : 0});
     }
   }
 
@@ -3147,7 +3162,7 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   forEachSpecialNetShape(
       [&](odb::dbTechLayer* tech_layer, const odb::Rect& rect) {
         if (tech_layer->getRoutingLevel() == top_layer_level) {
-          obstructions.push_back(rect);
+          obstructions.push_back({rect});
         }
       });
 
@@ -3155,9 +3170,13 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   for (odb::dbBTerm* term : getBlock()->getBTerms()) {
     for (odb::dbBPin* pin : term->getBPins()) {
       if (pin->getPlacementStatus().isFixed()) {
+        const int min_spacing = pin->hasMinSpacing() ? pin->getMinSpacing() : 0;
+        const int effective_width
+            = pin->hasEffectiveWidth() ? pin->getEffectiveWidth() : 0;
         for (odb::dbBox* box : pin->getBoxes()) {
           if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
-            obstructions.push_back(box->getBox());
+            obstructions.push_back(
+                {box->getBox(), min_spacing, effective_width});
           }
         }
       }
@@ -3183,14 +3202,15 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
   // check for slots that overlap with obstructions
   const int pin_min_dim = std::min(pin_width, pin_height);
   const int pin_max_dim = std::max(pin_width, pin_height);
-  for (const odb::Rect& rect : obstructions) {
-    // floor the keepout at the layer spacing required by the obstruction
-    const int spacing
-        = computeShapeSpacing(top_grid_->layer, rect, pin_min_dim, pin_max_dim);
+  for (const BlockingShape& shape : obstructions) {
+    // floor the keepout at the spacing required by the obstruction
+    const int spacing = computeShapeSpacing(
+        top_grid_->layer, shape, pin_min_dim, pin_max_dim);
     const int keepout = std::max(top_grid_->keepout, spacing);
     // pad the obstruction by the pin footprint instead of one rect per slot
     const odb::Rect keepout_rect
-        = rect.bloat(pin_width / 2 + keepout, odb::Orientation2D::Horizontal)
+        = shape.rect
+              .bloat(pin_width / 2 + keepout, odb::Orientation2D::Horizontal)
               .bloat(pin_height / 2 + keepout, odb::Orientation2D::Vertical);
     for (auto& slot : top_layer_slots_) {
       if (keepout_rect.intersects(slot.pos)) {
@@ -3258,6 +3278,28 @@ std::vector<Section> IOPlacer::findSectionsForTopLayer(const odb::Rect& region)
   return sections;
 }
 
+void IOPlacer::addFixedPinKeepouts(odb::dbBTerm* bterm)
+{
+  for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
+    // fixed pins can carry their own DEF spacing rules
+    const int min_spacing
+        = bterm_pin->hasMinSpacing() ? bterm_pin->getMinSpacing() : 0;
+    const int effective_width
+        = bterm_pin->hasEffectiveWidth() ? bterm_pin->getEffectiveWidth() : 0;
+    for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
+      odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
+      if (tech_layer == nullptr || tech_layer->getRoutingLevel() == 0) {
+        continue;
+      }
+      // store the shapes padded, so the pins created near them keep the
+      // min spacing
+      layer_fixed_pins_keepouts_[tech_layer->getRoutingLevel()].push_back(
+          computePinKeepout({bpin_box->getBox(), min_spacing, effective_width},
+                            tech_layer));
+    }
+  }
+}
+
 void IOPlacer::initNetlist()
 {
   netlist_->reset();
@@ -3275,15 +3317,7 @@ void IOPlacer::initNetlist()
     int y_pos = 0;
     bterm->getFirstPinLocation(x_pos, y_pos);
     if (bterm->getFirstPinPlacementStatus().isFixed()) {
-      for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
-        for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
-          odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
-          // store the shapes padded, so the pins created near them keep the
-          // min spacing
-          layer_fixed_pins_keepouts_[tech_layer->getRoutingLevel()].push_back(
-              computePinKeepout(bpin_box->getBox(), tech_layer));
-        }
-      }
+      addFixedPinKeepouts(bterm);
       continue;
     }
     odb::dbNet* net = bterm->getNet();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -73,6 +73,7 @@ void IOPlacer::clear()
   assignment_.clear();
   excluded_intervals_.clear();
   layer_fixed_pins_keepouts_.clear();
+  layer_blocked_shapes_.clear();
   pin_size_cache_.clear();
   spacing_cache_.clear();
   *parms_ = Parameters();
@@ -434,6 +435,16 @@ bool IOPlacer::checkBlocked(Edge edge,
       }
     }
   }
+  if (edge == Edge::polygonEdge) {
+    const auto blocked_shapes = layer_blocked_shapes_.find(layer);
+    if (blocked_shapes != layer_blocked_shapes_.end()) {
+      for (const odb::Rect& padded_shape : blocked_shapes->second) {
+        if (padded_shape.intersects(pos)) {
+          return true;
+        }
+      }
+    }
+  }
   bool vertical_pin = (edge == Edge::polygonEdge)
                           ? line.pt0().getY() == line.pt1().getY()
                           : hasVerticalPins(edge);
@@ -443,10 +454,10 @@ bool IOPlacer::checkBlocked(Edge edge,
     // the layer of the position
     if (blocked_interval.getLayer() == -1
         || blocked_interval.getLayer() == layer) {
-      // polygon slots match intervals of any edge with the same orientation,
-      // over-blocking parallel edges until intervals carry their source edge
+      // polygon slots match all-layer intervals of any edge with the same
+      // orientation; layer shapes are point-tested via layer_blocked_shapes_
       if ((blocked_interval.getEdge() == edge
-           || (edge == Edge::polygonEdge
+           || (edge == Edge::polygonEdge && blocked_interval.getLayer() == -1
                && hasVerticalPins(blocked_interval.getEdge()) == vertical_pin))
           && coord > blocked_interval.getBegin()
           && coord < blocked_interval.getEnd()) {
@@ -584,6 +595,22 @@ odb::Rect IOPlacer::computePinKeepout(const BlockingShape& shape,
       .bloat(pin_size.height + spacing, edge_dir.turn_90());
 }
 
+namespace {
+bool touchesLine(const odb::Rect& rect, const odb::Line& line)
+{
+  const odb::Point pt0 = line.pt0();
+  const odb::Point pt1 = line.pt1();
+  if (pt0.getY() == pt1.getY()) {
+    return rect.yMin() <= pt0.getY() && pt0.getY() <= rect.yMax()
+           && rect.xMin() <= std::max(pt0.getX(), pt1.getX())
+           && std::min(pt0.getX(), pt1.getX()) <= rect.xMax();
+  }
+  return rect.xMin() <= pt0.getX() && pt0.getX() <= rect.xMax()
+         && rect.yMin() <= std::max(pt0.getY(), pt1.getY())
+         && std::min(pt0.getY(), pt1.getY()) <= rect.yMax();
+}
+}  // namespace
+
 void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
                                     odb::dbTechLayer* tech_layer,
                                     const odb::Rect& die_area)
@@ -605,6 +632,17 @@ void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
   const odb::Rect padded_box = computePinKeepout(shape, tech_layer);
   if (!die_area.intersects(padded_box)) {
     return;
+  }
+  const std::vector<odb::Line>& die_edges = core_->getDieAreaEdges();
+  if (die_edges.size() > 4) {
+    // polygon dies have slots on edges the bounding box cannot represent, so
+    // also block their slots with the padded shape itself
+    for (const odb::Line& die_edge : die_edges) {
+      if (touchesLine(padded_box, die_edge)) {
+        layer_blocked_shapes_[layer].push_back(padded_box);
+        break;
+      }
+    }
   }
   const odb::Rect intersect = die_area.intersect(padded_box);
   for (const Interval& interval : findBlockedIntervals(die_area, intersect)) {
@@ -3304,6 +3342,7 @@ void IOPlacer::initNetlist()
 {
   netlist_->reset();
   layer_fixed_pins_keepouts_.clear();
+  layer_blocked_shapes_.clear();
   pin_size_cache_.clear();
   spacing_cache_.clear();
   const odb::Rect& coreBoundary = core_->getBoundary();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -593,8 +593,10 @@ odb::Rect IOPlacer::computePinKeepout(const BlockingShape& shape,
                                       odb::dbTechLayer* tech_layer)
 {
   const PinSize pin_size = computePinSize(tech_layer->getRoutingLevel());
-  const int spacing = computeShapeSpacing(
-      tech_layer, shape, 2 * pin_size.half_width, pin_size.height);
+  // place_pin can request a pin wider than the technology derived size
+  const int pin_width = std::max(2 * pin_size.half_width, manual_pin_width_);
+  const int spacing
+      = computeShapeSpacing(tech_layer, shape, pin_width, pin_size.height);
   // pad by the pin footprint plus spacing: half width along the edge, the pin
   // extension into the die on the other axis
   const odb::Orientation2D edge_dir
@@ -2810,6 +2812,23 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
 
   const int layer_level = layer->getRoutingLevel();
   if (force_to_die_bound) {
+    // pad the blocking shapes with the size requested for this pin
+    refreshPinSizeCache();
+    const bool vertical_pin
+        = layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
+    PinSize pin_size;
+    pin_size.half_width = (vertical_pin ? width : height) / 2;
+    pin_size.height = vertical_pin ? height : width;
+    pin_size_cache_[layer_level] = pin_size;
+    manual_pin_width_ = std::min(width, height);
+    // block the fixed supply pins; fixed signal pin positions are explicit
+    // user requests, like the position being placed now
+    for (odb::dbBTerm* fixed_bterm : getBlock()->getBTerms()) {
+      if (fixed_bterm != bterm && fixed_bterm->getSigType().isSupply()
+          && fixed_bterm->getFirstPinPlacementStatus().isFixed()) {
+        addFixedPinKeepouts(fixed_bterm);
+      }
+    }
     // block boundary PDN shapes for the checks below, without persisting the
     // intervals beyond this placement. Macros are not included, since their
     // intervals block all layers and the pin position is an explicit request
@@ -2834,28 +2853,31 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
       edge = (dist_lb < dist_ub) ? Edge::bottom : Edge::top;
     }
 
-    // check the whole pin shape to make sure no overlaps will happen
-    // between pins
+    // check the center and the extremities of the pin shape, so wide pins do
+    // not straddle a blocked region
     // empty line created to comply with definition
     odb::Line empty_line;
     bool placed_at_blocked
-        = horizontal
-              ? checkBlocked(edge,
-                             empty_line,
-                             odb::Point(pos.x(), pos.y() - height / 2),
-                             layer_level)
-                    || checkBlocked(edge,
-                                    empty_line,
-                                    odb::Point(pos.x(), pos.y() + height / 2),
-                                    layer_level)
-              : checkBlocked(edge,
-                             empty_line,
-                             odb::Point(pos.x() - width / 2, pos.y()),
-                             layer_level)
-                    || checkBlocked(edge,
-                                    empty_line,
-                                    odb::Point(pos.x() + width / 2, pos.y()),
-                                    layer_level);
+        = checkBlocked(edge, empty_line, pos, layer_level)
+          || (horizontal
+                  ? checkBlocked(edge,
+                                 empty_line,
+                                 odb::Point(pos.x(), pos.y() - height / 2),
+                                 layer_level)
+                        || checkBlocked(
+                            edge,
+                            empty_line,
+                            odb::Point(pos.x(), pos.y() + height / 2),
+                            layer_level)
+                  : checkBlocked(edge,
+                                 empty_line,
+                                 odb::Point(pos.x() - width / 2, pos.y()),
+                                 layer_level)
+                        || checkBlocked(
+                            edge,
+                            empty_line,
+                            odb::Point(pos.x() + width / 2, pos.y()),
+                            layer_level));
     // keep the search inside the die area, so the pin is never pushed out of it
     const int max_offset = horizontal
                                ? die_boundary.yMax() - height / 2 - pos.y()
@@ -2897,36 +2919,46 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
         offset_sub++;
       }
 
-      // check the whole pin shape to make sure no overlaps will happen
-      // between pins
+      // check the center and the extremities of the pin shape, so wide pins
+      // do not straddle a blocked region
+      const odb::Point offset_pos = horizontal
+                                        ? odb::Point(pos.x(), pos.y() + offset)
+                                        : odb::Point(pos.x() + offset, pos.y());
       placed_at_blocked
-          = horizontal
-                ? checkBlocked(
-                      edge,
-                      empty_line,
-                      odb::Point(pos.x(), pos.y() - height / 2 + offset),
-                      layer_level)
-                      || checkBlocked(
+          = checkBlocked(edge, empty_line, offset_pos, layer_level)
+            || (horizontal
+                    ? checkBlocked(
                           edge,
                           empty_line,
-                          odb::Point(pos.x(), pos.y() + height / 2 + offset),
+                          odb::Point(pos.x(), pos.y() - height / 2 + offset),
                           layer_level)
-                : checkBlocked(
-                      edge,
-                      empty_line,
-                      odb::Point(pos.x() - width / 2 + offset, pos.y()),
-                      layer_level)
-                      || checkBlocked(
+                          || checkBlocked(
+                              edge,
+                              empty_line,
+                              odb::Point(pos.x(),
+                                         pos.y() + height / 2 + offset),
+                              layer_level)
+                    : checkBlocked(
                           edge,
                           empty_line,
-                          odb::Point(pos.x() + width / 2 + offset, pos.y()),
-                          layer_level);
+                          odb::Point(pos.x() - width / 2 + offset, pos.y()),
+                          layer_level)
+                          || checkBlocked(
+                              edge,
+                              empty_line,
+                              odb::Point(pos.x() + width / 2 + offset, pos.y()),
+                              layer_level));
     }
     pos.addX(horizontal ? 0 : offset);
     pos.addY(horizontal ? offset : 0);
     excluded_intervals_.erase(
         excluded_intervals_.begin() + num_excluded_intervals,
         excluded_intervals_.end());
+    // drop the request-sized paddings along with the temporary keepouts
+    layer_fixed_pins_keepouts_.clear();
+    layer_blocked_shapes_.clear();
+    pin_size_cache_.clear();
+    manual_pin_width_ = 0;
   }
 
   odb::Point ll = odb::Point(pos.x() - width / 2, pos.y() - height / 2);

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -563,17 +563,21 @@ int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
                                   const int pin_width,
                                   const int pin_length)
 {
+  // a DEF SPACING attribute replaces the layer rules entirely
+  if (shape.min_spacing >= 0) {
+    return shape.min_spacing;
+  }
   // the spacing rules use the width of the widest shape and the parallel
-  // run length between the shapes
-  const int shape_width = std::max({std::min(shape.rect.dx(), shape.rect.dy()),
-                                    shape.effective_width,
-                                    pin_width});
+  // run length between the shapes; DESIGNRULEWIDTH replaces the shape width
+  const int shape_width = std::max(
+      shape.effective_width >= 0 ? shape.effective_width
+                                 : std::min(shape.rect.dx(), shape.rect.dy()),
+      pin_width);
   const SpacingKey cache_key{
       tech_layer->getRoutingLevel(), shape_width, pin_length};
-  // shapes can require more than the layer rules (DEF SPACING attribute)
   const auto cached = spacing_cache_.find(cache_key);
   if (cached != spacing_cache_.end()) {
-    return std::max(cached->second, shape.min_spacing);
+    return cached->second;
   }
   // width-dependent rules require larger clearance to wide PDN shapes
   int spacing = tech_layer->getSpacing(shape_width, pin_length);
@@ -581,7 +585,7 @@ int IOPlacer::computeShapeSpacing(odb::dbTechLayer* tech_layer,
     spacing = tech_layer->getWidth();
   }
   spacing_cache_[cache_key] = spacing;
-  return std::max(spacing, shape.min_spacing);
+  return spacing;
 }
 
 odb::Rect IOPlacer::computePinKeepout(const BlockingShape& shape,
@@ -732,9 +736,11 @@ void IOPlacer::getBlockedRegionsFromDbObstructions()
       continue;
     }
     // obstructions can carry their own DEF spacing rules
-    const BlockingShape shape{obstruct_box->getBox(),
-                              obstruction->getMinSpacing(),
-                              obstruction->getEffectiveWidth()};
+    const BlockingShape shape{
+        obstruct_box->getBox(),
+        obstruction->hasMinSpacing() ? obstruction->getMinSpacing() : -1,
+        obstruction->hasEffectiveWidth() ? obstruction->getEffectiveWidth()
+                                         : -1};
     excludeBoundaryShape(shape, tech_layer, die_area);
   }
 }
@@ -3197,9 +3203,11 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
     }
     odb::dbBox* box = obstruction->getBBox();
     if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
-      obstructions.push_back({box->getBox(),
-                              obstruction->getMinSpacing(),
-                              obstruction->getEffectiveWidth()});
+      obstructions.push_back(
+          {box->getBox(),
+           obstruction->hasMinSpacing() ? obstruction->getMinSpacing() : -1,
+           obstruction->hasEffectiveWidth() ? obstruction->getEffectiveWidth()
+                                            : -1});
     }
   }
 
@@ -3217,9 +3225,10 @@ void IOPlacer::filterObstructedSlotsForTopLayer()
       if (pin->getPlacementStatus().isFixed()) {
         for (odb::dbBox* box : pin->getBoxes()) {
           if (box->getTechLayer()->getRoutingLevel() == top_layer_level) {
-            obstructions.push_back({box->getBox(),
-                                    pin->getMinSpacing(),
-                                    pin->getEffectiveWidth()});
+            obstructions.push_back(
+                {box->getBox(),
+                 pin->hasMinSpacing() ? pin->getMinSpacing() : -1,
+                 pin->hasEffectiveWidth() ? pin->getEffectiveWidth() : -1});
           }
         }
       }
@@ -3336,10 +3345,12 @@ void IOPlacer::addFixedPinKeepouts(odb::dbBTerm* bterm)
       // store the shapes padded, so the pins created near them keep the
       // min spacing carried by their own DEF rules
       layer_fixed_pins_keepouts_[tech_layer->getRoutingLevel()].push_back(
-          computePinKeepout({bpin_box->getBox(),
-                             bterm_pin->getMinSpacing(),
-                             bterm_pin->getEffectiveWidth()},
-                            tech_layer));
+          computePinKeepout(
+              {bpin_box->getBox(),
+               bterm_pin->hasMinSpacing() ? bterm_pin->getMinSpacing() : -1,
+               bterm_pin->hasEffectiveWidth() ? bterm_pin->getEffectiveWidth()
+                                              : -1},
+              tech_layer));
     }
   }
 }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -514,8 +514,18 @@ int IOPlacer::roundUpToEvenMfgGrid(const int dim)
   return rounded;
 }
 
+void IOPlacer::refreshPinSizeCache()
+{
+  // parameter changes invalidate the cached pin sizes
+  if (cached_pin_size_revision_ != parms_->getPinSizeRevision()) {
+    pin_size_cache_.clear();
+    cached_pin_size_revision_ = parms_->getPinSizeRevision();
+  }
+}
+
 PinSize IOPlacer::computePinSize(const int layer)
 {
+  refreshPinSizeCache();
   const auto cached = pin_size_cache_.find(layer);
   if (cached != pin_size_cache_.end()) {
     return cached->second;

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -461,7 +461,8 @@ bool IOPlacer::checkBlocked(Edge edge,
     if (blocked_interval.getLayer() == -1
         || blocked_interval.getLayer() == layer) {
       // polygon slots match all-layer intervals of any edge with the same
-      // orientation; layer shapes are point-tested via layer_blocked_shapes_
+      // orientation, still over-blocking their parallel edges; layer shapes
+      // are point-tested via layer_blocked_shapes_ instead
       if ((blocked_interval.getEdge() == edge
            || (edge == Edge::polygonEdge && blocked_interval.getLayer() == -1
                && hasVerticalPins(blocked_interval.getEdge()) == vertical_pin))
@@ -611,7 +612,10 @@ void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
 
   const bool vertical_pin
       = tech_layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
-  if (!ver_layers_.empty() || !hor_layers_.empty()) {
+  // empty layer sets mean standalone place_pin, where every layer
+  // participates and polygon slots are never tested
+  const bool standalone_place_pin = ver_layers_.empty() && hor_layers_.empty();
+  if (!standalone_place_pin) {
     const std::set<int>& layers = vertical_pin ? ver_layers_ : hor_layers_;
     if (layers.find(layer) == layers.end()) {
       return;
@@ -622,10 +626,9 @@ void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
     return;
   }
   // polygon dies have slots on edges the bounding box cannot represent, so
-  // also block their slots with the padded shape itself. Empty layer sets
-  // mean standalone place_pin, which never tests polygon slots
+  // also block their slots with the padded shape itself
   const std::vector<odb::Line>& die_edges = core_->getDieAreaEdges();
-  if (die_edges.size() > 4 && (!ver_layers_.empty() || !hor_layers_.empty())) {
+  if (die_edges.size() > 4 && !standalone_place_pin) {
     for (const odb::Line& die_edge : die_edges) {
       if (boost::geometry::intersects(padded_box, die_edge)) {
         std::vector<odb::Rect>& shapes = layer_blocked_shapes_[layer];
@@ -2746,9 +2749,8 @@ void IOPlacer::reportHPWL()
                 static_cast<float>(getBlock()->dbuToMicrons(total_hpwl)));
 }
 
-// seeds the pin size caches with the size requested for one place_pin call
-// and drops every temporary blocking state on destruction, so an error
-// thrown during the placement search leaves nothing stale behind
+// blocking state for one place_pin call, seeded with the requested pin size
+// and dropped on destruction so errors leave nothing stale behind
 struct IOPlacer::ManualPinBlocking
 {
   ManualPinBlocking(IOPlacer* placer,
@@ -2757,6 +2759,9 @@ struct IOPlacer::ManualPinBlocking
                     const int height)
       : placer_(placer), num_intervals_(placer->excluded_intervals_.size())
   {
+    // an aborted place_pins run skips clear(), drop whatever it left
+    placer_->layer_fixed_pins_keepouts_.clear();
+    placer_->layer_blocked_shapes_.clear();
     placer_->pin_size_cache_.clear();
     const bool vertical_pin
         = layer->getDirection() == odb::dbTechLayerDir::VERTICAL;
@@ -2768,9 +2773,11 @@ struct IOPlacer::ManualPinBlocking
 
   ~ManualPinBlocking()
   {
+    // only the tail is erased, the head holds persistent user exclusions
     placer_->excluded_intervals_.erase(
         placer_->excluded_intervals_.begin() + num_intervals_,
         placer_->excluded_intervals_.end());
+    // the run flows rebuild these in initNetlist, so they are safe to wipe
     placer_->layer_fixed_pins_keepouts_.clear();
     placer_->layer_blocked_shapes_.clear();
     placer_->pin_size_cache_.clear();
@@ -2830,8 +2837,7 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
     // block the fixed supply pins; fixed signal pin positions are explicit
     // user requests, like the position being placed now
     for (odb::dbBTerm* fixed_bterm : getBlock()->getBTerms()) {
-      if (fixed_bterm != bterm && fixed_bterm->getSigType().isSupply()
-          && fixed_bterm->getFirstPinPlacementStatus().isFixed()) {
+      if (fixed_bterm != bterm && fixed_bterm->getSigType().isSupply()) {
         addFixedPinKeepouts(fixed_bterm);
       }
     }
@@ -3318,6 +3324,10 @@ std::vector<Section> IOPlacer::findSectionsForTopLayer(const odb::Rect& region)
 void IOPlacer::addFixedPinKeepouts(odb::dbBTerm* bterm)
 {
   for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
+    // multi bpin terms can mix placement statuses
+    if (!bterm_pin->getPlacementStatus().isFixed()) {
+      continue;
+    }
     for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
       odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
       if (tech_layer == nullptr || tech_layer->getRoutingLevel() == 0) {

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -636,8 +636,13 @@ void IOPlacer::excludeBoundaryShape(const BlockingShape& shape,
     for (const odb::Line& die_edge : die_edges) {
       if (boost::geometry::intersects(padded_box, die_edge)) {
         std::vector<odb::Rect>& shapes = layer_blocked_shapes_[layer];
-        // boundary via arrays produce near duplicate keepouts, skip them
-        if (shapes.empty() || !shapes.back().contains(padded_box)) {
+        // boundary via arrays produce near duplicate keepouts, keep the
+        // larger of consecutive nested shapes
+        if (shapes.empty()) {
+          shapes.push_back(padded_box);
+        } else if (padded_box.contains(shapes.back())) {
+          shapes.back() = padded_box;
+        } else if (!shapes.back().contains(padded_box)) {
           shapes.push_back(padded_box);
         }
         break;

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -106,6 +106,7 @@ COMPULSORY_TESTS = [
     "pdn_boundary_mirrored_pins",
     "pdn_boundary_pg_pins",
     "pdn_boundary_place_pin",
+    "pdn_boundary_place_pin_rules",
     "pdn_boundary_stripes",
     "pdn_boundary_stripes_length",
     "pdn_boundary_stripes_no_pins",

--- a/src/ppl/test/CMakeLists.txt
+++ b/src/ppl/test/CMakeLists.txt
@@ -99,6 +99,7 @@ or_integration_tests(
     pdn_boundary_mirrored_pins
     pdn_boundary_pg_pins
     pdn_boundary_place_pin
+    pdn_boundary_place_pin_rules
     pdn_boundary_stripes
     pdn_boundary_stripes_length
     pdn_boundary_stripes_no_pins

--- a/src/ppl/test/obstruction_boundary.ok
+++ b/src/ppl/test/obstruction_boundary.ok
@@ -10,4 +10,6 @@ Found 0 macro blocks.
 [INFO PPL-0005] Slots per section         200
 [INFO PPL-0008] Successfully assigned pins to sections.
 pin to obstruction violations: 0
+pin to min spacing obstruction violations: 0
+pin to effective width obstruction violations: 0
 pins over the fill and slot blockages: 19

--- a/src/ppl/test/obstruction_boundary.ok
+++ b/src/ppl/test/obstruction_boundary.ok
@@ -12,4 +12,6 @@ Found 0 macro blocks.
 pin to obstruction violations: 0
 pin to min spacing obstruction violations: 0
 pin to effective width obstruction violations: 0
+pin to spacing override obstruction violations: 0
+pins allowed within the table spacing of the override obstruction: 2
 pins over the fill and slot blockages: 19

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -12,9 +12,22 @@ read_def gcd_placed.def
 set block [ord::get_db_block]
 set metal2 [[ord::get_db_tech] findLayer metal2]
 
+# long pins reach the wide shape rows of the spacing table
+set_pin_length -hor_length 1.0 -ver_length 1.0
+
 # routing obstruction touching the top edge
 set obstruction_rect {100000 292000 104000 296000}
 odb::dbObstruction_create $block $metal2 {*}$obstruction_rect
+
+# obstruction with a min spacing rule larger than the layer spacing
+set min_spacing_rect {150000 292000 154000 296000}
+set spacing_obs [odb::dbObstruction_create $block $metal2 {*}$min_spacing_rect]
+$spacing_obs setMinSpacing 5000
+
+# narrow obstruction with an effective width selecting the wide spacing row
+set eff_width_rect {160400 295800 164400 296000}
+set eff_obs [odb::dbObstruction_create $block $metal2 {*}$eff_width_rect]
+$eff_obs setEffectiveWidth 2000
 
 # fill and slot only blockages allow routing metal, so pins may use them
 set blockage_rect {110000 292000 200000 296000}
@@ -45,5 +58,10 @@ proc count_pins_in_rect { llx lly urx ury } {
 
 puts "pin to obstruction violations:\
   [count_rect_violations metal2 [list $obstruction_rect] spacing]"
+puts "pin to min spacing obstruction violations:\
+  [count_rect_violations metal2 [list $min_spacing_rect] 5000]"
+puts "pin to effective width obstruction violations:\
+  [count_rect_violations metal2 [list $eff_width_rect] \
+  [$metal2 getSpacing 2000 2000]]"
 puts "pins over the fill and slot blockages:\
   [count_pins_in_rect {*}$blockage_rect]"

--- a/src/ppl/test/obstruction_boundary.tcl
+++ b/src/ppl/test/obstruction_boundary.tcl
@@ -29,6 +29,11 @@ set eff_width_rect {160400 295800 164400 296000}
 set eff_obs [odb::dbObstruction_create $block $metal2 {*}$eff_width_rect]
 $eff_obs setEffectiveWidth 2000
 
+# obstruction overriding the table spacing with a smaller value
+set override_rect {180000 292000 184000 296000}
+set override_obs [odb::dbObstruction_create $block $metal2 {*}$override_rect]
+$override_obs setMinSpacing 200
+
 # fill and slot only blockages allow routing metal, so pins may use them
 set blockage_rect {110000 292000 200000 296000}
 set fill_obs [odb::dbObstruction_create $block $metal2 {*}$blockage_rect]
@@ -63,5 +68,9 @@ puts "pin to min spacing obstruction violations:\
 puts "pin to effective width obstruction violations:\
   [count_rect_violations metal2 [list $eff_width_rect] \
   [$metal2 getSpacing 2000 2000]]"
+puts "pin to spacing override obstruction violations:\
+  [count_rect_violations metal2 [list $override_rect] 200]"
+puts "pins allowed within the table spacing of the override obstruction:\
+  [count_pins_in_rect 179460 292000 184540 296000]"
 puts "pins over the fill and slot blockages:\
   [count_pins_in_rect {*}$blockage_rect]"

--- a/src/ppl/test/pdn_boundary_pg_pins.ok
+++ b/src/ppl/test/pdn_boundary_pg_pins.ok
@@ -10,3 +10,4 @@ Found 0 macro blocks.
 [INFO PPL-0005] Slots per section         200
 [INFO PPL-0008] Successfully assigned pins to sections.
 pin violations against PG pins: 0
+pin violations against min spacing PG pin: 0

--- a/src/ppl/test/pdn_boundary_pg_pins.tcl
+++ b/src/ppl/test/pdn_boundary_pg_pins.tcl
@@ -23,7 +23,19 @@ set pin [odb::dbBPin_create $term]
 odb::dbBox_create $pin $metal2 22140 295440 273640 296000
 $pin setPlacementStatus FIRM
 
+# power pin on the bottom edge requiring more than the layer min spacing
+set bottom_net [odb::dbNet_create $block "VDDB"]
+set bottom_term [odb::dbBTerm_create $bottom_net "VDDB"]
+$bottom_term setSigType POWER
+set bottom_pin [odb::dbBPin_create $bottom_term]
+odb::dbBox_create $bottom_pin $metal2 22140 0 273640 560
+$bottom_pin setMinSpacing 5000
+$bottom_pin setPlacementStatus FIRM
+
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
-  -min_distance 0.12 -exclude left:* -exclude right:* -exclude bottom:*
+  -min_distance 0.12 -exclude left:* -exclude right:*
 
 puts "pin violations against PG pins: [count_pg_pin_violations spacing]"
+set min_spacing_rect [list [list 22140 0 273640 560]]
+puts "pin violations against min spacing PG pin:\
+  [count_rect_violations metal2 $min_spacing_rect 5000]"

--- a/src/ppl/test/pdn_boundary_place_pin_rules.ok
+++ b/src/ppl/test/pdn_boundary_place_pin_rules.ok
@@ -1,0 +1,9 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 53 components and 333 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 54 connections.
+[INFO PPL-0070] Pin req_msg\[0\] placed at (52.48um, 145.50um) instead of (51.00um, 148.00um). Pin was snapped to a routing track, to the manufacturing grid or moved away from blocked region.
+[INFO PPL-0070] Pin req_msg\[1\] placed at (99.78um, 147.97um) instead of (105.00um, 148.00um). Pin was snapped to a routing track, to the manufacturing grid or moved away from blocked region.
+pin to stripe violations: 0
+pin violations against PG pins: 0

--- a/src/ppl/test/pdn_boundary_place_pin_rules.ok
+++ b/src/ppl/test/pdn_boundary_place_pin_rules.ok
@@ -5,5 +5,9 @@
 [INFO ODB-0133]     Created 54 nets and 54 connections.
 [INFO PPL-0070] Pin req_msg\[0\] placed at (52.48um, 145.50um) instead of (51.00um, 148.00um). Pin was snapped to a routing track, to the manufacturing grid or moved away from blocked region.
 [INFO PPL-0070] Pin req_msg\[1\] placed at (99.78um, 147.97um) instead of (105.00um, 148.00um). Pin was snapped to a routing track, to the manufacturing grid or moved away from blocked region.
+[INFO PPL-0070] Pin req_msg\[2\] placed at (130.19um, 147.97um) instead of (125.00um, 148.00um). Pin was snapped to a routing track, to the manufacturing grid or moved away from blocked region.
+Found 0 macro blocks.
+[ERROR PPL-0024] Number of IO pins (51) exceeds maximum number of available positions (7). Increase the die perimeter from 592.00um to 5106.63um.
+[INFO PPL-0070] Pin req_msg\[3\] placed at (80.03um, 147.97um) instead of (80.03um, 148.00um). Pin was snapped to a routing track, to the manufacturing grid or moved away from blocked region.
 pin to stripe violations: 0
 pin violations against PG pins: 0

--- a/src/ppl/test/pdn_boundary_place_pin_rules.tcl
+++ b/src/ppl/test/pdn_boundary_place_pin_rules.tcl
@@ -24,9 +24,36 @@ set pg_pin [odb::dbBPin_create $pg_term]
 odb::dbBox_create $pg_pin $metal2 200000 295440 220000 296000
 $pg_pin setPlacementStatus FIRM
 
+# supply pin whose first bpin is placed and second is firm
+set pg2_net [odb::dbNet_create $block "VDDM"]
+set pg2_term [odb::dbBTerm_create $pg2_net "VDDM"]
+$pg2_term setSigType POWER
+set pg2_firm [odb::dbBPin_create $pg2_term]
+odb::dbBox_create $pg2_firm $metal2 240000 295440 260000 296000
+$pg2_firm setPlacementStatus FIRM
+set pg2_placed [odb::dbBPin_create $pg2_term]
+odb::dbBox_create $pg2_placed $metal2 20000 295440 30000 296000
+$pg2_placed setPlacementStatus PLACED
+
 place_pin -pin_name req_msg\[0\] -layer metal2 -location {51 148} \
   -pin_size {0.14 5.0} -force_to_die_boundary
 place_pin -pin_name req_msg\[1\] -layer metal2 -location {105 148} \
+  -force_to_die_boundary
+place_pin -pin_name req_msg\[2\] -layer metal2 -location {125 148} \
+  -force_to_die_boundary
+
+# firm signal pin, visible to place_pin only through stale run keepouts
+set sig_bpin [odb::dbBPin_create [$block findBTerm {resp_msg\[15\]}]]
+odb::dbBox_create $sig_bpin $metal2 160000 295440 160280 296000
+$sig_bpin setPlacementStatus FIRM
+
+# an aborted run must not leave its keepouts behind for place_pin
+catch {
+  place_pins -hor_layers metal3 -ver_layers metal2 -min_distance 100
+}
+
+# explicit request over the firm signal pin, must stay where asked
+place_pin -pin_name req_msg\[3\] -layer metal2 -location {80.025 148} \
   -force_to_die_boundary
 
 puts "pin to stripe violations: [count_pdn_shape_violations spacing]"

--- a/src/ppl/test/pdn_boundary_place_pin_rules.tcl
+++ b/src/ppl/test/pdn_boundary_place_pin_rules.tcl
@@ -1,0 +1,33 @@
+# place_pin -force_to_die_boundary must pad the blocking shapes with the
+# requested -pin_size and keep min spacing to fixed power/ground pins
+source "helpers.tcl"
+source "pdn_helpers.tcl"
+
+read_lef Nangate45/Nangate45.lef
+read_def gcd_placed.def
+
+set block [ord::get_db_block]
+set metal2 [[ord::get_db_tech] findLayer metal2]
+
+# stripe recessed from the top edge, only reachable by a long pin
+set net [odb::dbNet_create $block "VDD"]
+$net setSpecial
+$net setSigType POWER
+set swire [odb::dbSWire_create $net "ROUTED"]
+odb::dbSBox_create $swire $metal2 100000 294000 104000 295000 "STRIPE"
+
+# fixed power pin on a top edge segment
+set pg_net [odb::dbNet_create $block "VDDT"]
+set pg_term [odb::dbBTerm_create $pg_net "VDDT"]
+$pg_term setSigType POWER
+set pg_pin [odb::dbBPin_create $pg_term]
+odb::dbBox_create $pg_pin $metal2 200000 295440 220000 296000
+$pg_pin setPlacementStatus FIRM
+
+place_pin -pin_name req_msg\[0\] -layer metal2 -location {51 148} \
+  -pin_size {0.14 5.0} -force_to_die_boundary
+place_pin -pin_name req_msg\[1\] -layer metal2 -location {105 148} \
+  -force_to_die_boundary
+
+puts "pin to stripe violations: [count_pdn_shape_violations spacing]"
+puts "pin violations against PG pins: [count_pg_pin_violations spacing]"

--- a/src/ppl/test/pdn_boundary_stripes_polygon.tcl
+++ b/src/ppl/test/pdn_boundary_stripes_polygon.tcl
@@ -16,6 +16,9 @@ set metal2 [[ord::get_db_tech] findLayer metal2]
 set net [$block findNet "VDD"]
 set swire [odb::dbSWire_create $net "ROUTED"]
 odb::dbSBox_create $swire $metal2 70000 0 74000 20000 "STRIPE"
+# stripe touching an internal edge of the polygon, which the die area
+# bounding box cannot represent
+odb::dbSBox_create $swire $metal2 20000 80000 24000 100000 "STRIPE"
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 \
   -min_distance 0.12

--- a/src/ppl/test/pdn_helpers.tcl
+++ b/src/ppl/test/pdn_helpers.tcl
@@ -1,11 +1,14 @@
 # Helper procs for the boundary PDN tests. A violation is a signal pin shape
 # closer to a blocking shape than the required spacing: "overlap" requires
-# plain intersection, "spacing" uses the layer default spacing and "table"
-# the width-dependent spacing for wide shapes.
+# plain intersection, "spacing" uses the layer default spacing, "table" the
+# width-dependent spacing for wide shapes and an integer an explicit value.
 
 proc get_required_spacing { layer pin_box llx lly urx ury mode } {
   if { $mode == "overlap" } {
     return 0
+  }
+  if { [string is integer -strict $mode] } {
+    return $mode
   }
   if { $mode == "table" } {
     set pin_dx [expr { [$pin_box xMax] - [$pin_box xMin] }]

--- a/src/ppl/test/top_layer_pdn_spacing.ok
+++ b/src/ppl/test/top_layer_pdn_spacing.ok
@@ -7,13 +7,14 @@
 [INFO ODB-0133]     Created 54 nets and 155 connections.
 Found 1 macro blocks.
 Using 2 tracks default min distance between IO pins.
-[INFO PPL-0060] Restrict pins [ clk req_rdy req_val reset resp_rdy ... ] to region (50.00u, 122.95u)-(250.00u, 143.00u) at routing layer met5.
+[INFO PPL-0060] Restrict pins [ clk req_rdy req_val reset resp_rdy ... ] to region (50.00u, 122.95u)-(250.00u, 204.00u) at routing layer met5.
 [INFO PPL-0001] Number of available slots 866
-[INFO PPL-0062] Number of top layer slots 90
+[INFO PPL-0062] Number of top layer slots 360
 [INFO PPL-0002] Number of I/O             54
 [INFO PPL-0003] Number of I/O w/sink      54
 [INFO PPL-0004] Number of I/O w/o sink    0
 [INFO PPL-0005] Slots per section         200
 [INFO PPL-0008] Successfully assigned pins to sections.
-[INFO PPL-0012] I/O nets HPWL: 7584.69 um.
+[INFO PPL-0012] I/O nets HPWL: 7599.82 um.
 pin to strap spacing violations: 0
+pin to min spacing obstruction violations: 0

--- a/src/ppl/test/top_layer_pdn_spacing.tcl
+++ b/src/ppl/test/top_layer_pdn_spacing.tcl
@@ -19,13 +19,20 @@ $net setSigType POWER
 set swire [odb::dbSWire_create $net "ROUTED"]
 odb::dbSBox_create $swire $met5 50000 125000 250000 130000 "STRIPE"
 
+# obstruction with a min spacing rule larger than the layer spacing
+set obs [odb::dbObstruction_create $block $met5 50000 205000 250000 210000]
+$obs setMinSpacing 10000
+
 # the first slot row ends 0.8um below the strap: allowed by the 0.3um user
 # keepout, but closer than the layer min spacing
 define_pin_shape_pattern -layer met5 -x_step 6.8 -y_step 6.8 \
-  -region { 50 122.95 250 143 } -size { 1.6 2.5 } -pin_keepout 0.3
+  -region { 50 122.95 250 204 } -size { 1.6 2.5 } -pin_keepout 0.3
 set_io_pin_constraint \
   -pin_names {clk resp_val req_val resp_rdy reset req_rdy} -region "up:*"
 
 place_pins -hor_layer met3 -ver_layer met2
 
 puts "pin to strap spacing violations: [count_pdn_shape_violations table]"
+set obstruction_rect [list [list 50000 205000 250000 210000]]
+puts "pin to min spacing obstruction violations:\
+  [count_rect_violations met5 $obstruction_rect 10000]"


### PR DESCRIPTION
## Summary
Third PR of the boundary PDN/obstruction series (follows #11102 and #11246).
- Honor DEF `SPACING`/`DESIGNRULEWIDTH` on obstructions and PG pins as rule overrides (per DEF 5.8) when padding boundary shapes, in both the boundary and top-layer paths.
- Block slots on the internal edges of polygon dies, not only the bounding-box edges.
- `place_pin -force_to_die_boundary` now pads blockers with the requested `-pin_size` and keeps spacing to fixed supply pins; the temporary state is scoped in an RAII guard so aborted runs leave nothing stale.

## Type of Change
- Bug fix

## Impact
Pins placed by `place_pins`/`place_pin` respect obstruction spacing attributes and fixed PG pin geometry; overrides smaller than the table spacing no longer over-block slots. Fixed signal pin locations remain explicit user requests and are untouched.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Follow-up of #11102 and #11246.
