### PR TITLE
pdn: keep via connection counts on the shape and bulk-load the via trees

### DIFF
--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -901,11 +901,10 @@ void Grid::makeVias(const Shape::ShapeTreeMap& global_shapes,
              remove_vias.size());
   remove_set_of_vias(remove_vias);
 
-  // Remove overlapping vias and keep largest
-  Via::ViaTree overlapping_via_tree;
-  for (const auto& via : vias) {
-    overlapping_via_tree.insert(via);
-  }
+  // Remove overlapping vias and keep largest. Build the tree in one go:
+  // the packing constructor is far cheaper than inserting millions of
+  // vias one at a time, and nothing queries the tree while it is built.
+  Via::ViaTree overlapping_via_tree(vias.begin(), vias.end());
   for (const auto& via : vias) {
     if (via->isFailed()) {
       continue;
@@ -947,9 +946,8 @@ void Grid::makeVias(const Shape::ShapeTreeMap& global_shapes,
   remove_set_of_vias(remove_vias);
 
   // build via tree
-  vias_.clear();
+  vias_ = Via::ViaTree(vias.begin(), vias.end());
   for (auto& via : vias) {
-    vias_.insert(via);
     via->getLowerShape()->addVia(via);
     via->getUpperShape()->addVia(via);
   }

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -112,28 +112,35 @@ int Shape::getNumberOfConnections() const
   return vias_.size() + iterm_connections_.size() + bterm_connections_.size();
 }
 
+void Shape::clearVias()
+{
+  vias_.clear();
+  connections_above_ = 0;
+  connections_below_ = 0;
+}
+
+void Shape::addVia(const ViaPtr& via)
+{
+  vias_.push_back(via);
+  // Count on the way in rather than by rescanning the via list on every
+  // query. RepairChannelStraps::findRepairChannels asks every strap and
+  // followpin shape for its connections above, and on a large die a rail
+  // carries thousands of vias: the rescan was over 90% of pdngen's runtime.
+  if (via->getLowerLayer() == layer_) {
+    connections_above_++;
+  } else if (via->getUpperLayer() == layer_) {
+    connections_below_++;
+  }
+}
+
 int Shape::getNumberOfConnectionsBelow() const
 {
-  int connections = 0;
-  for (const auto& via : vias_) {
-    if (via->getUpperLayer() == layer_) {
-      connections++;
-    }
-  }
-
-  return connections;
+  return connections_below_;
 }
 
 int Shape::getNumberOfConnectionsAbove() const
 {
-  int connections = 0;
-  for (const auto& via : vias_) {
-    if (via->getLowerLayer() == layer_) {
-      connections++;
-    }
-  }
-
-  return connections;
+  return connections_above_;
 }
 
 bool Shape::isValid() const

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -135,7 +135,6 @@ class Shape
   void clearVias();
   void addVia(const ViaPtr& via);
   const std::vector<ViaPtr>& getVias() const { return vias_; }
-  void removeVia(const ViaPtr& via);
 
   void addITermConnection(const odb::Rect& iterm)
   {

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -132,8 +132,8 @@ class Shape
   // true if shape can be modified (cut or shortened) by trimming
   virtual bool isModifiable() const;
 
-  void clearVias() { vias_.clear(); }
-  void addVia(const ViaPtr& via) { vias_.push_back(via); }
+  void clearVias();
+  void addVia(const ViaPtr& via);
   const std::vector<ViaPtr>& getVias() const { return vias_; }
   void removeVia(const ViaPtr& via);
 
@@ -243,6 +243,10 @@ class Shape
   GridComponent* grid_component_;
 
   std::vector<ViaPtr> vias_;
+  // Kept in step with vias_ by addVia()/clearVias(); a via's layers are
+  // fixed by its Connect, so the counts never go stale.
+  int connections_above_ = 0;
+  int connections_below_ = 0;
   std::set<odb::Rect> iterm_connections_;
   std::set<odb::Rect> bterm_connections_;
 


### PR DESCRIPTION
### Summary

Two costs in via bookkeeping that are invisible on small dies and dominate a large one:

1. `Shape::getNumberOfConnectionsAbove()` / `Below()` rescanned the shape's whole via list on every call. `RepairChannelStraps::findRepairChannels` asks every strap and followpin shape for the count above, on every repair pass; on a 3.6 mm die a rail carries thousands of vias. A 20-second `perf` sample of `pdngen` on the reproducer below had 92% of its time in this scan and the one-line `Via::getLowerLayer()` it calls. A via's layers are fixed by its `Connect` and a shape's layer never changes, so the two counts are kept on the shape and updated in `addVia`/`clearVias`.
2. `Grid::makeVias` built its two via R-trees by inserting millions of vias one at a time. Nothing queries either tree while it is built, so both use the packing constructor.

### Reproducer

ORFS's public nangate45 `bp_quad` floorplan, untar and run, 95 MB so hosted as a release asset: https://github.com/The-OpenROAD-Project/bazel-orfs/releases/tag/repro-pdn-bp_quad-nangate45

These are performance changes: they do not by themselves make `pdngen` terminate on that design, which is #11362. In a five-minute capped run on master with these two changes the loop made 1161 repair passes, each a full via regeneration on the 3.6 mm die, against 314 for master; memory still grows (28 GB at the cap) because the via lists are never cleared, which is #11363. With the scan removed, the next sample was 40% in R-tree insert and redistribute; with both changes, one `makeVias` on the core grid runs in about 0.3 s.

### Testing

All 151 `src/pdn/test` regression scripts produce byte-identical output with and without these changes, including the golden DEF comparisons, so the packed trees iterate in the same order the tests depend on.
