### PR TITLE
web: bind the web server to loopback by default

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -102,6 +102,7 @@ static bool no_settings = false;
 static bool minimize = false;
 static bool web_enabled = false;
 static const char* web_port_arg = nullptr;
+static const char* web_bind_arg = nullptr;
 
 static const char* init_filename = ".openroad";
 
@@ -261,6 +262,7 @@ int main(int argc, char* argv[])
   minimize = findCmdLineFlag(argc, argv, "-minimize");
   web_enabled = findCmdLineFlag(argc, argv, "-web");
   web_port_arg = findCmdLineKey(argc, argv, "-web_port");
+  web_bind_arg = findCmdLineKey(argc, argv, "-web_bind");
 
   cmd_argc = argc;
   cmd_argv = argv;
@@ -399,6 +401,17 @@ static int tclAppInit(int& argc,
           exit(EXIT_FAILURE);
         }
       }
+      // Check the address here, not in serve(): serve() reports a bad one with
+      // utl::error, which throws, and nothing on this path catches it.
+      if (web_bind_arg
+          && web::classifyBindAddress(web_bind_arg)
+                 == web::BindAddressKind::kInvalid) {
+        fprintf(stderr,
+                "Error: invalid -web_bind value '%s'; %s\n",
+                web_bind_arg,
+                web::kBindAddressHint);
+        exit(EXIT_FAILURE);
+      }
       ord::OpenRoad::openRoad()->getWebServer()->initLogger();
     }
 
