### PR TITLE
web: avoid timing highlight crash without a top block

### DIFF
--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -4358,7 +4358,7 @@ WebSocketResponse TimingHandler::handleTimingHighlight(
 
         const std::string pin_name
             = jsonOr<std::string>(req.json, "pin_name", "");
-        if (!pin_name.empty()) {
+        if (block && !pin_name.empty()) {
           static const Color kStageColor{.r = 255, .g = 255, .b = 0, .a = 180};
           auto [iterm, bterm] = resolvePin(block, pin_name);
 

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -6412,6 +6412,12 @@ void collectTimingPathShapes(odb::dbBlock* block,
                              std::vector<ColoredRect>& rects,
                              std::vector<FlightLine>& lines)
 {
+  // A 3DBlox top chip can be a hierarchy-only chip with no dbBlock.  Timing
+  // paths still exist in STA, but there is no block geometry to resolve.
+  if (!block) {
+    return;
+  }
+
   static const Color kLaunchClkColor{
       .r = 0, .g = 255, .b = 255, .a = 180};                            // Cyan
   static const Color kSignalColor{.r = 255, .g = 0, .b = 0, .a = 180};  // Red

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -25,6 +25,7 @@
 #include "odb/geom.h"
 #include "third-party/lodepng/lodepng.h"
 #include "tile_generator.h"
+#include "timing_report.h"
 #include "tst/nangate45_fixture.h"
 
 namespace web {
@@ -4340,6 +4341,19 @@ TEST_F(TileGeneratorTest, NangateScaleIsTheOneModelledAbove)
 {
   EXPECT_EQ(getDb()->getDbuPerMicron(), 2000u);
   EXPECT_EQ(dbuPrecision(getDb()->getDbuPerMicron()), 4);
+}
+
+TEST(TimingPathShapesTest, NullBlockProducesNoGeometry)
+{
+  TimingPathSummary path;
+  path.data_nodes = {{.pin_name = "top/input"}, {.pin_name = "top/output"}};
+  std::vector<ColoredRect> rects;
+  std::vector<FlightLine> lines;
+
+  collectTimingPathShapes(nullptr, path, rects, lines);
+
+  EXPECT_TRUE(rects.empty());
+  EXPECT_TRUE(lines.empty());
 }
 
 }  // namespace


### PR DESCRIPTION
When a 3DBlox design is loaded, the top chip can legitimately have no dbBlock. Clicking a timing path still sent that null block into the shape collector and pin resolver, which caused a SIGSEGV.

Return without collecting shapes when there is no block, and skip the pin lookup in the request handler for the same case. Regular block-backed timing highlights keep the existing behavior.

Tested on the clean OpenROAD checkout on the VM:
- bazel --batch test --test_output=errors --cache_test_results=no //src/web/test:tile_generator_test //src/web/test:request_handler_test
- 2 tests passed