### PR TITLE
Render polygon floorplan outlines in web tiles

### DIFF
--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -2439,6 +2439,42 @@ void TileGenerator::outlineRectInTile(std::vector<unsigned char>& image,
   }
 }
 
+void TileGenerator::outlinePolygonInTile(std::vector<unsigned char>& image,
+                                         const odb::Polygon& polygon,
+                                         const Color& c,
+                                         const TileFrame& frame) const
+{
+  const auto& points = polygon.getPoints();
+  if (points.size() < 2) {
+    return;
+  }
+
+  const odb::Rect& tile = frame.cull;
+  const int dim = bufferDim(image);
+  const int width = hairlineCss(frame);
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    const odb::Point& p0 = points[i];
+    const odb::Point& p1 = points[(i + 1) % points.size()];
+    const int x_min = std::min(p0.x(), p1.x());
+    const int x_max = std::max(p0.x(), p1.x());
+    const int y_min = std::min(p0.y(), p1.y());
+    const int y_max = std::max(p0.y(), p1.y());
+    if (x_max < tile.xMin() || tile.xMax() < x_min || y_max < tile.yMin()
+        || tile.yMax() < y_min) {
+      continue;
+    }
+
+    drawLine(image,
+             toPxXd(p0.x(), frame),
+             toPxYd(p0.y(), frame, dim),
+             toPxXd(p1.x(), frame),
+             toPxYd(p1.y(), frame, dim),
+             c,
+             width,
+             dim);
+  }
+}
+
 /* static */
 void TileGenerator::drawOrientationTag(std::vector<unsigned char>& image,
                                        odb::dbInst* inst,
@@ -3086,18 +3122,16 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
       // on the _instances pass for all designs (Qt draws it always;
       // scoping to _instances keeps tech-layer tiles transparent).
       if (draw_die_outline || instances_only) {
-        const odb::Rect die = block->getDieArea();
-        if (die.area() > 0) {
-          outlineRectInTile(image_buffer, die, kOutlineGray, frame);
+        const odb::Polygon die = block->getDieAreaPolygon();
+        if (!die.getPoints().empty()) {
+          outlinePolygonInTile(image_buffer, die, kOutlineGray, frame);
         }
       }
       // Core area outline (Qt drawChip draws it right after the die).
-      // Unset core -> empty polygon -> mergeInit()-inverted rect, so
-      // check min<max explicitly rather than area()>0.
       if (instances_only) {
-        const odb::Rect core = block->getCoreArea();
-        if (core.xMin() < core.xMax() && core.yMin() < core.yMax()) {
-          outlineRectInTile(image_buffer, core, kOutlineGray, frame);
+        const odb::Polygon core = block->getCoreAreaPolygon();
+        if (!core.getPoints().empty()) {
+          outlinePolygonInTile(image_buffer, core, kOutlineGray, frame);
         }
       }
 

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -1006,6 +1006,11 @@ class TileGenerator
                          const odb::Rect& r,
                          const Color& c,
                          const TileFrame& frame) const;
+  // Draw polygon edges clamped to the tile (die/core outlines).
+  void outlinePolygonInTile(std::vector<unsigned char>& image,
+                            const odb::Polygon& polygon,
+                            const Color& c,
+                            const TileFrame& frame) const;
   // Diagonal across the master's origin corner, so a flipped or rotated
   // instance reads as such.  Mirrors RenderThread::drawInstanceOutlines();
   // callers gate on the master height, as Qt does.

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -2724,6 +2724,54 @@ TEST_F(TileGeneratorTest, DieAndCoreOutlinesOnInstancesLayer)
       << "Expected die + core vertical edges crossing the same row";
 }
 
+TEST_F(TileGeneratorTest, PolygonFloorplanOutlineFollowsDiagonalEdge)
+{
+  const odb::Polygon die({odb::Point(0, 0),
+                          odb::Point(4000, 0),
+                          odb::Point(4000, 3000),
+                          odb::Point(2500, 4000),
+                          odb::Point(0, 4000)});
+  block_->setDieArea(die);
+  placeInst("BUF_X16", "buf1", 0, 0);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  TileVisibility vis;
+  vis.stdcells = false;
+  unsigned w = 0, h = 0;
+  const auto pixels
+      = decodePng(tile_gen_->generateTile("_instances", 0, 0, 0, vis), w, h);
+  ASSERT_GT(w, 0u);
+  ASSERT_GT(h, 0u);
+
+  const odb::Rect bounds = tile_gen_->getBounds();
+  const auto grayNear = [&](double x, double y) {
+    const int cx = colOf(bounds, w, static_cast<int>(x));
+    const int cy = rowOf(bounds, w, h, static_cast<int>(y));
+    for (int yy = std::max(cy - 2, 0);
+         yy <= std::min(cy + 2, static_cast<int>(h) - 1);
+         ++yy) {
+      for (int xx = std::max(cx - 2, 0);
+           xx <= std::min(cx + 2, static_cast<int>(w) - 1);
+           ++xx) {
+        const size_t i = 4UL * (static_cast<size_t>(yy) * w + xx);
+        if (pixels[i + 3] > 0 && pixels[i] == 128 && pixels[i + 1] == 128
+            && pixels[i + 2] == 128) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  // The slanted edge runs from (4000,3000) to (2500,4000).  A rectangular
+  // renderer would leave all of these points empty.
+  for (const double t : {0.2, 0.5, 0.8}) {
+    SCOPED_TRACE(t);
+    EXPECT_TRUE(grayNear(4000.0 - 1500.0 * t, 3000.0 + 1000.0 * t));
+  }
+}
+
 TEST_F(TileGeneratorTest, NoOutlineOnTechLayerTiles)
 {
   // Guard against the regression that motivated the original multi-die-only


### PR DESCRIPTION
Fixes #11300.

The web tile renderer was still drawing the die and core as bounding rectangles. That made non-rectangular floorplans look rectangular in the browser, even though the Qt viewer uses the actual polygon.

This uses the ODB die/core polygons and clips each edge to the tile before rasterizing it. I also added a pentagon regression test that checks the diagonal edge is present.

Tested on the GCP VM:
- /home/naveenvenkat/bin/bazel test --test_output=errors --cache_test_results=no //src/web/test:tile_generator_test
- /home/naveenvenkat/bin/bazel test --test_output=errors --cache_test_results=no //src/web/test:tile_generator_test //src/web/test:request_handler_test
- git diff --check