### PR TITLE
bazel: take the doc build's Python from the toolchain, not the host

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -530,7 +530,13 @@ sh_test(
         # The handle the script uses to find the source tree it scans.
         "MODULE.bazel",
         "//etc:find_messages.py",
+        # The interpreter itself, so the script runs on the one the toolchain
+        # resolved rather than whatever python3 the host has on PATH.
+        "@rules_python//python:current_py_toolchain",
     ],
+    env = {
+        "PYTHON3_ROOTPATH": "$(PYTHON3_ROOTPATH)",
+    },
     # external: the sources being scanned are not declared inputs, so nothing
     # invalidates a cached result when one of them gains a duplicate ID. Without
     # this the check reports "(cached) PASSED" over a tree it never looked at.
@@ -538,6 +544,7 @@ sh_test(
         "external",
         "local",
     ],
+    toolchains = ["@rules_python//python:current_py_toolchain"],
 )
 
 # Make sure the Qt GUI variant keeps building. :openroad is exercised by

--- a/bazel/man_pages.bzl
+++ b/bazel/man_pages.bzl
@@ -7,8 +7,11 @@ The output filenames aren't known at analysis time (they depend on which
 modules exist under src/*/), so outputs are declared as TreeArtifacts and
 the real work is delegated to the `bazel-manpages` Makefile target.
 
-Host requirements: pandoc, nroff (groff), col (bsdextrautils), python3>=3.10.
+Host requirements: pandoc, nroff (groff), col (bsdextrautils). Python comes
+from the Bazel toolchain, not the host.
 """
+
+_PY_TOOLCHAIN_TYPE = "@rules_python//python:toolchain_type"
 
 def _man_pages_resource_set(_os, _num_inputs):
     # The 'cat web' make below fans out with -j$(nproc), so this action uses
@@ -22,6 +25,23 @@ def _man_pages_impl(ctx):
     cat_dir = ctx.actions.declare_directory("cat")
     html_dir = ctx.actions.declare_directory("html")
 
+    # The Makefile's preprocess step runs md_roff_compat.py, which needs
+    # Python >= 3.7 ('from __future__ import annotations'). Take the interpreter
+    # from the toolchain instead of leaving the Makefile on the host's python3:
+    # RHEL 8 ships 3.6 as /usr/bin/python3, and the action's environment is not
+    # the interactive shell's, so a newer python3 earlier on the user's PATH
+    # does not necessarily reach it either.
+    py3_runtime = ctx.toolchains[_PY_TOOLCHAIN_TYPE].py3_runtime
+    interpreter_files = []
+    if py3_runtime.interpreter:
+        # An in-build interpreter: its path is execroot-relative, and make runs
+        # with -C docs, so anchor it to the execroot the action starts in.
+        python = "$PWD/" + py3_runtime.interpreter.path
+        interpreter_files = [py3_runtime.files]
+    else:
+        # A platform runtime instead: an absolute path on the host.
+        python = py3_runtime.interpreter_path
+
     command = """
 set -euo pipefail
 CAT_OUT="$PWD/{cat_out}"
@@ -31,6 +51,10 @@ HTML_OUT="$PWD/{html_out}"
 # md_roff_compat.py looks for <root>/src/<module>/messages.txt and
 # <root>/messages.txt, which is exactly the bin dir's layout.
 export MESSAGES_ROOT_DIR="$PWD/{bin_dir}"
+# use_default_shell_env passes the client's environment through (pandoc, groff
+# and col are found on PATH). Drop the two variables that would redirect the
+# toolchain interpreter at a host installation's stdlib.
+unset PYTHONHOME PYTHONPATH
 # Two phases: 'preprocess' (serial) generates the md/man*/*.md sources, then
 # 'cat web' fan out pandoc/nroff in parallel. They cannot share one -j make
 # invocation: cat/web read the md files preprocess produces, and a parallel
@@ -45,19 +69,24 @@ JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
 # including the pandoc/groff diagnostics that are worth seeing. Those tools
 # name the file they failed on, so the echoed command adds nothing.
 make -s --no-print-directory -C docs -f Makefile preprocess \\
