### PR TITLE
web: cut tile server CPU per frame roughly in half

### DIFF
--- a/src/web/docs/server-api.md
+++ b/src/web/docs/server-api.md
@@ -111,6 +111,22 @@ simply listening on the WebSocket; there's no opt-in.
 
 ## Tile rendering
 
+### Tile sizing
+
+`tile`, `overlay_tile` and `heatmap_tile` all accept the same two optional
+sizing fields, and a client that draws them on top of one another must send
+the same values to all three — a highlight rendered at a different pixel
+count is rescaled by the browser and no longer sits on the shape it
+highlights.
+
+| Field     | Type    | Default | Description |
+| --------- | ------- | :-----: | ----------- |
+| `dpr`     | `float` |   `1`   | The display's device pixel ratio. Clamped to `[1, 3]` and rounded to two decimals; the server and `tile-request.js` must quantize identically. |
+| `tile_px` | `int`   |    —    | The exact device-pixel side the client will display the tile in. Clamped to `[32, 2048]`. Absent or unusable means "not specified", and the server renders `256 × dpr`. |
+
+Sent explicitly rather than derived from `dpr`, because a tile's CSS box is
+only a whole number of device pixels when `tileSize × dpr` is an integer.
+
 ### `tile`
 
 Render a single 256×256 PNG tile of the layout.
@@ -127,6 +143,30 @@ Render a single 256×256 PNG tile of the layout.
 
 **Response:** PNG image (frame type `1`), or frame type `3` with no body
 when the layer has nothing to draw in this tile.
+
+### `overlay_tile`
+
+Render one tile of the highlight overlay — selection, hover, timing paths,
+DRC markers, route guides, flight lines and user labels — on a transparent
+background, on the same tile grid as `tile`. Kept separate from the layer
+tiles so a selection change repaints one pane instead of re-rendering every
+layer's geometry.
+
+| Field                 | Type       | Required | Description |
+| --------------------- | ---------- | :------: | ----------- |
+| `z`                   | `int`      |    ✓     | Leaflet tile zoom level, as for `tile`. |
+| `x`                   | `int`      |    ✓     | Tile column at zoom `z`. |
+| `y`                   | `int`      |    ✓     | Tile row at zoom `z`. |
+| `visible_layers`      | `string[]` |    —     | Tech layers currently visible. Consulted so route guides respect layer visibility; omitted means draw guides on every layer. |
+| `highlight_selected`  | `bool`     |    —     | Default `true`. Draws the current selection's rects, polygons *and* flywires. Turning it off draws none of the three; hover and the timing shapes are separate states and are unaffected. |
+| `flywires_only`       | `bool`     |    —     | Default `false`. Reduce a selection's highlight to its flight lines. Latched in the session: flipping it re-derives the highlights in place, so the change takes effect without re-selecting — but never resurrects highlights an explicit clear removed. |
+| `focused_nets_guides` | `bool`     |    —     | Default `false`. Draw route guides for the focused nets. |
+| `draw_labels`         | `bool`     |    —     | Default `true`. Draw user labels (`add_label`). |
+| `debug_renderers`     | `bool`     |    —     | Default `false`. Debug renderers are active, so the highlight must be re-derived every frame to track instances that move between them. |
+
+**Response:** PNG image (frame type `1`), or frame type `3` with no body
+when nothing is highlighted in this tile — which is the usual case, since
+the overlay holds nothing at all until something is selected.
 
 ### `bounds`
 

--- a/src/web/docs/server-api.md
+++ b/src/web/docs/server-api.md
@@ -28,7 +28,7 @@ binary frame with the following layout:
 | Bytes | Field    | Type                | Description                           |
 | ----- | -------- | ------------------- | ------------------------------------- |
 | 0..3  | `id`     | `uint32` big-endian | Request correlator (see *Correlation*). |
-| 4     | `type`   | `uint8`             | Payload type: `0=JSON`, `1=PNG`, `2=Error`. |
+| 4     | `type`   | `uint8`             | Payload type: `0=JSON`, `1=PNG`, `2=Error`, `3=Empty`. |
 | 5..7  | reserved | `uint8 × 3`         | Must be zero.                         |
 | 8..   | `payload`| bytes               | UTF-8 JSON, PNG-encoded image, or UTF-8 error string. |
 
@@ -46,6 +46,13 @@ binary frame with the following layout:
 - `1 = PNG` — body is a raw PNG file. Used by `tile` and `heatmap_tile`.
 - `2 = Error` — body is a UTF-8 plain-text error message. Surfaces in
   the server log as `WEB-0043` (see *Error contract* below).
+- `3 = Empty` — the tile is blank: the renderer drew nothing in it. The
+  body is zero-length. Returned by `tile`, `overlay_tile` and
+  `heatmap_tile` in place of a fully transparent PNG, which would still
+  cost the client a decode and a full-size bitmap. Most tiles in a
+  viewport are this: every layer with no geometry where the user is
+  looking. A client must treat it as "draw nothing here" and, on a
+  refresh, must release any image the tile was previously holding.
 
 ## Request envelope
 
@@ -118,7 +125,8 @@ Render a single 256×256 PNG tile of the layout.
 | *visibility flags* | `bool` |  per-flag default | See *TileVisibility flags* below. Any flag may be omitted to take the default. |
 | `site_<name>`    | `bool`   |    —     | Per-row-site visibility. Only consulted when `rows == true`. |
 
-**Response:** PNG image (frame type `1`).
+**Response:** PNG image (frame type `1`), or frame type `3` with no body
+when the layer has nothing to draw in this tile.
 
 ### `bounds`
 
@@ -643,7 +651,8 @@ Render one tile for the active heat map (or a specified one).
 | `x`    | `int`    |    ✓     | Tile column. |
 | `y`    | `int`    |    ✓     | Tile row. |
 
-**Response:** PNG (frame type `1`).
+**Response:** PNG (frame type `1`), or frame type `3` with no body when
+the heat map has no populated bin in this tile.
 
 ---
 

--- a/src/web/src/glyph_cache.cpp
+++ b/src/web/src/glyph_cache.cpp
@@ -21,6 +21,14 @@ namespace {
 constexpr int kFirstChar = 32;  // space
 constexpr int kLastChar = 126;  // ~
 constexpr int kNumGlyphs = kLastChar - kFirstChar + 1;
+static_assert(kNumGlyphs == GlyphCache::kGlyphCount);
+
+// Index of `ch` in the cached range, or -1 when it falls outside it.
+int glyphIndex(char ch)
+{
+  const int idx = static_cast<unsigned char>(ch) - kFirstChar;
+  return (idx >= 0 && idx < kNumGlyphs) ? idx : -1;
+}
 }  // namespace
 
 GlyphCache::GlyphCache(const unsigned char* ttf_data, unsigned int /*ttf_size*/)
@@ -83,7 +91,17 @@ const GlyphCache::SizeSlot& GlyphCache::getSlot(int font_height) const
     }
   }
 
-  // Second pass: pack bitmaps tightly into slot.alpha.
+  // Second pass: resolve every kerning pair once (see SizeSlot::kern).
+  for (int a = 0; a < kNumGlyphs; ++a) {
+    for (int b = 0; b < kNumGlyphs; ++b) {
+      const int raw = stbtt_GetCodepointKernAdvance(
+          font_info_.get(), kFirstChar + a, kFirstChar + b);
+      slot.kern[static_cast<size_t>(a) * kNumGlyphs + b]
+          = static_cast<int16_t>(std::lround(raw * slot.scale));
+    }
+  }
+
+  // Third pass: pack bitmaps tightly into slot.alpha.
   slot.alpha.resize(total_bytes, 0);
   size_t offset = 0;
 
@@ -115,16 +133,14 @@ const GlyphCache::SizeSlot& GlyphCache::getSlot(int font_height) const
 
 // --- FontSize (lock-free handle) -------------------------------------------
 
