### PR TITLE
bazel: take pandoc from a pinned wheel, not the host

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5767,6 +5767,15 @@
             "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz": "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
             "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl": "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
           },
+          "pypandoc-binary": {
+            "https://files.pythonhosted.org/packages/0d/2d/6a51cd4e54bdf132c19416801077c34bd40ba182e85d843360d36ae03a2d/pypandoc_binary-1.17-py3-none-musllinux_1_2_x86_64.whl": "sha256:f6e6d3e4cfafbe23189a08db3d41f8def260bacd6e7e382bceadab7ba1f17da6",
+            "https://files.pythonhosted.org/packages/15/58/8fd107c68522957868c1e785fbea7595608df118e440e424d189668294df/pypandoc_binary-1.17-py3-none-macosx_11_0_arm64.whl": "sha256:fcfd28f347ed998dda28823fc6bc24f9310e7fdf3ddceaf925bf0563a100ab5b",
+            "https://files.pythonhosted.org/packages/3b/31/a5a867159c4080e5d368f4a53540a727501a2f31affc297dc8e0fced96a7/pypandoc_binary-1.17-py3-none-musllinux_1_2_aarch64.whl": "sha256:2f439dcd211183bb3460253ca4511101df6e1acf4a01f45f5617e1fa2ad24279",
+            "https://files.pythonhosted.org/packages/80/85/681a54111f0948821a5cf87ce30a88bb0a3f6848af5112c912abac4a2b77/pypandoc_binary-1.17-py3-none-macosx_10_9_x86_64.whl": "sha256:734726dc618ef276343e272e1a6b4567e59c2ef9ef41d5533042deac3b0531f1",
+            "https://files.pythonhosted.org/packages/8d/7f/1e5612b52900ebe590862dabeadf546f739b27527dcd8bfd632f8adac1be/pypandoc_binary-1.17-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "sha256:9ada156cb980cd54fd6534231788e668c00dbb591cbd24f0be0bd86812eb8788",
+            "https://files.pythonhosted.org/packages/c6/b9/f47b77ba75ed5d47ec85fcc2ecfbf7f78e3a73347f3a09836634d930de98/pypandoc_binary-1.17-py3-none-win_amd64.whl": "sha256:76fae066cd2d7e78fb97f0ec8e9e36f437b07187b689b0b415ca18216f8f898a",
+            "https://files.pythonhosted.org/packages/f4/27/ac1078239aae14b94c51975b7f46ad8e099e47d7ae26c175a5486b1c0099/pypandoc_binary-1.17-py3-none-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl": "sha256:d6b620b21c9374e3e48aabd518492bf0776b148442ee28816f6aaf52da3d4387"
+          },
           "pyparsing": {
             "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl": "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d",
             "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl": "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1",

--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get -y update \
       groff \
       lcov \
       openjdk-21-jre-headless \
-      pandoc \
       parallel \
       python3 \
       python3-yaml \

--- a/bazel/man_pages.bzl
+++ b/bazel/man_pages.bzl
@@ -7,8 +7,8 @@ The output filenames aren't known at analysis time (they depend on which
 modules exist under src/*/), so outputs are declared as TreeArtifacts and
 the real work is delegated to the `bazel-manpages` Makefile target.
 
-Host requirements: pandoc, nroff (groff), col (bsdextrautils). Python comes
-from the Bazel toolchain, not the host.
+Host requirements: nroff (groff), col (bsdextrautils). Python comes from the
+Bazel toolchain and pandoc from a pinned wheel, not the host.
 """
 
 _PY_TOOLCHAIN_TYPE = "@rules_python//python:toolchain_type"
@@ -42,6 +42,20 @@ def _man_pages_impl(ctx):
         # A platform runtime instead: an absolute path on the host.
         python = py3_runtime.interpreter_path
 
+    # Same reasoning for pandoc, which renders every man and html page: the
+    # host's version decides the output and RHEL 8 has no pandoc package at
+    # all. The pypandoc-binary wheel (pinned in bazel/requirements.in) ships a
+    # statically linked pandoc, so take the binary out of the wheel rather than
+    # off PATH. The wheel's other files are the Python bindings, which the doc
+    # build does not use, so only the binary becomes an action input.
+    pandoc = None
+    for f in ctx.files.pandoc:
+        if f.basename == "pandoc":
+            pandoc = f
+            break
+    if not pandoc:
+        fail("no 'pandoc' binary among the files of %s" % ctx.attr.pandoc.label)
+
     command = """
 set -euo pipefail
 CAT_OUT="$PWD/{cat_out}"
@@ -51,9 +65,9 @@ HTML_OUT="$PWD/{html_out}"
 # md_roff_compat.py looks for <root>/src/<module>/messages.txt and
 # <root>/messages.txt, which is exactly the bin dir's layout.
 export MESSAGES_ROOT_DIR="$PWD/{bin_dir}"
-# use_default_shell_env passes the client's environment through (pandoc, groff
-# and col are found on PATH). Drop the two variables that would redirect the
-# toolchain interpreter at a host installation's stdlib.
+# use_default_shell_env passes the client's environment through (groff and col
+# are found on PATH). Drop the two variables that would redirect the toolchain
+# interpreter at a host installation's stdlib.
 unset PYTHONHOME PYTHONPATH
 # Two phases: 'preprocess' (serial) generates the md/man*/*.md sources, then
 # 'cat web' fan out pandoc/nroff in parallel. They cannot share one -j make
@@ -71,11 +85,12 @@ JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
 make -s --no-print-directory -C docs -f Makefile preprocess \\
     PYTHON="{python}" CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
 make -s --no-print-directory -j"$JOBS" -C docs -f Makefile cat web \\
-    CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
+    PANDOC="$PWD/{pandoc}" CAT_ROOT_DIR="$CAT_OUT" HTML_ROOT_DIR="$HTML_OUT"
 """.format(
         bin_dir = ctx.bin_dir.path,
         cat_out = cat_dir.path,
         html_out = html_dir.path,
+        pandoc = pandoc.path,
         python = python,
     )
 
@@ -84,7 +99,7 @@ make -s --no-print-directory -j"$JOBS" -C docs -f Makefile cat web \\
         outputs = [cat_dir, html_dir],
         inputs = depset(
             ctx.files.docs_srcs + ctx.files.scripts + ctx.files.readmes +
-            ctx.files.messages,
+            ctx.files.messages + [pandoc],
             transitive = interpreter_files,
         ),
         command = command,
@@ -109,6 +124,14 @@ man_pages = rule(
         "messages": attr.label_list(
             doc = "Module messages.txt files needed for man3 page generation.",
             allow_files = [".txt"],
+        ),
+        "pandoc": attr.label(
+            doc = "Wheel files holding the pandoc binary the Makefile runs.",
+            default = "@openroad-pip//pypandoc_binary:extracted_whl_files",
+            allow_files = True,
+            # pandoc runs during the build, so pick the wheel for the platform
+            # that executes the action, not the one being built for.
+            cfg = "exec",
         ),
         "readmes": attr.label_list(
             doc = "Module README.md files (src/*/README.md).",

--- a/bazel/requirements.in
+++ b/bazel/requirements.in
@@ -9,6 +9,15 @@ pandas==3.0.5
 tclint==0.7.0
 yamlfix==1.19.1
 
+# pandoc for the man page build (//docs:man_pages). The wheel ships a
+# statically linked pandoc binary for linux/macOS x86_64 and arm64, so the
+# Bazel doc build neither needs the host to have pandoc installed nor depends
+# on which version it happens to have. Pandoc itself is GPL-2.0-or-later; it
+# is invoked as a separate process by the doc build and never linked, and no
+# OpenROAD artifact embeds it. See:
+#   https://github.com/The-OpenROAD-Project/OpenROAD/issues/11291
+pypandoc-binary==1.17
+
 # Sphinx documentation build (replicates ReadTheDocs CI check)
 # See: https://github.com/The-OpenROAD-Project/OpenROAD/issues/9885
 sphinx==5.3.0

--- a/bazel/requirements_lock_3_13.txt
+++ b/bazel/requirements_lock_3_13.txt
@@ -613,6 +613,15 @@ pygments==2.20.0 \
     #   rich
     #   sphinx
     #   sphinx-tabs
+pypandoc-binary==1.17 \
+    --hash=sha256:2f439dcd211183bb3460253ca4511101df6e1acf4a01f45f5617e1fa2ad24279 \
+    --hash=sha256:734726dc618ef276343e272e1a6b4567e59c2ef9ef41d5533042deac3b0531f1 \
+    --hash=sha256:76fae066cd2d7e78fb97f0ec8e9e36f437b07187b689b0b415ca18216f8f898a \
+    --hash=sha256:9ada156cb980cd54fd6534231788e668c00dbb591cbd24f0be0bd86812eb8788 \
+    --hash=sha256:d6b620b21c9374e3e48aabd518492bf0776b148442ee28816f6aaf52da3d4387 \
+    --hash=sha256:f6e6d3e4cfafbe23189a08db3d41f8def260bacd6e7e382bceadab7ba1f17da6 \
+    --hash=sha256:fcfd28f347ed998dda28823fc6bc24f9310e7fdf3ddceaf925bf0563a100ab5b
+    # via -r bazel/requirements.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,7 +25,10 @@ export LC_ALL := $(UTF8_LOCALE)
 endif
 
 # Define variables
-PANDOC = pandoc
+# //docs:man_pages overrides PANDOC with the statically linked pandoc from the
+# pypandoc-binary wheel (pinned in bazel/requirements.in), so the Bazel build
+# does not depend on the host having pandoc, or on which version it has.
+PANDOC ?= pandoc
 GROFF ?= groff
 # Interpreter for the man page generation scripts, which need Python >= 3.7
 # (`from __future__ import annotations`). Distributions still shipping an older

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This on-line documentation is available at [https://openroad.readthedocs.io/en/l
 
 ## Prerequisites
 
-- To install pandoc, refer to this [link](https://github.com/jgm/pandoc/blob/main/INSTALL.md). `apt-get` *should* just work for Ubuntu. 
+- To install pandoc, refer to this [link](https://github.com/jgm/pandoc/blob/main/INSTALL.md). `apt-get` *should* just work for Ubuntu. This is only needed for the `make` instructions below; `bazel build //docs:man_pages` uses a pinned pandoc from `bazel/requirements.in` instead. 
 - To install sphinx requirements, **create a virtual environment (e.g. conda/virtualenv)** and then run `pip install -r requirements.txt`.
 
 You may install Doxygen from this [link](https://www.doxygen.nl/download.html).


### PR DESCRIPTION
Fixes #11291.

`//docs:man_pages` shells out to `docs/Makefile`, whose pandoc rules ran `pandoc` off `PATH`. That makes man/html page rendering depend on whatever pandoc the host happens to have -- Ubuntu 24.04 ships 3.1.3, brew tracks latest, `etc/DependencyInstaller.sh` downloads 3.1.11.1 -- and on RHEL 8, where no pandoc package exists at all, the build fails outright with `make: pandoc: Command not found`. Same class of bug as #11290 (python3), and fixed the same way.

- `bazel/requirements.in` + lock: pin `pypandoc-binary==1.17`, which bundles a statically linked pandoc 3.9 for linux and macOS on x86_64 and arm64. The x86_64 linux wheel is tagged `manylinux_2_5`, so it runs on distributions old enough to have no pandoc of their own.
- `bazel/man_pages.bzl`: new `pandoc` attr defaulting to the wheel's `extracted_whl_files`; the rule picks the `pandoc` binary out of it, declares just that file as an action input, and hands it to make as `PANDOC`. `cfg = "exec"` so the wheel is selected for the platform that runs the action.
- `docs/Makefile`: `PANDOC = pandoc` -> `PANDOC ?= pandoc`, so a non-Bazel `make -C docs` is unchanged.
- `bazel/Dockerfile`: drop the `pandoc` apt package. `groff` and `bsdextrautils` (`col`) remain host requirements.
- `docs/README.md`: note that the pandoc install step is only for the `make` path.

pandoc is GPL-2.0-or-later. The doc build invokes it as a separate process and never links it, and only the man pages it emits are packaged, so no OpenROAD artifact embeds it.

### Notes for review

**Man page output changes**, since the Bazel build moves from the host's pandoc to 3.9. Rendering is equivalent: pandoc 3.9 dropped its own `\f[V]` verbatim-font preamble and emits `\f[CR]`/`\f[CB]` instead, which `docs/src/man_fontfix.tmac` already remaps, so there are no new troff warnings. The `V`-font lines in that tmac are now inert; they are left in place because the CMake path still uses host pandoc. Nothing compares man page output against a golden.

**Where the pin lives.** #11291 suggested a development-only `requirements*.txt`. This adds the pin to the existing `bazel/requirements.in` instead of introducing a second requirements file and pip hub: that file is already dev-tools-only (tclint, yamlfix, sphinx), and rules_python fetches wheel repos lazily, so the 34 MB wheel is downloaded only when something actually builds the docs. Happy to split it out if a separate hub is preferred.