-    CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
+    PYTHON="{python}" CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
 make -s --no-print-directory -j"$JOBS" -C docs -f Makefile cat web \\
     CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
 """.format(
         bin_dir = ctx.bin_dir.path,
         cat_out = cat_dir.path,
         html_out = html_dir.path,
+        python = python,
     )
 
     ctx.actions.run_shell(
         resource_set = _man_pages_resource_set,
         outputs = [cat_dir, html_dir],
-        inputs = ctx.files.docs_srcs + ctx.files.scripts + ctx.files.readmes + ctx.files.messages,
+        inputs = depset(
+            ctx.files.docs_srcs + ctx.files.scripts + ctx.files.readmes +
+            ctx.files.messages,
+            transitive = interpreter_files,
+        ),
         command = command,
         mnemonic = "ManPages",
         progress_message = "Generating man pages (cat + html)",
@@ -90,4 +119,5 @@ man_pages = rule(
             allow_files = True,
         ),
     },
+    toolchains = [_PY_TOOLCHAIN_TYPE],
 )

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,6 +27,12 @@ endif
 # Define variables
 PANDOC = pandoc
 GROFF ?= groff
+# Interpreter for the man page generation scripts, which need Python >= 3.7
+# (`from __future__ import annotations`). Distributions still shipping an older
+# /usr/bin/python3 (RHEL 8 has 3.6) need this pointed at a newer one;
+# //docs:man_pages overrides it with the interpreter from the Bazel Python
+# toolchain so the Bazel build does not depend on the host's python3 at all.
+PYTHON ?= python3
 # Roff snippet injected into every man page to remap Pandoc's Courier-based
 # code/verbatim fonts on devices that lack them, silencing troff "cannot
 # select font" warnings (see the file for details).
@@ -87,7 +93,7 @@ all: doc web cat
 # md/man1 is checked in and must survive.
 preprocess:
 	rm -rf $(SRC_DIR)/$(MAN2) $(SRC_DIR)/$(MAN3)
-	./src/scripts/link_readmes.sh && python3 src/scripts/md_roff_compat.py
+	./src/scripts/link_readmes.sh && $(PYTHON) src/scripts/md_roff_compat.py
 
 # Target to generate all man pages
 doc: $(MAN1_PAGES) $(MAN2_PAGES) $(MAN3_PAGES)

--- a/etc/find_dup_ids.sh
+++ b/etc/find_dup_ids.sh
@@ -23,6 +23,15 @@ fi
 # Absolute: the scan below runs from a different directory.
 FIND_MESSAGES="$(realpath "${FIND_MESSAGES}")"
 
+# The interpreter the Bazel Python toolchain resolved, passed in as a
+# runfiles-relative path, so this test does not depend on the host's python3.
+# Fall back to PATH when run outside Bazel.
+if [[ -n "${PYTHON3_ROOTPATH:-}" ]]; then
+    PYTHON3="$(realpath "${RUNFILES_DIR}/_main/${PYTHON3_ROOTPATH}")"
+else
+    PYTHON3=python3
+fi
+
 # Run from the source tree. A test runs in its runfiles directory, which holds
 # nothing but its own declared data, so scanning "src" from there would walk a
 # path that does not exist -- find_messages.py would report zero messages and
@@ -37,4 +46,4 @@ cd "$(dirname "$(readlink MODULE.bazel)")"
 # //src/<module>:messages_txt targets, which each scan their own module only.
 # find_messages.py exits non-zero naming both sites; its listing of every
 # message goes to stdout and is not interesting here.
-python3 "${FIND_MESSAGES}" -d src > /dev/null
+"${PYTHON3}" "${FIND_MESSAGES}" -d src > /dev/null

--- a/etc/find_dup_ids.sh
+++ b/etc/find_dup_ids.sh
@@ -23,11 +23,14 @@ fi
 # Absolute: the scan below runs from a different directory.
 FIND_MESSAGES="$(realpath "${FIND_MESSAGES}")"
 
-# The interpreter the Bazel Python toolchain resolved, passed in as a
-# runfiles-relative path, so this test does not depend on the host's python3.
-# Fall back to PATH when run outside Bazel.
+# The interpreter the Bazel Python toolchain resolved, so this test does not
+# depend on the host's python3. A hermetic toolchain names it relative to the
+# runfiles root -- which is what a test starts in, so resolve it here, before
+# the cd below leaves that tree. A platform toolchain names an absolute host
+# path instead, which realpath passes through unchanged. Outside Bazel the
+# variable is unset and PATH decides.
 if [[ -n "${PYTHON3_ROOTPATH:-}" ]]; then
-    PYTHON3="$(realpath "${RUNFILES_DIR}/_main/${PYTHON3_ROOTPATH}")"
+    PYTHON3="$(realpath "${PYTHON3_ROOTPATH}")"
 else
     PYTHON3=python3
 fi


### PR DESCRIPTION
//docs:man_pages shells out to docs/Makefile, whose preprocess step ran `python3` off PATH. The action's environment is not the invoking shell's, so a newer interpreter earlier on the user's PATH does not necessarily reach it, and md_roff_compat.py needs Python >= 3.7 ('from __future__ import annotations'). On distributions that still ship 3.6 as /usr/bin/python3 -- RHEL 8, for instance -- the build fails with "SyntaxError: future feature annotations is not defined".

Resolve @rules_python//python:toolchain_type in the man_pages rule and hand the interpreter to make as PYTHON, declaring the runtime's files as action inputs; the Makefile keeps `python3` as its default so a non-Bazel `make -C docs` is unchanged. The same toolchain lookup already backs tcl_encode_or and the messages_txt genrules.

//:dup_id_test was the one remaining host-python user in the Bazel graph; give it the interpreter through PYTHON3_ROOTPATH for the same reason.

Fixes #11290
