### PR TITLE
pdn: terminate channel repair when a strap has run out of options

### DIFF
--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -2089,6 +2089,9 @@ int RepairChannelStraps::getMaxLength() const
 
 bool RepairChannelStraps::isAtEndOfRepairOptions() const
 {
+  if (repair_options_exhausted_) {
+    return true;
+  }
   const TechLayer layer(getLayer());
   if (getWidth() != layer.getMinWidth()) {
     return false;
@@ -2119,8 +2122,17 @@ void RepairChannelStraps::continueRepairs(
       getNetString(),
       getWidth() / static_cast<double>(getBlock()->getDbUnitsPerMicron()),
       next_width / static_cast<double>(getBlock()->getDbUnitsPerMicron()));
+  const int prev_width = getWidth();
+  const int prev_spacing = getSpacing();
   setWidth(next_width);
   determineParameters(other_shapes);
+  // A "continued" repair that changes nothing rebuilds the same strap, and
+  // repairGridChannels counts a successful rebuild as a repair and goes
+  // around again: with the width already at minimum and the spacing above
+  // it, that loop never ends. Record the dead end so the next pass stops.
+  if (getWidth() == prev_width && getSpacing() == prev_spacing) {
+    repair_options_exhausted_ = true;
+  }
 }
 
 void RepairChannelStraps::determineParameters(

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -2786,6 +2786,36 @@ void RepairChannelStraps::repairGridChannels(
     }
 
     // create strap repair channel
+    // A repair strap for this channel that has run out of options means
+    // every width and spacing has been built here and the channel is still
+    // open. Making another strap would start the same sequence over, and
+    // repairGridChannels would recurse on it forever.
+    bool options_exhausted = false;
+    for (const auto& strap : grid->getStraps()) {
+      if (strap->type() != GridComponent::kRepairChannel) {
+        continue;
+      }
+      auto* repair_strap = dynamic_cast<RepairChannelStraps*>(strap.get());
+      if (repair_strap != nullptr
+          && repair_strap->getLayer() == channel.target->getLayer()
+          && repair_strap->getArea() == channel.area
+          && repair_strap->isAtEndOfRepairOptions()) {
+        options_exhausted = true;
+        break;
+      }
+    }
+    if (options_exhausted) {
+      debugPrint(grid->getLogger(),
+                 utl::PDN,
+                 "Channel",
+                 1,
+                 "No repair options left at {} in {}.",
+                 Shape::getRectText(channel.area,
+                                    grid->getBlock()->getDbUnitsPerMicron()),
+                 channel.target->getLayer()->getName());
+      continue;
+    }
+
     auto strap = std::make_unique<RepairChannelStraps>(grid,
                                                        channel.target,
                                                        channel.connect_to,

--- a/src/pdn/src/straps.h
+++ b/src/pdn/src/straps.h
@@ -325,6 +325,10 @@ class RepairChannelStraps : public Straps
   odb::Rect obs_check_area_;
 
   bool invalid_ = false;
+  // Set when continueRepairs() could change neither width nor spacing:
+  // the strap has run out of options, whatever isAtEndOfRepairOptions()
+  // computes from the current values.
+  bool repair_options_exhausted_ = false;
 
   // search for the right width, spacing, and offset to connect to the channel
   void determineParameters(const Shape::ObstructionTreeMap& obstructions);


### PR DESCRIPTION
### Summary

`RepairChannelStraps::repairGridChannels` recurses until a pass repairs nothing, and relies on `isAtEndOfRepairOptions()` to say when a strap has nothing left to try. For a strap whose width is already at the layer minimum while its spacing is above the layer minimum, that test says "keep going": `continueRepairs()` recomputes the same width, `determineParameters()` accepts the unchanged parameters, the rebuild succeeds, and a successful rebuild counts as a repair. The recursion never reaches its terminating branch. Stopping that strap alone is not enough either: the next pass creates a fresh strap for the same channel and starts the sequence over.

Two commits, one per hole in the termination argument:

1. `continueRepairs()` that changes neither width nor spacing marks the strap exhausted, and `isAtEndOfRepairOptions()` honours that.
2. `repairGridChannels()` does not create another repair strap for a channel that already has an exhausted one; the channel is reported as remaining.

### Reproducer

ORFS's public nangate45 `bp_quad` floorplan (BlackParrot quad-core, 3.6 x 3.6 mm), untar and run, 95 MB so hosted as a release asset: https://github.com/The-OpenROAD-Project/bazel-orfs/releases/tag/repro-pdn-bp_quad-nangate45

At master, `pdngen` on it never ends: 322 repair passes in the first five minutes, 305 of them at the same four channels, and the debug stream shows the same strap continued every pass with `changing width from 0.14 um to 0.14 um`. With this PR alone, on master, it ends after 28 passes, 58 s and 3.2 GB with `PDN-0179 Unable to repair all channels` for four channels on metal1 that no metal4 strap can close, which is the answer the code is designed to give and which the loop had made unreachable.

Each pass on this design also regenerates every via on the grid and appends them to via lists that are never cleared, so the loop presented as pdngen being pathologically slow at 34 to 58 GB rather than as a hang. Those costs are separate concerns and separate PRs; this one is only about termination.

### Testing

All 151 `src/pdn/test` regression scripts produce byte-identical output with and without this change (114 golden DEF matches, 24 expected-error tests, no divergence), which is expected: no test design has an unrepairable channel. The reproducer above is the failing case; a whittled version that fits the test directory can follow if wanted.
