### PR TITLE
ci: revert first-interaction to v1.3.0 and block major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    # v3 greets returning contributors as first-timers (actions/first-interaction#369).
+    ignore:
+      - dependency-name: "actions/first-interaction"
+        update-types: ["version-update:semver-major"]
     groups:
       actions:
         patterns:

--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Greet First-Time Contributor
-        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3.1.0
+        uses: actions/first-interaction@34f15e814fe48ac9312ccf29db4e74fa767cbab7  # v1.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |


### PR DESCRIPTION
Commit 39c6cc6863 moved actions/first-interaction to v3.1.0 again. v3 uses snake_case input names. The workflow still passes the v1 kebab-case names. Every greet run now fails with "Input required and not supplied: issue_message".

v3 also greets a returning contributor as a first-timer when that person has opened PRs but no issue (actions/first-interaction#369). Commit 0226532a reverted the same bump in July for this reason.

Pin back to v1.3.0. Ignore major bumps of this action in dependabot, so the same PR does not return after the cooldown. Minor and patch updates on v1 still arrive.
