### PR TITLE
odb: structure-of-arrays switch for dbTable (iterm first: 1.38x smaller .odb, 10% less RSS; 2.5x ceiling measured)

### DIFF
--- a/src/odb/include/odb/dbStream.h
+++ b/src/odb/include/odb/dbStream.h
@@ -288,6 +288,16 @@ class dbIStream
     return *this;
   }
 
+  // Bulk counterpart to dbOStream::writeBytes. A field-major table block
+  // moves whole columns, and a column is contiguous by construction, so it
+  // wants one call rather than one per byte.
+  void readBytes(std::span<char> bytes)
+  {
+    if (!bytes.empty()) {
+      f_.read(bytes.data(), (std::streamsize) bytes.size());
+    }
+  }
+
   dbIStream& operator>>(char*& c)
   {
     int l;

--- a/src/odb/src/db/dbAccessPoint.cpp
+++ b/src/odb/src/db/dbAccessPoint.cpp
@@ -436,10 +436,10 @@ void dbAccessPoint::destroy(dbAccessPoint* ap)
     }
     for (const auto& iterm_id : _ap->iterms_) {
       _dbITerm* iterm = block->iterm_tbl_->getPtr(iterm_id);
-      auto ap_itr = iterm->aps_.begin();
-      while (ap_itr != iterm->aps_.end()) {
+      auto ap_itr = iterm->aps().begin();
+      while (ap_itr != iterm->aps().end()) {
         if ((*ap_itr).second == ap->getImpl()->getOID()) {
-          iterm->aps_.erase(ap_itr);
+          iterm->aps().erase(ap_itr);
           break;
         }
         ++ap_itr;

--- a/src/odb/src/db/dbBTerm.cpp
+++ b/src/odb/src/db/dbBTerm.cpp
@@ -702,9 +702,9 @@ dbBTerm* dbBTerm::create(dbNet* net_, const char* name)
 
     _dbITerm* iterm = parent_block->iterm_tbl_->create();
     inst_impl->iterms_.push_back(iterm->getOID());
-    iterm->flags_.mterm_idx = mterm->order_id_;
-    iterm->inst_ = inst_impl->getOID();
-    iterm->mterm_ = mterm;
+    iterm->flags().mterm_idx = mterm->order_id_;
+    iterm->inst() = inst_impl->getOID();
+    iterm->mterm() = mterm;
 
     bterm->parent_block_ = parent_block->getOID();
     bterm->parent_iterm_ = inst_impl->iterms_[mterm->order_id_];
@@ -989,14 +989,14 @@ dbBTerm* dbBTerm::getBTerm(dbBlock* block_, uint32_t oid)
 
 uint32_t dbBTerm::staVertexId()
 {
-  _dbBTerm* iterm = (_dbBTerm*) this;
-  return iterm->sta_vertex_id_;
+  _dbBTerm* bterm = (_dbBTerm*) this;
+  return bterm->sta_vertex_id_;
 }
 
 void dbBTerm::staSetVertexId(uint32_t id)
 {
-  _dbBTerm* iterm = (_dbBTerm*) this;
-  iterm->sta_vertex_id_ = id;
+  _dbBTerm* bterm = (_dbBTerm*) this;
+  bterm->sta_vertex_id_ = id;
 }
 
 void dbBTerm::setConstraintRegion(const Rect& constraint_region)

--- a/src/odb/src/db/dbCore.h
+++ b/src/odb/src/db/dbCore.h
@@ -246,6 +246,10 @@ class dbObjectPage
   dbObjectTable* table_;
   uint32_t page_addr_;
   uint32_t alloc_cnt_;
+  // The page's columns, for a table that stores its fields as arrays; null
+  // for a table that stores them in the slots. Owned by dbTable, which is
+  // what creates and destroys pages.
+  void* fields_ = nullptr;
 };
 
 ///////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,11 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 139;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 140;  // Current revision number
+
+// Revision where opted-in dbTables write their pages field-major, in blocks,
+// instead of one whole record per slot
+inline constexpr uint32_t kSchemaFieldMajorBlocks = 140;
 
 // Revision where dbTech::extraction_rules_file_ was removed
 inline constexpr uint32_t kSchemaRemoveTechExtractionRulesFile = 139;

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -40,45 +40,47 @@ namespace odb {
 
 template class dbTable<_dbITerm>;
 
+const ApMap _dbITermFields::kNoAps;
+
 bool _dbITerm::operator==(const _dbITerm& rhs) const
 {
-  if (flags_.mterm_idx != rhs.flags_.mterm_idx) {
+  if (flags().mterm_idx != rhs.flags().mterm_idx) {
     return false;
   }
 
-  if (flags_.spef != rhs.flags_.spef) {
+  if (flags().spef != rhs.flags().spef) {
     return false;
   }
 
-  if (flags_.special != rhs.flags_.special) {
+  if (flags().special != rhs.flags().special) {
     return false;
   }
 
-  if (flags_.connected != rhs.flags_.connected) {
+  if (flags().connected != rhs.flags().connected) {
     return false;
   }
 
-  if (ext_id_ != rhs.ext_id_) {
+  if (ext_id() != rhs.ext_id()) {
     return false;
   }
 
-  if (net_ != rhs.net_) {
+  if (net() != rhs.net()) {
     return false;
   }
 
-  if (inst_ != rhs.inst_) {
+  if (inst() != rhs.inst()) {
     return false;
   }
 
-  if (next_net_iterm_ != rhs.next_net_iterm_) {
+  if (next_net_iterm() != rhs.next_net_iterm()) {
     return false;
   }
 
-  if (prev_net_iterm_ != rhs.prev_net_iterm_) {
+  if (prev_net_iterm() != rhs.prev_net_iterm()) {
     return false;
   }
 
-  if (aps_ != rhs.aps_) {
+  if (aps() != rhs.aps()) {
     return false;
   }
 
@@ -90,8 +92,8 @@ bool _dbITerm::operator<(const _dbITerm& rhs) const
   _dbBlock* lhs_blk = (_dbBlock*) getOwner();
   _dbBlock* rhs_blk = (_dbBlock*) rhs.getOwner();
 
-  _dbInst* lhs_inst = lhs_blk->inst_tbl_->getPtr(inst_);
-  _dbInst* rhs_inst = rhs_blk->inst_tbl_->getPtr(rhs.inst_);
+  _dbInst* lhs_inst = lhs_blk->inst_tbl_->getPtr(inst());
+  _dbInst* rhs_inst = rhs_blk->inst_tbl_->getPtr(rhs.inst());
   int r = strcmp(lhs_inst->name_, rhs_inst->name_);
 
   if (r < 0) {
@@ -110,25 +112,24 @@ bool _dbITerm::operator<(const _dbITerm& rhs) const
 void _dbITerm::resolveMTerm()
 {
   _dbBlock* block = (_dbBlock*) getOwner();
-  _dbInst* inst = block->inst_tbl_->getPtr(inst_);
-  _dbInstHdr* inst_hdr = block->inst_hdr_tbl_->getPtr(inst->inst_hdr_);
+  _dbInst* owner = block->inst_tbl_->getPtr(inst());
+  _dbInstHdr* inst_hdr = block->inst_hdr_tbl_->getPtr(owner->inst_hdr_);
   _dbDatabase* db = getDatabase();
   _dbLib* lib = db->lib_tbl_->getPtr(inst_hdr->lib_);
   _dbMaster* master = lib->master_tbl_->getPtr(inst_hdr->master_);
-  dbId<_dbMTerm> mterm = inst_hdr->mterms_[flags_.mterm_idx];
-  mterm_ = master->mterm_tbl_->getPtr(mterm);
+  dbId<_dbMTerm> mterm_id = inst_hdr->mterms_[flags().mterm_idx];
+  mterm() = master->mterm_tbl_->getPtr(mterm_id);
 }
 
 _dbMTerm* _dbITerm::getMTerm() const
 {
-  return mterm_;
+  return mterm();
 }
 
 _dbInst* _dbITerm::getInst() const
 {
   _dbBlock* block = (_dbBlock*) getOwner();
-  _dbInst* inst = block->inst_tbl_->getPtr(inst_);
-  return inst;
+  return block->inst_tbl_->getPtr(inst());
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -141,7 +142,7 @@ dbInst* dbITerm::getInst() const
 {
   _dbITerm* iterm = (_dbITerm*) this;
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
-  _dbInst* inst = block->inst_tbl_->getPtr(iterm->inst_);
+  _dbInst* inst = block->inst_tbl_->getPtr(iterm->inst());
   if (inst == nullptr) {
     iterm->getLogger()->critical(
         utl::ODB, 446, "dbITerm does not have dbInst.");
@@ -154,25 +155,25 @@ dbNet* dbITerm::getNet() const
   _dbITerm* iterm = (_dbITerm*) this;
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
 
-  if (iterm->net_ == 0) {
+  if (iterm->net() == 0) {
     return nullptr;
   }
 
-  _dbNet* net = block->net_tbl_->getPtr(iterm->net_);
+  _dbNet* net = block->net_tbl_->getPtr(iterm->net());
   return (dbNet*) net;
 }
 
 dbMTerm* dbITerm::getMTerm() const
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return (dbMTerm*) iterm->mterm_;
+  return (dbMTerm*) iterm->mterm();
 }
 
 dbBTerm* dbITerm::getBTerm()
 {
   _dbITerm* iterm = (_dbITerm*) this;
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
-  _dbInst* inst = block->inst_tbl_->getPtr(iterm->inst_);
+  _dbInst* inst = block->inst_tbl_->getPtr(iterm->inst());
 
   if (inst->hierarchy_ == 0) {
     return nullptr;
@@ -182,7 +183,7 @@ dbBTerm* dbITerm::getBTerm()
 
   _dbChip* chip = (_dbChip*) block->getOwner();
   _dbBlock* child = chip->block_tbl_->getPtr(hier->child_block_);
-  dbId<_dbBTerm> bterm = hier->child_bterms_[iterm->flags_.mterm_idx];
+  dbId<_dbBTerm> bterm = hier->child_bterms_[iterm->flags().mterm_idx];
   return (dbBTerm*) child->bterm_tbl_->getPtr(bterm);
 }
 
@@ -199,86 +200,86 @@ dbBlock* dbITerm::getBlock() const
 void dbITerm::setClocked(bool v)
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.clocked = v;
+  iterm->flags().clocked = v;
 }
 
 bool dbITerm::isClocked()
 {
   bool masterFlag = getMTerm()->getSigType() == dbSigType::CLOCK;
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->flags_.clocked > 0 || masterFlag;
+  return iterm->flags().clocked > 0 || masterFlag;
 }
 
 void dbITerm::setMark(uint32_t v)
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.mark = v;
+  iterm->flags().mark = v;
 }
 
 bool dbITerm::isSetMark()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->flags_.mark > 0;
+  return iterm->flags().mark > 0;
 }
 
 bool dbITerm::isSpecial()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->flags_.special == 1;
+  return iterm->flags().special == 1;
 }
 
 void dbITerm::setSpecial()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.special = 1;
+  iterm->flags().special = 1;
 }
 
 void dbITerm::clearSpecial()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.special = 0;
+  iterm->flags().special = 0;
 }
 
 void dbITerm::setSpef(uint32_t v)
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.spef = v;
+  iterm->flags().spef = v;
 }
 
 bool dbITerm::isSpef()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->flags_.spef > 0;
+  return iterm->flags().spef > 0;
 }
 
 void dbITerm::setExtId(uint32_t v)
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->ext_id_ = v;
+  iterm->ext_id() = v;
 }
 
 uint32_t dbITerm::getExtId()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->ext_id_;
+  return iterm->ext_id();
 }
 
 bool dbITerm::isConnected()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->flags_.connected == 1;
+  return iterm->flags().connected == 1;
 }
 
 void dbITerm::setConnected()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.connected = 1;
+  iterm->flags().connected = 1;
 }
 
 void dbITerm::clearConnected()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->flags_.connected = 0;
+  iterm->flags().connected = 0;
 }
 
 /*
@@ -306,7 +307,7 @@ void dbITerm::connect(dbNet* net_)
   }
 
   // Do Nothing if already connected
-  if (iterm->net_ == net->getOID()) {
+  if (iterm->net() == net->getOID()) {
     return;
   }
 
@@ -338,7 +339,7 @@ void dbITerm::connect(dbNet* net_)
   // both the hierarchical net and the flat net
   // use disconnect() ).
   //
-  if (iterm->net_ != 0) {
+  if (iterm->net() != 0) {
     disconnectDbNet();
   }
 
@@ -364,16 +365,16 @@ void dbITerm::connect(dbNet* net_)
     block->journal_->endAction();
   }
 
-  iterm->net_ = net->getOID();
+  iterm->net() = net->getOID();
 
   if (net->iterms_ != 0) {
     _dbITerm* tail = block->iterm_tbl_->getPtr(net->iterms_);
-    iterm->next_net_iterm_ = net->iterms_;
-    iterm->prev_net_iterm_ = 0;
-    tail->prev_net_iterm_ = iterm->getOID();
+    iterm->next_net_iterm() = net->iterms_;
+    iterm->prev_net_iterm() = 0;
+    tail->prev_net_iterm() = iterm->getOID();
   } else {
-    iterm->next_net_iterm_ = 0;
-    iterm->prev_net_iterm_ = 0;
+    iterm->next_net_iterm() = 0;
+    iterm->prev_net_iterm() = 0;
   }
 
   net->iterms_ = iterm->getOID();
@@ -387,10 +388,10 @@ dbModNet* dbITerm::getModNet() const
 {
   _dbITerm* iterm = (_dbITerm*) this;
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
-  if (iterm->mnet_ == 0) {
+  if (iterm->mnet() == 0) {
     return nullptr;
   }
-  _dbModNet* net = block->modnet_tbl_->getPtr(iterm->mnet_);
+  _dbModNet* net = block->modnet_tbl_->getPtr(iterm->mnet());
   return ((dbModNet*) (net));
 }
 
@@ -401,18 +402,18 @@ void dbITerm::connect(dbModNet* mod_net)
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
   _dbInst* inst = iterm->getInst();
 
-  if (iterm->mnet_ == _mod_net->getId()) {
+  if (iterm->mnet() == _mod_net->getId()) {
     return;
   }
 
   // If already connected, disconnect just the modnet (so we don't
   // accidentally blow away prior flat net connections)
 
-  if (iterm->mnet_ != 0) {
+  if (iterm->mnet() != 0) {
     disconnectDbModNet();
   }
 
-  iterm->mnet_ = _mod_net->getId();
+  iterm->mnet() = _mod_net->getId();
 
   if (inst->flags_.dont_touch) {
     inst->getLogger()->error(
@@ -441,13 +442,13 @@ void dbITerm::connect(dbModNet* mod_net)
 
   if (_mod_net->iterms_ != 0) {
     _dbITerm* head = block->iterm_tbl_->getPtr(_mod_net->iterms_);
-    iterm->next_modnet_iterm_ = _mod_net->iterms_;
+    iterm->next_modnet_iterm() = _mod_net->iterms_;
     // prev is this one
-    head->prev_modnet_iterm_ = iterm->getOID();
+    head->prev_modnet_iterm() = iterm->getOID();
   } else {
-    iterm->next_modnet_iterm_ = 0;
+    iterm->next_modnet_iterm() = 0;
   }
-  iterm->prev_modnet_iterm_ = 0;
+  iterm->prev_modnet_iterm() = 0;
   _mod_net->iterms_ = iterm->getOID();
 }
 
@@ -456,7 +457,7 @@ void dbITerm::disconnect()
 {
   _dbITerm* iterm = (_dbITerm*) this;
 
-  if (iterm->net_ == 0 && iterm->mnet_ == 0) {
+  if (iterm->net() == 0 && iterm->mnet() == 0) {
     return;
   }
 
@@ -472,9 +473,9 @@ void dbITerm::disconnect()
 
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
   _dbNet* net
-      = iterm->net_ == 0 ? nullptr : block->net_tbl_->getPtr(iterm->net_);
+      = iterm->net() == 0 ? nullptr : block->net_tbl_->getPtr(iterm->net());
   _dbModNet* mod_net_impl
-      = iterm->mnet_ == 0 ? nullptr : block->modnet_tbl_->getPtr(iterm->mnet_);
+      = iterm->mnet() == 0 ? nullptr : block->modnet_tbl_->getPtr(iterm->mnet());
   dbModNet* mod_net = (dbModNet*) mod_net_impl;
 
   if (net && net->flags_.dont_touch) {
@@ -512,22 +513,22 @@ void dbITerm::disconnect()
 
   if (net) {
     if (net->iterms_ == id) {
-      net->iterms_ = iterm->next_net_iterm_;
+      net->iterms_ = iterm->next_net_iterm();
       if (net->iterms_ != 0) {
         _dbITerm* t = block->iterm_tbl_->getPtr(net->iterms_);
-        t->prev_net_iterm_ = 0;
+        t->prev_net_iterm() = 0;
       }
     } else {
-      if (iterm->next_net_iterm_ != 0) {
-        _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_net_iterm_);
-        next->prev_net_iterm_ = iterm->prev_net_iterm_;
+      if (iterm->next_net_iterm() != 0) {
+        _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_net_iterm());
+        next->prev_net_iterm() = iterm->prev_net_iterm();
       }
-      if (iterm->prev_net_iterm_ != 0) {
-        _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_net_iterm_);
-        prev->next_net_iterm_ = iterm->next_net_iterm_;
+      if (iterm->prev_net_iterm() != 0) {
+        _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_net_iterm());
+        prev->next_net_iterm() = iterm->next_net_iterm();
       }
     }
-    iterm->net_ = 0;
+    iterm->net() = 0;
     for (auto callback : block->callbacks_) {
       callback->inDbITermPostDisconnect(this, (dbNet*) net);
     }
@@ -535,22 +536,22 @@ void dbITerm::disconnect()
 
   if (mod_net_impl) {
     if (mod_net_impl->iterms_ == id) {
-      mod_net_impl->iterms_ = iterm->next_modnet_iterm_;
+      mod_net_impl->iterms_ = iterm->next_modnet_iterm();
       if (mod_net_impl->iterms_ != 0) {
         _dbITerm* t = block->iterm_tbl_->getPtr(mod_net_impl->iterms_);
-        t->prev_modnet_iterm_ = 0;
+        t->prev_modnet_iterm() = 0;
       }
     } else {
-      if (iterm->next_modnet_iterm_ != 0) {
-        _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_modnet_iterm_);
-        next->prev_modnet_iterm_ = iterm->prev_modnet_iterm_;
+      if (iterm->next_modnet_iterm() != 0) {
+        _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_modnet_iterm());
+        next->prev_modnet_iterm() = iterm->prev_modnet_iterm();
       }
-      if (iterm->prev_modnet_iterm_ != 0) {
-        _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_modnet_iterm_);
-        prev->next_modnet_iterm_ = iterm->next_modnet_iterm_;
+      if (iterm->prev_modnet_iterm() != 0) {
+        _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_modnet_iterm());
+        prev->next_modnet_iterm() = iterm->next_modnet_iterm();
       }
     }
-    iterm->mnet_ = 0;
+    iterm->mnet() = 0;
   }
 }
 
@@ -560,7 +561,7 @@ void dbITerm::disconnectDbNet()
 {
   _dbITerm* iterm = (_dbITerm*) this;
 
-  if (iterm->net_ == 0) {
+  if (iterm->net() == 0) {
     return;
   }
 
@@ -574,7 +575,7 @@ void dbITerm::disconnectDbNet()
         inst->name_);
   }
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
-  _dbNet* net = block->net_tbl_->getPtr(iterm->net_);
+  _dbNet* net = block->net_tbl_->getPtr(iterm->net());
 
   if (net->flags_.dont_touch) {
     inst->getLogger()->error(
@@ -611,22 +612,22 @@ void dbITerm::disconnectDbNet()
   uint32_t id = iterm->getOID();
 
   if (net->iterms_ == id) {
-    net->iterms_ = iterm->next_net_iterm_;
+    net->iterms_ = iterm->next_net_iterm();
     if (net->iterms_ != 0) {
       _dbITerm* t = block->iterm_tbl_->getPtr(net->iterms_);
-      t->prev_net_iterm_ = 0;
+      t->prev_net_iterm() = 0;
     }
   } else {
-    if (iterm->next_net_iterm_ != 0) {
-      _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_net_iterm_);
-      next->prev_net_iterm_ = iterm->prev_net_iterm_;
+    if (iterm->next_net_iterm() != 0) {
+      _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_net_iterm());
+      next->prev_net_iterm() = iterm->prev_net_iterm();
     }
-    if (iterm->prev_net_iterm_ != 0) {
-      _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_net_iterm_);
-      prev->next_net_iterm_ = iterm->next_net_iterm_;
+    if (iterm->prev_net_iterm() != 0) {
+      _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_net_iterm());
+      prev->next_net_iterm() = iterm->next_net_iterm();
     }
   }
-  iterm->net_ = 0;
+  iterm->net() = 0;
   for (auto callback : block->callbacks_) {
     callback->inDbITermPostDisconnect(this, (dbNet*) net);
   }
@@ -640,8 +641,8 @@ void dbITerm::disconnectDbModNet()
   _dbITerm* iterm = (_dbITerm*) this;
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
 
-  if (iterm->mnet_ != 0) {
-    _dbModNet* mod_net = block->modnet_tbl_->getPtr(iterm->mnet_);
+  if (iterm->mnet() != 0) {
+    _dbModNet* mod_net = block->modnet_tbl_->getPtr(iterm->mnet());
 
     debugPrint(iterm->getImpl()->getLogger(),
                utl::ODB,
@@ -662,25 +663,25 @@ void dbITerm::disconnectDbModNet()
     }
 
     if (mod_net->iterms_ == getId()) {
-      mod_net->iterms_ = iterm->next_modnet_iterm_;
+      mod_net->iterms_ = iterm->next_modnet_iterm();
       if (mod_net->iterms_ != 0) {
         _dbITerm* t = block->iterm_tbl_->getPtr(mod_net->iterms_);
-        t->prev_modnet_iterm_ = 0;
+        t->prev_modnet_iterm() = 0;
       }
     } else {
-      if (iterm->next_modnet_iterm_ != 0) {
-        _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_modnet_iterm_);
-        next->prev_modnet_iterm_ = iterm->prev_modnet_iterm_;
+      if (iterm->next_modnet_iterm() != 0) {
+        _dbITerm* next = block->iterm_tbl_->getPtr(iterm->next_modnet_iterm());
+        next->prev_modnet_iterm() = iterm->prev_modnet_iterm();
       }
-      if (iterm->prev_modnet_iterm_ != 0) {
-        _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_modnet_iterm_);
-        prev->next_modnet_iterm_ = iterm->next_modnet_iterm_;
+      if (iterm->prev_modnet_iterm() != 0) {
+        _dbITerm* prev = block->iterm_tbl_->getPtr(iterm->prev_modnet_iterm());
+        prev->next_modnet_iterm() = iterm->next_modnet_iterm();
       }
     }
 
-    iterm->next_modnet_iterm_ = 0;
-    iterm->prev_modnet_iterm_ = 0;
-    iterm->mnet_ = 0;
+    iterm->next_modnet_iterm() = 0;
+    iterm->prev_modnet_iterm() = 0;
+    iterm->mnet() = 0;
   }
 }
 
@@ -790,26 +791,26 @@ bool dbITerm::getAvgXY(int* x, int* y) const
 uint32_t dbITerm::staVertexId()
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  return iterm->sta_vertex_id_;
+  return iterm->sta_vertex_id();
 }
 
 void dbITerm::staSetVertexId(uint32_t id)
 {
   _dbITerm* iterm = (_dbITerm*) this;
-  iterm->sta_vertex_id_ = id;
+  iterm->sta_vertex_id() = id;
 }
 
 void dbITerm::setAccessPoint(dbMPin* pin, dbAccessPoint* ap)
 {
   _dbITerm* iterm = (_dbITerm*) this;
   if (ap != nullptr) {
-    iterm->aps_[pin->getImpl()->getOID()] = ap->getImpl()->getOID();
+    iterm->aps()[pin->getImpl()->getOID()] = ap->getImpl()->getOID();
     _dbAccessPoint* _ap = (_dbAccessPoint*) ap;
     auto& iterms = _ap->iterms_;
     auto pos = std::lower_bound(iterms.begin(), iterms.end(), iterm->getOID());
     iterms.insert(pos, iterm->getOID());
   } else {
-    iterm->aps_[pin->getImpl()->getOID()] = dbId<_dbAccessPoint>();
+    iterm->aps()[pin->getImpl()->getOID()] = dbId<_dbAccessPoint>();
   }
 
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
@@ -842,7 +843,7 @@ std::vector<dbAccessPoint*> dbITerm::getPrefAccessPoints() const
   _dbITerm* iterm = (_dbITerm*) this;
   std::vector<std::pair<dbId<_dbMPin>, dbId<_dbAccessPoint>>> sorted_aps;
 
-  for (auto& [pin_id, ap_id] : iterm->aps_) {
+  for (auto& [pin_id, ap_id] : iterm->aps()) {
     if (ap_id.isValid()) {
       sorted_aps.emplace_back(pin_id, ap_id);
     }
@@ -870,7 +871,7 @@ void dbITerm::clearPrefAccessPoints()
   _dbITerm* iterm = (_dbITerm*) this;
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
   // Remove this iterm from each AP's back-reference list before clearing.
-  for (auto& [pin_id, ap_id] : iterm->aps_) {
+  for (auto& [pin_id, ap_id] : iterm->aps()) {
     if (ap_id.isValid()) {
       auto* ap = block->ap_tbl_->getPtr(ap_id);
       auto& iterms = ap->iterms_;
@@ -878,7 +879,7 @@ void dbITerm::clearPrefAccessPoints()
                    iterms.end());
     }
   }
-  iterm->aps_.clear();
+  iterm->aps().clear();
 }
 
 std::vector<std::pair<dbTechLayer*, Rect>> dbITerm::getGeometries() const
@@ -902,7 +903,7 @@ void _dbITerm::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  info.children["aps"].add(aps_);
+  info.children["aps"].add(aps());
 }
 
 }  // namespace odb

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -474,8 +474,9 @@ void dbITerm::disconnect()
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
   _dbNet* net
       = iterm->net() == 0 ? nullptr : block->net_tbl_->getPtr(iterm->net());
-  _dbModNet* mod_net_impl
-      = iterm->mnet() == 0 ? nullptr : block->modnet_tbl_->getPtr(iterm->mnet());
+  _dbModNet* mod_net_impl = iterm->mnet() == 0
+                                ? nullptr
+                                : block->modnet_tbl_->getPtr(iterm->mnet());
   dbModNet* mod_net = (dbModNet*) mod_net_impl;
 
   if (net && net->flags_.dont_touch) {

--- a/src/odb/src/db/dbITerm.h
+++ b/src/odb/src/db/dbITerm.h
@@ -5,8 +5,8 @@
 
 #include <cstdint>
 #include <cstring>
-#include <utility>
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "boost/container/flat_map.hpp"
@@ -76,7 +76,7 @@ struct _dbITermFields
   std::vector<dbId<_dbITerm>> prev_net_iterm;
   std::vector<dbId<_dbITerm>> next_modnet_iterm;
   std::vector<dbId<_dbITerm>> prev_modnet_iterm;
-  std::vector<_dbMTerm*> mterm;  // not saved - cached pointer
+  std::vector<_dbMTerm*> mterm;         // not saved - cached pointer
   std::vector<uint32_t> sta_vertex_id;  // not saved
 
   // Access points are the one field most slots do not have: before pin
@@ -129,8 +129,8 @@ class _dbITerm : public _dbObject
   }
   uint32_t slot() const { return getOID() - getObjectPage()->page_addr_; }
 
-#define ODB_ITERM_COLUMN(name, type)                     \
-  type& name() { return columns()->name[slot()]; }       \
+#define ODB_ITERM_COLUMN(name, type)               \
+  type& name() { return columns()->name[slot()]; } \
   const type& name() const { return columns()->name[slot()]; }
 
   ODB_ITERM_COLUMN(flags, dbITermFlags)
@@ -169,8 +169,6 @@ class _dbITerm : public _dbObject
   void initFields();
   void clearFields();
 };
-
-
 
 // A slot's columns are default-constructed with its page and reset when it
 // is freed, so allocating one has nothing left to initialize. This is what

--- a/src/odb/src/db/dbITerm.h
+++ b/src/odb/src/db/dbITerm.h
@@ -4,7 +4,10 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
+#include <utility>
 #include <map>
+#include <vector>
 
 #include "boost/container/flat_map.hpp"
 #include "dbCore.h"
@@ -25,6 +28,8 @@ class dbOStream;
 class _dbAccessPoint;
 class _dbMPin;
 
+using ApMap = boost::container::flat_map<dbId<_dbMPin>, dbId<_dbAccessPoint>>;
+
 struct dbITermFlags
 {
   // note: number of bits must add up to 32 !!!
@@ -37,16 +42,76 @@ struct dbITermFlags
   uint32_t connected : 1;  // terminal is physically connected
 };
 
+// The columns of iterm_tbl. One array per field, page_size entries each,
+// owned by the page -- the structure-of-arrays half of the same table a
+// dbTable has always been.
+//
+// Two of the columns do double duty. While a slot is free its next and prev
+// free-list links live in `net` and `mnet`, which mean nothing for a free
+// slot: exactly the overlay _dbFreeObject performs on an allocated record's
+// bytes today, moved into the columns.
+struct _dbITermFields
+{
+  explicit _dbITermFields(uint32_t slots)
+      : flags(slots),
+        ext_id(slots),
+        net(slots),
+        mnet(slots),
+        inst(slots),
+        next_net_iterm(slots),
+        prev_net_iterm(slots),
+        next_modnet_iterm(slots),
+        prev_modnet_iterm(slots),
+        mterm(slots, nullptr),
+        sta_vertex_id(slots)
+  {
+  }
+
+  std::vector<dbITermFlags> flags;
+  std::vector<uint32_t> ext_id;
+  std::vector<dbId<_dbNet>> net;
+  std::vector<dbId<_dbModNet>> mnet;
+  std::vector<dbId<_dbInst>> inst;
+  std::vector<dbId<_dbITerm>> next_net_iterm;
+  std::vector<dbId<_dbITerm>> prev_net_iterm;
+  std::vector<dbId<_dbITerm>> next_modnet_iterm;
+  std::vector<dbId<_dbITerm>> prev_modnet_iterm;
+  std::vector<_dbMTerm*> mterm;  // not saved - cached pointer
+  std::vector<uint32_t> sta_vertex_id;  // not saved
+
+  // Access points are the one field most slots do not have: before pin
+  // access runs, none of them do, and a dense column would spend 24 bytes
+  // per slot on an empty map. This one is keyed by slot instead.
+  boost::container::flat_map<uint32_t, ApMap> aps;
+
+  // What a slot without an entry reads as. Const so a read cannot create
+  // one by accident.
+  static const ApMap kNoAps;
+};
+
+// A slot in iterm_tbl. It carries no fields of its own: what a slot still
+// needs an address for is that every dbITerm* handed out by the public API
+// is that address, and that dbObject::getObjectPage() finds its page from
+// the offset word it inherits. The fields live in the page's columns, and
+// the accessors below return references into them -- so a call site reads
+// `iterm->net() = n` where it used to read `iterm->net_ = n`.
 class _dbITerm : public _dbObject
 {
  public:
+  // iterm_tbl is the largest table in a placed design, and most of a slot's
+  // columns are constant or monotone. See dbFieldMajorTable().
+  static constexpr bool kFieldMajorTable = true;
+
+  // ... and it stores those columns as arrays. See dbSoaTable().
+  static constexpr bool kSoaTable = true;
+  using Fields = _dbITermFields;
+
   enum Field  // dbJournal field name
   {
     kFlags
   };
 
-  _dbITerm(_dbDatabase*);
-  _dbITerm(_dbDatabase*, const _dbITerm& i);
+  _dbITerm(_dbDatabase*) {}
 
   bool operator==(const _dbITerm& rhs) const;
   bool operator!=(const _dbITerm& rhs) const { return !operator==(rhs); }
@@ -57,61 +122,98 @@ class _dbITerm : public _dbObject
   _dbInst* getInst() const;
   void resolveMTerm();
 
-  dbITermFlags flags_;
-  uint32_t ext_id_;
-  dbId<_dbNet> net_;
-  dbId<_dbModNet> mnet_;
-  dbId<_dbInst> inst_;
-  dbId<_dbITerm> next_net_iterm_;
-  dbId<_dbITerm> prev_net_iterm_;
-  dbId<_dbITerm> next_modnet_iterm_;
-  dbId<_dbITerm> prev_modnet_iterm_;
-  _dbMTerm* mterm_ = nullptr;  // not saved - cached pointer
-  uint32_t sta_vertex_id_;     // not saved
-  boost::container::flat_map<dbId<_dbMPin>, dbId<_dbAccessPoint>> aps_;
+  // The slot's own columns.
+  _dbITermFields* columns() const
+  {
+    return (_dbITermFields*) getObjectPage()->fields_;
+  }
+  uint32_t slot() const { return getOID() - getObjectPage()->page_addr_; }
+
+#define ODB_ITERM_COLUMN(name, type)                     \
+  type& name() { return columns()->name[slot()]; }       \
+  const type& name() const { return columns()->name[slot()]; }
+
+  ODB_ITERM_COLUMN(flags, dbITermFlags)
+  ODB_ITERM_COLUMN(ext_id, uint32_t)
+  ODB_ITERM_COLUMN(net, dbId<_dbNet>)
+  ODB_ITERM_COLUMN(mnet, dbId<_dbModNet>)
+  ODB_ITERM_COLUMN(inst, dbId<_dbInst>)
+  ODB_ITERM_COLUMN(next_net_iterm, dbId<_dbITerm>)
+  ODB_ITERM_COLUMN(prev_net_iterm, dbId<_dbITerm>)
+  ODB_ITERM_COLUMN(next_modnet_iterm, dbId<_dbITerm>)
+  ODB_ITERM_COLUMN(prev_modnet_iterm, dbId<_dbITerm>)
+  ODB_ITERM_COLUMN(sta_vertex_id, uint32_t)
+#undef ODB_ITERM_COLUMN
+
+  // Reading is sparse-aware; writing creates the slot's entry, so a caller
+  // that only wants to look should use the const overload.
+  const ApMap& aps() const
+  {
+    const auto& sparse = columns()->aps;
+    const auto entry = sparse.find(slot());
+    return entry == sparse.end() ? _dbITermFields::kNoAps : entry->second;
+  }
+  ApMap& aps() { return columns()->aps[slot()]; }
+
+  _dbMTerm*& mterm() { return columns()->mterm[slot()]; }
+  _dbMTerm* mterm() const { return columns()->mterm[slot()]; }
+
+  // While the slot is free these two columns hold the free-list links.
+  uint32_t freeNext() const { return columns()->net[slot()]; }
+  uint32_t freePrev() const { return columns()->mnet[slot()]; }
+  void setFreeNext(uint32_t id) { columns()->net[slot()] = id; }
+  void setFreePrev(uint32_t id) { columns()->mnet[slot()] = id; }
+
+  // dbTable calls these where it would otherwise run a constructor or a
+  // destructor over the slot's own storage.
+  void initFields();
+  void clearFields();
 };
 
-inline _dbITerm::_dbITerm(_dbDatabase*)
+
+
+// A slot's columns are default-constructed with its page and reset when it
+// is freed, so allocating one has nothing left to initialize. This is what
+// dbTable calls in place of running a constructor over slot storage.
+inline void _dbITerm::initFields()
 {
-  // For pointer tagging the bottom 3 bits.
-  static_assert(alignof(_dbITerm) % 8 == 0);
-  flags_.mterm_idx = 0;
-  flags_.spare_bits = 0;
-  flags_.clocked = 0;
-  flags_.mark = 0;
-  flags_.spef = 0;
-  flags_.special = 0;
-  flags_.connected = 0;
-  ext_id_ = 0;
-  sta_vertex_id_ = 0;
+  flags() = dbITermFlags{};
+  ext_id() = 0;
+  net() = dbId<_dbNet>();
+  mnet() = dbId<_dbModNet>();
+  inst() = dbId<_dbInst>();
+  next_net_iterm() = dbId<_dbITerm>();
+  prev_net_iterm() = dbId<_dbITerm>();
+  next_modnet_iterm() = dbId<_dbITerm>();
+  prev_modnet_iterm() = dbId<_dbITerm>();
+  mterm() = nullptr;
+  sta_vertex_id() = 0;
+  columns()->aps.erase(slot());
 }
 
-inline _dbITerm::_dbITerm(_dbDatabase*, const _dbITerm& i)
-    : flags_(i.flags_),
-      ext_id_(i.ext_id_),
-      net_(i.net_),
-      inst_(i.inst_),
-      next_net_iterm_(i.next_net_iterm_),
-      prev_net_iterm_(i.prev_net_iterm_),
-      next_modnet_iterm_(i.next_modnet_iterm_),
-      prev_modnet_iterm_(i.prev_modnet_iterm_),
-      sta_vertex_id_(0)
+inline void _dbITerm::clearFields()
 {
+  // The sparse column is the only one that owns anything.
+  columns()->aps.erase(slot());
+  mterm() = nullptr;
 }
 
 inline dbOStream& operator<<(dbOStream& stream, const _dbITerm& iterm)
 {
-  uint32_t* bit_field = (uint32_t*) &iterm.flags_;
-  stream << *bit_field;
-  stream << iterm.ext_id_;
-  stream << iterm.net_;
-  stream << iterm.inst_;
-  stream << iterm.next_net_iterm_;
-  stream << iterm.prev_net_iterm_;
-  stream << iterm.mnet_;
-  stream << iterm.next_modnet_iterm_;
-  stream << iterm.prev_modnet_iterm_;
-  stream << iterm.aps_;
+  const dbITermFlags flags = iterm.flags();
+  uint32_t bit_field;
+  static_assert(sizeof(bit_field) == sizeof(flags));
+  std::memcpy(&bit_field, &flags, sizeof(bit_field));
+  stream << bit_field;
+  stream << iterm.ext_id();
+  stream << iterm.net();
+  stream << iterm.inst();
+  stream << iterm.next_net_iterm();
+  stream << iterm.prev_net_iterm();
+  stream << iterm.mnet();
+  stream << iterm.next_modnet_iterm();
+  stream << iterm.prev_modnet_iterm();
+  stream << iterm.aps();
   return stream;
 }
 
@@ -119,19 +221,30 @@ inline dbIStream& operator>>(dbIStream& stream, _dbITerm& iterm)
 {
   dbBlock* block = (dbBlock*) (iterm.getOwner());
   _dbDatabase* db = (_dbDatabase*) (block->getDataBase());
-  uint32_t* bit_field = (uint32_t*) &iterm.flags_;
-  stream >> *bit_field;
-  stream >> iterm.ext_id_;
-  stream >> iterm.net_;
-  stream >> iterm.inst_;
-  stream >> iterm.next_net_iterm_;
-  stream >> iterm.prev_net_iterm_;
+  uint32_t bit_field;
+  stream >> bit_field;
+  dbITermFlags flags;
+  std::memcpy(&flags, &bit_field, sizeof(bit_field));
+  iterm.flags() = flags;
+  stream >> iterm.ext_id();
+  stream >> iterm.net();
+  stream >> iterm.inst();
+  stream >> iterm.next_net_iterm();
+  stream >> iterm.prev_net_iterm();
   if (db->isSchema(kSchemaUpdateHierarchy)) {
-    stream >> iterm.mnet_;
-    stream >> iterm.next_modnet_iterm_;
-    stream >> iterm.prev_modnet_iterm_;
+    stream >> iterm.mnet();
+    stream >> iterm.next_modnet_iterm();
+    stream >> iterm.prev_modnet_iterm();
   }
-  stream >> iterm.aps_;
+  // Read into a local and only create the slot's entry if there is
+  // something to put in it: asking for a mutable reference would give every
+  // iterm in the design an entry, which is what the sparse column exists to
+  // avoid.
+  ApMap aps;
+  stream >> aps;
+  if (!aps.empty()) {
+    iterm.aps() = std::move(aps);
+  }
   return stream;
 }
 

--- a/src/odb/src/db/dbITermItr.cpp
+++ b/src/odb/src/db/dbITermItr.cpp
@@ -40,8 +40,8 @@ void dbNetITermItr::reverse(dbObject* parent)
 
   while (id != 0) {
     _dbITerm* iterm = iterm_tbl_->getPtr(id);
-    uint32_t n = iterm->next_net_iterm_;
-    iterm->next_net_iterm_ = list;
+    uint32_t n = iterm->next_net_iterm();
+    iterm->next_net_iterm() = list;
     list = id;
     id = n;
   }
@@ -51,9 +51,9 @@ void dbNetITermItr::reverse(dbObject* parent)
 
   while (id != 0) {
     _dbITerm* iterm = iterm_tbl_->getPtr(id);
-    iterm->prev_net_iterm_ = prev;
+    iterm->prev_net_iterm() = prev;
     prev = id;
-    id = iterm->next_net_iterm_;
+    id = iterm->next_net_iterm();
   }
 
   net->iterms_ = list;
@@ -91,7 +91,7 @@ uint32_t dbNetITermItr::end(dbObject* /* unused: parent */) const
 uint32_t dbNetITermItr::next(uint32_t id, ...) const
 {
   _dbITerm* iterm = iterm_tbl_->getPtr(id);
-  return iterm->next_net_iterm_;
+  return iterm->next_net_iterm();
 }
 
 dbObject* dbNetITermItr::getObject(uint32_t id, ...)
@@ -157,9 +157,9 @@ uint32_t dbInstITermItr::next(uint32_t id, ...) const
 {
   _dbITerm* iterm = _iterm_tbl->getPtr(id);
   _dbBlock* block = (_dbBlock*) iterm->getOwner();
-  _dbInst* inst = block->inst_tbl_->getPtr(iterm->inst_);
+  _dbInst* inst = block->inst_tbl_->getPtr(iterm->inst());
   uint32_t cnt = inst->iterms_.size();
-  uint32_t idx = iterm->flags_.mterm_idx + 1;
+  uint32_t idx = iterm->flags().mterm_idx + 1;
 
   if (idx == cnt) {
     return 0;

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -70,7 +70,7 @@ class sortITerm
   {
     _dbITerm* iterm1 = block_->iterm_tbl_->getPtr(it1);
     _dbITerm* iterm2 = block_->iterm_tbl_->getPtr(it2);
-    return iterm1->flags_.mterm_idx < iterm2->flags_.mterm_idx;
+    return iterm1->flags().mterm_idx < iterm2->flags().mterm_idx;
   }
 };
 
@@ -1280,10 +1280,10 @@ bool dbInst::swapMaster(dbMaster* new_master_)
   uint32_t i;
   for (i = 0; i < cnt; ++i) {
     _dbITerm* it = block->iterm_tbl_->getPtr(inst->iterms_[i]);
-    uint32_t old_idx = it->flags_.mterm_idx;
+    uint32_t old_idx = it->flags().mterm_idx;
     uint32_t new_idx = idx_map[old_idx];
-    it->flags_.mterm_idx = new_idx;
-    it->mterm_ = new_master->mterm_tbl_->getPtr(new_inst_hdr->mterms_[new_idx]);
+    it->flags().mterm_idx = new_idx;
+    it->mterm() = new_master->mterm_tbl_->getPtr(new_inst_hdr->mterms_[new_idx]);
   }
 
   // 2) reorder the iterms vector
@@ -1386,9 +1386,9 @@ dbInst* dbInst::create(dbBlock* block_,
   for (int i = 0; i < mterm_cnt; ++i) {
     _dbITerm* iterm = block->iterm_tbl_->create();
     inst_impl->iterms_[i] = iterm->getOID();
-    iterm->flags_.mterm_idx = i;
-    iterm->inst_ = inst_impl->getOID();
-    iterm->mterm_ = master->mterm_tbl_->getPtr(inst_hdr->mterms_[i]);
+    iterm->flags().mterm_idx = i;
+    iterm->inst() = inst_impl->getOID();
+    iterm->mterm() = master->mterm_tbl_->getPtr(inst_hdr->mterms_[i]);
   }
 
   _dbBox* box = block->box_tbl_->create();

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -1283,7 +1283,8 @@ bool dbInst::swapMaster(dbMaster* new_master_)
     uint32_t old_idx = it->flags().mterm_idx;
     uint32_t new_idx = idx_map[old_idx];
     it->flags().mterm_idx = new_idx;
-    it->mterm() = new_master->mterm_tbl_->getPtr(new_inst_hdr->mterms_[new_idx]);
+    it->mterm()
+        = new_master->mterm_tbl_->getPtr(new_inst_hdr->mterms_[new_idx]);
   }
 
   // 2) reorder the iterms vector

--- a/src/odb/src/db/dbJournal.cpp
+++ b/src/odb/src/db/dbJournal.cpp
@@ -1275,7 +1275,7 @@ void dbJournal::redo_updateITermField()
     case _dbITerm::kFlags: {
       uint32_t prev_flags;
       log_.pop(prev_flags);
-      uint32_t* flags = (uint32_t*) &iterm->flags_;
+      uint32_t* flags = (uint32_t*) &iterm->flags();
       log_.pop(*flags);
       debugPrint(logger_,
                  utl::ODB,

--- a/src/odb/src/db/dbModuleModNetITermItr.cpp
+++ b/src/odb/src/db/dbModuleModNetITermItr.cpp
@@ -72,7 +72,7 @@ uint32_t dbModuleModNetITermItr::next(uint32_t id, ...) const
 {
   // User Code Begin next
   _dbITerm* _iterm = iterm_tbl_->getPtr(id);
-  return _iterm->next_modnet_iterm_;
+  return _iterm->next_modnet_iterm();
   // User Code End next
 }
 

--- a/src/odb/src/db/dbTable.h
+++ b/src/odb/src/db/dbTable.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 #include "boost/integer/static_log2.hpp"
 #include "dbCore.h"
@@ -21,6 +22,51 @@ class dbTablePage final : public dbObjectPage
  public:
   char objects_[1];
 };
+
+// Opt-in, per slot type, to writing this table's pages field-major (see
+// dbTable::writeBlock). Nothing about the in-memory layout changes: the same
+// bytes are written in a different order, so ids, free lists and iteration
+// order are untouched, and only the byte stream moves. Tables opt in one at
+// a time because the win is proportional to how much of the artifact they
+// are, and because a smaller change is a reviewable one.
+//
+// A slot type opts in by declaring `static constexpr bool kFieldMajorTable
+// = true;`. It has to be a member of the type rather than a specialization
+// of a trait: dbTable<T> is instantiated in whichever translation unit
+// happens to serialize the block, and a specialization declared in T's own
+// header is not necessarily visible there, so the writer and the reader
+// could be instantiated with different answers -- which is a silently
+// corrupt file, and was exactly the first bug this code had.
+template <class T>
+constexpr bool dbFieldMajorTable()
+{
+  if constexpr (requires { T::kFieldMajorTable; }) {
+    return T::kFieldMajorTable;
+  } else {
+    return false;
+  }
+}
+
+// Opt-in, per slot type, to storing the table's fields as arrays -- one per
+// field, page_size entries each, owned by the page -- instead of inside the
+// slots. A slot keeps only what dbObject needs to be an address the public
+// API can hand out and to find its page; everything else moves to a column,
+// reached through an accessor that returns a reference, so a call site says
+// `iterm->net()` where it said `iterm->net_`.
+//
+// A type opts in the same way it opts into the field-major file format:
+// `static constexpr bool kSoaTable = true;`, plus the columns themselves and
+// the initFields/clearFields pair dbTable calls in place of running a
+// constructor or destructor over slot storage.
+template <class T>
+constexpr bool dbSoaTable()
+{
+  if constexpr (requires { T::kSoaTable; }) {
+    return T::kSoaTable;
+  } else {
+    return false;
+  }
+}
 
 template <class T, uint32_t page_size /* = 128 */>
 class dbTable final : public dbObjectTable, public dbIterator
@@ -81,13 +127,47 @@ class dbTable final : public dbObjectTable, public dbIterator
  private:
   void resizePageTbl();
   void newPage();
-  void pushQ(uint32_t& Q, _dbFreeObject* e);
-  _dbFreeObject* popQ(uint32_t& Q);
+  // The free list, in whichever storage this table uses: the slot bytes a
+  // _dbFreeObject overlays, or two columns that mean nothing while a slot
+  // is free. Everything above these three works the same either way.
+  uint32_t freeNext(T* t) const;
+  uint32_t freePrev(T* t) const;
+  void setFreeLinks(T* t, uint32_t next, uint32_t prev);
+
+  void pushQ(uint32_t& Q, T* t);
+  T* popQ(uint32_t& Q);
   void findTop();
   void findBottom();
 
   void readPage(dbIStream& stream, dbTablePage* page);
   void writePage(dbOStream& stream, const dbTablePage* page) const;
+
+  // Field-major form of the same bytes, a group of pages at a time. The
+  // group -- not the page -- is the unit, because a page is as small as 128
+  // slots and the compression a field-major layout buys grows with the run
+  // length. Enlarging the page instead would renumber every object, since
+  // an id is `page_addr | slot`.
+  // A block whose records are nearly all distinct lengths gets columns one
+  // byte wide, which buys nothing and costs a header entry each; past this
+  // many classes the block is written verbatim instead. The bound is on
+  // pointlessness, not on cost -- the writer buckets records by length, so
+  // many classes are not themselves expensive.
+  static constexpr size_t kMaxLengthClasses = 64;
+
+  static constexpr uint32_t kSlotsPerBlock = 8192;
+  static constexpr uint32_t kPagesPerBlock
+      = (kSlotsPerBlock / page_size) ? (kSlotsPerBlock / page_size) : 1;
+
+  // Records are sized by sizeof(T) for the purpose of choosing a boundary;
+  // a type whose records carry a heap payload will overrun this, which is
+  // why the bound is generous rather than tight.
+  static constexpr uint64_t kMaxBlockBytes = 4u << 20;
+
+  uint32_t blockPages(uint32_t first_page) const;
+  void writeBlocks(dbOStream& stream) const;
+  void readBlocks(dbIStream& stream);
+  void writeBlock(dbOStream& stream, uint32_t first_page, uint32_t pages) const;
+  void readBlock(dbIStream& stream, uint32_t first_page, uint32_t pages);
 
   _dbFreeObject* getFreeObj(dbId<T> id);
 

--- a/src/odb/src/db/dbTable.inc
+++ b/src/odb/src/db/dbTable.inc
@@ -8,6 +8,10 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <new>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "dbCommon.h"
 #include "dbCore.h"
@@ -63,26 +67,61 @@ inline bool dbTable<T, page_size>::validId(dbId<T> id) const
 }
 
 template <class T, uint32_t page_size>
-inline void dbTable<T, page_size>::pushQ(uint32_t& Q, _dbFreeObject* e)
+inline uint32_t dbTable<T, page_size>::freeNext(T* t) const
 {
-  e->prev_ = 0;
-  e->next_ = Q;
-  const uint32_t head_id = e->getImpl()->getOID();
+  if constexpr (dbSoaTable<T>()) {
+    return t->freeNext();
+  } else {
+    return ((_dbFreeObject*) t)->next_;
+  }
+}
+
+template <class T, uint32_t page_size>
+inline uint32_t dbTable<T, page_size>::freePrev(T* t) const
+{
+  if constexpr (dbSoaTable<T>()) {
+    return t->freePrev();
+  } else {
+    return ((_dbFreeObject*) t)->prev_;
+  }
+}
+
+template <class T, uint32_t page_size>
+inline void dbTable<T, page_size>::setFreeLinks(T* t,
+                                                const uint32_t next,
+                                                const uint32_t prev)
+{
+  if constexpr (dbSoaTable<T>()) {
+    t->setFreeNext(next);
+    t->setFreePrev(prev);
+  } else {
+    _dbFreeObject* o = (_dbFreeObject*) t;
+    o->next_ = next;
+    o->prev_ = prev;
+  }
+}
+
+template <class T, uint32_t page_size>
+inline void dbTable<T, page_size>::pushQ(uint32_t& Q, T* t)
+{
+  const uint32_t head_id = t->getImpl()->getOID();
+  setFreeLinks(t, Q, 0);
   if (Q != 0) {
-    getFreeObj(Q)->prev_ = head_id;
+    T* head = (T*) getFreeObj(Q);
+    setFreeLinks(head, freeNext(head), head_id);
   }
   Q = head_id;
 }
 
 template <class T, uint32_t page_size>
-inline _dbFreeObject* dbTable<T, page_size>::popQ(uint32_t& Q)
+inline T* dbTable<T, page_size>::popQ(uint32_t& Q)
 {
-  _dbFreeObject* e = getFreeObj(Q);
-  Q = e->next_;
+  T* e = (T*) getFreeObj(Q);
+  Q = freeNext(e);
 
   if (Q) {
-    _dbFreeObject* head = getFreeObj(Q);
-    head->prev_ = 0;
+    T* head = (T*) getFreeObj(Q);
+    setFreeLinks(head, freeNext(head), 0);
   }
 
   return e;
@@ -100,6 +139,12 @@ void dbTable<T, page_size>::clear()
       if (t->offset_in_bytes_ & kAllocBit) {
         t->~T();
       }
+    }
+
+    // The columns outlive the slots and are freed with the page.
+    if constexpr (dbSoaTable<T>()) {
+      delete (typename T::Fields*) page->fields_;
+      page->fields_ = nullptr;
     }
 
     free(page);
@@ -179,33 +224,26 @@ void dbTable<T, page_size>::newPage()
   page->table_ = this;
   page->page_addr_ = page_id << kPageShift;
   page->alloc_cnt_ = 0;
+  // The columns have to exist before anything reaches for a field, and the
+  // free list below is threaded through two of them.
+  if constexpr (dbSoaTable<T>()) {
+    page->fields_ = new typename T::Fields(pageSize());
+  }
   pages_[page_id] = page;
 
   // The objects are put on the list in reverse order, so they can be removed
   // in low-to-high order.
-  if (page_id == 0) {
-    T* b = (T*) page->objects_;
-    T* t = &b[kPageMask];
+  T* b = (T*) page->objects_;
+  T* t = &b[kPageMask];
 
-    for (; t >= b; --t) {
-      _dbFreeObject* o = (_dbFreeObject*) t;
-      o->offset_in_bytes_ = (uint32_t) ((char*) t - (char*) b);
-      o->oid_ = page->page_addr_ | (uint32_t) (t - b);
+  for (; t >= b; --t) {
+    t->offset_in_bytes_ = (uint32_t) ((char*) t - (char*) b);
+    t->oid_ = page->page_addr_ | (uint32_t) (t - b);
 
-      if (t != b) {  // don't link zero-object
-        pushQ(free_list_, o);
-      }
+    if (page_id == 0 && t == b) {
+      continue;  // don't link zero-object
     }
-  } else {
-    T* b = (T*) page->objects_;
-    T* t = &b[kPageMask];
-
-    for (; t >= b; --t) {
-      _dbFreeObject* o = (_dbFreeObject*) t;
-      o->offset_in_bytes_ = (uint32_t) ((char*) t - (char*) b);
-      o->oid_ = page->page_addr_ | (uint32_t) (t - b);
-      pushQ(free_list_, o);
-    }
+    pushQ(free_list_, t);
   }
 }
 
@@ -218,13 +256,17 @@ T* dbTable<T, page_size>::create()
     newPage();
   }
 
-  _dbFreeObject* o = popQ(free_list_);
-  const uint32_t offset = o->offset_in_bytes_;
-  const uint32_t saved_oid = o->oid_;
-  new (o) T(db_);
-  T* t = (T*) o;
+  T* t = popQ(free_list_);
+  const uint32_t offset = t->offset_in_bytes_;
+  const uint32_t saved_oid = t->oid_;
+  new (t) T(db_);
   t->offset_in_bytes_ = offset | kAllocBit;
   t->oid_ = saved_oid;
+  // A columnar slot holds nothing for the constructor to initialize, so the
+  // fields it left behind in the columns are reset here instead.
+  if constexpr (dbSoaTable<T>()) {
+    t->initFields();
+  }
 
   dbTablePage* page = (dbTablePage*) t->getObjectPage();
   page->alloc_cnt_++;
@@ -362,20 +404,26 @@ void dbTable<T, page_size>::destroy(T* t)
   assert(t->offset_in_bytes_ & kAllocBit);
 
   dbTablePage* page = (dbTablePage*) t->getObjectPage();
-  _dbFreeObject* o = (_dbFreeObject*) t;
 
   page->alloc_cnt_--;
   const uint32_t offset = t->offset_in_bytes_;
   const uint32_t oid = t->oid_;
+  // Release whatever the slot owns. For a columnar table that is in the
+  // columns rather than in the slot, so the destructor has nothing to do
+  // and clearFields does the work -- and it has to run while the slot can
+  // still find its page.
+  if constexpr (dbSoaTable<T>()) {
+    t->clearFields();
+  }
   t->~T();  // call destructor
-  o->offset_in_bytes_ = offset & ~kAllocBit;
-  o->oid_ = oid;
+  t->offset_in_bytes_ = offset & ~kAllocBit;
+  t->oid_ = oid;
 
   const uint32_t id_in_page = t - (T*) page->objects_;
   const uint32_t id = page->page_addr_ + id_in_page;
 
   // Add to freelist
-  pushQ(free_list_, o);
+  pushQ(free_list_, t);
 
   if (id == bottom_idx_) {
     findBottom();
@@ -488,9 +536,8 @@ void dbTable<T, page_size>::writePage(dbOStream& stream,
     } else {
       const char allocated = 0;
       stream << allocated;
-      _dbFreeObject* o = (_dbFreeObject*) t;
-      stream << o->next_;
-      stream << o->prev_;
+      stream << freeNext((T*) t);
+      stream << freePrev((T*) t);
     }
   }
 }
@@ -512,9 +559,11 @@ void dbTable<T, page_size>::readPage(dbIStream& stream, dbTablePage* page)
     if (!allocated) {
       t->offset_in_bytes_ = (uint32_t) ((char*) t - page->objects_);
       t->oid_ = obj_oid;
-      _dbFreeObject* o = (_dbFreeObject*) t;
-      stream >> o->next_;
-      stream >> o->prev_;
+      uint32_t next;
+      uint32_t prev;
+      stream >> next;
+      stream >> prev;
+      setFreeLinks(t, next, prev);
     } else {
       new (t) T(db_);
       uint32_t offset = uint32_t((char*) t - page->objects_) | kAllocBit;
@@ -526,6 +575,287 @@ void dbTable<T, page_size>::readPage(dbIStream& stream, dbTablePage* page)
       // Check that the streaming code did not overwrite the offset
       assert(t->offset_in_bytes_ == offset);
     }
+  }
+}
+
+template <class T, uint32_t page_size>
+void dbTable<T, page_size>::writeBlock(dbOStream& stream,
+                                       const uint32_t first_page,
+                                       const uint32_t pages) const
+{
+  const uint32_t slots = pages * page_size;
+
+  // Serialize every allocated slot through the type's own operator<<, which
+  // is the point: a field-major writer that needed a hand-written
+  // serializer per type would not be worth having. The records land
+  // end-to-end in a scratch buffer and we remember where each one starts.
+  std::ostringstream scratch(std::ios::binary);
+  dbOStream records(stream.getDatabase(), scratch);
+  std::vector<uint32_t> lengths;      // per allocated slot, in slot order
+  std::vector<uint32_t> starts;       // ditto, into the scratch buffer
+  std::vector<uint32_t> free_links;   // next, prev per free slot, in order
+  std::vector<char> allocated(slots, 0);
+
+  dbOStream::Position mark = records.pos();
+  for (uint32_t i = 0; i < slots; ++i) {
+    const dbTablePage* page = pages_[first_page + (i >> kPageShift)];
+    const T* t = &((const T*) page->objects_)[i & kPageMask];
+
+    if ((t->offset_in_bytes_ & kAllocBit) == 0) {
+      free_links.push_back(freeNext((T*) t));
+      free_links.push_back(freePrev((T*) t));
+      continue;
+    }
+
+    allocated[i] = 1;
+    records << *t;
+    const dbOStream::Position now = records.pos();
+    starts.push_back((uint32_t) mark);
+    lengths.push_back((uint32_t) (now - mark));
+    mark = now;
+  }
+
+  const std::string buffer = scratch.str();
+
+  // Records of one length transpose; records of different lengths do not.
+  // After pin access an iterm either carries an access point or does not, so
+  // a block holds two lengths and splitting by length is what keeps the
+  // layout working -- measured at +14% on the routed case over passing a
+  // mixed block through unchanged.
+  std::vector<uint32_t> classes(lengths);
+  std::sort(classes.begin(), classes.end());
+  classes.erase(std::unique(classes.begin(), classes.end()), classes.end());
+
+  // A table whose records are all different lengths -- a net and its wire,
+  // say -- has as many classes as records, and then splitting by length
+  // buys nothing and costs a pass per class. Past a handful of classes the
+  // block goes out exactly as the per-slot writer would have written it,
+  // which is also what makes it safe to opt every table in: the ones the
+  // layout cannot help simply fall back.
+  const bool transposable = classes.size() <= kMaxLengthClasses;
+  if (!transposable) {
+    classes.clear();
+  }
+
+  stream << (uint32_t) classes.size();
+  for (const uint32_t length : classes) {
+    stream << length;
+  }
+
+  // The allocation bitmap, and then one byte of class index per allocated
+  // slot. A byte rather than packed bits on purpose: the index column is
+  // one of the most compressible things in the block, so the bytes cost
+  // almost nothing once the block is compressed, and the reader stays
+  // obvious.
+  for (uint32_t i = 0; i < slots; i += 8) {
+    unsigned char bits = 0;
+    for (uint32_t bit = 0; bit < 8 && i + bit < slots; ++bit) {
+      if (allocated[i + bit]) {
+        bits |= (unsigned char) (1u << bit);
+      }
+    }
+    stream << bits;
+  }
+  // One class needs no index at all, and the fallback needs none either.
+  if (classes.size() > 1) {
+    for (const uint32_t length : lengths) {
+      const uint32_t index
+          = (uint32_t) (std::lower_bound(classes.begin(), classes.end(), length)
+                        - classes.begin());
+      stream << (unsigned char) index;
+    }
+  }
+  for (const uint32_t link : free_links) {
+    stream << link;
+  }
+
+
+  // Field-major at last: byte j of every record of a class, then byte j + 1.
+  // Gathered into one column and written with a single call -- a byte at a
+  // time through the stream is a function call per byte, which costs more
+  // than the whole rest of the write put together.
+  if (!transposable) {
+    stream.writeBytes(buffer);
+    return;
+  }
+
+  // Bucket the records by length in one pass. Scanning every record once
+  // per class instead is quadratic when a table's records are all different
+  // lengths, which is the common case for anything carrying a wire.
+  std::vector<std::vector<uint32_t>> members(classes.size());
+  for (size_t record = 0; record < lengths.size(); ++record) {
+    const size_t klass
+        = (size_t) (std::lower_bound(classes.begin(), classes.end(), lengths[record])
+                    - classes.begin());
+    members[klass].push_back(starts[record]);
+  }
+
+  std::vector<char> column;
+  for (size_t klass = 0; klass < classes.size(); ++klass) {
+    const std::vector<uint32_t>& group = members[klass];
+    column.resize(group.size());
+    for (uint32_t j = 0; j < classes[klass]; ++j) {
+      for (size_t i = 0; i < group.size(); ++i) {
+        column[i] = buffer[group[i] + j];
+      }
+      stream.writeBytes(column);
+    }
+  }
+}
+
+template <class T, uint32_t page_size>
+void dbTable<T, page_size>::readBlock(dbIStream& stream,
+                                      const uint32_t first_page,
+                                      const uint32_t pages)
+{
+  const uint32_t slots = pages * page_size;
+
+  uint32_t class_cnt;
+  stream >> class_cnt;
+  std::vector<uint32_t> classes(class_cnt);
+  for (uint32_t i = 0; i < class_cnt; ++i) {
+    stream >> classes[i];
+  }
+
+  std::vector<char> allocated(slots, 0);
+  uint32_t alloc_cnt = 0;
+  for (uint32_t i = 0; i < slots; i += 8) {
+    unsigned char bits;
+    stream >> bits;
+    for (uint32_t bit = 0; bit < 8 && i + bit < slots; ++bit) {
+      allocated[i + bit] = (bits >> bit) & 1u;
+      alloc_cnt += allocated[i + bit];
+    }
+  }
+
+  std::vector<uint32_t> lengths(alloc_cnt, 0);
+  if (class_cnt == 1) {
+    std::fill(lengths.begin(), lengths.end(), classes[0]);
+  } else if (class_cnt > 1) {
+    for (uint32_t i = 0; i < alloc_cnt; ++i) {
+      unsigned char index;
+      stream >> index;
+      lengths[i] = classes[index];
+    }
+  }
+
+  std::vector<uint32_t> free_links(2 * (slots - alloc_cnt));
+  for (uint32_t& link : free_links) {
+    stream >> link;
+  }
+
+  // No classes means the writer could not use the layout for this block and
+  // wrote the records verbatim, in slot order -- which is the order the
+  // per-slot reader wants anyway, so it reads them straight from the file.
+  const bool transposed = class_cnt > 0;
+
+  std::string buffer;
+  if (transposed) {
+    // Un-transpose into the records the per-slot reader expects, so the
+    // rest of this is the same code path a legacy read takes.
+    std::vector<uint32_t> starts(alloc_cnt);
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < alloc_cnt; ++i) {
+      starts[i] = total;
+      total += lengths[i];
+    }
+    buffer.assign(total, '\0');
+
+    std::vector<std::vector<uint32_t>> members(classes.size());
+    for (uint32_t record = 0; record < alloc_cnt; ++record) {
+      const size_t klass
+          = (size_t) (std::lower_bound(
+                          classes.begin(), classes.end(), lengths[record])
+                      - classes.begin());
+      members[klass].push_back(starts[record]);
+    }
+
+    std::vector<char> column;
+    for (size_t klass = 0; klass < classes.size(); ++klass) {
+      const std::vector<uint32_t>& group = members[klass];
+      column.resize(group.size());
+      for (uint32_t j = 0; j < classes[klass]; ++j) {
+        stream.readBytes(column);
+        for (size_t i = 0; i < group.size(); ++i) {
+          buffer[group[i] + j] = column[i];
+        }
+      }
+    }
+  }
+
+  std::istringstream scratch(buffer, std::ios::binary);
+  dbIStream unpacked(stream.getDatabase(), scratch);
+  dbIStream& records = transposed ? unpacked : stream;
+
+  uint32_t next_record = 0;
+  uint32_t next_link = 0;
+  for (uint32_t i = 0; i < slots; ++i) {
+    dbTablePage* page = pages_[first_page + (i >> kPageShift)];
+    T* t = &((T*) page->objects_)[i & kPageMask];
+    const uint32_t slot = i & kPageMask;
+    const uint32_t obj_oid = page->page_addr_ | slot;
+
+    if (!allocated[i]) {
+      t->offset_in_bytes_ = slot * sizeof(T);
+      t->oid_ = obj_oid;
+      const uint32_t next = free_links[next_link++];
+      const uint32_t prev = free_links[next_link++];
+      setFreeLinks(t, next, prev);
+      continue;
+    }
+
+    new (t) T(db_);
+    const uint32_t offset = (uint32_t) (slot * sizeof(T)) | kAllocBit;
+    t->offset_in_bytes_ = offset;
+    t->oid_ = obj_oid;
+    page->alloc_cnt_++;
+    records >> *t;
+    // The record must have been consumed exactly, or the field-major layout
+    // and the per-slot reader disagree about this type.
+    assert(t->offset_in_bytes_ == offset);
+    ++next_record;
+  }
+  assert(next_record == alloc_cnt);
+}
+
+template <class T, uint32_t page_size>
+uint32_t dbTable<T, page_size>::blockPages(const uint32_t first_page) const
+{
+  // Slots bound the block, and so does its size in bytes. Without the byte
+  // bound a table of large records -- a net and its wire -- would buffer
+  // thousands of them at once, which costs more memory than the layout
+  // saves. Records are sized here by walking the page's allocation counts
+  // rather than by serializing anything: the estimate only has to be good
+  // enough to pick a boundary, and the boundary is written to the stream.
+  uint32_t pages = 0;
+  uint64_t bytes = 0;
+  while (first_page + pages < page_cnt_ && pages < kPagesPerBlock
+         && bytes < kMaxBlockBytes) {
+    bytes += (uint64_t) pages_[first_page + pages]->alloc_cnt_ * sizeof(T);
+    ++pages;
+  }
+  return pages ? pages : 1;
+}
+
+template <class T, uint32_t page_size>
+void dbTable<T, page_size>::writeBlocks(dbOStream& stream) const
+{
+  for (uint32_t page = 0; page < page_cnt_;) {
+    const uint32_t pages = blockPages(page);
+    stream << pages;
+    writeBlock(stream, page, pages);
+    page += pages;
+  }
+}
+
+template <class T, uint32_t page_size>
+void dbTable<T, page_size>::readBlocks(dbIStream& stream)
+{
+  for (uint32_t page = 0; page < page_cnt_;) {
+    uint32_t pages;
+    stream >> pages;
+    readBlock(stream, page, pages);
+    page += pages;
   }
 }
 
@@ -550,9 +880,14 @@ dbOStream& operator<<(dbOStream& stream, const dbTable<T, page_size>& table)
   stream << table.alloc_cnt_;
   stream << table.free_list_;
 
-  for (uint32_t i = 0; i < table.page_cnt_; ++i) {
-    const dbTablePage* page = table.pages_[i];
-    table.writePage(stream, page);
+
+  if constexpr (dbFieldMajorTable<T>()) {
+    table.writeBlocks(stream);
+  } else {
+    for (uint32_t i = 0; i < table.page_cnt_; ++i) {
+      const dbTablePage* page = table.pages_[i];
+      table.writePage(stream, page);
+    }
   }
 
   stream << table.prop_list_;
@@ -595,6 +930,14 @@ dbIStream& operator>>(dbIStream& stream, dbTable<T, page_size>& table)
     table.pages_ = new dbTablePage*[table.page_tbl_size_];
   }
 
+  // A file written before kSchemaFieldMajorBlocks holds whole records, one
+  // per slot, whatever this table opted into since. Reading it is the same
+  // per-slot loop it always was -- simple, and deliberately not made fast:
+  // the cost falls only on files older than the bump, and correctness there
+  // matters far more than speed.
+  const bool field_major
+      = dbFieldMajorTable<T>() && db->isSchema(kSchemaFieldMajorBlocks);
+
   uint32_t i;
   for (i = 0; i < table.page_cnt_; ++i) {
     uint32_t size = (table.pageSize() * sizeof(T)) + sizeof(dbObjectPage);
@@ -602,8 +945,19 @@ dbIStream& operator>>(dbIStream& stream, dbTable<T, page_size>& table)
     memset(page, 0, size);
     page->page_addr_ = i << table.kPageShift;
     page->table_ = &table;
+    // Pages read from a file are built here rather than by newPage(), so
+    // their columns have to be created here too.
+    if constexpr (dbSoaTable<T>()) {
+      page->fields_ = new typename T::Fields(table.pageSize());
+    }
     table.pages_[i] = page;
-    table.readPage(stream, page);
+    if (!field_major) {
+      table.readPage(stream, page);
+    }
+  }
+
+  if (field_major) {
+    table.readBlocks(stream);
   }
 
   for (; i < table.page_tbl_size_; ++i) {

--- a/src/odb/src/db/dbTable.inc
+++ b/src/odb/src/db/dbTable.inc
@@ -712,6 +712,14 @@ void dbTable<T, page_size>::readBlock(dbIStream& stream,
 
   uint32_t class_cnt;
   stream >> class_cnt;
+  // Sizes an allocation, so it is bounded by what writeBlock can emit.
+  if (class_cnt > kMaxLengthClasses) {
+    db_->getLogger()->error(utl::ODB,
+                            481,
+                            "Table block claims {} record lengths, at most {}",
+                            class_cnt,
+                            kMaxLengthClasses);
+  }
   std::vector<uint32_t> classes(class_cnt);
   for (uint32_t i = 0; i < class_cnt; ++i) {
     stream >> classes[i];
@@ -735,6 +743,13 @@ void dbTable<T, page_size>::readBlock(dbIStream& stream,
     for (uint32_t i = 0; i < alloc_cnt; ++i) {
       unsigned char index;
       stream >> index;
+      if (index >= class_cnt) {
+        db_->getLogger()->error(utl::ODB,
+                                482,
+                                "Table block slot names record length {} of {}",
+                                index,
+                                class_cnt);
+      }
       lengths[i] = classes[index];
     }
   }
@@ -854,6 +869,13 @@ void dbTable<T, page_size>::readBlocks(dbIStream& stream)
   for (uint32_t page = 0; page < page_cnt_;) {
     uint32_t pages;
     stream >> pages;
+    // This count comes from the file and bounds the loop: zero would spin
+    // forever, and too large would walk off the page table.
+    if (pages == 0 || pages > page_cnt_ - page) {
+      db_->getLogger()->error(
+          utl::ODB, 480, "Table block claims {} pages at page {} of {}",
+          pages, page, page_cnt_);
+    }
     readBlock(stream, page, pages);
     page += pages;
   }

--- a/src/odb/test/cpp/BUILD
+++ b/src/odb/test/cpp/BUILD
@@ -410,8 +410,8 @@ cc_test(
     ],
     deps = [
         "//src/odb/src/db",
-        "//src/utl",
         "//src/odb/test/cpp/helper",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/odb/test/cpp/BUILD
+++ b/src/odb/test/cpp/BUILD
@@ -402,3 +402,17 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "TestSoaTable",
+    srcs = [
+        "TestSoaTable.cpp",
+    ],
+    deps = [
+        "//src/odb/src/db",
+        "//src/utl",
+        "//src/odb/test/cpp/helper",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/src/odb/test/cpp/TestSoaTable.cpp
+++ b/src/odb/test/cpp/TestSoaTable.cpp
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+// What the field-major dbTable block format has to preserve.
+//
+// These assert the properties the format claims, not the bytes it currently
+// produces: no golden file, nothing to regenerate when an unrelated change
+// perturbs output. The claim is that writing a block field-major is a
+// permutation of the same bytes, so a database that has been through it is
+// indistinguishable from one that has not -- same ids, same connectivity,
+// and, the subtle one, the same *next* id, because allocation order is the
+// free list's order and the free list is part of what gets written.
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "helper/helper.h"
+#include "odb/db.h"
+#include "utl/deleter.h"
+
+namespace odb {
+namespace {
+
+class SoaTable : public SimpleDbFixture
+{
+ protected:
+  void SetUp() override { create2LevetDbNoBTerms(); }
+
+  std::string write(dbDatabase* db)
+  {
+    std::ostringstream out(std::ios::binary);
+    db->write(out);
+    return out.str();
+  }
+
+  // A fresh database holding what `bytes` describes. Kept alive by the
+  // caller so ids can be compared against the original.
+  utl::UniquePtrWithDeleter<dbDatabase> read(const std::string& bytes)
+  {
+    utl::UniquePtrWithDeleter<dbDatabase> db(dbDatabase::create(),
+                                             &dbDatabase::destroy);
+    db->setLogger(getLogger());
+    std::istringstream in(bytes, std::ios::binary);
+    db->read(in);
+    return db;
+  }
+
+  static dbBlock* blockOf(dbDatabase* db) { return db->getChip()->getBlock(); }
+
+  // Every iterm as (id, instance name, terminal name, net name). Enough to
+  // catch an id that moved, a connection that changed, or an object that
+  // came back as a different one.
+  static std::vector<std::string> itermSummary(dbBlock* block)
+  {
+    std::vector<std::string> summary;
+    for (dbITerm* iterm : block->getITerms()) {
+      dbNet* net = iterm->getNet();
+      summary.push_back(std::to_string(iterm->getId()) + " "
+                        + iterm->getInst()->getName() + " "
+                        + iterm->getMTerm()->getName() + " "
+                        + (net ? net->getName() : "<none>"));
+    }
+    return summary;
+  }
+
+  // The ids a freshly created instance's iterms get. This is what free-list
+  // order decides, and what a reload must not perturb.
+  static std::vector<uint32_t> nextIds(dbDatabase* db, const char* name)
+  {
+    dbBlock* block = blockOf(db);
+    dbMaster* master = db->findLib("lib1")->findMaster("and2");
+    dbInst* inst = dbInst::create(block, master, name);
+    std::vector<uint32_t> ids;
+    for (dbITerm* iterm : inst->getITerms()) {
+      ids.push_back(iterm->getId());
+    }
+    return ids;
+  }
+};
+
+TEST_F(SoaTable, RoundTripPreservesIdsAndConnectivity)
+{
+  const std::vector<std::string> before = itermSummary(blockOf(getDb()));
+  auto reloaded = read(write(getDb()));
+  EXPECT_EQ(itermSummary(blockOf(reloaded.get())), before);
+}
+
+TEST_F(SoaTable, WritingWhatWasReadReproducesTheSameBytes)
+{
+  // A permutation is only lossless if it round-trips exactly. This is the
+  // cheapest statement of that, and it covers every table at once.
+  const std::string once = write(getDb());
+  auto reloaded = read(once);
+  EXPECT_EQ(write(reloaded.get()), once);
+}
+
+TEST_F(SoaTable, AllocationOrderSurvivesAReload)
+{
+  // Destroying an instance returns its iterms to the free list, so the next
+  // allocation reuses those slots in the order the free list holds them.
+  // If a reload rebuilt the list from the allocation bitmap instead of
+  // reading it, ids would still be *valid* and the design would still be
+  // correct -- and every later object would get a different id, which
+  // reaches placement and routing through dbSet iteration order.
+  dbBlock* block = blockOf(getDb());
+  dbInst::destroy(block->findInst("i2"));
+
+  const std::string bytes = write(getDb());
+  const std::vector<uint32_t> without_reload = nextIds(getDb(), "i4");
+
+  auto reloaded = read(bytes);
+  const std::vector<uint32_t> after_reload = nextIds(reloaded.get(), "i4");
+
+  EXPECT_EQ(after_reload, without_reload);
+  EXPECT_FALSE(after_reload.empty());
+}
+
+// Records of two different lengths in one block -- the case that appears
+// once pin access has run and an iterm carries an access point -- is not
+// covered here. Building that state synthetically did not reproduce it:
+// dbAccessPoint::create() followed by dbITerm::setAccessPoint() leaves
+// dbITerm::getAccessPoints() empty, with or without the field-major layout,
+// so the setup a test would rest on cannot be asserted. It is covered
+// end-to-end instead, on a routed design where 71.8% of iterms carry an
+// access point, by study/soa/roundtrip_gate.sh in the bazel-orfs study.
+
+}  // namespace
+}  // namespace odb


### PR DESCRIPTION
## The switch, and what it unlocks

`dbTable` stores a table's fields inside its slots. This PR adds the option to store them as **columns** instead, in memory, on the wire, or both, and turns it on for one table. Each further table is a one-line follow-up on its slot type. This is the PR that carries the mechanism; everything below the first table is a smaller PR that only flips a switch or drops a field.

Measured on five public ORFS designs across three PDKs, with `iterm_tbl` converted and nothing else:

| now, this PR | |
|---|---|
| compressed `.odb` | **1.07x–1.44x** smaller (1.38x aggregate) |
| peak RSS of `read_db` | **8.8%–11.8%** lower |
| uncompressed `.odb` | 0.4%–1.5% smaller |
| read time, write time | unchanged |

And what the same switch gives when the follow-ups land, each measured with the same scripts (https://github.com/The-OpenROAD-Project/bazel-orfs/pull/948):

| follow-up | measured | size of the change |
|---|---|---|
| `box_tbl` + `sbox_tbl` on the wire | compressed `.odb` 1.38x → **1.53x** | one line each |
| every table on the wire | **2.51x** compressed | needs slot-granular blocks: today a block is sized by `sizeof(T)`, which does not bind for records with a heap payload (7.1x read time, 2.3x RSS until fixed) |
| `box_tbl`, `sbox_tbl` in memory | 48 → 36 and 52 → 40 bytes per slot; `iterm_tbl` here goes 88 → 48 | one line each plus the field-to-accessor rename |
| drop the derivable `oid_` | 4 bytes per slot, every table; also the field behind #9960 | small, all tables at once |
| drop the derivable `prev_net_iterm_` | 7.2 MB of a 10.8 MB column total on one design | small |
| access-point map as a side table | reclaims one heap allocation per routed iterm, not counted in any number above | small |

Single tables compress far more than the whole file does, because the file is dominated by tables not yet converted. At the block size this PR uses, on the floorplan-stage designs: `iterm_tbl` 2.3x–2.9x, `box_tbl` 2.6x–6.2x, `sbox_tbl` 7.6x–22x.

| design | artifact | peak RSS |
|---|---|---|
| `nangate45/ariane133` | 1.41x | 274.2 → 243.1 MB |
| `nangate45/black_parrot` | 1.44x | 360.9 → 318.2 MB |
| `sky130hd/microwatt` | 1.40x | 248.2 → 226.4 MB |
| `asap7/aes` (floorplan) | 1.35x | — |
| `asap7/aes` (routed) | 1.07x | — |

## Why it works

A slot's serialized record is a row of fixed-width fields. Read as *columns*, most of them turn out to be constant or monotone — five of `_dbITerm`'s ten 4-byte columns hold a single value on `ariane133`, and three more have a constant first difference 65–89% of the time. Array-of-structs interleaves those with the two columns that carry real entropy, so no compressor ever sees a run longer than a single field. Every record is distinct; only *adjacency* changes.

The same layout helps in memory for a different reason: a slot stops paying for padding and for fields most slots do not use. An access-point map is 24 bytes per slot and is empty on every iterm until pin access runs.

This is also why an external compressor cannot get there. Nothing in the byte stream says which bytes belong to the same field — only the schema knows that.

## How

`dbTable` gains the option to store a table's fields as columns, in memory, on the wire, or both. Each is one line on the slot type:

```cpp
static constexpr bool kSoaTable = true;         // columns in memory
static constexpr bool kFieldMajorTable = true;  // columns on the wire
```

`iterm_tbl` takes both and is the first table to. It was chosen because it is the largest; `box_tbl` and `sbox_tbl` are next.

**In memory.** A slot keeps what `dbObject` needs: an address the public API can hand out, and the offset word that finds its page. Fields move to columns owned by the page, reached through accessors that return references — so the migration is a rename, `iterm->net_` becomes `iterm->net()`, and an assignment reads as it did. Nothing outside odb changes: a `dbITerm*` is still the slot's address, so every tool compiles untouched.

**On the wire.** An opted-in table writes its pages in blocks whose bytes are permuted field-major, produced by the type's **existing** `operator<<`. There is no per-type serializer — that was the condition this was worth doing under at all. A block spans several pages: raising a table's `page_size` would give the same adjacency and must not be used, because an id is `page_addr | slot`. Records of different lengths inside a block are split by length, and past 64 distinct lengths the block is written verbatim, so a table the layout cannot help is simply not helped.

## Compatibility

One schema constant, `kSchemaFieldMajorBlocks`, gates the read.

- **Old file, new binary.** A file written before the constant takes the per-slot path: the same `operator>>` the type has today, called once per slot, storing into columns instead of a struct. Deliberately simple rather than fast, since it only runs on files written before the bump.
- **New file, new binary.** Blocks are read, un-permuted, and handed to the same `operator>>`. Both paths end in the same per-type code; the only thing that differs is the order the bytes arrive in.
- **Ids do not move.** A block spans pages rather than resizing them, so `page_addr | slot` is unchanged for every object, and every `dbSet` iterates in the same order.
- **Evidence.** On all five designs, the DEF written after a round trip is byte-identical to the DEF written before it, and write → read → write reproduces the same bytes (`roundtrip_gate.sh` in the linked PR).
- **Tools.** Nothing outside `src/odb` changes. A `dbITerm*` is still the slot's address.

## Tests

Intent-based, no goldens (#11281): a round trip preserves every iterm's id, instance, terminal and net; writing what was read reproduces the same bytes; and allocation order survives a reload — rebuilding a free list from the allocation bitmap would still be *valid* and would still renumber every later object, which reaches placement and routing through `dbSet` iteration order.

## Reading the diff

Fifteen files, three separable pieces. Each can be reviewed on its own.

1. **Wire blocks** — `dbTable.inc`, `dbTable.h`, `dbStream.h`, `dbDatabase.h`. The block writer and reader, the schema constant, and one bulk `readBytes`. This is where the compression comes from and is independent of the other two.
2. **Column storage** — `dbCore.h`, `dbTable.h`. Where a page owns its columns and how a slot reaches them. This is where the RSS comes from.
3. **First table** — `dbITerm.h`, `dbITerm.cpp`, and the seven call-site files. The field-to-accessor rename, mechanical, plus the sparse access-point column.

Piece 1 without piece 2 would still give the compressed-file gain; piece 2 without piece 1 would still give the RSS gain. They share the switch so a table opts in once.
