### PR TITLE
ord: default the OpenMP wait policy to passive

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -216,6 +216,9 @@ static void handler(int sig)
 
 int main(int argc, char* argv[])
 {
+  // Idle OpenMP workers sleep instead of spinning between parallel regions.
+  // A user-set OMP_WAIT_POLICY takes precedence.
+  setenv("OMP_WAIT_POLICY", "passive", 0);
   // This avoids problems with locale setting dependent
   // C functions like strtod (e.g. 0.5 vs 0,5).
   std::array locales = {"en_US.UTF-8", "C.UTF-8", "C"};


### PR DESCRIPTION
OpenROAD sets no OpenMP wait policy, so the behaviour is whatever the linked runtime defaults to: libomp spins for 200 ms after every parallel region before sleeping, libgomp for about a millisecond. OpenROAD's parallel regions are milliseconds long and separated by serial code, so with libomp the idle workers spin through every serial section of every stage. That costs CPU time, energy and heat for no wall-time benefit, and on SMT machines the spinning sibling competes with the working thread.

This sets `OMP_WAIT_POLICY=passive` at the top of `main`, before the runtime initializes, with `overwrite=0` so an explicitly set environment still wins.

### Measurements

ORFS designs on asap7, floorplan through detailed route, 48 threads on a 24-core/48-thread AMD Threadripper 3960X, package and core energy from perf's RAPL counters (`power/energy-pkg/`, `power_core/energy-core/`), spinning → passive. Results are bit-identical in every stage that was checked.

**jpeg_encoder**

| stage | wall s | package kJ | core kJ | CPU user s |
|---|---|---|---|---|
| floorplan | 131 → 131 | 11.3 → 11.5 | 2.5 → 2.5 | 180 → 180 |
| place | 150 → 147 | 15.7 → 13.8 | 5.3 → 3.3 | 1174 → 405 |
| cts | 168 → 167 | 14.9 → 14.9 | 4.2 → 4.1 | 877 → 862 |
| global route | 389 → 355 | 74.0 → 39.7 | 46.1 → 14.5 | 13113 → 2955 |
| detailed route | 211 → 218 | 41.0 → 41.8 | 25.4 → 25.5 | 6285 → 6144 |
| **total** | **1049 → 1018 (−3%)** | **157 → 122 (−22%)** | **83.5 → 50.0 (−40%)** | |

Global route, whose threads mostly wait, gets the same result with 46% less package energy; detailed route, whose threads do real work, is unchanged in every column.

**aes_cipher_top**

| stage | wall s | package kJ | core kJ | CPU user s |
|---|---|---|---|---|
| global place | 17 → 16 | | | 152 → 49 |
| global route | 63 → 54 | 11.2 → 5.6 | 7.0 → 2.2 | 2067 → 402 |
| detailed route | 122 → 122 | 21.8 → 20.4 | 12.5 → 11.1 | 2129 → 1788 |

**gcd** (stages of 2–15 s, too short for the 10 s energy bins)

| stage | wall s | CPU user s |
|---|---|---|
| global route | 3.7 → 3.4 | 88 → 16 |
| detailed route | 14.7 → 13.9 | 155 → 28 |

No stage on any of the three designs got slower; the wake-up cost of sleeping workers does not show even on regions of a few seconds. Also confirmed on a large private design (global placement: wall within noise, core energy −37%).