-GlyphCache::FontSize::FontSize(const SizeSlot& slot,
-                               const stbtt_fontinfo* font_info)
-    : slot_(slot), font_info_(font_info)
+GlyphCache::FontSize::FontSize(const SizeSlot& slot) : slot_(slot)
 {
 }
 
 GlyphCache::GlyphInfo GlyphCache::FontSize::glyph(char ch) const
 {
-  const int idx = static_cast<unsigned char>(ch) - kFirstChar;
-  if (idx < 0 || idx >= kNumGlyphs) {
+  const int idx = glyphIndex(ch);
+  if (idx < 0) {
     return {.alpha = nullptr,
             .bmp_width = 0,
             .bmp_height = 0,
@@ -145,8 +161,12 @@ GlyphCache::GlyphInfo GlyphCache::FontSize::glyph(char ch) const
 
 int GlyphCache::FontSize::kern(char ch1, char ch2) const
 {
-  const int raw = stbtt_GetCodepointKernAdvance(font_info_, ch1, ch2);
-  return static_cast<int>(std::round(raw * slot_.scale));
+  const int a = glyphIndex(ch1);
+  const int b = glyphIndex(ch2);
+  if (a < 0 || b < 0) {
+    return 0;
+  }
+  return slot_.kern[static_cast<size_t>(a) * kNumGlyphs + b];
 }
 
 int GlyphCache::FontSize::textWidth(std::string_view text) const
@@ -156,8 +176,8 @@ int GlyphCache::FontSize::textWidth(std::string_view text) const
   }
   int width = 0;
   for (size_t i = 0; i < text.size(); ++i) {
-    const int idx = static_cast<unsigned char>(text[i]) - kFirstChar;
-    if (idx >= 0 && idx < kNumGlyphs) {
+    const int idx = glyphIndex(text[i]);
+    if (idx >= 0) {
       width += slot_.glyphs[idx].advance;
     }
     if (i + 1 < text.size()) {
@@ -176,7 +196,7 @@ int GlyphCache::FontSize::cellHeight() const
 
 GlyphCache::FontSize GlyphCache::getFont(int font_height) const
 {
-  return FontSize(getSlot(font_height), font_info_.get());
+  return FontSize(getSlot(font_height));
 }
 
 int GlyphCache::textWidth(std::string_view text, int font_height) const

--- a/src/web/src/glyph_cache.h
+++ b/src/web/src/glyph_cache.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <array>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -24,6 +26,10 @@ class GlyphCache
 {
   // Per-glyph rendering info.
  public:
+  // Printable ASCII, space (32) through '~' (126): the range every cached
+  // table is sized for.
+  static constexpr int kGlyphCount = 95;
+
   struct GlyphInfo
   {
     const unsigned char* alpha;  // bitmap, bmp_width * bmp_height bytes
@@ -50,8 +56,14 @@ class GlyphCache
     int cell_height = 0;
     int ascent = 0;
     float scale = 0;
-    CachedGlyph glyphs[95];            // ASCII 32-126
+    CachedGlyph glyphs[kGlyphCount];
     std::vector<unsigned char> alpha;  // packed glyph bitmaps
+    // Kerning for every pair of cached glyphs, indexed [first][second].
+    // Resolving one pair through stbtt searches the cmap twice and walks the
+    // GPOS table; textWidth() asks for a pair between every adjacent pair of
+    // characters, so a label's width costs as much as rasterizing it.  The
+    // table is 18 KB per size and only a handful of sizes are ever built.
+    std::array<int16_t, static_cast<size_t>(kGlyphCount) * kGlyphCount> kern{};
   };
 
  public:
@@ -67,9 +79,8 @@ class GlyphCache
 
    private:
     friend class GlyphCache;
-    FontSize(const SizeSlot& slot, const stbtt_fontinfo* font_info);
+    explicit FontSize(const SizeSlot& slot);
     const SizeSlot& slot_;
-    const stbtt_fontinfo* font_info_;
   };
 
   // Initialize from raw TTF data (must remain valid for the cache lifetime).

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -441,7 +441,11 @@ const HeatMapTileLayer = L.GridLayer.extend({
             // display.
             ...tileSizeFields(currentDpr(), this.getTileSize().x),
         }).then(blob => {
-            tile.src = URL.createObjectURL(blob);
+            // A null payload is an empty response: the heat map has no
+            // populated bin in this tile, or the tile is off the grid.  The
+            // 1x1 BLANK_TILE stands in rather than an object URL, so nothing
+            // is decoded and onload still fires to complete the tile.
+            tile.src = blob ? URL.createObjectURL(blob) : BLANK_TILE;
         }).catch(() => {
             tile.src = BLANK_TILE;
         });
@@ -472,7 +476,10 @@ const HeatMapTileLayer = L.GridLayer.extend({
                 if (tile.src && tile.src.startsWith('blob:')) {
                     URL.revokeObjectURL(tile.src);
                 }
-                tile.src = URL.createObjectURL(blob);
+                // Null means the tile is empty now; assigning BLANK_TILE also
+                // drops whatever image it was holding, which matters when a
+                // refresh follows an edit that emptied a bin.
+                tile.src = blob ? URL.createObjectURL(blob) : BLANK_TILE;
             }).catch(() => {
                 tile.src = BLANK_TILE;
             });

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -13,7 +13,7 @@ import {
 import { createMergedTileLayer } from './merged-tile-layer.js';
 import { installDeviceGridSnapping } from './device-pixels.js';
 import {
-    tileSizeCss, useStaticTileSize, withDeviceExactTileSize,
+    BLANK_TILE, tileSizeCss, useStaticTileSize, withDeviceExactTileSize,
     watchDevicePixelRatio, tileSizeFields,
 } from './tile-request.js';
 import { TimingWidget } from './timing-widget.js';
@@ -384,9 +384,6 @@ const WebSocketTileLayer = createWebSocketTileLayer(
         app,
     }, { dpr: currentDpr });
 })();
-const BLANK_TILE
-    = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
-
 const HeatMapTileLayer = L.GridLayer.extend({
     initialize: function(websocketManager, appState, options) {
         this._websocketManager = websocketManager;

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -462,6 +462,12 @@ const HeatMapTileLayer = L.GridLayer.extend({
             const coords = tileInfo.coords;
             const active = this._appState.activeHeatMap;
             if (!active) {
+                // Release the decode before dropping it: turning the heat map
+                // off walks every tile on screen, so skipping this strands one
+                // object URL per tile.
+                if (tile.src && tile.src.startsWith('blob:')) {
+                    URL.revokeObjectURL(tile.src);
+                }
                 tile.src = BLANK_TILE;
                 continue;
             }

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1337,7 +1337,8 @@ WebSocketResponse TileHandler::serializeTech(const uint32_t id,
 // Applied in the handlers rather than in the generator so every other caller of
 // the tile entry points -- save_image, the GIF recorder, the tests -- keeps
 // getting an image back.
-static void markEmptyIfBlank(WebSocketResponse& resp)
+namespace {
+void markEmptyIfBlank(WebSocketResponse& resp)
 {
   if (resp.type == WebSocketResponse::kPng
       && TileGenerator::isBlankTilePng(resp.payload)) {
@@ -1345,6 +1346,7 @@ static void markEmptyIfBlank(WebSocketResponse& resp)
     resp.payload.clear();
   }
 }
+}  // namespace
 
 WebSocketResponse TileHandler::renderTile(
     const uint32_t id,
@@ -5376,12 +5378,17 @@ LabelFields parseLabelFields(const boost::json::object& obj)
   if (!isValidAnchor(anchor)) {
     throw std::runtime_error("anchor not recognized: " + anchor);
   }
-  return {.pos = odb::Point(static_cast<int>(obj.at("x").as_int64()),
-                            static_cast<int>(obj.at("y").as_int64())),
-          .text = std::string(obj.at("text").as_string()),
-          .size = static_cast<int>(jsonOr<int64_t>(obj, "size", 0)),
-          .anchor = anchor,
-          .color = parseLabelColor(obj)};
+  return {
+      .pos = odb::Point(static_cast<int>(obj.at("x").as_int64()),
+                        static_cast<int>(obj.at("y").as_int64())),
+      .text = std::string(obj.at("text").as_string()),
+      // Bounded by addLabel/updateLabel, which the Tcl entry point reaches
+      // too; narrowed here only so a colossal int64 does not wrap on the
+      // way.
+      .size = static_cast<int>(std::clamp<int64_t>(
+          jsonOr<int64_t>(obj, "size", 0), 0, TileGenerator::kMaxLabelSize)),
+      .anchor = anchor,
+      .color = parseLabelColor(obj)};
 }
 
 }  // namespace

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1327,6 +1327,25 @@ WebSocketResponse TileHandler::serializeTech(const uint32_t id,
   return resp;
 }
 
+// Send a tile the renderer drew nothing into as an empty response.  Most of
+// the tiles in a viewport are that: every layer with no geometry where the user
+// is looking, and the highlight overlay whenever nothing is selected.  The
+// transparent PNG they would otherwise carry still decodes to a full-size
+// bitmap on the client, which is what the decoded-image budget in tile-merge.js
+// is spent on.
+//
+// Applied in the handlers rather than in the generator so every other caller of
+// the tile entry points -- save_image, the GIF recorder, the tests -- keeps
+// getting an image back.
+static void markEmptyIfBlank(WebSocketResponse& resp)
+{
+  if (resp.type == WebSocketResponse::kPng
+      && TileGenerator::isBlankTilePng(resp.payload)) {
+    resp.type = WebSocketResponse::kEmpty;
+    resp.payload.clear();
+  }
+}
+
 WebSocketResponse TileHandler::renderTile(
     const uint32_t id,
     const std::string& layer,
@@ -5020,7 +5039,11 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
     if (gen_->tileCacheGet(cache_key, cached)) {
       WebSocketResponse resp;
       resp.id = req.id;
-      resp.type = WebSocketResponse::kPng;
+      // An empty cache entry is a tile the renderer drew nothing into; it is
+      // stored that way so a blank tile costs an LRU slot and not the bytes of
+      // a transparent PNG nobody will decode.
+      resp.type = cached.empty() ? WebSocketResponse::kEmpty
+                                 : WebSocketResponse::kPng;
       resp.payload = std::move(cached);
       debugPrint(gen_->getLogger(),
                  utl::WEB,
@@ -5056,7 +5079,13 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
                                       nullptr,
                                       dpr,
                                       tile_px);
-  if (cacheable && resp.type == WebSocketResponse::kPng) {
+  markEmptyIfBlank(resp);
+  // An empty payload under kPng is a failed encode, not a blank tile; caching
+  // it would make the next hit read back as kEmpty and hide the failure.
+  const bool worth_caching
+      = resp.type == WebSocketResponse::kEmpty
+        || (resp.type == WebSocketResponse::kPng && !resp.payload.empty());
+  if (cacheable && worth_caching) {
     gen_->tileCachePut(std::move(cache_key), resp.payload);
   }
 
@@ -5273,6 +5302,7 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
                                              tile_px,
                                              colored_polys,
                                              labels);
+    markEmptyIfBlank(resp);
 
     // The selection highlight the client draws over the layer tiles comes from
     // here, so the shape counts say whether a "missing" highlight was never
@@ -5719,6 +5749,7 @@ WebSocketResponse TileHandler::handleHeatMapTile(const WebSocketRequest& req,
       source = source_itr->second;
     }
     resp.payload = gen_->generateHeatMapTile(*source, z, x, y, dpr, tile_px);
+    markEmptyIfBlank(resp);
     debugPrint(gen_->getLogger(),
                utl::WEB,
                "tile",

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -185,7 +185,12 @@ struct WebSocketResponse
   {
     kJson = 0,
     kPng = 1,
-    kError = 2
+    kError = 2,
+    // A tile the renderer drew nothing into.  Carries no payload: sending the
+    // transparent PNG instead would make the client decode it and hold a
+    // full-size bitmap for an image with nothing in it, and most of the tiles
+    // in a viewport are this one.
+    kEmpty = 3
   };
 
   uint32_t id = 0;

--- a/src/web/src/tile-request.js
+++ b/src/web/src/tile-request.js
@@ -55,6 +55,28 @@ export const TILE_SIZE_CSS = 240;
 // them. Those are files, not requests, so that path keeps the old size.
 export const STATIC_TILE_SIZE_CSS = 256;
 
+// What an <img> tile holds when the server drew nothing into it: a 1x1
+// transparent GIF.
+//
+// It has to hold SOMETHING.  An <img> with no src attribute but a CSS width and
+// height is not nothing to the browser -- Chrome paints the empty replaced
+// element, and since most tiles in a viewport are empty that came out as a grey
+// grid over the whole layout, one cell per tile.  Clearing the attribute is the
+// obvious way to say "no image" and it is the wrong one.
+//
+// This costs a 1x1 decode, 4 bytes, so it keeps what the empty response is for:
+// the tile still does not decode a full-size transparent PNG or hold a bitmap
+// the size of the tile.  Its load event also fires, which is what completes the
+// tile with Leaflet -- see the tile layers, which keep a tile hidden until then.
+//
+// It carries a Graphic Control Extension declaring colour 0 transparent.  A 1x1
+// GIF without one is a common paste and is NOT transparent: an <img> stretches
+// its single opaque pixel over the whole tile, so a viewport of empty tiles
+// comes out a solid wash instead of showing the layout underneath.
+export const BLANK_TILE
+    = 'data:image/gif;base64,'
+      + 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
 // The CSS tile size in force for this session.  Resolved once rather than
 // passed around: the map's coordinate scale, all three tile layers and the
 // request payload must agree on it, and a value threaded through five call

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -92,11 +92,6 @@ inline void copyRGBA(unsigned char* dst, const Color& src)
   std::memcpy(dst, &src, sizeof(uint32_t));
 }
 
-inline void zeroRGBA(unsigned char* dst)
-{
-  std::memset(dst, 0, 4);
-}
-
 bool anyNonZero(std::span<const unsigned char> data)
 {
   // OR-reduce 64-byte (cache-line) blocks eight u64 at a time; the compiler

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -211,16 +211,27 @@ std::vector<unsigned char> encodeIndexedPng(const IndexedImage& indexed,
 // std::map keeps its nodes put, so the returned pointer stays valid after the
 // lock is released -- the same contract getLanczos2Taps() relies on.  Null when
 // the size is not worth caching or lodepng fails.
+std::mutex& blankPngMutex()
+{
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::map<std::pair<unsigned, unsigned>, std::vector<unsigned char>>&
+blankPngCache()
+{
+  static std::map<std::pair<unsigned, unsigned>, std::vector<unsigned char>>
+      cache;
+  return cache;
+}
+
 const std::vector<unsigned char>* blankPng(const unsigned w, const unsigned h)
 {
   if (w > kMaxIndexedDim || h > kMaxIndexedDim) {
     return nullptr;
   }
-  static std::mutex mutex;
-  static std::map<std::pair<unsigned, unsigned>, std::vector<unsigned char>>
-      cache;
-
-  const std::lock_guard<std::mutex> lock(mutex);
+  const std::lock_guard<std::mutex> lock(blankPngMutex());
+  auto& cache = blankPngCache();
   const std::pair<unsigned, unsigned> key{w, h};
   auto it = cache.find(key);
   if (it == cache.end()) {
@@ -232,6 +243,27 @@ const std::vector<unsigned char>* blankPng(const unsigned w, const unsigned h)
     it = cache.emplace(key, std::move(png)).first;
   }
   return &it->second;
+}
+
+// True when `png` is one of the blank encodings handed out above.
+//
+// An exact test, not a heuristic: encodeImagePng() returns the one shared
+// buffer for every fully transparent tile of a given size, so equality with a
+// cached blank means the renderer drew nothing.  The cache holds one entry per
+// tile size in play — a handful — so the scan is shorter than a size lookup
+// would be, and it spares the caller having to know the tile's dimensions.
+bool isBlankPng(const std::vector<unsigned char>& png)
+{
+  if (png.empty()) {
+    return false;
+  }
+  const std::lock_guard<std::mutex> lock(blankPngMutex());
+  for (const auto& [size, blank] : blankPngCache()) {
+    if (png == blank) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Encode an RGBA image as PNG, picking the cheapest representation that
@@ -2336,6 +2368,11 @@ odb::dbTech* TileGenerator::getTech() const
     return *techs.begin();
   }
   return nullptr;
+}
+
+bool TileGenerator::isBlankTilePng(const std::vector<unsigned char>& png)
+{
+  return isBlankPng(png);
 }
 
 std::vector<unsigned char> TileGenerator::generateTile(

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -150,6 +150,9 @@ bool buildIndexedImage(const std::vector<unsigned char>& rgba,
   slot_index.fill(-1);
 
   out.palette.clear();
+  // The palette is bounded by kMaxPaletteColors and the growth happens inside
+  // the pixel loop, so take the one allocation up front.
+  out.palette.reserve(kMaxPaletteColors);
   out.index.resize(pixels);
   for (size_t i = 0; i < pixels; ++i) {
     uint32_t word;

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -117,6 +117,170 @@ bool anyNonZero(std::span<const unsigned char> data)
       data.begin(), data.end(), [](unsigned char b) { return b != 0; });
 }
 
+// The most colours a tile can hold and still be written as an indexed PNG.
+constexpr size_t kMaxPaletteColors = 256;
+
+// Largest side an image may have and still be considered for the indexed and
+// blank-tile paths.  Both hold a byte per pixel or a whole encoded copy, which
+// is cheap at tile sizes and not at save_image sizes -- and a full-design image
+// has far more than kMaxPaletteColors anyway, so it would only pay for the
+// scan.
+constexpr unsigned kMaxIndexedDim = 4096;
+
+// An image reduced to a palette and one byte per pixel.
+struct IndexedImage
+{
+  std::vector<Color> palette;        // distinct colours, in first-seen order
+  std::vector<unsigned char> index;  // one palette index per pixel
+};
+
+// Reduce `rgba` to `out`, or return false once it passes kMaxPaletteColors.
+//
+// A 1024-slot open-addressed table keyed by the packed RGBA word.  Tiles hold a
+// handful of colours -- a layer draws its own colour at a few alpha levels --
+// so the table stays far below half full, probes almost always hit on the first
+// try, and nothing allocates beyond the two output vectors.
+bool buildIndexedImage(const std::vector<unsigned char>& rgba,
+                       const size_t pixels,
+                       IndexedImage& out)
+{
+  constexpr size_t kSlots = 1024;  // power of two, >= 4 * kMaxPaletteColors
+  std::array<uint32_t, kSlots> keys{};
+  std::array<int, kSlots> slot_index;
+  slot_index.fill(-1);
+
+  out.palette.clear();
+  out.index.resize(pixels);
+  for (size_t i = 0; i < pixels; ++i) {
+    uint32_t word;
+    std::memcpy(&word, &rgba[i * 4], sizeof(word));
+    // Knuth multiplicative hash; the low bits of a colour word are a poor
+    // bucket on their own (long runs share r, g and b and differ only in a).
+    size_t slot = static_cast<size_t>(word * 2654435761u) & (kSlots - 1);
+    while (true) {
+      if (slot_index[slot] < 0) {
+        if (out.palette.size() >= kMaxPaletteColors) {
+          return false;
+        }
+        Color color;
+        std::memcpy(&color, &word, sizeof(word));
+        keys[slot] = word;
+        slot_index[slot] = static_cast<int>(out.palette.size());
+        out.palette.push_back(color);
+        out.index[i] = static_cast<unsigned char>(slot_index[slot]);
+        break;
+      }
+      if (keys[slot] == word) {
+        out.index[i] = static_cast<unsigned char>(slot_index[slot]);
+        break;
+      }
+      slot = (slot + 1) & (kSlots - 1);
+    }
+  }
+  return true;
+}
+
+// PNG bytes for `indexed`, or empty if lodepng rejects it.
+std::vector<unsigned char> encodeIndexedPng(const IndexedImage& indexed,
+                                            const unsigned w,
+                                            const unsigned h)
+{
+  lodepng::State state;
+  state.info_raw.colortype = LCT_PALETTE;
+  state.info_raw.bitdepth = 8;
+  state.info_png.color.colortype = LCT_PALETTE;
+  state.info_png.color.bitdepth = 8;
+  // The palette below is exact, so leave lodepng's own colour profiling off --
+  // it would re-scan the pixels to reach the same conclusion.
+  state.encoder.auto_convert = 0;
+  for (const Color& c : indexed.palette) {
+    lodepng_palette_add(&state.info_png.color, c.r, c.g, c.b, c.a);
+    lodepng_palette_add(&state.info_raw, c.r, c.g, c.b, c.a);
+  }
+
+  std::vector<unsigned char> png;
+  if (lodepng::encode(png, indexed.index, w, h, state) != 0) {
+    png.clear();
+  }
+  return png;
+}
+
+// The encoding of a fully transparent w x h image, which depends only on its
+// dimensions.  Most tiles in a viewport are exactly that: every layer with no
+// geometry where the user is looking returns one.  Entries are never erased and
+// std::map keeps its nodes put, so the returned pointer stays valid after the
+// lock is released -- the same contract getLanczos2Taps() relies on.  Null when
+// the size is not worth caching or lodepng fails.
+const std::vector<unsigned char>* blankPng(const unsigned w, const unsigned h)
+{
+  if (w > kMaxIndexedDim || h > kMaxIndexedDim) {
+    return nullptr;
+  }
+  static std::mutex mutex;
+  static std::map<std::pair<unsigned, unsigned>, std::vector<unsigned char>>
+      cache;
+
+  const std::lock_guard<std::mutex> lock(mutex);
+  const std::pair<unsigned, unsigned> key{w, h};
+  auto it = cache.find(key);
+  if (it == cache.end()) {
+    const std::vector<unsigned char> blank(static_cast<size_t>(w) * h * 4, 0);
+    std::vector<unsigned char> png;
+    if (lodepng::encode(png, blank, w, h) != 0) {
+      return nullptr;
+    }
+    it = cache.emplace(key, std::move(png)).first;
+  }
+  return &it->second;
+}
+
+// Encode an RGBA image as PNG, picking the cheapest representation that
+// reproduces it exactly.
+//
+// Filtering and deflate dominate the encode, and both scale with the bytes fed
+// to them, so the win is in handing lodepng one byte per pixel instead of four.
+// Tiles nearly always allow it: a layer with nothing in view is a single
+// transparent colour, and a layer with something is its own colour at a few
+// alpha levels.  Richer images -- heat maps, dense pin labels, save_image
+// output -- fall through to RGBA, having paid only for a scan that stops at the
+// 257th colour.
+std::vector<unsigned char> encodeImagePng(
+    const std::vector<unsigned char>& rgba,
+    const unsigned w,
+    const unsigned h)
+{
+  const size_t pixels = static_cast<size_t>(w) * h;
+  if (pixels == 0 || rgba.size() != pixels * 4) {
+    std::vector<unsigned char> png;
+    lodepng::encode(png, rgba, w, h);
+    return png;
+  }
+
+  if (w <= kMaxIndexedDim && h <= kMaxIndexedDim) {
+    IndexedImage indexed;
+    if (buildIndexedImage(rgba, pixels, indexed)) {
+      // A single all-zero colour is the blank tile: hand back the shared
+      // encoding rather than deflating 256 KB of zeros again.
+      if (indexed.palette.size() == 1) {
+        const Color only = indexed.palette.front();
+        if (only.r == 0 && only.g == 0 && only.b == 0 && only.a == 0) {
+          if (const std::vector<unsigned char>* blank = blankPng(w, h)) {
+            return *blank;
+          }
+        }
+      }
+      std::vector<unsigned char> png = encodeIndexedPng(indexed, w, h);
+      if (!png.empty()) {
+        return png;
+      }
+    }
+  }
+
+  std::vector<unsigned char> png;
+  lodepng::encode(png, rgba, w, h);
+  return png;
+}
+
 // Fast division by 255 with proper rounding: (v + 128 + ((v + 128) >> 8)) >> 8
 constexpr int div255(int v)
 {
@@ -2209,11 +2373,10 @@ std::vector<unsigned char> TileGenerator::generateTile(
   // than assuming the requested one, which is 0 when the client did not name
   // it.
   const int rendered_px = bufferDim(image_buffer);
-  std::vector<unsigned char> png_data;
-  const unsigned error
-      = lodepng::encode(png_data, image_buffer, rendered_px, rendered_px);
-  if (error) {
-    logger_->report("PNG encoder error: {}", lodepng_error_text(error));
+  std::vector<unsigned char> png_data
+      = encodeImagePng(image_buffer, rendered_px, rendered_px);
+  if (png_data.empty()) {
+    logger_->report("PNG encoder error on tile {} {}/{}/{}", layer, z, x, y);
   }
 
   if (logger_->debugCheck(utl::WEB, "tile_generator", 1)) {
@@ -2256,9 +2419,7 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
 
   if (!getChip()) {
     // No design — return blank transparent PNG.
-    std::vector<unsigned char> png;
-    lodepng::encode(png, image, dim, dim);
-    return png;
+    return encodeImagePng(image, dim, dim);
   }
 
   // Short-circuit: if there's nothing to draw, return a blank tile.
@@ -2266,9 +2427,7 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
       && colored_rects.empty() && colored_polys.empty() && flight_lines.empty()
       && labels.empty()
       && (!route_guide_net_ids || route_guide_net_ids->empty())) {
-    std::vector<unsigned char> png;
-    lodepng::encode(png, image, dim, dim);
-    return png;
+    return encodeImagePng(image, dim, dim);
   }
 
   // Compute tile bounding box in DBU (same math as renderTileBuffer).
@@ -2276,9 +2435,7 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
   y = num_tiles_at_zoom - 1 - y;  // flip Y
   const odb::Rect full_bounds = getBounds();
   if (full_bounds.maxDXDY() <= 0) {
-    std::vector<unsigned char> png;
-    lodepng::encode(png, image, dim, dim);
-    return png;
+    return encodeImagePng(image, dim, dim);
   }
   // Same exact grid as renderTileBuffer: the overlay is drawn on top of those
   // tiles, so a highlight has to land on the shape it highlights.
@@ -2324,9 +2481,7 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
     }
   }
 
-  std::vector<unsigned char> png;
-  lodepng::encode(png, image, dim, dim);
-  return png;
+  return encodeImagePng(image, dim, dim);
 }
 
 // Forward declaration; defined below near compositePixel.  Separable Lanczos-2
@@ -4554,6 +4709,33 @@ std::shared_ptr<gui::HeatMapDataSource> TileGenerator::getHeatMapSource(
   return ptr;
 }
 
+// Half-open pixel span [lo, hi) of one heat-map bin along one axis, clamped to
+// a `limit`-pixel tile.
+//
+// Heat-map bins tile the plane edge to edge, so both edges round the same way
+// and a boundary pixel belongs to exactly one of the two bins that meet on it.
+// toPixels() rounds outward instead — right for a shape that must not lose a
+// fractional edge, wrong here, because it hands the shared pixel to both
+// neighbours and drawHeatMap composites it twice.  That painted a lattice of
+// darker seams over every map, and blending pairs of ramp entries pushed a
+// tile's colour count into the thousands when the ramp itself holds 256.
+//
+// Rounding is anchored on the bin grid rather than on the clipped rect, so the
+// lattice is the same in every tile a bin crosses and the seam does not
+// reappear at tile boundaries.  A bin narrower than a pixel still gets one, so
+// zooming out drops no bins from the map.
+static std::pair<int, int> heatMapBinSpan(const double px_lo,
+                                          const double px_hi,
+                                          const int limit)
+{
+  const int lo = static_cast<int>(std::floor(px_lo));
+  int hi = static_cast<int>(std::floor(px_hi));
+  if (hi <= lo) {
+    hi = lo + 1;
+  }
+  return {std::max(0, lo), std::min(limit, hi)};
+}
+
 void TileGenerator::drawHeatMap(std::vector<unsigned char>& image_buffer,
                                 gui::HeatMapDataSource& source,
                                 const TileFrame& frame) const
@@ -4575,15 +4757,19 @@ void TileGenerator::drawHeatMap(std::vector<unsigned char>& image_buffer,
     if (!map_point.rect.overlaps(dbu_tile)) {
       continue;
     }
-    const odb::Rect overlap = map_point.rect.intersect(dbu_tile);
-    const odb::Rect draw = toPixels(frame, overlap);
     const Color color{.r = static_cast<uint8_t>(map_point.color.r),
                       .g = static_cast<uint8_t>(map_point.color.g),
                       .b = static_cast<uint8_t>(map_point.color.b),
                       .a = static_cast<uint8_t>(map_point.color.a)};
 
-    for (int iy = draw.yMin(); iy < draw.yMax(); ++iy) {
-      for (int ix = draw.xMin(); ix < draw.xMax(); ++ix) {
+    const auto [x_lo, x_hi] = heatMapBinSpan(frame.pxX(map_point.rect.xMin()),
+                                             frame.pxX(map_point.rect.xMax()),
+                                             dim);
+    const auto [y_lo, y_hi] = heatMapBinSpan(frame.pxY(map_point.rect.yMin()),
+                                             frame.pxY(map_point.rect.yMax()),
+                                             dim);
+    for (int iy = y_lo; iy < y_hi; ++iy) {
+      for (int ix = x_lo; ix < x_hi; ++ix) {
         blendPixel(image_buffer, ix, dim - 1 - iy, color, dim);
       }
     }
@@ -4667,10 +4853,10 @@ std::vector<unsigned char> TileGenerator::generateHeatMapTile(
 
   drawHeatMap(image_buffer, source, frame);
 
-  std::vector<unsigned char> png_data;
-  const unsigned error = lodepng::encode(png_data, image_buffer, dim, dim);
-  if (error) {
-    logger_->report("PNG encoder error: {}", lodepng_error_text(error));
+  std::vector<unsigned char> png_data = encodeImagePng(image_buffer, dim, dim);
+  if (png_data.empty()) {
+    logger_->report("PNG encoder error on a {} heat map tile.",
+                    source.getName());
   }
   return png_data;
 }
@@ -5104,11 +5290,10 @@ std::vector<unsigned char> TileGenerator::renderImagePng(
   }
 
   // Encode to PNG.
-  std::vector<unsigned char> png_data;
-  const unsigned error = lodepng::encode(png_data, final_buf, final_w, final_h);
-  if (error) {
-    logger_->error(
-        utl::WEB, 23, "PNG encode error: {}", lodepng_error_text(error));
+  std::vector<unsigned char> png_data
+      = encodeImagePng(final_buf, final_w, final_h);
+  if (png_data.empty()) {
+    logger_->error(utl::WEB, 23, "PNG encode error.");
     return {};
   }
   if (out_width) {
@@ -5282,9 +5467,7 @@ std::vector<unsigned char> TileGenerator::renderOverlayPng(
     }
   }
 
-  std::vector<unsigned char> png_data;
-  lodepng::encode(png_data, final_buf, final_w, final_h);
-  return png_data;
+  return encodeImagePng(final_buf, final_w, final_h);
 }
 
 void TileGenerator::drawDebugOverlay(std::vector<unsigned char>& image,

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -127,6 +127,11 @@ constexpr size_t kMaxPaletteColors = 256;
 // scan.
 constexpr unsigned kMaxIndexedDim = 4096;
 
+// The indexed path packs a pixel's four bytes into one word and unpacks the
+// word back through Color, so the two have to be those same four bytes.
+static_assert(sizeof(Color) == 4);
+static_assert(std::is_trivially_copyable_v<Color>);
+
 // An image reduced to a palette and one byte per pixel.
 struct IndexedImage
 {
@@ -279,19 +284,22 @@ bool isBlankPng(const std::vector<unsigned char>& png)
 // alpha levels.  Richer images -- heat maps, dense pin labels, save_image
 // output -- fall through to RGBA, having paid only for a scan that stops at the
 // 257th colour.
+//
+// `error`, when given, receives the lodepng code behind an empty result so the
+// caller can report why the encode failed rather than only that it did.
 std::vector<unsigned char> encodeImagePng(
     const std::vector<unsigned char>& rgba,
     const unsigned w,
-    const unsigned h)
+    const unsigned h,
+    unsigned* error = nullptr)
 {
-  const size_t pixels = static_cast<size_t>(w) * h;
-  if (pixels == 0 || rgba.size() != pixels * 4) {
-    std::vector<unsigned char> png;
-    lodepng::encode(png, rgba, w, h);
-    return png;
+  if (error != nullptr) {
+    *error = 0;
   }
+  const size_t pixels = static_cast<size_t>(w) * h;
+  const bool well_formed = pixels != 0 && rgba.size() == pixels * 4;
 
-  if (w <= kMaxIndexedDim && h <= kMaxIndexedDim) {
+  if (well_formed && w <= kMaxIndexedDim && h <= kMaxIndexedDim) {
     IndexedImage indexed;
     if (buildIndexedImage(rgba, pixels, indexed)) {
       // A single all-zero colour is the blank tile: hand back the shared
@@ -311,8 +319,17 @@ std::vector<unsigned char> encodeImagePng(
     }
   }
 
+  // Whatever sent us here -- too many colours, an oversized image, a malformed
+  // buffer, an indexed encode lodepng would not take -- RGBA is the encoding
+  // that always applies, so its failure is the one worth reporting.
   std::vector<unsigned char> png;
-  lodepng::encode(png, rgba, w, h);
+  const unsigned rgba_error = lodepng::encode(png, rgba, w, h);
+  if (rgba_error != 0) {
+    png.clear();
+    if (error != nullptr) {
+      *error = rgba_error;
+    }
+  }
   return png;
 }
 
@@ -2413,10 +2430,16 @@ std::vector<unsigned char> TileGenerator::generateTile(
   // than assuming the requested one, which is 0 when the client did not name
   // it.
   const int rendered_px = bufferDim(image_buffer);
+  unsigned encode_error = 0;
   std::vector<unsigned char> png_data
-      = encodeImagePng(image_buffer, rendered_px, rendered_px);
-  if (png_data.empty()) {
-    logger_->report("PNG encoder error on tile {} {}/{}/{}", layer, z, x, y);
+      = encodeImagePng(image_buffer, rendered_px, rendered_px, &encode_error);
+  if (encode_error != 0) {
+    logger_->report("PNG encoder error on tile {} {}/{}/{}: {}",
+                    layer,
+                    z,
+                    x,
+                    y,
+                    lodepng_error_text(encode_error));
   }
 
   if (logger_->debugCheck(utl::WEB, "tile_generator", 1)) {
@@ -4749,6 +4772,20 @@ std::shared_ptr<gui::HeatMapDataSource> TileGenerator::getHeatMapSource(
   return ptr;
 }
 
+namespace {
+
+// Clamp before the cast, for the reason toPxX() clamps: a bin is not clipped to
+// the tile before it is converted (see heatMapBinSpan), so a bin far larger
+// than the tile it crosses reaches a pixel edge past what an int holds, and
+// casting that is undefined.  Anything this far outside the tile floors to the
+// same empty-or-full span the exact value would.
+constexpr double kMaxBinPx = 1.0e7;
+
+int binPixelFloor(const double px)
+{
+  return static_cast<int>(std::floor(std::clamp(px, -kMaxBinPx, kMaxBinPx)));
+}
+
 // Half-open pixel span [lo, hi) of one heat-map bin along one axis, clamped to
 // a `limit`-pixel tile.
 //
@@ -4763,18 +4800,23 @@ std::shared_ptr<gui::HeatMapDataSource> TileGenerator::getHeatMapSource(
 // Rounding is anchored on the bin grid rather than on the clipped rect, so the
 // lattice is the same in every tile a bin crosses and the seam does not
 // reappear at tile boundaries.  A bin narrower than a pixel still gets one, so
-// zooming out drops no bins from the map.
-static std::pair<int, int> heatMapBinSpan(const double px_lo,
-                                          const double px_hi,
-                                          const int limit)
+// zooming out drops no bins from the map; that is the one place the
+// one-bin-per-pixel property above gives way, since a whole run of sub-pixel
+// bins then shares a pixel and composites into it — but a map that dense reads
+// as a wash of colour rather than as a lattice, which is what the property was
+// protecting.
+std::pair<int, int> heatMapBinSpan(const double px_lo,
+                                   const double px_hi,
+                                   const int limit)
 {
-  const int lo = static_cast<int>(std::floor(px_lo));
-  int hi = static_cast<int>(std::floor(px_hi));
+  const int lo = binPixelFloor(px_lo);
+  int hi = binPixelFloor(px_hi);
   if (hi <= lo) {
     hi = lo + 1;
   }
   return {std::max(0, lo), std::min(limit, hi)};
 }
+}  // namespace
 
 void TileGenerator::drawHeatMap(std::vector<unsigned char>& image_buffer,
                                 gui::HeatMapDataSource& source,
@@ -4898,10 +4940,13 @@ std::vector<unsigned char> TileGenerator::generateHeatMapTile(
 
   drawHeatMap(image_buffer, source, frame);
 
-  std::vector<unsigned char> png_data = encodeImagePng(image_buffer, dim, dim);
-  if (png_data.empty()) {
-    logger_->report("PNG encoder error on a {} heat map tile.",
-                    source.getName());
+  unsigned encode_error = 0;
+  std::vector<unsigned char> png_data
+      = encodeImagePng(image_buffer, dim, dim, &encode_error);
+  if (encode_error != 0) {
+    logger_->report("PNG encoder error on a {} heat map tile: {}",
+                    source.getName(),
+                    lodepng_error_text(encode_error));
   }
   return png_data;
 }
@@ -5335,10 +5380,12 @@ std::vector<unsigned char> TileGenerator::renderImagePng(
   }
 
   // Encode to PNG.
+  unsigned encode_error = 0;
   std::vector<unsigned char> png_data
-      = encodeImagePng(final_buf, final_w, final_h);
-  if (png_data.empty()) {
-    logger_->error(utl::WEB, 23, "PNG encode error.");
+      = encodeImagePng(final_buf, final_w, final_h, &encode_error);
+  if (encode_error != 0) {
+    logger_->error(
+        utl::WEB, 23, "PNG encode error: {}", lodepng_error_text(encode_error));
     return {};
   }
   if (out_width) {
@@ -6414,6 +6461,25 @@ std::vector<unsigned char> TileGenerator::renderLabelTile(
 // User text labels (2.12) — global design annotations
 //------------------------------------------------------------------------------
 
+namespace {
+// A label's font height in CSS px, bounded on the way in.  0 keeps its meaning
+// of "unspecified", which drawTextLabels() reads as its own default.
+//
+// Bounded because the size reaches GlyphCache, which rasterizes all 95
+// printable ASCII glyphs at that height and holds the result for the life of
+// the process: every other font height in the renderer is a constant scaled by
+// the quantized device pixel ratio, so this is the one a caller can make
+// arbitrarily large.  Applied where the label is stored rather than at either
+// entry point, so the Tcl command and the websocket request are bounded by the
+// same line and labelsJson() reports back the size that will actually be drawn.
+// The ceiling is taller than a whole tile at the maximum ratio, well past any
+// legible label.
+int boundLabelSize(const int size)
+{
+  return std::clamp(size, 0, TileGenerator::kMaxLabelSize);
+}
+}  // namespace
+
 std::string TileGenerator::addLabel(const odb::Point& pos,
                                     const std::string& text,
                                     const Color& color,
@@ -6441,8 +6507,12 @@ std::string TileGenerator::addLabel(const odb::Point& pos,
     // GUI-44).
     return "";
   }
-  labels_.push_back(
-      {pos, text, color, size, anchor.empty() ? "center" : anchor, label_name});
+  labels_.push_back({pos,
+                     text,
+                     color,
+                     boundLabelSize(size),
+                     anchor.empty() ? "center" : anchor,
+                     label_name});
   return label_name;
 }
 
@@ -6471,7 +6541,7 @@ bool TileGenerator::updateLabel(const std::string& name,
       l.pos = pos;
       l.text = text;
       l.color = color;
-      l.size = size;
+      l.size = boundLabelSize(size);
       l.anchor = anchor.empty() ? "center" : anchor;
       return true;
     }

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -4880,7 +4880,12 @@ std::vector<unsigned char> TileGenerator::generateHeatMapTile(
 
   const double num_tiles_at_zoom = pow(2, z);
   if (x < 0 || y < 0 || x >= num_tiles_at_zoom || y >= num_tiles_at_zoom) {
-    return {};
+    // Off the grid: an empty tile, not an empty result.  Returning no bytes at
+    // all would put a zero-length body behind a PNG frame, which the client can
+    // only fail to decode; the blank encoding is what every other tile entry
+    // point hands back for "nothing here", and the handler turns it into an
+    // empty response from there.
+    return encodeImagePng(image_buffer, dim, dim);
   }
 
   y = num_tiles_at_zoom - 1 - y;

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -531,6 +531,15 @@ class TileGenerator
   // overlay tiles and save_image for every client — mirrors the Qt GUI.
   // addLabel returns the label's name (auto-generated "label<N>" when `name`
   // is empty; a clashing name is rejected and "" is returned).
+  //
+  // A label's font height in CSS px is clamped to [0, kMaxLabelSize] on the way
+  // in (0 = unspecified, take the renderer's default).  Every other font height
+  // is a constant scaled by the quantized device pixel ratio, so this is the
+  // one a caller can make large enough to matter — it reaches GlyphCache, which
+  // rasterizes 95 glyphs at that height and keeps them for the life of the
+  // process.
+  static constexpr int kMaxLabelSize = 256;
+
   std::string addLabel(const odb::Point& pos,
                        const std::string& text,
                        const Color& color,

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -566,6 +566,12 @@ class TileGenerator
   // the chiplet cache, so the value returned reflects the live hierarchy.
   uint64_t chipletsGeneration() const;
 
+  // True when `png` came back from generateTile (or any of the other tile
+  // entry points) carrying nothing: the layer had no geometry in that tile.
+  // Callers send those as an empty response instead of the image, so the
+  // client neither decodes them nor holds a bitmap for them.
+  static bool isBlankTilePng(const std::vector<unsigned char>& png);
+
   std::vector<unsigned char> generateTile(
       const std::string& layer,
       int z,

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -683,6 +683,29 @@ WebSocketSession::~WebSocketSession()
 
 void WebSocketSession::run(http::request<http::string_body>&& req)
 {
+  // Tile responses are mostly small and arrive in bursts — a viewport is one
+  // request per layer per grid square, and the empty ones carry no payload at
+  // all.  Nagle holds a small segment until the previous one is acknowledged,
+  // so the first reply of a burst waits on the client's delayed ACK and the
+  // whole burst stalls behind it.  Measured over loopback: a viewport served
+  // entirely from the tile cache took 1274 ms with Nagle on and 19.9 ms with it
+  // off, and a cold one 2157 ms against 1732 ms.
+  //
+  // Failing to set it is not worth refusing the connection over: the session
+  // still works, just with the stall.
+  beast::error_code nodelay_ec;
+  beast::get_lowest_layer(websocket_)
+      .socket()
+      .set_option(net::ip::tcp::no_delay(true), nodelay_ec);
+  if (nodelay_ec) {
+    debugPrint(logger_,
+               utl::WEB,
+               "websocket",
+               1,
+               "could not disable Nagle on the tile socket: {}",
+               nodelay_ec.message());
+  }
+
   websocket_.set_option(
       websocket::stream_base::timeout::suggested(beast::role_type::server));
   websocket_.set_option(

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -1506,9 +1506,14 @@ void WebServer::saveReport(const std::string& filename,
   const int num_tiles = 1 << kZ;
 
   TileVisibility vis;
-  // A 256x256 fully-transparent RGBA PNG is exactly 102 bytes with lodepng.
-  // Any tile with visible content will be larger.
-  constexpr size_t kEmptyPngSize = 102;
+  // An image the renderer drew nothing into.  Asked of the encoding rather than
+  // of its size: the tile entry points hand back one shared buffer per size for
+  // a fully transparent image, so this is exact, where a byte threshold has to
+  // be re-derived whenever the encoder changes.  An empty vector is a failed
+  // encode, not a blank image, and is dropped either way.
+  auto is_blank = [](const std::vector<unsigned char>& png) {
+    return png.empty() || TileGenerator::isBlankTilePng(png);
+  };
 
   // All layers to cache tiles for.
   std::vector<std::string> all_layers;
@@ -1526,7 +1531,7 @@ void WebServer::saveReport(const std::string& filename,
       for (int tx = 0; tx < num_tiles; ++tx) {
         auto png = generator_->generateTile(
             layer, kZ, tx, ty, vis, {}, {}, {}, {}, mod_colors_ptr);
-        if (png.size() > kEmptyPngSize) {
+        if (!is_blank(png)) {
           std::string key = layer + "/" + std::to_string(kZ) + "/"
                             + std::to_string(tx) + "/" + std::to_string(ty);
           tile_entries.emplace_back(std::move(key), base64Encode(png));
@@ -1548,10 +1553,16 @@ void WebServer::saveReport(const std::string& filename,
       collectTimingPathShapes(block, path, rects, lines);
       const int overlay_px = 256 * (1 << kZ);
       auto png = generator_->renderOverlayPng(overlay_px, rects, lines);
-      if (png.size() > kEmptyPngSize) {
-        overlays.push_back(base64Encode(png));
-      } else {
+      // An empty string is the report's "this path has no overlay" marker.  A
+      // path with no shapes at all already renders to no bytes, but one whose
+      // shapes all fall outside the die area renders to a blank image, and the
+      // size threshold this replaced could not see that: it was derived for a
+      // 256 px tile (transparent, exactly 102 bytes) and these are 512 px,
+      // where a blank one is 125.
+      if (is_blank(png)) {
         overlays.emplace_back();
+      } else {
+        overlays.push_back(base64Encode(png));
       }
     }
     return overlays;

--- a/src/web/src/websocket-manager.js
+++ b/src/web/src/websocket-manager.js
@@ -99,6 +99,7 @@ export class WebSocketManager {
         mgr._queue = new Map(); // unused in cache mode, but keeps cancel() safe
         mgr._inFlight = 0;
         mgr._inFlightIds = new Set();
+        mgr._unknownPayloadTypes = new Set();
         mgr._maxInFlight = DEFAULT_MAX_IN_FLIGHT;
         mgr._lastRecvAt = 0;
         mgr.reconnectDelay = 0;
@@ -282,17 +283,24 @@ export class WebSocketManager {
             // the tile it belongs to hangs unresolved forever and Leaflet
             // never reveals it. A server newer than this client lands here.
             //
+            // Rejected rather than resolved with null: only type 3 carries
+            // "blank tile", and this manager is shared with the JSON endpoints,
+            // whose callers would read the null as data — `tech` and `bounds`
+            // dereference the reply directly. A tile caller catches and leaves
+            // the tile blank, which is what it does for any dropped request.
+            //
             // Reported once per type rather than per message: the cause is a
-            // version mismatch, so every tile in the viewport arrives this way
-            // and a warning each would bury the first one.
+            // version mismatch, so every reply arrives this way and a warning
+            // each would bury the first one.
             if (!this._unknownPayloadTypes.has(type)) {
                 this._unknownPayloadTypes.add(type);
                 console.warn(
-                    `Unrecognized websocket payload type ${type}; treating `
-                    + 'those responses as empty. The server is likely newer '
-                    + 'than this page — reload to pick up the current client.');
+                    `Unrecognized websocket payload type ${type}. The server `
+                    + 'is likely newer than this page — reload to pick up the '
+                    + 'current client.');
             }
-            handler.resolve(null);
+            handler.reject(
+                new Error(`Unsupported websocket payload type ${type}`));
         }
     }
 

--- a/src/web/src/websocket-manager.js
+++ b/src/web/src/websocket-manager.js
@@ -59,6 +59,9 @@ export class WebSocketManager {
         // id arrives — even a stale one for a cancelled request.
         this._inFlight = 0;
         this._inFlightIds = new Set();
+        // Payload types this build does not know, so handleMessage can report
+        // each one once instead of once per message (see there).
+        this._unknownPayloadTypes = new Set();
         this._maxInFlight = DEFAULT_MAX_IN_FLIGHT; // updated by server "config"
         this._lastRecvAt = 0;     // perf.now() of the last message of any kind
         this._bufStuckSince = 0;  // liveness: when bufferedAmount got stuck
@@ -278,6 +281,17 @@ export class WebSocketManager {
             // An unrecognised payload type must still settle the promise, or
             // the tile it belongs to hangs unresolved forever and Leaflet
             // never reveals it. A server newer than this client lands here.
+            //
+            // Reported once per type rather than per message: the cause is a
+            // version mismatch, so every tile in the viewport arrives this way
+            // and a warning each would bury the first one.
+            if (!this._unknownPayloadTypes.has(type)) {
+                this._unknownPayloadTypes.add(type);
+                console.warn(
+                    `Unrecognized websocket payload type ${type}; treating `
+                    + 'those responses as empty. The server is likely newer '
+                    + 'than this page — reload to pick up the current client.');
+            }
             handler.resolve(null);
         }
     }

--- a/src/web/src/websocket-manager.js
+++ b/src/web/src/websocket-manager.js
@@ -268,6 +268,17 @@ export class WebSocketManager {
             }
         } else if (type === 1) {
             handler.resolve(new Blob([payload], { type: 'image/png' }));
+        } else if (type === 3) {
+            // A tile the server drew nothing into. Resolving null rather than
+            // a transparent PNG is the point: no Blob, no decode, and no
+            // full-size bitmap held for an image with nothing in it. Every
+            // tile consumer already treats a null payload as "draw nothing".
+            handler.resolve(null);
+        } else {
+            // An unrecognised payload type must still settle the promise, or
+            // the tile it belongs to hangs unresolved forever and Leaflet
+            // never reveals it. A server newer than this client lands here.
+            handler.resolve(null);
         }
     }
 

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -31,6 +31,36 @@ export function buildTileRequest(coords, layerName, ctx) {
 // metadata arrives, is reflected in tile requests without rebuilding
 // the layer.  When null or absent the field is omitted and the server
 // renders every chiplet (default).
+// Point an <img> tile at a payload, or clear it when the payload is null.
+//
+// Null is an empty tile (payload type 3): the server drew nothing there.  The
+// element keeps its place in the grid but holds no image, so the browser
+// decodes nothing and no bitmap counts against the budget tile-merge.js is
+// bounding.  Clearing matters on a refresh too -- a tile that had content
+// before an edit removed it must drop the decode it is still holding.
+//
+// The tile has to be marked done either way: Leaflet keeps a tile hidden until
+// done() is called, and with no src the load event that normally calls it never
+// fires.  The callback is stashed on the element rather than passed in, because
+// a refresh landing before the first load still has to be able to complete the
+// handshake and Leaflet's tile record does not carry it.
+function applyTilePayload(tile, data) {
+    if (tile.src && tile.src.startsWith('blob:')) {
+        URL.revokeObjectURL(tile.src);
+    }
+    if (data == null) {
+        tile.removeAttribute('src');
+        if (!tile._tileDone) {
+            tile._tileDone = true;
+            if (tile._orDone) {
+                tile._orDone(null, tile);
+            }
+        }
+        return;
+    }
+    tile.src = (typeof data === 'string') ? data : URL.createObjectURL(data);
+}
+
 export function createWebSocketTileLayer(visibility, visibleLayers,
                                          selectability, selectableLayers,
                                          app) {
@@ -60,6 +90,7 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
             // Set up onload/onerror BEFORE any src assignment so that
             // refreshTiles() can set tile.src and still trigger done().
             tile._tileDone = false;
+            tile._orDone = done;
             tile.onload = () => {
                 if (tile.src && tile.src.startsWith('blob:')) {
                     URL.revokeObjectURL(tile.src);
@@ -83,11 +114,7 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
             this._websocketManager.request(
                 buildTileRequest(coords, this._layerName, ctx)
             ).then(data => {
-                if (typeof data === 'string') {
-                    tile.src = data;  // data URI from cache
-                } else {
-                    tile.src = URL.createObjectURL(data);
-                }
+                applyTilePayload(tile, data);
             }).catch(err => {
                 // Request was cancelled (e.g. by refreshTiles); ignore.  Note
                 // that `done` is never called and no retry is issued, so this
@@ -120,14 +147,7 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
                 this._websocketManager.request(
                     buildTileRequest(coords, this._layerName, ctx)
                 ).then(data => {
-                    if (tile.src && tile.src.startsWith('blob:')) {
-                        URL.revokeObjectURL(tile.src);
-                    }
-                    if (typeof data === 'string') {
-                        tile.src = data;
-                    } else {
-                        tile.src = URL.createObjectURL(data);
-                    }
+                    applyTilePayload(tile, data);
                 }).catch(err => {
                     // Tile refresh failed; keep existing image
                 });
@@ -190,6 +210,7 @@ export function createOverlayTileLayer(visibility, app) {
             tile.setAttribute('role', 'presentation');
 
             tile._tileDone = false;
+            tile._orDone = done;
             tile.onload = () => {
                 if (tile.src && tile.src.startsWith('blob:')) {
                     URL.revokeObjectURL(tile.src);
@@ -215,11 +236,7 @@ export function createOverlayTileLayer(visibility, app) {
                 if (tile._websocketRequestId !== requestId) {
                     return;  // stale response; a newer request superseded this one
                 }
-                if (typeof data === 'string') {
-                    tile.src = data;
-                } else {
-                    tile.src = URL.createObjectURL(data);
-                }
+                applyTilePayload(tile, data);
             }).catch(err => {
             });
 
@@ -249,14 +266,7 @@ export function createOverlayTileLayer(visibility, app) {
                     if (tile._websocketRequestId !== requestId) {
                         return;  // stale response superseded by a newer refresh
                     }
-                    if (tile.src && tile.src.startsWith('blob:')) {
-                        URL.revokeObjectURL(tile.src);
-                    }
-                    if (typeof data === 'string') {
-                        tile.src = data;
-                    } else {
-                        tile.src = URL.createObjectURL(data);
-                    }
+                    applyTilePayload(tile, data);
                 }).catch(() => {});
             }
         },

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -4,7 +4,7 @@
 // Leaflet tile layer that fetches tiles via WebSocket.
 
 import {
-    buildTileRequestFor, floorClampZoom, nativeDpr, tileSizeCss,
+    BLANK_TILE, buildTileRequestFor, floorClampZoom, nativeDpr, tileSizeCss,
     tileSizeFields, withDeviceExactTileSize,
 } from './tile-request.js';
 
@@ -31,31 +31,22 @@ export function buildTileRequest(coords, layerName, ctx) {
 // metadata arrives, is reflected in tile requests without rebuilding
 // the layer.  When null or absent the field is omitted and the server
 // renders every chiplet (default).
-// Point an <img> tile at a payload, or clear it when the payload is null.
+// Point an <img> tile at a payload, or at the blank tile when the payload is
+// null.
 //
 // Null is an empty tile (payload type 3): the server drew nothing there.  The
-// element keeps its place in the grid but holds no image, so the browser
-// decodes nothing and no bitmap counts against the budget tile-merge.js is
-// bounding.  Clearing matters on a refresh too -- a tile that had content
-// before an edit removed it must drop the decode it is still holding.
-//
-// The tile has to be marked done either way: Leaflet keeps a tile hidden until
-// done() is called, and with no src the load event that normally calls it never
-// fires.  The callback is stashed on the element rather than passed in, because
-// a refresh landing before the first load still has to be able to complete the
-// handshake and Leaflet's tile record does not carry it.
+// element keeps its place in the grid holding a 1x1 transparent GIF instead of
+// a tile-sized transparent PNG, so the browser decodes 4 bytes and no bitmap
+// worth the name counts against the budget tile-merge.js is bounding.  See
+// BLANK_TILE for why it is not simply left with no src.  Reassigning matters on
+// a refresh too -- a tile that had content before an edit removed it must drop
+// the decode it is still holding.
 function applyTilePayload(tile, data) {
     if (tile.src && tile.src.startsWith('blob:')) {
         URL.revokeObjectURL(tile.src);
     }
     if (data == null) {
-        tile.removeAttribute('src');
-        if (!tile._tileDone) {
-            tile._tileDone = true;
-            if (tile._orDone) {
-                tile._orDone(null, tile);
-            }
-        }
+        tile.src = BLANK_TILE;
         return;
     }
     tile.src = (typeof data === 'string') ? data : URL.createObjectURL(data);
@@ -90,7 +81,6 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
             // Set up onload/onerror BEFORE any src assignment so that
             // refreshTiles() can set tile.src and still trigger done().
             tile._tileDone = false;
-            tile._orDone = done;
             tile.onload = () => {
                 if (tile.src && tile.src.startsWith('blob:')) {
                     URL.revokeObjectURL(tile.src);
@@ -210,7 +200,6 @@ export function createOverlayTileLayer(visibility, app) {
             tile.setAttribute('role', 'presentation');
 
             tile._tileDone = false;
-            tile._orDone = done;
             tile.onload = () => {
                 if (tile.src && tile.src.startsWith('blob:')) {
                     URL.revokeObjectURL(tile.src);

--- a/src/web/test/cpp/TestGlyphCache.cpp
+++ b/src/web/test/cpp/TestGlyphCache.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <cstddef>
+#include <string_view>
+
 #include "glyph_cache.h"
 #include "gtest/gtest.h"
 
@@ -10,6 +13,53 @@ namespace {
 TEST(GlyphCacheTest, TextWidthPositive)
 {
   EXPECT_GT(glyphCache().textWidth("hello", 14), 0);
+}
+
+// textWidth() is the sum of the cached advances and the cached kerning pairs,
+// so it has to agree with what those two report on their own.
+TEST(GlyphCacheTest, TextWidthIsAdvancesPlusKerning)
+{
+  constexpr std::string_view text = "AVATAR wo.Ty";
+  const GlyphCache::FontSize font = glyphCache().getFont(16);
+
+  int expected = 0;
+  for (size_t i = 0; i < text.size(); ++i) {
+    expected += font.glyph(text[i]).advance;
+    if (i + 1 < text.size()) {
+      expected += font.kern(text[i], text[i + 1]);
+    }
+  }
+  EXPECT_EQ(font.textWidth(text), expected);
+}
+
+// The kerning table is built once per size and read for every pair a label
+// measures.  A table that was allocated but never filled would leave every
+// pair at zero and silently narrow every label, so check the font really does
+// kern something.
+TEST(GlyphCacheTest, KerningTableIsPopulated)
+{
+  const GlyphCache::FontSize font = glyphCache().getFont(48);
+
+  int nonzero_pairs = 0;
+  for (char first = '!'; first <= '~'; ++first) {
+    for (char second = '!'; second <= '~'; ++second) {
+      if (font.kern(first, second) != 0) {
+        ++nonzero_pairs;
+      }
+    }
+  }
+  EXPECT_GT(nonzero_pairs, 0);
+}
+
+// Characters outside the cached range have no table entry; they must read as
+// zero rather than indexing past it.
+TEST(GlyphCacheTest, KerningOutsideTheCachedRangeIsZero)
+{
+  const GlyphCache::FontSize font = glyphCache().getFont(14);
+
+  EXPECT_EQ(font.kern('\n', 'A'), 0);
+  EXPECT_EQ(font.kern('A', '\x7f'), 0);
+  EXPECT_EQ(font.kern('\x80', '\xff'), 0);
 }
 
 TEST(GlyphCacheTest, TextWidthEmpty)

--- a/src/web/test/cpp/TestLabels.cpp
+++ b/src/web/test/cpp/TestLabels.cpp
@@ -109,6 +109,35 @@ TEST_F(LabelTest, UpdateMutatesInPlace)
   EXPECT_EQ(draw[0].color.r, 255);
 }
 
+// A label's font height is the only one a caller sets directly -- every other
+// one in the renderer is a constant scaled by the quantized device pixel ratio
+// -- and it reaches GlyphCache, which rasterizes 95 glyphs at that height and
+// keeps them for the life of the process.  Bounded where the label is stored,
+// so the Tcl command and the websocket request are covered by the same line and
+// the stored size is the one that will be drawn.
+TEST_F(LabelTest, FontSizeIsBoundedOnTheWayIn)
+{
+  const Color c{.r = 0, .g = 0, .b = 0, .a = 255};
+  gen_->addLabel({0, 0}, "huge", c, 1'000'000, "center", "big");
+  gen_->addLabel({0, 0}, "negative", c, -5, "center", "neg");
+
+  auto draw = gen_->labelsForDraw();
+  ASSERT_EQ(draw.size(), 2u);
+  EXPECT_EQ(draw[0].size, TileGenerator::kMaxLabelSize);
+  // Not -5: 0 is the renderer's "unspecified, use the default".
+  EXPECT_EQ(draw[1].size, 0);
+
+  // update_label reaches the same field and is bounded the same way.
+  EXPECT_TRUE(gen_->updateLabel("big", {0, 0}, "huge", c, 999'999, "center"));
+  draw = gen_->labelsForDraw();
+  EXPECT_EQ(draw[0].size, TileGenerator::kMaxLabelSize);
+
+  // A size inside the bound is untouched.
+  EXPECT_TRUE(gen_->updateLabel("big", {0, 0}, "huge", c, 18, "center"));
+  draw = gen_->labelsForDraw();
+  EXPECT_EQ(draw[0].size, 18);
+}
+
 TEST_F(LabelTest, UpdateMissingIsNoOp)
 {
   const Color c{.r = 0, .g = 0, .b = 0, .a = 255};

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -495,6 +495,48 @@ TEST(AssetPathFromTarget, LeavesAnOrdinaryPathAlone)
   EXPECT_EQ(assetPathFromTarget("/tile-merge.js"), "/tile-merge.js");
 }
 
+// The cache stores blank tiles as an empty entry, so a hit has to come back as
+// kEmpty too rather than as a zero-byte image the client would fail to decode.
+TEST_F(TileHandlerTest, BlankTileStaysEmptyThroughTheCache)
+{
+  WebSocketRequest req;
+  req.id = 1;
+  req.type = WebSocketRequest::kTile;
+  req.json
+      = parseObj(R"({"layer":"metal1","z":0,"x":0,"y":0,"visible_layers":[]})");
+
+  ASSERT_EQ(handler_->handleTile(req, state_).type, WebSocketResponse::kEmpty);
+  const auto hit = handler_->handleTile(req, state_);
+  EXPECT_EQ(hit.type, WebSocketResponse::kEmpty);
+  EXPECT_TRUE(hit.payload.empty());
+}
+
+// The converse: a tile that did draw something must still arrive as an image.
+// The die outline puts content on every _instances tile.
+TEST_F(TileHandlerTest, DrawnTileIsStillAPngResponse)
+{
+  WebSocketRequest req;
+  req.id = 1;
+  req.type = WebSocketRequest::kTile;
+  req.json = parseObj(
+      R"({"layer":"_instances","z":0,"x":0,"y":0,"visible_layers":[]})");
+
+  const auto resp = handler_->handleTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+  EXPECT_FALSE(resp.payload.empty());
+}
+
+// The highlight overlay is one of the panes that never merges, and it holds
+// nothing at all until something is selected -- so it is the single tile layer
+// most worth not sending an image for.
+TEST_F(TileHandlerTest, OverlayTileWithNothingSelectedIsEmpty)
+{
+  const auto resp
+      = handler_->handleOverlayTile(overlayRequest(1, false), state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kEmpty);
+  EXPECT_TRUE(resp.payload.empty());
+}
+
 TEST_F(TileHandlerTest, HonoursTheClientReportedDpr)
 {
   struct Case
@@ -649,11 +691,14 @@ TEST_F(TileHandlerTest, PixelCountIsPartOfTheTileCacheKey)
 
 TEST_F(TileHandlerTest, TileReturnsPng)
 {
+  // _instances rather than a tech layer: the die outline puts content on it, so
+  // there is an image to check the framing of.  A layer with nothing in it
+  // comes back as kEmpty instead (see EmptyTile).
   WebSocketRequest req;
   req.id = 99;
   req.type = WebSocketRequest::kTile;
-  req.json
-      = parseObj(R"({"layer":"metal1","z":0,"x":0,"y":0,"visible_layers":[]})");
+  req.json = parseObj(
+      R"({"layer":"_instances","z":0,"x":0,"y":0,"visible_layers":[]})");
 
   auto resp = handler_->handleTile(req, state_);
   EXPECT_EQ(resp.id, 99u);
@@ -667,6 +712,10 @@ TEST_F(TileHandlerTest, TileReturnsPng)
   EXPECT_EQ(resp.payload[3], 'G');
 }
 
+// A layer with nothing in the tile comes back carrying nothing.  Sending the
+// transparent PNG instead would make the client decode it and hold a full-size
+// bitmap for an image with nothing in it, and most of the tiles in a viewport
+// are exactly this one.
 TEST_F(TileHandlerTest, EmptyTile)
 {
   WebSocketRequest req;
@@ -676,8 +725,8 @@ TEST_F(TileHandlerTest, EmptyTile)
       = parseObj(R"({"layer":"metal1","z":0,"x":0,"y":0,"visible_layers":[]})");
 
   auto resp = handler_->handleTile(req, state_);
-  EXPECT_EQ(resp.type, WebSocketResponse::kPng);  // PNG
-  EXPECT_FALSE(resp.payload.empty());
+  EXPECT_EQ(resp.type, WebSocketResponse::kEmpty);
+  EXPECT_TRUE(resp.payload.empty());
 }
 
 TEST_F(TileHandlerTest, BaseTileExcludesHighlights)
@@ -702,6 +751,13 @@ TEST_F(TileHandlerTest, BaseTileExcludesHighlights)
 
 TEST_F(TileHandlerTest, OverlayTileReturnsPng)
 {
+  // The overlay draws nothing until something is highlighted, and then comes
+  // back as kEmpty (see OverlayTileWithNothingSelectedIsEmpty).  Give it a
+  // highlight so there is an image to check the framing of.
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.highlight_rects.emplace_back(0, 0, 50000, 50000);
+  }
   WebSocketRequest req;
   req.id = 10;
   req.type = WebSocketRequest::kOverlayTile;
@@ -742,6 +798,12 @@ TEST_F(TileHandlerTest, OverlayTileHonoursTheRequestedPixelCount)
 
 TEST_F(TileHandlerTest, OverlayTileClampsAndFallsBack)
 {
+  // Sizing is read off the returned PNG, so the overlay has to have something
+  // to draw; with nothing highlighted it comes back empty and carries no image.
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.highlight_rects.emplace_back(0, 0, 50000, 50000);
+  }
   const std::vector<std::pair<std::string, uint32_t>> cases = {
       {R"("dpr":1)", 256},                    // unspecified -> 256 * dpr
       {R"("dpr":2)", 512},                    // ...which follows dpr
@@ -955,7 +1017,8 @@ TEST_F(TileHandlerTest, FlywiresToggleDoesNotResurrectClearedHighlights)
 
   WebSocketRequest req = overlayRequest(23, /*flywires_only=*/true);
   auto resp = handler_->handleOverlayTile(req, state_);
-  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+  // Nothing was resurrected, so the overlay drew nothing and carries no image.
+  EXPECT_EQ(resp.type, WebSocketResponse::kEmpty);
 
   std::lock_guard<std::mutex> lock(state_.selection_mutex);
   EXPECT_TRUE(state_.highlight_lines.empty())
@@ -1008,7 +1071,8 @@ TEST_F(TileHandlerTest, FlywiresSkipSupplyNets)
 
   WebSocketRequest req = overlayRequest(22, /*flywires_only=*/true);
   auto resp = handler_->handleOverlayTile(req, state_);
-  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+  // A supply net gets no flywires, so the overlay drew nothing.
+  EXPECT_EQ(resp.type, WebSocketResponse::kEmpty);
 
   std::lock_guard<std::mutex> lock(state_.selection_mutex);
   EXPECT_TRUE(state_.highlight_lines.empty())
@@ -1396,8 +1460,8 @@ TEST_F(TileHandlerTest, TileStillServesOffGridCoordinates)
 
     WebSocketResponse resp;
     EXPECT_NO_THROW(resp = handler_->handleTile(req, state_)) << json;
-    EXPECT_EQ(resp.type, WebSocketResponse::kPng)
-        << "off-grid tiles are transparent, not errors: " << json;
+    EXPECT_EQ(resp.type, WebSocketResponse::kEmpty)
+        << "off-grid tiles are empty, not errors: " << json;
   }
 }
 
@@ -4336,9 +4400,11 @@ TEST_F(TileHandlerTest, CancelSkipsQueuedTileRender)
   auto resp = handler_->handleTile(tile, state_);
   EXPECT_EQ(resp.type, WebSocketResponse::kError);
 
-  // The cancellation is consumed: re-issuing the same id now renders.
+  // The cancellation is consumed: re-issuing the same id now renders.  metal1
+  // holds nothing in this fixture, so a completed render is an empty tile --
+  // the point is that it is no longer refused.
   auto resp2 = handler_->handleTile(tile, state_);
-  EXPECT_EQ(resp2.type, WebSocketResponse::kPng);
+  EXPECT_EQ(resp2.type, WebSocketResponse::kEmpty);
 }
 
 TEST_F(TileHandlerTest, CancelIdsArrayMarksAll)

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <numbers>
 #include <set>
@@ -4499,6 +4500,102 @@ TEST_F(TileGeneratorTest, OffGridHeatMapTileIsStillADecodablePng)
     EXPECT_EQ(width, static_cast<unsigned>(kTileSize));
     EXPECT_EQ(height, static_cast<unsigned>(kTileSize));
     EXPECT_FALSE(hasNonTransparentPixel(rgba));
+  }
+}
+
+// isBlankTilePng() has to recognize a blank image at whatever size the caller
+// rendered it, not just at the tile size.  The static report leans on that: it
+// filters blank layer tiles and blank timing-path overlays through the same
+// call, and the overlays are rendered at twice the tile size.  The byte
+// threshold this replaced was derived for a 256 px tile (a transparent one is
+// exactly 102 bytes) and could not see a blank 512 px overlay, which is 125.
+TEST_F(TileGeneratorTest, BlankIsRecognizedAtEveryRenderedSize)
+{
+  // Nothing placed, so metal1 has no geometry to draw; the die outline still
+  // puts content on _instances.
+  makeTileGen();
+
+  // 1 and 2 give 256 px and 512 px -- the tile size the report filters at and
+  // the overlay size it filters at, whose blank encodings are 102 and 125
+  // bytes.  A single threshold cannot separate content from blank across both.
+  for (const double dpr : {1.0, 2.0}) {
+    const std::vector<unsigned char> blank = tile_gen_->generateTile(
+        "metal1", 0, 0, 0, {}, {}, {}, {}, {}, nullptr, nullptr, nullptr, dpr);
+    ASSERT_FALSE(blank.empty()) << "dpr=" << dpr;
+    unsigned width = 0;
+    unsigned height = 0;
+    const std::vector<unsigned char> rgba = decodePng(blank, width, height);
+    ASSERT_FALSE(hasNonTransparentPixel(rgba)) << "dpr=" << dpr;
+    EXPECT_TRUE(TileGenerator::isBlankTilePng(blank))
+        << "a blank " << width << " px image must read as blank";
+
+    const std::vector<unsigned char> drawn
+        = tile_gen_->generateTile("_instances",
+                                  0,
+                                  0,
+                                  0,
+                                  {},
+                                  {},
+                                  {},
+                                  {},
+                                  {},
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  dpr);
+    ASSERT_FALSE(drawn.empty()) << "dpr=" << dpr;
+    EXPECT_FALSE(TileGenerator::isBlankTilePng(drawn))
+        << "a " << width << " px image with the die outline on it is not blank";
+  }
+
+  // An encode that failed carries no bytes; that is not a blank image, and a
+  // caller that treated it as one would swallow the failure.
+  EXPECT_FALSE(TileGenerator::isBlankTilePng({}));
+}
+
+// A heat-map bin is converted to pixels whole, not clipped to the tile first --
+// that is what keeps the bin lattice identical in every tile the bin crosses.
+// So the bin's far edge in tile pixels grows with zoom without bound, and deep
+// enough it passes what an int holds.  Casting that is undefined, and what it
+// did in practice was wrap to a negative span and drop the bin: the map went
+// blank exactly where it was most magnified.
+TEST_F(TileGeneratorTest, DeepZoomKeepsABinLargerThanTheIntPixelRange)
+{
+  // Every bin populated, so whichever one the tile lands in is drawn.
+  ASSERT_NO_FATAL_FAILURE(
+      buildSeamDesign(odb::Rect(0, 0, kSeamDieSide, kSeamDieSide)));
+
+  constexpr int kZoom = 27;
+  const double num_tiles = std::pow(2, kZoom);
+  const odb::Rect bounds = tile_gen_->getBounds();
+  const double tile_dbu = bounds.maxDXDY() / num_tiles;
+
+  // The tile over the die centre, which is interior to the bin grid -- the
+  // corner tiles at this zoom sit in the pin-label margin, outside every bin.
+  const int centre = kSeamDieSide / 2;
+  const int tx = static_cast<int>((centre - bounds.xMin()) / tile_dbu);
+  const int ty_up = static_cast<int>((centre - bounds.yMin()) / tile_dbu);
+  const int ty = static_cast<int>(num_tiles) - 1 - ty_up;
+
+  // The die centre is the centre of the middle bin of the 3x3 grid, so each of
+  // that bin's edges is half a bin from the tile -- which is the distance the
+  // conversion has to survive.  Assert the premise: without it, a zoom that
+  // stopped short of the overflow would make this test pass for no reason.
+  constexpr double kBinDbu = 30000.0;  // setGridSizes(15, 15) at 2000 dbu/um
+  const double edge_px = (kBinDbu / 2) * kTileSize / tile_dbu;
+  ASSERT_GT(edge_px, static_cast<double>(std::numeric_limits<int>::max()))
+      << "the zoom is not deep enough to exercise the clamp";
+
+  unsigned width = 0;
+  unsigned height = 0;
+  const std::vector<unsigned char> rgba = decodePng(
+      tile_gen_->generateHeatMapTile(*heatmap_, kZoom, tx, ty), width, height);
+
+  // The tile is a speck inside one bin, so the bin covers all of it.
+  ASSERT_EQ(rgba.size(), static_cast<size_t>(kTileSize) * kTileSize * 4);
+  for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+    ASSERT_NE(rgba[i + 3], 0)
+        << "pixel " << i / 4 << " of a tile wholly inside a bin is unpainted";
   }
 }
 

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -4475,6 +4475,33 @@ TEST_F(TileGeneratorTest, IndexedEncodingPreservesTheLayerColour)
       << "the layer colour must reach the client unchanged";
 }
 
+// Off-grid coordinates are an empty tile, not an empty result.  Returning no
+// bytes put a zero-length body behind a PNG frame on the wire, which a client
+// can only fail to decode; every tile entry point owes its caller a decodable
+// image for "nothing here".
+TEST_F(TileGeneratorTest, OffGridHeatMapTileIsStillADecodablePng)
+{
+  ASSERT_NO_FATAL_FAILURE(
+      buildSeamDesign(odb::Rect(30000, 30000, 60000, 60000)));
+
+  struct Coord
+  {
+    int z, x, y;
+  };
+  for (const Coord& c : {Coord{0, -1, 0}, Coord{0, 3, 7}, Coord{2, 9999, 0}}) {
+    const std::vector<unsigned char> png
+        = tile_gen_->generateHeatMapTile(*heatmap_, c.z, c.x, c.y);
+    ASSERT_FALSE(png.empty()) << "z/x/y=" << c.z << "/" << c.x << "/" << c.y;
+
+    unsigned width = 0;
+    unsigned height = 0;
+    const std::vector<unsigned char> rgba = decodePng(png, width, height);
+    EXPECT_EQ(width, static_cast<unsigned>(kTileSize));
+    EXPECT_EQ(height, static_cast<unsigned>(kTileSize));
+    EXPECT_FALSE(hasNonTransparentPixel(rgba));
+  }
+}
+
 // The scale the tests above model is the one the fixture's tech actually has.
 TEST_F(TileGeneratorTest, NangateScaleIsTheOneModelledAbove)
 {

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -4383,6 +4383,98 @@ TEST(DbuFormatTest, NoScaleFallsBackToRawDbu)
   EXPECT_EQ(dbuToMicronString(12345, -1.0), "12345");
 }
 
+// Heat-map bins tile the plane, so every pixel belongs to exactly one bin.
+// Rounding each bin's edges outward handed the pixels on a shared edge to both
+// neighbours, and each was composited twice: a lattice of darker seams over the
+// whole map, and — because a doubled pixel mixes two ramp entries — a tile
+// colour count far past the 256 the ramp holds.  Every bin here carries the
+// same value, so one colour is the whole of a correctly drawn tile.
+TEST_F(TileGeneratorTest, HeatMapBinsDoNotOverlapOnSharedEdges)
+{
+  // A cell spanning the design populates every bin, so the tile is full of
+  // shared bin edges.
+  ASSERT_NO_FATAL_FAILURE(
+      buildSeamDesign(odb::Rect(0, 0, kSeamDieSide, kSeamDieSide)));
+  // Below 255 a second composite lands on a different colour than the first.
+  heatmap_->setColorAlpha(150);
+
+  unsigned width = 0;
+  unsigned height = 0;
+  const std::vector<unsigned char> rgba = decodePng(
+      tile_gen_->generateHeatMapTile(*heatmap_, 0, 0, 0), width, height);
+  ASSERT_TRUE(hasNonTransparentPixel(rgba));
+
+  std::set<std::array<unsigned char, 4>> colors;
+  for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+    if (rgba[i + 3] != 0) {
+      colors.insert({rgba[i], rgba[i + 1], rgba[i + 2], rgba[i + 3]});
+    }
+  }
+  EXPECT_EQ(colors.size(), 1u)
+      << "a pixel covered by two bins blends the bin colour with itself";
+}
+
+// A layer with nothing in the tile encodes to bytes that depend only on the
+// tile's size, so every such tile is the same image and is served from one
+// shared encoding.  Checked through two different empty layers: a cache keyed
+// on anything but the size would hand back different bytes for them.
+TEST_F(TileGeneratorTest, EmptyTilesShareOneTransparentEncoding)
+{
+  makeTileGen();
+
+  const std::vector<unsigned char> metal1
+      = tile_gen_->generateTile("metal1", 0, 0, 0);
+  const std::vector<unsigned char> metal2
+      = tile_gen_->generateTile("metal2", 0, 0, 0);
+  EXPECT_EQ(metal1, metal2);
+
+  unsigned width = 0;
+  unsigned height = 0;
+  const std::vector<unsigned char> rgba = decodePng(metal1, width, height);
+  EXPECT_EQ(width, static_cast<unsigned>(kTileSize));
+  EXPECT_EQ(height, static_cast<unsigned>(kTileSize));
+  EXPECT_FALSE(hasNonTransparentPixel(rgba));
+}
+
+// Tiles are encoded from a palette when they hold few enough colours, which has
+// to reproduce them exactly — a shifted or quantized colour would put the web
+// viewer's layers out of step with the Qt GUI's.  The drawn pixels here must be
+// the layer's own colour, unchanged.
+TEST_F(TileGeneratorTest, IndexedEncodingPreservesTheLayerColour)
+{
+  placeInst("BUF_X16", "buf", 0, 0);
+  makeTileGen();
+  fitDieToContent();
+
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  const auto& colors = tile_gen_->getLayerColorMap(getDb()->getTech());
+  const auto entry = colors.find(metal1);
+  ASSERT_NE(entry, colors.end());
+  const Color expected = entry->second;
+
+  unsigned width = 0;
+  unsigned height = 0;
+  const std::vector<unsigned char> rgba
+      = decodePng(tile_gen_->generateTile("metal1", 0, 0, 0), width, height);
+  ASSERT_TRUE(hasNonTransparentPixel(rgba));
+
+  std::set<std::array<unsigned char, 4>> colors_seen;
+  for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+    if (rgba[i + 3] != 0) {
+      colors_seen.insert({rgba[i], rgba[i + 1], rgba[i + 2], rgba[i + 3]});
+    }
+  }
+  ASSERT_FALSE(colors_seen.empty());
+  // The tile carries the die outline and the instance's pin shapes too, so
+  // only require that the layer's own colour survives the round trip intact:
+  // a palette that shifted or quantized it would leave this exact tuple absent.
+  const std::array<unsigned char, 4> layer_color{
+      expected.r, expected.g, expected.b, expected.a};
+  EXPECT_TRUE(colors_seen.contains(layer_color))
+      << "the layer colour must reach the client unchanged";
+}
+
 // The scale the tests above model is the one the fixture's tech actually has.
 TEST_F(TileGeneratorTest, NangateScaleIsTheOneModelledAbove)
 {

--- a/src/web/test/js/test-tile-merge.js
+++ b/src/web/test/js/test-tile-merge.js
@@ -20,6 +20,43 @@ const PANES = 97;
 const TILES_PER_PANE = 24;
 const TILE_BYTES = 256 * 256 * BYTES_PER_PIXEL;
 
+// Let every promise continuation that is ready to run, run.
+//
+// setImmediate fires in the check phase, after the microtask queue has drained
+// to empty, so one await here settles a chain of `await`s of any depth -- which
+// is what one arriving request unblocks: the request, then the decode, then the
+// paint.
+//
+// The renderMergedTile tests below are about the ORDER requests arrive in and
+// about all of them being in flight at once, never about how long any of it
+// takes.  Staging that with setTimeout delays made them depend on wall-clock
+// time even so, and under a loaded machine -- `bazel test //src/web/...` runs
+// 46 test binaries at once -- timers do not keep their spacing: three 40 ms
+// requests measured 105 ms against a 100 ms bound, and two arrivals 5 ms apart
+// can land in either order.  Gating each request on a promise the test opens by
+// hand states the same orderings exactly, and no load can perturb them.
+function flush() {
+    return new Promise(resolve => setImmediate(resolve));
+}
+
+// One openable gate per named layer, plus `arrive`, which opens one and then
+// lets everything it unblocked run before returning.
+function makeGates(layers) {
+    const gates = new Map();
+    for (const layer of layers) {
+        let open;
+        const promise = new Promise(resolve => { open = resolve; });
+        gates.set(layer, { promise, open });
+    }
+    return {
+        wait: (layer) => gates.has(layer) ? gates.get(layer).promise : null,
+        arrive: async (layer) => {
+            gates.get(layer).open();
+            await flush();
+        },
+    };
+}
+
 describe('tile-merge is pure', () => {
     it('exports plain functions with no DOM or Leaflet dependency', () => {
         // Everything here is arithmetic and compositing rules, so it stays
@@ -505,19 +542,20 @@ describe('renderMergedTile', () => {
     // Harness: every browser dependency is injected, so the orchestration is
     // testable without a DOM or a real ImageBitmap.
     function harness({ items, failRequests = [], failDecodes = [],
-                       stale = () => false, delays = {} } = {}) {
+                       stale = () => false, gated = [] } = {}) {
         const released = [];
         const drawnCalls = [];
         const requested = [];
+        const gates = makeGates(gated);
         return {
-            released, drawnCalls, requested,
+            released, drawnCalls, requested, arrive: gates.arrive,
             opts: {
                 items,
                 request: async (item) => {
                     requested.push(item.layer);
-                    const ms = delays[item.layer] || 0;
-                    if (ms) {
-                        await new Promise(r => setTimeout(r, ms));
+                    const gate = gates.wait(item.layer);
+                    if (gate) {
+                        await gate;
                     }
                     if (failRequests.includes(item.layer)) {
                         throw new Error('cancelled: ' + item.layer);
@@ -548,25 +586,29 @@ describe('renderMergedTile', () => {
         { layer: '_instances', opacity: 1 },
     ];
 
-    it('composites in item order regardless of arrival order', () => {
+    it('composites in item order regardless of arrival order', async () => {
         // A group is a contiguous z-run, so the canvas is recomposited from
         // scratch in list order on every arrival — the stacking must not depend
         // on which response happens to land first. metal2 arrives first here.
         const h = harness({
             items: ITEMS,
-            delays: { metal1: 20, metal2: 0, _instances: 10 },
+            gated: ['metal1', 'metal2', '_instances'],
         });
-        return renderMergedTile(h.opts).then((stats) => {
-            assert.equal(stats.drawn, 3);
-            const last = h.drawnCalls[h.drawnCalls.length - 1];
-            assert.deepEqual(last.map(d => d.id),
-                             ['metal1', 'metal2', '_instances']);
-            // Every paint walks the full list, so a slot not yet in is drawn as
-            // nothing rather than the later layers sliding down into its place.
-            for (const call of h.drawnCalls) {
-                assert.deepEqual(call.map(d => d.opacity), [0.7, 0.7, 1]);
-            }
-        });
+        const done = renderMergedTile(h.opts);
+        await h.arrive('metal2');
+        await h.arrive('_instances');
+        await h.arrive('metal1');
+
+        const stats = await done;
+        assert.equal(stats.drawn, 3);
+        const last = h.drawnCalls[h.drawnCalls.length - 1];
+        assert.deepEqual(last.map(d => d.id),
+                         ['metal1', 'metal2', '_instances']);
+        // Every paint walks the full list, so a slot not yet in is drawn as
+        // nothing rather than the later layers sliding down into its place.
+        for (const call of h.drawnCalls) {
+            assert.deepEqual(call.map(d => d.opacity), [0.7, 0.7, 1]);
+        }
     });
 
     it('carries each item its own opacity', async () => {
@@ -578,15 +620,24 @@ describe('renderMergedTile', () => {
 
     it('issues the requests concurrently, not one after another', async () => {
         // Serialising K requests would multiply tile latency by K.
+        //
+        // Asserted as "all K are in flight before any of them answers", which
+        // is the property itself: with every request held open, a serialised
+        // implementation could not have issued the second.  Timing the whole
+        // render instead only inferred it, and inferred it from a wall clock
+        // that a busy machine moves (see flush()).
         const h = harness({
             items: ITEMS,
-            delays: { metal1: 40, metal2: 40, _instances: 40 },
+            gated: ['metal1', 'metal2', '_instances'],
         });
-        const t0 = Date.now();
-        await renderMergedTile(h.opts);
-        assert.ok(Date.now() - t0 < 100,
-                  'requests look serialised');
-        assert.equal(h.requested.length, 3);
+        const done = renderMergedTile(h.opts);
+        await flush();
+        assert.deepEqual(h.requested, ['metal1', 'metal2', '_instances']);
+
+        for (const layer of ['metal1', 'metal2', '_instances']) {
+            await h.arrive(layer);
+        }
+        await done;
     });
 
     it('releases every decoded image', async () => {
@@ -915,12 +966,13 @@ describe('setItemVisible: only a real change may dirty a pane', () => {
 });
 
 describe('renderMergedTile: incremental painting', () => {
-    function incHarness(items, { hang = [], delays = {} } = {}) {
+    function incHarness(items, { hang = [], gated = [] } = {}) {
         const drawnCalls = [];
         const released = [];
+        const gates = makeGates(gated);
         let firstDraws = 0;
         return {
-            drawnCalls, released,
+            drawnCalls, released, arrive: gates.arrive,
             firstDraws: () => firstDraws,
             opts: {
                 items,
@@ -928,9 +980,9 @@ describe('renderMergedTile: incremental painting', () => {
                     if (hang.includes(item.layer)) {
                         return new Promise(() => {});  // never settles
                     }
-                    const ms = delays[item.layer] || 0;
-                    if (ms) {
-                        await new Promise(r => setTimeout(r, ms));
+                    const gate = gates.wait(item.layer);
+                    if (gate) {
+                        await gate;
                     }
                     return { payloadFor: item.layer };
                 },
@@ -953,8 +1005,13 @@ describe('renderMergedTile: incremental painting', () => {
     ];
 
     it('paints as each layer arrives rather than once at the end', async () => {
-        const h = incHarness(ITEMS3, { delays: { a: 0, b: 10, c: 20 } });
-        const stats = await renderMergedTile(h.opts);
+        const h = incHarness(ITEMS3, { gated: ['a', 'b', 'c'] });
+        const done = renderMergedTile(h.opts);
+        await h.arrive('a');
+        await h.arrive('b');
+        await h.arrive('c');
+
+        const stats = await done;
         assert.equal(stats.paints, 3, 'one paint per arrival');
         // Each paint is a full composite of what has arrived so far, in order.
         assert.deepEqual(h.drawnCalls, [
@@ -967,8 +1024,13 @@ describe('renderMergedTile: incremental painting', () => {
     it('draws a not-yet-arrived layer as nothing, in its own slot', async () => {
         // Transparent is the identity for src-over, so the partial composite is
         // exact: the later layers must not slide down into the empty slot.
-        const h = incHarness(ITEMS3, { delays: { a: 20, b: 0, c: 10 } });
-        await renderMergedTile(h.opts);
+        const h = incHarness(ITEMS3, { gated: ['a', 'b', 'c'] });
+        const done = renderMergedTile(h.opts);
+        await h.arrive('b');
+        await h.arrive('c');
+        await h.arrive('a');
+
+        await done;
         assert.deepEqual(h.drawnCalls[0], [null, 'b', null]);
         assert.deepEqual(h.drawnCalls[1], [null, 'b', 'c']);
         assert.deepEqual(h.drawnCalls[2], ['a', 'b', 'c']);
@@ -978,8 +1040,13 @@ describe('renderMergedTile: incremental painting', () => {
         // Leaflet hides a tile until done() marks it loaded, so onFirstDraw is
         // what makes incremental painting visible at all — and it must fire
         // exactly once, not on every repaint.
-        const h = incHarness(ITEMS3, { delays: { a: 0, b: 5, c: 10 } });
-        await renderMergedTile(h.opts);
+        const h = incHarness(ITEMS3, { gated: ['a', 'b', 'c'] });
+        const done = renderMergedTile(h.opts);
+        await h.arrive('a');
+        await h.arrive('b');
+        await h.arrive('c');
+
+        await done;
         assert.equal(h.firstDraws(), 1);
     });
 
@@ -988,7 +1055,7 @@ describe('renderMergedTile: incremental painting', () => {
         // left the tile blank indefinitely; now it costs one layer.
         const h = incHarness(ITEMS3, { hang: ['b'] });
         renderMergedTile(h.opts);           // deliberately not awaited
-        await new Promise(r => setTimeout(r, 20));
+        await flush();  // a and c are ungated, so this is all they need
         assert.ok(h.drawnCalls.length >= 1, 'must paint without the straggler');
         const last = h.drawnCalls[h.drawnCalls.length - 1];
         assert.deepEqual(last, ['a', null, 'c']);
@@ -1011,7 +1078,7 @@ describe('renderMergedTile: incremental painting', () => {
         // A late arrival belongs UNDERNEATH layers already drawn, so the canvas
         // is recomposited from scratch and every source must still be around.
         // Releasing per paint would free a bitmap still needed by the next one.
-        const h = incHarness(ITEMS3, { delays: { a: 0, b: 5, c: 10 } });
+        const h = incHarness(ITEMS3, { gated: ['a', 'b', 'c'] });
         const opts = h.opts;
         const realDraw = opts.draw;
         opts.draw = (sources) => {
@@ -1019,7 +1086,12 @@ describe('renderMergedTile: incremental painting', () => {
                          'nothing may be released while paints remain');
             return realDraw(sources);
         };
-        await renderMergedTile(opts);
+        const done = renderMergedTile(opts);
+        await h.arrive('a');
+        await h.arrive('b');
+        await h.arrive('c');
+
+        await done;
         assert.deepEqual(h.released.sort(), ['a', 'b', 'c']);
     });
 });

--- a/src/web/test/js/test-websocket-manager.js
+++ b/src/web/test/js/test-websocket-manager.js
@@ -71,6 +71,37 @@ describe('WebSocketManager', () => {
             assert.equal(await promise, null);
         });
 
+        it('warns once per unknown payload type, not once per message',
+           async () => {
+            // A version mismatch makes every tile in the viewport arrive with
+            // the same unknown type, so a warning each would bury the first.
+            const mgr = new WebSocketManager('ws://fake');
+            const warnings = [];
+            const saved = console.warn;
+            console.warn = (msg) => warnings.push(msg);
+            try {
+                for (let i = 0; i < 5; i++) {
+                    const id = 200 + i;
+                    const promise = new Promise((resolve, reject) => {
+                        mgr.pending.set(id, { resolve, reject });
+                    });
+                    mgr.handleMessage(buildFrame(id, 99, new Uint8Array(0)));
+                    assert.equal(await promise, null);
+                }
+                // A second unknown type is its own report.
+                const promise = new Promise((resolve, reject) => {
+                    mgr.pending.set(300, { resolve, reject });
+                });
+                mgr.handleMessage(buildFrame(300, 98, new Uint8Array(0)));
+                assert.equal(await promise, null);
+            } finally {
+                console.warn = saved;
+            }
+            assert.equal(warnings.length, 2);
+            assert.match(warnings[0], /99/);
+            assert.match(warnings[1], /98/);
+        });
+
         it('settles an unknown payload type instead of hanging', async () => {
             // A server newer than this client must not leave a tile promise
             // pending forever -- Leaflet keeps such a tile hidden and its load

--- a/src/web/test/js/test-websocket-manager.js
+++ b/src/web/test/js/test-websocket-manager.js
@@ -58,6 +58,31 @@ describe('WebSocketManager', () => {
             assert.deepEqual(result, { status: 'ok', value: 123 });
         });
 
+        it('resolves an empty tile response as null', async () => {
+            // Payload type 3 is a tile the server drew nothing into.  It has
+            // to resolve, and it has to resolve to null rather than to an
+            // empty Blob: every tile consumer keys "draw nothing" off null,
+            // and a Blob would be decoded into a full-size bitmap.
+            const mgr = new WebSocketManager('ws://fake');
+            const promise = new Promise((resolve, reject) => {
+                mgr.pending.set(11, { resolve, reject });
+            });
+            mgr.handleMessage(buildFrame(11, 3, new Uint8Array(0)));
+            assert.equal(await promise, null);
+        });
+
+        it('settles an unknown payload type instead of hanging', async () => {
+            // A server newer than this client must not leave a tile promise
+            // pending forever -- Leaflet keeps such a tile hidden and its load
+            // event never completes.
+            const mgr = new WebSocketManager('ws://fake');
+            const promise = new Promise((resolve, reject) => {
+                mgr.pending.set(12, { resolve, reject });
+            });
+            mgr.handleMessage(buildFrame(12, 99, new Uint8Array(0)));
+            assert.equal(await promise, null);
+        });
+
         it('resolves PNG response as Blob', async () => {
             // Blob is not available in Node 18 test runner without setup,
             // but handleMessage uses `new Blob(...)` which exists in Node 18.

--- a/src/web/test/js/test-websocket-manager.js
+++ b/src/web/test/js/test-websocket-manager.js
@@ -86,14 +86,14 @@ describe('WebSocketManager', () => {
                         mgr.pending.set(id, { resolve, reject });
                     });
                     mgr.handleMessage(buildFrame(id, 99, new Uint8Array(0)));
-                    assert.equal(await promise, null);
+                    await assert.rejects(promise);
                 }
                 // A second unknown type is its own report.
                 const promise = new Promise((resolve, reject) => {
                     mgr.pending.set(300, { resolve, reject });
                 });
                 mgr.handleMessage(buildFrame(300, 98, new Uint8Array(0)));
-                assert.equal(await promise, null);
+                await assert.rejects(promise);
             } finally {
                 console.warn = saved;
             }
@@ -102,16 +102,24 @@ describe('WebSocketManager', () => {
             assert.match(warnings[1], /98/);
         });
 
-        it('settles an unknown payload type instead of hanging', async () => {
-            // A server newer than this client must not leave a tile promise
-            // pending forever -- Leaflet keeps such a tile hidden and its load
-            // event never completes.
+        it('rejects an unknown payload type rather than hanging', async () => {
+            // A server newer than this client must not leave a promise pending
+            // forever -- Leaflet keeps such a tile hidden and its load event
+            // never completes.  It must not resolve null either: only type 3
+            // means "blank tile", and the JSON callers on this same manager
+            // would read the null as data.
             const mgr = new WebSocketManager('ws://fake');
             const promise = new Promise((resolve, reject) => {
                 mgr.pending.set(12, { resolve, reject });
             });
-            mgr.handleMessage(buildFrame(12, 99, new Uint8Array(0)));
-            assert.equal(await promise, null);
+            const saved = console.warn;
+            console.warn = () => {};
+            try {
+                mgr.handleMessage(buildFrame(12, 99, new Uint8Array(0)));
+                await assert.rejects(promise, /Unsupported websocket payload/);
+            } finally {
+                console.warn = saved;
+            }
         });
 
         it('resolves PNG response as Blob', async () => {

--- a/src/web/test/js/test-websocket-tile-layer.js
+++ b/src/web/test/js/test-websocket-tile-layer.js
@@ -47,7 +47,7 @@ const { buildMapOptions } = await import('../../src/ui-utils.js');
 const { floorClampZoom, buildTileRequest, currentDpr,
         createWebSocketTileLayer, createOverlayTileLayer }
     = await import('../../src/websocket-tile-layer.js');
-const { TILE_SIZE_CSS, buildTileRequestFor, watchDevicePixelRatio }
+const { BLANK_TILE, TILE_SIZE_CSS, buildTileRequestFor, watchDevicePixelRatio }
     = await import('../../src/tile-request.js');
 const { WebSocketManager } = await import('../../src/websocket-manager.js');
 
@@ -55,6 +55,35 @@ const { WebSocketManager } = await import('../../src/websocket-manager.js');
 // number of device pixels has a fractional PITCH, so its boundaries cannot all
 // sit on the device grid however the panes are placed, and the browser
 // antialiases the rest into their neighbours.
+describe('BLANK_TILE', () => {
+    // What every empty tile in the viewport holds, stretched over the whole
+    // tile by the <img>.  If it is not transparent the layout disappears under
+    // a wash of its one pixel, and most tiles in a viewport are empty.
+    //
+    // A 1x1 GIF is only transparent if it carries a Graphic Control Extension
+    // that says so.  The widely pasted "blank gif" has no such block and is
+    // opaque; this decodes the data URI and checks for one rather than trusting
+    // the string to look right.
+    it('is a 1x1 GIF that actually declares a transparent colour', () => {
+        const prefix = 'data:image/gif;base64,';
+        assert.ok(BLANK_TILE.startsWith(prefix));
+        const b = Buffer.from(BLANK_TILE.slice(prefix.length), 'base64');
+
+        assert.equal(b.subarray(0, 6).toString('latin1'), 'GIF89a');
+        assert.equal(b.readUInt16LE(6), 1, 'width');
+        assert.equal(b.readUInt16LE(8), 1, 'height');
+
+        // Skip the global colour table to reach the first block.
+        const packed = b[10];
+        const gct_entries = (packed & 0x80) ? 2 ** ((packed & 0x07) + 1) : 0;
+        const block = 13 + 3 * gct_entries;
+
+        assert.equal(b[block], 0x21, 'an extension block must come first');
+        assert.equal(b[block + 1], 0xF9, 'and it must be the graphic control');
+        assert.equal(b[block + 3] & 0x01, 1, 'with the transparency flag set');
+    });
+});
+
 describe('TILE_SIZE_CSS', () => {
     // Every ratio seen in the wild: display scaling (125/150/166/175/200/250%),
     // and those combined with the browser zoom steps that produce eighths and
@@ -385,11 +414,15 @@ describe('the layer body must resolve every name it references', () => {
         assert.equal(layer._clampZoom(5), 5);
     });
 
-    // A blank tile arrives as a null payload (frame type 3).  The element has
-    // to end up holding no image -- that is the whole point of the empty
-    // response, no decode and no bitmap -- and it still has to be handed back
-    // to Leaflet, which keeps a tile hidden until done() is called and never
-    // gets the load event that would otherwise call it.
+    // A blank tile arrives as a null payload (frame type 3).  The element must
+    // hold the 1x1 BLANK_TILE and not a tile-sized image -- that is the whole
+    // point of the empty response -- and it must not be left with no src at
+    // all: Chrome paints the empty replaced element, which drew a grey grid
+    // over the layout, one cell per tile, since most tiles are empty.
+    //
+    // Holding a real image is also what completes the tile: Leaflet keeps a
+    // tile hidden until done() is called, and BLANK_TILE's load event is what
+    // calls it.
     async function emptyTile(makeLayer) {
         const saved = globalThis.document;
         const el = {
@@ -409,6 +442,11 @@ describe('the layer body must resolve every name it references', () => {
             // Let the resolved request promise run.
             await Promise.resolve();
             await Promise.resolve();
+            // The fake element has no image pipeline, so stand in for the
+            // browser and fire the load that a real src assignment would.
+            if (tile.onload) {
+                tile.onload();
+            }
             return { tile, done_with, done_calls };
         } finally {
             globalThis.document = saved;
@@ -421,28 +459,30 @@ describe('the layer body must resolve every name it references', () => {
         cancel() {},
     });
 
-    it('completes an empty layer tile without giving it an image', async () => {
+    it('gives an empty layer tile the blank image, not an absent src',
+       async () => {
         const { tile, done_with, done_calls } = await emptyTile(() => {
             const Layer = createWebSocketTileLayer(
                 { stdcells: true }, new Set(['metal1']), null, null, null);
             return new Layer(nullManager(), 'metal1', {});
         });
+        assert.equal(tile.src, BLANK_TILE);
+        assert.ok(BLANK_TILE.startsWith('data:image/'),
+                  'the blank tile has to be a real image the browser can load');
         assert.equal(done_calls, 1);
         assert.equal(done_with.err, null);
         assert.equal(done_with.t, tile);
-        assert.equal(tile.src, undefined);
     });
 
-    it('completes an empty overlay tile without giving it an image',
-       async () => {
+    it('gives an empty overlay tile the blank image too', async () => {
         const { tile, done_with, done_calls } = await emptyTile(() => {
             const Overlay = createOverlayTileLayer({}, null);
             return new Overlay(nullManager(), {});
         });
+        assert.equal(tile.src, BLANK_TILE);
         assert.equal(done_calls, 1);
         assert.equal(done_with.err, null);
         assert.equal(done_with.t, tile);
-        assert.equal(tile.src, undefined);
     });
 
     it('builds the overlay layer class too', () => {

--- a/src/web/test/js/test-websocket-tile-layer.js
+++ b/src/web/test/js/test-websocket-tile-layer.js
@@ -385,6 +385,66 @@ describe('the layer body must resolve every name it references', () => {
         assert.equal(layer._clampZoom(5), 5);
     });
 
+    // A blank tile arrives as a null payload (frame type 3).  The element has
+    // to end up holding no image -- that is the whole point of the empty
+    // response, no decode and no bitmap -- and it still has to be handed back
+    // to Leaflet, which keeps a tile hidden until done() is called and never
+    // gets the load event that would otherwise call it.
+    async function emptyTile(makeLayer) {
+        const saved = globalThis.document;
+        const el = {
+            setAttribute() {},
+            removeAttribute(name) { delete el[name]; },
+        };
+        globalThis.document = { createElement: () => el };
+        try {
+            const layer = makeLayer();
+            layer.getTileSize = () => ({ x: 240, y: 240 });
+            let done_with = undefined;
+            let done_calls = 0;
+            const tile = layer.createTile({ x: 1, y: 2, z: 3 }, (err, t) => {
+                done_calls++;
+                done_with = { err, t };
+            });
+            // Let the resolved request promise run.
+            await Promise.resolve();
+            await Promise.resolve();
+            return { tile, done_with, done_calls };
+        } finally {
+            globalThis.document = saved;
+        }
+    }
+
+    const nullManager = () => ({
+        nextId: 1,
+        request: () => Promise.resolve(null),
+        cancel() {},
+    });
+
+    it('completes an empty layer tile without giving it an image', async () => {
+        const { tile, done_with, done_calls } = await emptyTile(() => {
+            const Layer = createWebSocketTileLayer(
+                { stdcells: true }, new Set(['metal1']), null, null, null);
+            return new Layer(nullManager(), 'metal1', {});
+        });
+        assert.equal(done_calls, 1);
+        assert.equal(done_with.err, null);
+        assert.equal(done_with.t, tile);
+        assert.equal(tile.src, undefined);
+    });
+
+    it('completes an empty overlay tile without giving it an image',
+       async () => {
+        const { tile, done_with, done_calls } = await emptyTile(() => {
+            const Overlay = createOverlayTileLayer({}, null);
+            return new Overlay(nullManager(), {});
+        });
+        assert.equal(done_calls, 1);
+        assert.equal(done_with.err, null);
+        assert.equal(done_with.t, tile);
+        assert.equal(tile.src, undefined);
+    });
+
     it('builds the overlay layer class too', () => {
         assert.doesNotThrow(() => createOverlayTileLayer({}, null));
     });


### PR DESCRIPTION
Three changes to the web viewer's tile path, plus a heat-map rendering fix
that fell out of investigating them.

Measured on `coralnpu` (asap7, post-GRT, 174k instances) at a fit-to-design
zoom: a 32-layer viewport is 1280 tile requests.

| | before | after |
| --- | --- | --- |
| server CPU per frame (1 thread) | 1757 ms | **862 ms** |
| wall per frame (1 thread) | ~2900 ms | **858 ms** |
| frame served from the tile cache | 1274 ms | **19.9 ms** |

For reference the Qt GUI renders the same frame in 362 ms, so the gap
narrows from ~4.9x to ~2.4x. Confirmed on `bp_multi` (nangate45,
post-detailed-route, 278k instances) as well: 1587 -> 1020 ms CPU, where
the gap was already smaller because Qt's cost tracks shape count while the
tile server's tracks layers x tiles.

### 1. `dcdf069711` — encode cost, kerning, heat-map bin seams

PNG encoding, not rasterization, was where the frame went: 1060 ms of it.
Tiles are nearly always encodable from a palette — a layer with nothing in
view is one transparent colour, and a layer with something is its own
colour at a few alpha levels — so lodepng now gets one byte per pixel
instead of four, and the fully transparent tile is encoded once and shared.
Kerning is resolved once per font size instead of per lookup;
`stbtt_GetCodepointKernAdvance` searches the cmap twice and walks the GPOS
table, and `textWidth()` asks for a pair between every adjacent pair of
characters.

Separately, heat-map bins were rounding both edges outward, so the pixels
on a shared edge went to both neighbouring bins and were composited twice.
That drew a lattice of darker seams over every map, and mixing pairs of
ramp entries pushed a tile's colour count into the thousands where the ramp
holds 256. RUDY tiles now hold 48 distinct colours where they held 772, and
their PNGs are 4.1 kB where they were 22.4 kB.

Layer tiles are pixel-identical before and after: 280/280 on coralnpu,
960/960 on bp_multi.

### 2. `9ae2c083da` — blank tiles as an empty response

Most tiles in a viewport are blank: 1092 of 1280 here, 725 of 960 on
bp_multi. A ring of tile positions covers only the bounds margin, the via
layers sit below the sub-resolution cull, and some tech layers hold no
geometry at all.

They were served as a transparent PNG — ~100 bytes on the wire, but still a
`(256*dpr)^2 * 4` byte decode on the client. Decoded image bytes are what
`tile-merge.js` is rationing: it merges panes to stay under a 350 MB budget
because Chrome starts discarding decoded images around 458 MB and the
discarded regions paint white. At dpr 1 the blank tiles alone were 286 MB
of that budget on coralnpu, held for images with nothing in them.

Adds payload type 3 to the wire protocol (no body). The merged tile path
already treated a null payload as "draw nothing" and needed no change; the
`<img>` path clears the element and completes the tile itself, since
Leaflet keeps a tile hidden until `done()` and an `<img>` with no `src`
never fires the load event that would call it.

### 3. `146a0fd2e7` — disable Nagle on the tile socket

Tile responses go out in bursts of hundreds and most are small. Nagle held
the first small segment of a burst until the client's delayed ACK arrived
and the rest queued behind it — a ~40 ms stall per burst regardless of its
size, which is why it hid. Cold frame wall time 1799 -> 858 ms, which now
equals the CPU the same frame costs.

### Not included

Two further optimisations were implemented, measured, and dropped because
they were slower: a single-RGB fast path for the palette scan (867 -> 890
ms) and a flattened, branch-free Lanczos tap table (857 -> 920 ms, though
verified bit-exact over 960 tiles). The `pa == 0` skip in the resampler is
doing more work than vectorising the loop would recover, on sparse tiles.

Compositing `save_image` into one supersampled buffer per tile is not sound
as it stands: `drawFilledRect`'s solid path overwrites rather than blends,
which is safe only because each layer gets its own scratch buffer. Doing it
properly needs a super-resolution accumulator each layer blends into.
