### PR TITLE
gif: zero-initialize palette to avoid out-of-bounds access in GifGetClosestPaletteColor

### DIFF
--- a/third-party/gif-h/gif.h
+++ b/third-party/gif-h/gif.h
@@ -430,6 +430,7 @@ void GifMakePalette(const uint8_t* lastFrame,
                     bool buildForDither,
                     GifPalette* pPal)
 {
+  memset(pPal, 0, sizeof(*pPal));
   pPal->bitDepth = bitDepth;
 
   // SplitPalette is destructive (it sorts the pixels by color) so


### PR DESCRIPTION
## Summary
If pPal->treeSplitElt[treeRoot] holds uninitialized stack memory (e.g., >= 3, or `0xaa` under pattern initialization from compiler), it indexes out of bounds on `int comps[3]` in function GifGetClosestPaletteColor, triggering an out-of-bounds read and crashes under compilers with array-bounds sanitization enabled -fsanitize=array-bounds.

Zero-initialize pPal with memset at the start of GifMakePalette() so that unvisited tree nodes default to 0 (comps[0]).

## Type of Change
- Bug fix
Reproduce command:
```
bazel test //src/web/test:gif_test -c fastbuild \
  --copt=-fsanitize=array-bounds \
  --copt=-fsanitize-trap=array-bounds \
  --copt=-ftrivial-auto-var-init=pattern \
  --nocache_test_results --remote_cache= --disk_cache= \
  --test_output=errors
```

## Impact
Fixes the GIF tests.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
