### PR TITLE
rcx: preserve segments for repeated BTERM markers

### DIFF
--- a/src/rcx/src/extmain_v2.cpp
+++ b/src/rcx/src/extmain_v2.cpp
@@ -686,15 +686,27 @@ dbRSeg* extMain::addRSeg_v2(dbNet* net,
     captbl = _tmpSumCapTable;
   }
 
-  if (!path.bterm && isTermPathEnded(pshape.bterm, pshape.iterm)) {
-    _rsegJid.clear();
-    return nullptr;
+  const bool repeated_term
+      = !path.bterm && isTermPathEnded(pshape.bterm, pshape.iterm);
+
+  uint32_t dstId;
+  if (repeated_term) {
+    // A wide BTERM can mark adjacent wire points with the same terminal.
+    // Keep the physical segment by making the repeated point internal.
+    _nodeTable->set(pshape.junction_id, -1);
+    dstId = getCapNodeId_v2(net, pshape.junction_id, isBranch);
+  } else {
+    dstId = getCapNodeId_v2(net, pshape, pshape.junction_id, isBranch);
   }
-  const uint32_t dstId
-      = getCapNodeId_v2(net, pshape, pshape.junction_id, isBranch);
 
   // const uint32_t dstId= getCapNodeId( net, pshape.bterm, pshape.iterm,
   // pshape.junction_id, isBranch);
+
+  if (dstId == srcId && pshape.bterm != nullptr) {
+    // The same wide BTERM may be attached to two adjacent path points.
+    _nodeTable->set(pshape.junction_id, -1);
+    dstId = getCapNodeId_v2(net, pshape.junction_id, isBranch);
+  }
 
   if (dstId == srcId) {
     loopWarning(net, pshape);

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -660,12 +660,25 @@ dbRSeg* extMain::addRSeg(dbNet* net,
                          const double* restbl,
                          const double* captbl)
 {
-  if (!path.bterm && isTermPathEnded(pshape.bterm, pshape.iterm)) {
-    rsegJid.clear();
-    return nullptr;
+  const bool repeated_term
+      = !path.bterm && isTermPathEnded(pshape.bterm, pshape.iterm);
+
+  uint32_t dstId;
+  if (repeated_term) {
+    // A wide BTERM can mark adjacent wire points with the same terminal.
+    // Keep the physical segment by making the repeated point internal.
+    _nodeTable->set(pshape.junction_id, -1);
+    dstId = getCapNodeId(net, nullptr, nullptr, pshape.junction_id, isBranch);
+  } else {
+    dstId = getCapNodeId(
+        net, pshape.bterm, pshape.iterm, pshape.junction_id, isBranch);
   }
-  const uint32_t dstId = getCapNodeId(
-      net, pshape.bterm, pshape.iterm, pshape.junction_id, isBranch);
+  if (dstId == srcId && pshape.bterm != nullptr) {
+    // The same wide BTERM may be attached to two adjacent path points.
+    _nodeTable->set(pshape.junction_id, -1);
+    dstId = getCapNodeId(net, nullptr, nullptr, pshape.junction_id, isBranch);
+  }
+
   if (dstId == srcId) {
     std::string tname;
     if (pshape.bterm) {

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -22,6 +22,7 @@ COMPULSORY_TESTS = [
     "coordinates",
     "no_merging",
     "short_resover",
+    "duplicate_bterm",
 ]
 
 # From CMakeLists.txt or_integration_tests(PASSFAIL_TESTS

--- a/src/rcx/test/CMakeLists.txt
+++ b/src/rcx/test/CMakeLists.txt
@@ -11,6 +11,7 @@ or_integration_tests(
     coordinates
     no_merging
     short_resover
+    duplicate_bterm
   PASSFAIL_TESTS
     rcx_unit_test
     test_dielectric_epsilon

--- a/src/rcx/test/duplicate_bterm.def
+++ b/src/rcx/test/duplicate_bterm.def
@@ -1,0 +1,17 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN duplicate_bterm ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 5000 4000 ) ;
+PINS 2 ;
+    - in1 + NET n1 + DIRECTION INPUT + PLACED ( 1000 2000 ) N
+      + LAYER metal3 ( -70 -70 ) ( 70 70 ) ;
+    - out1 + NET n1 + DIRECTION OUTPUT + PLACED ( 2500 2000 ) N
+      + LAYER metal3 ( -750 -750 ) ( 750 750 ) ;
+END PINS
+NETS 1 ;
+    - n1 ( PIN in1 ) ( PIN out1 )
+      + ROUTED metal3 ( 1000 2000 ) ( 2000 2000 ) ( 3000 2000 ) ( 4000 2000 ) ;
+END NETS
+END DESIGN

--- a/src/rcx/test/duplicate_bterm.ok
+++ b/src/rcx/test/duplicate_bterm.ok
@@ -1,0 +1,15 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: duplicate_bterm
+[INFO ODB-0130]     Created 2 pins.
+[INFO ODB-0133]     Created 1 nets and 0 connections.
+[INFO RCX-0431] Defined process_corner X with ext_model_index 0
+[INFO RCX-0029] Defined extraction corner X
+[INFO RCX-0435] Reading extraction model file 45_patterns.rules ...
+[INFO RCX-0436] RC segment generation duplicate_bterm (max_merge_res 0.0) ...
+[INFO RCX-0040] Final 3 rc segments
+[INFO RCX-0439] Coupling Cap extraction duplicate_bterm ...
+[INFO RCX-0440] Coupling threshhold is 0.1000 fF, coupling capacitance less than 0.1000 fF will be grounded.
+[INFO RCX-0442] 100% of 3 wires extracted
+[INFO RCX-0045] Extract -1 nets, 4 rsegs, 4 caps, 0 ccs
+[INFO RCX-0443] 1 nets finished
+duplicate bterm resistors: 3

--- a/src/rcx/test/duplicate_bterm.tcl
+++ b/src/rcx/test/duplicate_bterm.tcl
@@ -1,0 +1,22 @@
+source helpers.tcl
+
+read_lef Nangate45/Nangate45.lef
+read_def duplicate_bterm.def
+
+define_process_corner -ext_model_index 0 X
+set_extraction_rules_file 45_patterns.rules
+extract_parasitics -max_res 0 -coupling_threshold 0.1
+
+set spef_file [make_result_file duplicate_bterm.spef]
+write_spef $spef_file
+set fp [open $spef_file r]
+set spef [read $fp]
+close $fp
+set res_start [string first "*RES\n" $spef]
+set res_end [string first "*END" $spef $res_start]
+set res_section [string range $spef $res_start $res_end]
+set resistor_count [regexp -all -line {^[0-9]+ [^ \t]+ [^ \t]+ [^ \t]+} $res_section]
+puts "duplicate bterm resistors: $resistor_count"
+if {$resistor_count != 3} {
+  error "expected three resistors for the three physical wire segments"
+}


### PR DESCRIPTION
Fixes #11271.

A wide pad pin can mark two adjacent wire points with the same BTERM. RCX then reuses the terminal cap node for both ends of a physical segment, reports a false loop, and drops the resistor.

This keeps repeated terminal points as internal extraction nodes. The change is applied to both RCX extraction paths. The regression uses a four-point straight wire and checks that all three physical resistors are present in SPEF.

Validation on the OpenROAD VM:
- Full RCX suite: 19/19 passed
- Reproducer with extractor v1: no RCX-0111 warning and 3 resistors
- Reproducer with extractor v2: no RCX-0117 warning and 3 resistors
- New duplicate_bterm regression: passed