@@ -490,7 +503,8 @@ static int tclAppInit(int& argc,
     // for the GUI).  After this returns, fall through to readline.
     if (web_enabled) {
       auto* server = ord::OpenRoad::openRoad()->getWebServer();
-      server->serve(web_port);
+      // Empty means web::kDefaultBindAddress; see BindAddressKind.
+      server->serve(web_port, web_bind_arg ? web_bind_arg : "");
       server->waitForStop();
       // `exit` typed in the browser Tcl widget signalled stop; do the
       // real process exit now from the main thread (worker threads are
@@ -557,6 +571,10 @@ static void showUsage(const char* prog, const char* init_filename)
   printf("  -gui                  start in gui mode\n");
   printf("  -web                  start in web viewer mode\n");
   printf("  -web_port port        web server port (default auto-assigned)\n");
+  printf(
+      "  -web_bind address     web server bind address (default 127.0.0.1;\n"
+      "                        a wider bind exposes a Tcl shell to the "
+      "network)\n");
   printf("  -minimize             start the gui minimized\n");
   printf("  -no_settings          do not load the previous gui settings\n");
 #ifdef ENABLE_PYTHON3

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -22,6 +22,7 @@ console run on the server.
 ```tcl
 web_server
     [-port port]
+    [-bind address]
     [-stop]
 ```
 
@@ -30,8 +31,34 @@ web_server
 | Switch Name | Description |
 | ---------- | -------------------------------------------------- |
 | `-port` | TCP port to listen on. Default: `0`, which picks a free port. |
+| `-bind` | IP address to listen on. Default: `127.0.0.1` (loopback only). Accepts an IP literal, not a hostname. |
 | `-stop` | Stop a running server and return from the blocked `web_server` call. |
 | `-dir` | Deprecated and ignored; the web assets are embedded in the binary. |
+
+```{warning}
+The browser console evaluates Tcl on the server, so anyone who can reach the
+port can run commands as the user who started `openroad`. The default loopback
+bind keeps that local. Only pass `-bind` (for example `-bind 0.0.0.0`) on a
+network you trust; the server has no authentication.
+```
+
+Because the default is loopback, a viewer started inside a container or on a
+remote host is not reachable from outside it — the connection is refused with no
+message from the server. Bind explicitly in that case, and publish the port:
+
+```tcl
+web_server -port 8080 -bind 0.0.0.0
+```
+
+```shell
+docker run -p 8080:8080 ...        # then browse to http://localhost:8080
+```
+
+The same applies to the command-line entry point, which takes `-web_bind`:
+
+```shell
+openroad -web -web_port 8080 -web_bind 0.0.0.0
+```
 
 ### Save Image
 

--- a/src/web/include/web/web.h
+++ b/src/web/include/web/web.h
@@ -14,6 +14,7 @@
 #include <thread>
 #include <vector>
 
+#include "boost/asio/ip/address.hpp"
 #include "boost/asio/ip/tcp.hpp"
 #include "boost/asio/steady_timer.hpp"
 #include "odb/db.h"
@@ -60,6 +61,12 @@ enum class BindAddressKind
 // reach serve() from C++ (Main.cc) must check this first: serve() reports a
 // bad address with utl::error, which throws.
 BindAddressKind classifyBindAddress(std::string_view address);
+
+// Host to put in the URL the browser is pointed at, for a server listening on
+// `address`.  "localhost" only where it actually resolves to the listener —
+// naming it for the whole 127.0.0.0/8 range sends the browser to a port
+// nobody is bound to.  IPv6 literals come back bracketed, ready for a URL.
+std::string browserHostForBind(const boost::asio::ip::address& address);
 
 // What serve() binds to when the caller passes no address.  Owned here so the
 // Tcl and command-line front ends cannot drift apart on the security default.

--- a/src/web/include/web/web.h
+++ b/src/web/include/web/web.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -43,6 +44,30 @@ struct TclEvaluator;
 class TimingReport;
 class WebViewerHook;
 struct WebGif;  // defined in web.cpp; holds a GifEncoder + frame dimensions
+
+// How a `web_server -bind` / `-web_bind` address must be treated.  The viewer
+// runs Tcl commands, so binding anywhere but loopback hands a shell to whoever
+// can reach the port (issue #11167).
+enum class BindAddressKind
+{
+  kInvalid,
+  kLoopback,
+  kExposed
+};
+
+// Classify a bind address.  IP literals only: there is no name resolution, so
+// "localhost" is kInvalid — the contract the commands document.  Callers that
+// reach serve() from C++ (Main.cc) must check this first: serve() reports a
+// bad address with utl::error, which throws.
+BindAddressKind classifyBindAddress(std::string_view address);
+
+// What serve() binds to when the caller passes no address.  Owned here so the
+// Tcl and command-line front ends cannot drift apart on the security default.
+inline constexpr const char* kDefaultBindAddress = "127.0.0.1";
+
+// Shared by every "that address is not usable" message, so they cannot drift.
+inline constexpr const char* kBindAddressHint
+    = "expected an IP literal such as 127.0.0.1 or ::1";
 
 // Returned by createAndRunListener: a shutdown callback and the actual
 // port the listener bound to (useful when the caller passes port 0).
@@ -90,10 +115,11 @@ class WebServer
   // generator.
   void setThreadCount(int num_threads);
 
-  // Start the web server on the given port.  Launches background
-  // I/O threads and returns immediately.  A second call is a no-op if
-  // the server is already running.
-  void serve(int port);
+  // Start the web server on the given port, listening on `bind_address` — an
+  // IP literal, or empty for kDefaultBindAddress; see BindAddressKind.
+  // Launches background I/O threads and returns immediately.  A second call is
+  // a no-op if the server is already running.
+  void serve(int port, const std::string& bind_address);
 
   // True after serve() returns and before stop/destructor.
   bool isRunning() const { return ioc_ != nullptr; }

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -26,6 +26,7 @@
 #include <variant>
 #include <vector>
 
+#include "boost/asio/ip/address.hpp"
 #include "boost/json/array.hpp"
 #include "boost/json/object.hpp"
 #include "boost/json/serialize.hpp"
@@ -52,6 +53,7 @@
 #include "timing_report.h"
 #include "utl/Logger.h"
 #include "utl/algorithms.h"
+#include "web/web.h"
 
 namespace web {
 
@@ -320,6 +322,28 @@ std::string assetPathFromTarget(const std::string_view target)
     return "/index.html";
   }
   return path;
+}
+
+BindAddressKind classifyBindAddress(const std::string_view address)
+{
+  // make_address parses IP literals only — it never resolves a name, so
+  // "localhost" lands here as invalid rather than silently binding somewhere.
+  boost::system::error_code ec;
+  const auto parsed = boost::asio::ip::make_address(address, ec);
+  if (ec) {
+    return BindAddressKind::kInvalid;
+  }
+  // is_loopback() covers 127.0.0.0/8 and ::1, but not ::ffff:127.0.0.1 — an
+  // IPv4 bind wearing a v6 literal, which would otherwise be reported as
+  // exposed.  Unwrap those and judge them by their IPv4 half.  Everything
+  // else, the unspecified 0.0.0.0/:: included, is reachable off-machine.
+  bool loopback = parsed.is_loopback();
+  if (parsed.is_v6() && parsed.to_v6().is_v4_mapped()) {
+    loopback = boost::asio::ip::make_address_v4(boost::asio::ip::v4_mapped,
+                                                parsed.to_v6())
+                   .is_loopback();
+  }
+  return loopback ? BindAddressKind::kLoopback : BindAddressKind::kExposed;
 }
 
 WebSocketResponse errorResponse(const uint32_t id,

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -346,6 +346,25 @@ BindAddressKind classifyBindAddress(const std::string_view address)
   return loopback ? BindAddressKind::kLoopback : BindAddressKind::kExposed;
 }
 
+std::string browserHostForBind(const boost::asio::ip::address& address)
+{
+  // "localhost" reads better than a literal, but it resolves to the canonical
+  // loopback only — naming it for the whole 127.0.0.0/8 range would send the
+  // browser to 127.0.0.1 while the listener sits on, say, 127.0.0.2.  The
+  // wildcard is not a destination at all, and localhost is inside it.
+  if (address.is_unspecified()
+      || address
+             == boost::asio::ip::address(
+                 boost::asio::ip::address_v4::loopback())
+      || address
+             == boost::asio::ip::address(
+                 boost::asio::ip::address_v6::loopback())) {
+    return "localhost";
+  }
+  const std::string literal = address.to_string();
+  return address.is_v6() ? "[" + literal + "]" : literal;
+}
+
 WebSocketResponse errorResponse(const uint32_t id,
                                 const std::string_view message)
 {

--- a/src/web/src/web.i
+++ b/src/web/src/web.i
@@ -16,10 +16,10 @@
 namespace web {
 
 void
-web_server_cmd(int port)
+web_server_cmd(int port, const char *bind_address)
 {
   web::WebServer *server = ord::OpenRoad::openRoad()->getWebServer();
-  server->serve(port);
+  server->serve(port, bind_address);
 }
 
 void

--- a/src/web/src/web.tcl
+++ b/src/web/src/web.tcl
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2019-2026, The OpenROAD Authors
 
-sta::define_cmd_args "web_server" { [-port port] [-dir dir] [-stop] }
+sta::define_cmd_args "web_server" { [-port port] [-bind address] [-dir dir] [-stop] }
 
 proc web_server { args } {
   sta::parse_key_args "web_server" args \
-    keys {-port -dir} flags {-stop}
+    keys {-port -bind -dir} flags {-stop}
 
   if { [info exists flags(-stop)] } {
     web::web_server_stop_cmd
@@ -17,13 +17,25 @@ proc web_server { args } {
   set port 0
   if { [info exists keys(-port)] } {
     set port $keys(-port)
+    # Checked here because the C++ side narrows to uint16_t: without this a
+    # -port of 70000 would silently listen on 4464.
+    if { ![string is integer -strict $port] || $port < 0 || $port > 65535 } {
+      utl::error WEB 81 "-port must be an integer between 0 and 65535."
+    }
   }
 
   if { [info exists keys(-dir)] } {
     utl::warn WEB 37 "-dir is deprecated and ignored; assets are embedded in the binary."
   }
 
-  web::web_server_cmd $port
+  # Empty lets the server apply its own loopback default: the browser console
+  # evaluates Tcl, so a wider bind gives a shell to anyone reaching the port.
+  set bind ""
+  if { [info exists keys(-bind)] } {
+    set bind $keys(-bind)
+  }
+
+  web::web_server_cmd $port $bind
   web::web_server_wait_cmd
 }
 

--- a/src/web/src/web_serve.cpp
+++ b/src/web/src/web_serve.cpp
@@ -296,15 +296,9 @@ void WebServer::serve(int port, const std::string& bind_address)
                                        max_in_flight);
     shutdown_listener_ = std::move(handle.shutdown);
 
-    // Point the browser at something it can actually reach: 0.0.0.0 is not a
-    // destination, and a loopback literal is better spelled "localhost".
-    std::string host = "localhost";
-    if (bind_kind != BindAddressKind::kLoopback && !address.is_unspecified()) {
-      host
-          = address.is_v6() ? "[" + bind_to + "]" : bind_to;  // URLs bracket v6
-    }
-    const std::string url
-        = "http://" + host + ":" + std::to_string(handle.port);
+    // Point the browser at something it can actually reach.
+    const std::string url = "http://" + browserHostForBind(address) + ":"
+                            + std::to_string(handle.port);
 
     // Bind the timer to a strand so all timer operations (expires_after,
     // async_wait, cancel) run serialized on a single io thread.  Without

--- a/src/web/src/web_serve.cpp
+++ b/src/web/src/web_serve.cpp
@@ -149,7 +149,7 @@ void WebServer::initLogger()
   logger_initialized_ = true;
 }
 
-void WebServer::serve(int port)
+void WebServer::serve(int port, const std::string& bind_address)
 {
   if (ioc_) {
     logger_->warn(utl::WEB, 6, "Web server is already running.");
@@ -251,7 +251,28 @@ void WebServer::serve(int port)
       hook->sessions().broadcast(R"({"type":"refresh"})");
     });
 
-    auto const address = net::ip::make_address("0.0.0.0");
+    // Who may reach the port decides who may run Tcl here; see
+    // BindAddressKind (issue #11167).
+    const std::string bind_to
+        = bind_address.empty() ? kDefaultBindAddress : bind_address;
+    const BindAddressKind bind_kind = classifyBindAddress(bind_to);
+    if (bind_kind == BindAddressKind::kInvalid) {
+      // noreturn: the catch below tears the half-built server down.
+      logger_->error(utl::WEB,
+                     79,
+                     "Invalid bind address \"{}\"; {}.",
+                     bind_to,
+                     kBindAddressHint);
+    }
+    if (bind_kind == BindAddressKind::kExposed) {
+      logger_->warn(utl::WEB,
+                    80,
+                    "Web server bound to {}, reachable beyond this machine. "
+                    "The viewer runs Tcl commands, so anyone who can reach "
+                    "this port can run commands as this user.",
+                    bind_to);
+    }
+    auto const address = net::ip::make_address(bind_to);  // validated above
     uint16_t const u_port = port;
     int const num_threads = num_threads_;
 
@@ -275,7 +296,15 @@ void WebServer::serve(int port)
                                        max_in_flight);
     shutdown_listener_ = std::move(handle.shutdown);
 
-    const std::string url = "http://localhost:" + std::to_string(handle.port);
+    // Point the browser at something it can actually reach: 0.0.0.0 is not a
+    // destination, and a loopback literal is better spelled "localhost".
+    std::string host = "localhost";
+    if (bind_kind != BindAddressKind::kLoopback && !address.is_unspecified()) {
+      host
+          = address.is_v6() ? "[" + bind_to + "]" : bind_to;  // URLs bracket v6
+    }
+    const std::string url
+        = "http://" + host + ":" + std::to_string(handle.port);
 
     // Bind the timer to a strand so all timer operations (expires_after,
     // async_wait, cancel) run serialized on a single io thread.  Without

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -330,6 +330,7 @@ cc_test(
         "//src/tst:nangate45_fixture",
         "//src/utl",
         "//src/web",
+        "@boost.asio",
         "@boost.json",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -28,6 +28,7 @@
 #include "tile_generator.h"
 #include "tst/nangate45_fixture.h"
 #include "utl/Logger.h"
+#include "web/web.h"
 #include "web_viewer_hook.h"
 
 namespace web {
@@ -535,6 +536,40 @@ TEST_F(TileHandlerTest, OverlayTileWithNothingSelectedIsEmpty)
       = handler_->handleOverlayTile(overlayRequest(1, false), state_);
   EXPECT_EQ(resp.type, WebSocketResponse::kEmpty);
   EXPECT_TRUE(resp.payload.empty());
+}
+
+// Bind-address classification for web_server -bind (issue #11167).
+TEST(ClassifyBindAddress, LoopbackIsRecognised)
+{
+  EXPECT_EQ(classifyBindAddress("127.0.0.1"), BindAddressKind::kLoopback);
+  EXPECT_EQ(classifyBindAddress("::1"), BindAddressKind::kLoopback);
+}
+
+TEST(ClassifyBindAddress, NonLoopbackIsExposed)
+{
+  // 0.0.0.0 was the old hard-coded default: listens on every interface.
+  EXPECT_EQ(classifyBindAddress("0.0.0.0"), BindAddressKind::kExposed);
+  EXPECT_EQ(classifyBindAddress("::"), BindAddressKind::kExposed);
+  EXPECT_EQ(classifyBindAddress("192.168.1.5"), BindAddressKind::kExposed);
+}
+
+TEST(ClassifyBindAddress, IPv4MappedIsClassifiedByItsIPv4Part)
+{
+  // ::ffff:a.b.c.d is an IPv4 bind in v6 clothing; is_loopback() alone would
+  // call the loopback one exposed and raise a spurious warning.
+  EXPECT_EQ(classifyBindAddress("::ffff:127.0.0.1"),
+            BindAddressKind::kLoopback);
+  EXPECT_EQ(classifyBindAddress("::ffff:192.168.1.5"),
+            BindAddressKind::kExposed);
+}
+
+TEST(ClassifyBindAddress, NonLiteralsAreInvalid)
+{
+  // IP literals only, never resolved — pins the documented contract.
+  EXPECT_EQ(classifyBindAddress("localhost"), BindAddressKind::kInvalid);
+  EXPECT_EQ(classifyBindAddress(""), BindAddressKind::kInvalid);
+  EXPECT_EQ(classifyBindAddress("not-an-ip"), BindAddressKind::kInvalid);
+  EXPECT_EQ(classifyBindAddress("999.999.999.999"), BindAddressKind::kInvalid);
 }
 
 TEST_F(TileHandlerTest, HonoursTheClientReportedDpr)

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "boost/asio/ip/address.hpp"
 #include "boost/json/object.hpp"
 #include "boost/json/parse.hpp"
 #include "boost/json/serialize.hpp"
@@ -570,6 +571,36 @@ TEST(ClassifyBindAddress, NonLiteralsAreInvalid)
   EXPECT_EQ(classifyBindAddress(""), BindAddressKind::kInvalid);
   EXPECT_EQ(classifyBindAddress("not-an-ip"), BindAddressKind::kInvalid);
   EXPECT_EQ(classifyBindAddress("999.999.999.999"), BindAddressKind::kInvalid);
+}
+
+// The URL the browser is pointed at has to name where the listener actually is.
+static std::string browserHost(const std::string& literal)
+{
+  return browserHostForBind(boost::asio::ip::make_address(literal));
+}
+
+TEST(BrowserHostForBind, CanonicalLoopbackAndWildcardBecomeLocalhost)
+{
+  // localhost resolves to these, and it is inside the wildcard, which is not
+  // an address a browser can connect to.
+  EXPECT_EQ(browserHost("127.0.0.1"), "localhost");
+  EXPECT_EQ(browserHost("::1"), "localhost");
+  EXPECT_EQ(browserHost("0.0.0.0"), "localhost");
+  EXPECT_EQ(browserHost("::"), "localhost");
+}
+
+TEST(BrowserHostForBind, OtherLoopbackAddressesKeepTheirLiteral)
+{
+  // The bug this pins: localhost resolves to 127.0.0.1, so naming it for the
+  // rest of 127.0.0.0/8 sends the browser to a port nobody is listening on.
+  EXPECT_EQ(browserHost("127.0.0.2"), "127.0.0.2");
+  EXPECT_EQ(browserHost("::ffff:127.0.0.1"), "[::ffff:127.0.0.1]");
+}
+
+TEST(BrowserHostForBind, RoutableAddressesKeepTheirLiteral)
+{
+  EXPECT_EQ(browserHost("192.168.1.5"), "192.168.1.5");
+  EXPECT_EQ(browserHost("fd00::1"), "[fd00::1]");  // URLs bracket v6
 }
 
 TEST_F(TileHandlerTest, HonoursTheClientReportedDpr)


### PR DESCRIPTION
The web viewer's browser console evaluates Tcl on the server. The server listened on every network interface with no authentication, so anyone who could reach the port could run commands as the user who started openroad.

It now listens on 127.0.0.1 only. Exposing it to the network takes an explicit `-bind` (or `-web_bind` on the command line), and doing so logs a warning saying what is being handed out. An address that is not a valid IP literal is refused with a clear error instead of a generic startup failure, and an out-of-range port is rejected instead of being silently truncated to a different one.

Prevents a machine on the network, or a co-tenant on a shared or CI host, from getting a shell just by connecting to the viewer's port.

Part of #[11167](https://github.com/The-OpenROAD-Project/OpenROAD/issues/11167).
