### PR TITLE
Make the messages/man-page pipeline locale-independent

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 
 # -- Project information -----------------------------------------------------
 
@@ -155,10 +156,10 @@ html_theme_options = {
 
 
 def swap_prefix(file, old, new):
-    with open(file, "r") as f:
+    with open(file, "r", encoding="utf-8") as f:
         lines = f.read()
     lines = lines.replace(old, new)
-    with open(file, "wt") as f:
+    with open(file, "wt", encoding="utf-8") as f:
         f.write(lines)
 
 
@@ -179,11 +180,12 @@ def setup(app):
         swap_prefix(filename, "(docs/", "(../")
         swap_prefix(filename, "```mermaid", "```{mermaid}\n:align: center\n")
 
-    # for populating OR Messages page.
+    # for populating OR Messages page. The output of both commands is
+    # discarded rather than decoded, so neither depends on the ambient locale.
     command = "python getMessages.py"
-    _ = os.popen(command).read()
+    subprocess.run(command, shell=True, stdout=subprocess.DEVNULL)
 
     if not os.path.exists("../_readthedocs/html/doxygen_output"):
         os.makedirs("../_readthedocs/html/doxygen_output", exist_ok=True)
     command = "cd .. ; doxygen"
-    _ = os.popen(command).read()
+    subprocess.run(command, shell=True, stdout=subprocess.DEVNULL)

--- a/docs/getMessages.py
+++ b/docs/getMessages.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 
-import os
 import re
+import subprocess
 
-command = "python ../etc/find_messages.py -d ../src"
-output = os.popen(command).read()
+# Decode the message list as UTF-8 rather than in whatever encoding the
+# ambient locale selects; find_messages.py writes it as UTF-8. stderr is left
+# alone so its duplicate-id diagnostics stay visible.
+command = ["python", "../etc/find_messages.py", "-d", "../src"]
+output = subprocess.run(command, stdout=subprocess.PIPE, encoding="utf-8").stdout
 
-with open("user/MessagesFinal.md", "w") as f:
+with open("user/MessagesFinal.md", "w", encoding="utf-8") as f:
     f.write("# OpenROAD Messages Glossary\n")
     f.write(
         "Listed below are the OpenROAD warning/errors you may encounter while using the application.\n"
@@ -27,7 +30,9 @@ with open("user/MessagesFinal.md", "w") as f:
         tool = columns[0].lower()
         try:
             # aim is to match all level1 header and their corresponding text.
-            message = open(f"../src/{tool}/doc/messages/{num}.md").read()
+            message = open(
+                f"../src/{tool}/doc/messages/{num}.md", encoding="utf-8"
+            ).read()
             pattern = re.compile(
                 r"#\s*(?P<header1>[^\n]+)\n*(?P<body_text>.*?)(?=\n#|$)", re.DOTALL
             )

--- a/docs/src/scripts/man_tcl_check.py
+++ b/docs/src/scripts/man_tcl_check.py
@@ -36,7 +36,7 @@ class TestManTclCheck(unittest.TestCase):
             if "ICeWall" in path or "PdnGen" in path:
                 continue
 
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 content = f.read()
                 help_dict[tool_dir] = help_dict.get(tool_dir, 0) + len(
                     extract_help(content)
@@ -51,7 +51,7 @@ class TestManTclCheck(unittest.TestCase):
             if re.search(f".*{'|'.join(e for e in exclude)}.*", path):
                 continue
             tool_dir = os.path.dirname(path)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 results = [
                     x
                     for x in extract_tcl_code(f.read())

--- a/docs/src/scripts/manpage.py
+++ b/docs/src/scripts/manpage.py
@@ -96,7 +96,7 @@ class ManPage:
         # it is okay for a function to have no switches.
         # assert self.switches, print("func switches not set")
         filepath = f"{dst_dir}/{self.name}.md"
-        with open(filepath, "w") as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             self.write_header(f)
             self.write_name(f)
             self.write_synopsis(f)
@@ -255,7 +255,7 @@ if __name__ == "__main__":
 
         # Read and print the generated content
         filepath = os.path.join(temp_dir, f"{man.name}.md")
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             generated_content = f.read()
 
         print("Generated man page content:")

--- a/docs/src/scripts/md_roff_compat.py
+++ b/docs/src/scripts/md_roff_compat.py
@@ -139,7 +139,7 @@ def man2(path=DEST_DIR2):
 # The whole-tree build above silences it: repeated across every module it
 # drowns out the diagnostics worth reading.
 def man2_translate(doc, path, quiet=False):
-    with open(doc) as f:
+    with open(doc, encoding="utf-8") as f:
         text = f.read()
         # new function names (reading tcl synopsis + convert gui:: to gui_)
         func_names = extract_tcl_command(text)
@@ -258,7 +258,7 @@ def man3(path=DEST_DIR3):
 
 
 def man3_translate(doc, path, quiet=False):
-    with open(doc) as f:
+    with open(doc, encoding="utf-8") as f:
         for line in f:
             parts = line.split()
             module, num, message, level = (

--- a/etc/find_messages.py
+++ b/etc/find_messages.py
@@ -9,6 +9,7 @@
 
 import argparse
 import glob
+import io
 import os
 import re
 import sys
@@ -112,11 +113,30 @@ def scan_dir(path, files, msgs):
             scan_file(path, file_name, msgs)
 
 
+# Messages are read as UTF-8, so write them back out as UTF-8 rather than in
+# whatever encoding the ambient locale selects. TextIOWrapper.reconfigure()
+# needs Python 3.7 and Rocky 8 ships 3.6, so rewrap the underlying binary
+# buffer there instead. sys.__stdout__ keeps the replaced wrapper alive, so it
+# is not collected out from under the buffer the two share. A stream with
+# neither -- an io.StringIO a caller substituted, say -- encodes nothing and so
+# needs nothing done to it.
+def write_output_as_utf8():
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8")
+        elif hasattr(stream, "buffer"):
+            wrapper = io.TextIOWrapper(
+                stream.buffer,
+                encoding="utf-8",
+                line_buffering=stream.line_buffering,
+            )
+            setattr(sys, name, wrapper)
+
+
 def main():
-    # Messages are read as UTF-8, so write them back out as UTF-8 rather than
-    # in whatever encoding the ambient locale selects.
-    sys.stdout.reconfigure(encoding="utf-8")
-    sys.stderr.reconfigure(encoding="utf-8")
+    write_output_as_utf8()
 
     args = parse_args()
 

--- a/etc/find_messages.py
+++ b/etc/find_messages.py
@@ -113,6 +113,11 @@ def scan_dir(path, files, msgs):
 
 
 def main():
+    # Messages are read as UTF-8, so write them back out as UTF-8 rather than
+    # in whatever encoding the ambient locale selects.
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
     args = parse_args()
 
     # "tool id" -> "file:line message"


### PR DESCRIPTION
Fixes The-OpenROAD-Project/OpenROAD#11248.

`etc/find_messages.py` reads sources as UTF-8 but printed with whatever
encoding the ambient locale selected, so a message string containing a
non-ASCII character aborted `messages.txt` generation on hosts whose locale
is not UTF-8:

```
$ bazel build //src/web:messages_txt --action_env=LANG=en_US
UnicodeEncodeError: 'latin-1' codec can't encode character '—' in position 38
```

The docs scripts that consume the generated `messages.txt` — and that read
Tcl sources and READMEs — had the mirror-image problem: they `open()` without
an explicit encoding. ISO-8859-1 masks it, because its decode/encode
round-trip is byte-lossless, which is why the reporter never saw this half.
A multibyte locale is not so forgiving:

```
LC_ALL=ja_JP.eucjp -> man3_translate('src/web/messages.txt')
UnicodeDecodeError: 'euc_jp' codec can't decode byte 0xe2 ... illegal multibyte sequence
```

This names UTF-8 explicitly at every I/O point on both paths out of
`find_messages.py`:

- the man-page path: `find_messages.py`'s stdout/stderr, plus the six
  `open()` calls in `md_roff_compat.py`, `manpage.py`, and
  `man_tcl_check.py`;
- the Sphinx glossary path: `docs/getMessages.py` decoded the child's stdout
  via `os.popen()`, so the WEB-0030 em dash broke `MessagesFinal.md` under
  `ja_JP.eucjp` even with `find_messages.py` writing UTF-8. It now reads that
  output through `subprocess` with `encoding="utf-8"`, leaving stderr alone so
  duplicate-id diagnostics stay visible. `conf.py`'s `swap_prefix()` failed
  the same way on `README.md`, which also carries an em dash, aborting the
  Sphinx build before it got that far; its two shell-outs discard their
  output, so they no longer decode it at all.

Forcing UTF-8 on the way out cannot go through `sys.stdout.reconfigure()`,
which needs Python 3.7: Rocky 8's `/usr/bin/python3` is 3.6.8, and the first
revision of this PR crashed its `cmake` build with

```
AttributeError: '_io.TextIOWrapper' object has no attribute 'reconfigure'
```

Guarding that call with `hasattr()` would only trade the crash back for the
`UnicodeEncodeError` this branch set out to fix, since Rocky 8 with
`LANG=en_US` picks ISO-8859-1 for stdout. So `reconfigure()` is used where it
exists and the stream's binary buffer is rewrapped as UTF-8 where it is not.

Neither the generated `messages.txt`, the man pages, nor the messages
glossary now depend on the build host's locale, or on the host Python being
3.7+.

Verified over `en_US.ISO-8859-1`, `ja_JP.eucjp`, `C`, and `C.UTF-8`, with the
em-dash deliberately left in the WEB-30 message string: `find_messages.py`
over the whole tree, `//src/web:messages_txt`, `//docs:man_pages`,
`//docs/...`, `//:dup_id_test`, and the 48 `*_man_tcl_check` /
`*_readme_msgs_check` tests all pass; the em-dash reaches the generated
`WEB-0030.md` as correct UTF-8 bytes in every locale; and `MessagesFinal.md`
comes out byte-identical in all four. `//docs:sphinx_build_test` gives the
Sphinx half regression coverage — it fails under `ja_JP.eucjp` before this
change and passes after. The Python 3.6 half is verified against Rocky 8's
own 3.6.8 under `LANG` unset, `C`, `en_US`, and `en_US.iso88591`: both the
whole-tree scan and the `cd src/ppl && find_messages.py -l` command that CI
failed on succeed, and the em dash comes out as UTF-8 in every case.

Note this fixes the reported build failure but not issue #11248's broader
ask — a policy on non-ASCII in source, and the ~8100 such characters already
present (dominated by `─` comment dividers, `—`, and `→`). Since the
pipeline no longer cares about them, that is now a style question rather than
a correctness one.
