### PR TITLE
odb: parsing of the LEF58_ENCLOSURETABLE property

### DIFF
--- a/src/odb/src/lefin/CMakeLists.txt
+++ b/src/odb/src/lefin/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(lefin
     lefTechLayerCutSpacingParser.cpp
     lefTechLayerCutSpacingTableParser.cpp
     lefTechLayerCutEnclosureParser.cpp
+    lefTechLayerCutEnclosureTableParser.cpp
     lefTechLayerTypeParser.cpp
     lefTechLayerEolExtensionParser.cpp
     lefTechLayerEolKeepOutRuleParser.cpp

--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -149,7 +150,7 @@ class lefTechLayerCutEnclosureTableRuleParser
 {
  public:
   lefTechLayerCutEnclosureTableRuleParser(lefinReader*);
-  void parse(const std::string&, odb::dbTechLayer*);
+  void parse(std::string_view, odb::dbTechLayer*);
 
  private:
   lefinReader* lefin_;

--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -144,6 +144,18 @@ class lefTechLayerCutEnclosureRuleParser
                    odb::dbTechLayerCutEnclosureRule* rule,
                    odb::dbTechLayer* layer);
 };
+
+class lefTechLayerCutEnclosureTableRuleParser
+{
+ public:
+  lefTechLayerCutEnclosureTableRuleParser(lefinReader*);
+  void parse(const std::string&, odb::dbTechLayer*);
+
+ private:
+  lefinReader* lefin_;
+  void checkCutClass(const std::string& val, odb::dbTechLayer* layer);
+};
+
 class lefTechLayerEolExtensionRuleParser
 {
  public:

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureTableParser.cpp
@@ -32,7 +32,7 @@ void lefTechLayerCutEnclosureTableRuleParser::checkCutClass(
 }
 
 void lefTechLayerCutEnclosureTableRuleParser::parse(const std::string& s,
-                                                     odb::dbTechLayer* layer)
+                                                    odb::dbTechLayer* layer)
 {
   qi::rule<std::string::const_iterator, space_type> cut_class_rule
       = -(lit("CUTCLASS") >> _string)[boost::bind(
@@ -74,10 +74,10 @@ void lefTechLayerCutEnclosureTableRuleParser::parse(const std::string& s,
                && first == last;
   if (!valid) {
     lefin_->warning(603,
-                     "parse mismatch in layer property LEF58_ENCLOSURETABLE "
-                     "for layer {} :\"{}\"",
-                     layer->getName(),
-                     s);
+                    "parse mismatch in layer property LEF58_ENCLOSURETABLE "
+                    "for layer {} :\"{}\"",
+                    layer->getName(),
+                    s);
   }
 }
 

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureTableParser.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2019-2025, The OpenROAD Authors
+
+#include <string>
+
+#include "boost/bind/bind.hpp"
+#include "boostParser.h"
+#include "lefLayerPropParser.h"
+#include "odb/db.h"
+#include "odb/lefin.h"
+
+namespace odb {
+
+lefTechLayerCutEnclosureTableRuleParser::
+    lefTechLayerCutEnclosureTableRuleParser(lefinReader* l)
+{
+  lefin_ = l;
+}
+
+void lefTechLayerCutEnclosureTableRuleParser::checkCutClass(
+    const std::string& val,
+    odb::dbTechLayer* layer)
+{
+  auto cutClass = layer->findTechLayerCutClassRule(val.c_str());
+  if (cutClass == nullptr) {
+    lefin_->warning(
+        602,
+        "cut class {} not found for LEF58_ENCLOSURETABLE rule for layer {}",
+        val,
+        layer->getName());
+  }
+}
+
+void lefTechLayerCutEnclosureTableRuleParser::parse(const std::string& s,
+                                                     odb::dbTechLayer* layer)
+{
+  qi::rule<std::string::const_iterator, space_type> cut_class_rule
+      = -(lit("CUTCLASS") >> _string)[boost::bind(
+          &lefTechLayerCutEnclosureTableRuleParser::checkCutClass,
+          this,
+          _1,
+          layer)];
+
+  qi::rule<std::string::const_iterator, space_type> above_below_rule
+      = -(lit("ABOVE") | lit("BELOW"));
+
+  // Trim-metal-aware overhang row (references a TRIMMETAL layer such as CM1).
+  // Trim layers are not modeled in OpenROAD yet, so the clause is recognized
+  // and discarded like the rest of the rule.
+  qi::rule<std::string::const_iterator, space_type> layer_overlap_rule
+      = -(lit("LAYER") >> _string >> -(lit("OVERLAP") >> int_));
+
+  // A single WIDTH (or DEFAULT) value may be followed by more than one
+  // overhang quadruple, each an alternative choice of overhang values (the
+  // last one is typically flagged MINSUM to indicate the two opposite-side
+  // overhangs are tradeable against each other).
+  qi::rule<std::string::const_iterator, space_type> overhang_group_rule
+      = (above_below_rule >> double_ >> double_ >> double_ >> double_
+         >> -lit("MINSUM") >> layer_overlap_rule);
+
+  qi::rule<std::string::const_iterator, space_type> default_row_rule
+      = (lit("DEFAULT") >> +overhang_group_rule);
+
+  qi::rule<std::string::const_iterator, space_type> width_row_rule
+      = (lit("WIDTH") >> double_ >> +overhang_group_rule);
+
+  qi::rule<std::string::const_iterator, space_type> enclosure_table_rule
+      = (lit("ENCLOSURETABLE") >> cut_class_rule >> *default_row_rule
+         >> +width_row_rule >> lit(";"));
+
+  auto first = s.begin();
+  auto last = s.end();
+  bool valid = qi::phrase_parse(first, last, enclosure_table_rule, space)
+               && first == last;
+  if (!valid) {
+    lefin_->warning(603,
+                     "parse mismatch in layer property LEF58_ENCLOSURETABLE "
+                     "for layer {} :\"{}\"",
+                     layer->getName(),
+                     s);
+  }
+}
+
+}  // namespace odb

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureTableParser.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
 #include <string>
+#include <string_view>
 
 #include "boost/bind/bind.hpp"
 #include "boostParser.h"
@@ -13,8 +14,8 @@ namespace odb {
 
 lefTechLayerCutEnclosureTableRuleParser::
     lefTechLayerCutEnclosureTableRuleParser(lefinReader* l)
+    : lefin_(l)
 {
-  lefin_ = l;
 }
 
 void lefTechLayerCutEnclosureTableRuleParser::checkCutClass(
@@ -31,9 +32,15 @@ void lefTechLayerCutEnclosureTableRuleParser::checkCutClass(
   }
 }
 
-void lefTechLayerCutEnclosureTableRuleParser::parse(const std::string& s,
+void lefTechLayerCutEnclosureTableRuleParser::parse(std::string_view s,
                                                     odb::dbTechLayer* layer)
 {
+  // boost::spirit's shared _string sub-rule (boostParser.h) is hardcoded to
+  // std::string::const_iterator, which is a distinct type from
+  // std::string_view::const_iterator on this toolchain, so the grammar below
+  // still needs a real std::string to parse against.
+  const std::string value(s);
+
   qi::rule<std::string::const_iterator, space_type> cut_class_rule
       = -(lit("CUTCLASS") >> _string)[boost::bind(
           &lefTechLayerCutEnclosureTableRuleParser::checkCutClass,
@@ -68,8 +75,8 @@ void lefTechLayerCutEnclosureTableRuleParser::parse(const std::string& s,
       = (lit("ENCLOSURETABLE") >> cut_class_rule >> *default_row_rule
          >> +width_row_rule >> lit(";"));
 
-  auto first = s.begin();
-  auto last = s.end();
+  auto first = value.begin();
+  auto last = value.end();
   bool valid = qi::phrase_parse(first, last, enclosure_table_rule, space)
                && first == last;
   if (!valid) {

--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -759,6 +759,9 @@ void lefinReader::layer(LefParser::lefiLayer* layer)
       } else if (!strcmp(layer->propName(iii), "LEF58_ENCLOSURE")) {
         lefTechLayerCutEnclosureRuleParser encParser(this);
         encParser.parse(layer->propValue(iii), l);
+      } else if (!strcmp(layer->propName(iii), "LEF58_ENCLOSURETABLE")) {
+        lefTechLayerCutEnclosureTableRuleParser encTableParser(this);
+        encTableParser.parse(layer->propValue(iii), l);
       } else if (!strcmp(layer->propName(iii), "LEF58_SPACINGTABLE")) {
         lefTechLayerCutSpacingTableParser cutSpacingTableParser(l);
         valid = cutSpacingTableParser.parse(


### PR DESCRIPTION
## Summary
Introduces the LEF58_ENCLOSURETABLE property parser. The parsed information is not yet consumed by the ODB, it is just parsed and discarded.

## Type of Change
- New feature

## Impact
Simply parses the new property

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**