### PR TITLE
web: report no DRC categories instead of failing without a design

### DIFF
--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -6052,23 +6052,27 @@ WebSocketResponse DRCHandler::handleDRCCategories(const WebSocketRequest& req)
   resp.type = WebSocketResponse::kJson;
 
   try {
-    auto [block, chip] = getBlockAndChip();
+    // The viewer asks for categories as soon as it connects, so having no
+    // design yet is a normal state with no categories, not a failed request.
+    odb::dbChip* chip = gen_->getChip();
 
     boost::json::object root;
     boost::json::array categories;
-    for (odb::dbMarkerCategory* category : chip->getMarkerCategories()) {
-      boost::json::object o;
-      o["name"] = std::string(category->getName());
-      o["count"] = category->getMarkerCount();
-      const std::string desc = category->getDescription();
-      if (!desc.empty()) {
-        o["description"] = desc;
+    if (chip != nullptr) {
+      for (odb::dbMarkerCategory* category : chip->getMarkerCategories()) {
+        boost::json::object o;
+        o["name"] = std::string(category->getName());
+        o["count"] = category->getMarkerCount();
+        const std::string desc = category->getDescription();
+        if (!desc.empty()) {
+          o["description"] = desc;
+        }
+        const std::string source = category->getSource();
+        if (!source.empty()) {
+          o["source"] = source;
+        }
+        categories.emplace_back(std::move(o));
       }
-      const std::string source = category->getSource();
-      if (!source.empty()) {
-        o["source"] = source;
-      }
-      categories.emplace_back(std::move(o));
     }
     root["categories"] = std::move(categories);
     writePayload(resp, root);

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -3792,6 +3792,26 @@ TEST_F(DRCHandlerTest, CategoriesEmpty)
   EXPECT_NE(json.find("\"categories\":[]"), std::string::npos);
 }
 
+// The viewer requests categories on connect, before any design exists; that
+// must answer with an empty list rather than an error the server logs.
+TEST(DRCHandlerNoDesignTest, CategoriesWithoutChipIsNotAnError)
+{
+  std::unique_ptr<odb::dbDatabase, void (*)(odb::dbDatabase*)> db(
+      odb::dbDatabase::create(), odb::dbDatabase::destroy);
+  auto gen = std::make_shared<TileGenerator>(
+      db.get(), /*sta=*/nullptr, /*logger=*/nullptr);
+  DRCHandler handler(gen);
+
+  WebSocketRequest req;
+  req.id = 1;
+  req.type = WebSocketRequest::kDrcCategories;
+
+  auto resp = handler.handleDRCCategories(req);
+  EXPECT_EQ(resp.id, 1u);
+  EXPECT_EQ(resp.type, WebSocketResponse::kJson);
+  EXPECT_NE(payloadStr(resp).find("\"categories\":[]"), std::string::npos);
+}
+
 TEST_F(DRCHandlerTest, CategoriesWithMarkers)
 {
   createTestCategory("DRC", 3);


### PR DESCRIPTION
The Web GUI asks for the categories as soon as it connects, so a session started without a design logged WEB-0043 in a normal state.

Fix #[11337](https://github.com/The-OpenROAD-Project/OpenROAD/issues/11337)