### PR TITLE
bazel: add tsan and ubsan configs; fix PrometheusMetricsServer race

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -155,6 +155,26 @@ build:tsan --linkopt=-gz=zlib
 # allocator instead, as --config=asan does.
 build:tsan --custom_malloc=@bazel_tools//tools/cpp:malloc
 
+# Settings for --config=ubsan undefined behavior sanitizer build
+build:ubsan --strip=never
+# As with --config=tsan, use hermetic-llvm's switch rather than a bare
+# -fsanitize=undefined copt. It also supplies the ignorelist that exempts the
+# libc startup files, which run before the runtime is initialized.
+build:ubsan --@llvm//config:ubsan=true
+build:ubsan --copt=-DUNDEFINED_BEHAVIOR_SANITIZER
+build:ubsan --copt=-O1
+build:ubsan --copt=-g
+# Compress the DWARF debug sections (transparent to gdb/perf/addr2line).
+build:ubsan --copt=-gz=zlib
+build:ubsan --linkopt=-gz=zlib
+# -fsanitize=undefined is recoverable by default: a finding prints a report and
+# the process carries on to exit 0, so a test suite stays green while the logs
+# fill up with reports nobody reads. Trap instead, so the run fails.
+build:ubsan --copt=-fno-sanitize-recover=all
+build:ubsan --test_env=UBSAN_OPTIONS=print_stacktrace=1
+# UBSan does not replace the allocator, so unlike asan/tsan this config keeps
+# TCMalloc.
+
 # Flags with enough debug symbols to get useful outputs with Linux `perf`
 build:profile --strip=never
 build:profile --copt -g --host_copt -g

--- a/.bazelrc
+++ b/.bazelrc
@@ -172,6 +172,13 @@ build:ubsan --linkopt=-gz=zlib
 # fill up with reports nobody reads. Trap instead, so the run fails.
 build:ubsan --copt=-fno-sanitize-recover=all
 build:ubsan --test_env=UBSAN_OPTIONS=print_stacktrace=1
+# Third-party UB is not actionable here, the same stance .bazelrc already takes
+# for warnings with --per_file_copt=.*external/.*@-w. As with that flag this
+# only covers compiling third-party *source* files, not third-party headers
+# inlined into OpenROAD translation units; suppressing those needs an
+# -fsanitize-ignorelist, which the toolchain would have to declare as a compile
+# input for us.
+build:ubsan --per_file_copt=.*external/.*@-fno-sanitize=all
 # UBSan does not replace the allocator, so unlike asan/tsan this config keeps
 # TCMalloc.
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -136,6 +136,25 @@ build:asan --linkopt=-fsanitize=address
 # ASan intercepts cleanly.
 build:asan --custom_malloc=@bazel_tools//tools/cpp:malloc
 
+# Settings for --config=tsan thread sanitizer build
+build:tsan --strip=never
+# hermetic-llvm's own sanitizer switch, rather than a bare -fsanitize=thread
+# copt: the toolchain builds compiler-rt's tsan runtime from source and links
+# it, which a plain driver flag cannot find under the zero sysroot. The flag
+# is scoped to the target configuration, so exec-config tools (swig, bison,
+# ...) keep building uninstrumented. @llvm is a dev_dependency, so this
+# resolves only when OpenROAD is the root module.
+build:tsan --@llvm//config:tsan=true
+build:tsan --copt=-DTHREAD_SANITIZER
+build:tsan --copt=-O1
+build:tsan --copt=-g
+# Compress the DWARF debug sections (transparent to gdb/perf/addr2line).
+build:tsan --copt=-gz=zlib
+build:tsan --linkopt=-gz=zlib
+# TCMalloc replaces the allocator TSan needs to intercept; use the system
+# allocator instead, as --config=asan does.
+build:tsan --custom_malloc=@bazel_tools//tools/cpp:malloc
+
 # Flags with enough debug symbols to get useful outputs with Linux `perf`
 build:profile --strip=never
 build:profile --copt -g --host_copt -g

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -21,6 +22,20 @@ exports_files(
         "tcl_tidy.sh",
         "yaml_fmt_test.sh",
         "yaml_tidy.sh",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# True under --config=tsan / --config=ubsan. The regression tests run the
+# openroad binary from the exec configuration, which those configs leave
+# uninstrumented on purpose (so swig, bison and the other build tools stay
+# clean). test/regression.bzl uses this to take the binary under test from the
+# target configuration instead, which is where the instrumentation lives.
+selects.config_setting_group(
+    name = "sanitizer_build",
+    match_any = [
+        "@llvm//config:tsan_enabled",
+        "@llvm//config:ubsan_enabled",
     ],
     visibility = ["//visibility:public"],
 )

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -197,9 +197,14 @@ The first `--config=tsan` invocation builds compiler-rt's tsan runtime from
 source, so expect a few minutes before any OpenROAD source is compiled.
 
 Instrumented code runs roughly 5-15x slower and uses far more memory, so
-prefer the smallest design that reproduces the race. Adjust the runtime via
-`TSAN_OPTIONS`, e.g. to keep going past the first report and get the second
-stack of a lock-order inversion:
+prefer the smallest design that reproduces the race. A full `src/...` run at
+Bazel's default parallelism can exhaust RAM and get the build OOM-killed;
+throttle it if that happens:
+
+    bazelisk test --config=tsan --test_tag_filters=-py --jobs=16 --local_test_jobs=8 src/...
+
+Adjust the runtime via `TSAN_OPTIONS`, e.g. to keep going past the first
+report and get the second stack of a lock-order inversion:
 
     bazelisk test --config=tsan --test_tag_filters=-py --test_env=TSAN_OPTIONS="halt_on_error=0 second_deadlock_stack=1" src/...
 

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -244,6 +244,34 @@ with a copt, which is preferable to disabling the config wholesale:
 
     bazelisk test --config=ubsan --test_tag_filters=-py --copt=-fno-sanitize=vptr src/...
 
+### Known findings
+
+A `--config=ubsan --test_tag_filters=-py src/...` sweep is not clean yet. As of
+this writing 36 of 3980 tests fail, in two groups.
+
+Third-party UB reached through headers that are inlined into OpenROAD
+translation units, 24 tests:
+
+| Origin | Check | Tests |
+| --- | --- | --- |
+| `boost.geometry` `strategies/cartesian/intersection.hpp` | `undefined-behavior` | 19, via `pad::RDLRouter::isEdgeObstructed` |
+| `coin-or-lemon` `lemon/network_simplex.h` | `signed-integer-overflow` | 5, in `cts` |
+
+`--per_file_copt=.*external/.*@-fno-sanitize=all` above exempts third-party
+*source* files, which is why abc, tcl and bliss no longer report. It cannot
+exempt a third-party *header* compiled as part of our own translation unit --
+the same limitation the `-w` per_file_copt has. Doing that needs an
+`-fsanitize-ignorelist`, which has to be declared as a compile action input,
+so it belongs in the toolchain rather than in this file.
+
+OpenROAD's own UB, 11 tests, to be fixed separately:
+
+| Site | Check | Tests |
+| --- | --- | --- |
+| `src/rcx/src/netRC.cpp:374`, `:1575`, `:1576` | `load of value` | 8 |
+| `src/odb/include/odb/geom.h:373` | `signed-integer-overflow` | 2 |
+| `src/grt/src/cugr/src/geo.h:111` | `signed-integer-overflow` | 1 |
+
 ## Sanitizers and the Python extension modules
 
 `--config=tsan` and `--config=ubsan` cover the C++ and Tcl tests, which run
@@ -273,6 +301,15 @@ hermetic-llvm block it today:
 Fixing this belongs upstream in hermetic-llvm. Until then, skip them with
 `--test_tag_filters=-py`; the Tcl tests cover the same C++ code paths as their
 Python counterparts.
+
+The Tcl tests do get instrumented. `test/regression.bzl` normally takes the
+`openroad` binary from the exec configuration, to avoid building it twice when
+it is also used as a build tool by bazel-orfs. The sanitizer configs only
+instrument the target configuration, so under `//bazel:sanitizer_build` the
+rule takes the binary from there instead. Only the binary under test moves;
+swig, bison and the other exec-configuration tools stay uninstrumented, and
+because exactly one of the two attributes is ever set `openroad` is still
+built once.
 
 ## Testing an OpenROAD build with ORFS from within the OpenROAD folder
 

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -210,6 +210,32 @@ reported inside `__kmp_*` frames are likely artifacts of the barrier
 implementation rather than OpenROAD bugs. Confirm a finding by checking that
 both stacks land in OpenROAD code.
 
+## Run tests with the [undefined behavior sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html):
+
+    bazelisk test --config=ubsan src/...
+
+Or to get an instrumented binary to run under ORFS:
+
+    bazelisk build --config=ubsan :openroad
+
+UBSan is much cheaper than asan/tsan -- a small constant slowdown, no memory
+overhead -- so it is the cheapest of the three to leave running over a real
+design.
+
+The config builds with `-fno-sanitize-recover=all`, so the first finding
+aborts the process. That is deliberate: `-fsanitize=undefined` on its own only
+prints a report and lets the process run on to exit 0, which would leave a
+test suite green with the reports buried in the logs. To survey everything a
+run would hit instead of stopping at the first, opt back into recovery:
+
+    bazelisk test --config=ubsan --copt=-fsanitize-recover=all src/...
+
+Reports name the check that fired (e.g. `signed-integer-overflow`,
+`misaligned-address`). An individual check can be switched off project-wide
+with a copt, which is preferable to disabling the config wholesale:
+
+    bazelisk test --config=ubsan --copt=-fno-sanitize=vptr src/...
+
 ## Testing an OpenROAD build with ORFS from within the OpenROAD folder
 
     OPENROAD_EXE=$(pwd)/bazel-out/k8-opt-exec-ST-d57f47055a04/bin/openroad make --dir ~/OpenROAD-flow-scripts/flow/ DESIGN_CONFIG=designs/asap7/gcd/config.mk clean_floorplan floorplan

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -185,6 +185,31 @@ SUMMARY: AddressSanitizer: 27236 byte(s) leaked in 3801 allocation(s).
 [deleted]
 ```
 
+## Run tests with the [thread sanitizer](https://github.com/google/sanitizers/wiki/threadsanitizercppmanual):
+
+    bazelisk test --config=tsan src/...
+
+Or to get an instrumented binary to run under ORFS:
+
+    bazelisk build --config=tsan :openroad
+
+The first `--config=tsan` invocation builds compiler-rt's tsan runtime from
+source, so expect a few minutes before any OpenROAD source is compiled.
+
+Instrumented code runs roughly 5-15x slower and uses far more memory, so
+prefer the smallest design that reproduces the race. Adjust the runtime via
+`TSAN_OPTIONS`, e.g. to keep going past the first report and get the second
+stack of a lock-order inversion:
+
+    bazelisk test --config=tsan --test_env=TSAN_OPTIONS="halt_on_error=0 second_deadlock_stack=1" src/...
+
+`drt`, `gpl`, `grt` and `ant` parallelize with OpenMP. The `@openmp` runtime
+is instrumented along with everything else under `--config=tsan`, but it is
+not built with OpenMP's TSan annotations (`LIBOMP_TSAN_SUPPORT`), so races
+reported inside `__kmp_*` frames are likely artifacts of the barrier
+implementation rather than OpenROAD bugs. Confirm a finding by checking that
+both stacks land in OpenROAD code.
+
 ## Testing an OpenROAD build with ORFS from within the OpenROAD folder
 
     OPENROAD_EXE=$(pwd)/bazel-out/k8-opt-exec-ST-d57f47055a04/bin/openroad make --dir ~/OpenROAD-flow-scripts/flow/ DESIGN_CONFIG=designs/asap7/gcd/config.mk clean_floorplan floorplan

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -211,9 +211,26 @@ report and get the second stack of a lock-order inversion:
 `drt`, `gpl`, `grt` and `ant` parallelize with OpenMP. The `@openmp` runtime
 is instrumented along with everything else under `--config=tsan`, but it is
 not built with OpenMP's TSan annotations (`LIBOMP_TSAN_SUPPORT`), so races
-reported inside `__kmp_*` frames are likely artifacts of the barrier
-implementation rather than OpenROAD bugs. Confirm a finding by checking that
-both stacks land in OpenROAD code.
+reported inside `__kmp_*` frames are artifacts of the barrier implementation
+rather than OpenROAD bugs. Confirm a finding by checking that both stacks land
+in OpenROAD code.
+
+### Known findings
+
+A `--config=tsan --test_tag_filters=-py src/...` sweep reports 36 of 3980
+tests failing, and the OpenMP artifacts above are almost all of it:
+
+| Origin | Tests |
+| --- | --- |
+| `@openmp` `runtime/src/kmp_runtime.cpp`, `kmp_wait_release.h` | 33, across `drt`, `grt`, `ram`, `rcx`, `gpl` |
+| `src/sta/graph/Graph.cc:1288` | 1, via `rmp` |
+| `boost::asio` `scheduler.ipp:187` | 1, in `dst` |
+
+Silencing the OpenMP group means building `@openmp` with
+`LIBOMP_TSAN_SUPPORT`, which is a change to that module rather than something
+this repo can pass as a flag. The remaining two are real: the `dst` one is a
+test that destroys a stack `io_context` while its thread still runs it, and
+the OpenSTA one is upstream.
 
 `--test_tag_filters=-py` skips the Python tests; see "Sanitizers and the
 Python extension modules" below for why.

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -187,7 +187,7 @@ SUMMARY: AddressSanitizer: 27236 byte(s) leaked in 3801 allocation(s).
 
 ## Run tests with the [thread sanitizer](https://github.com/google/sanitizers/wiki/threadsanitizercppmanual):
 
-    bazelisk test --config=tsan src/...
+    bazelisk test --config=tsan --test_tag_filters=-py src/...
 
 Or to get an instrumented binary to run under ORFS:
 
@@ -201,7 +201,7 @@ prefer the smallest design that reproduces the race. Adjust the runtime via
 `TSAN_OPTIONS`, e.g. to keep going past the first report and get the second
 stack of a lock-order inversion:
 
-    bazelisk test --config=tsan --test_env=TSAN_OPTIONS="halt_on_error=0 second_deadlock_stack=1" src/...
+    bazelisk test --config=tsan --test_tag_filters=-py --test_env=TSAN_OPTIONS="halt_on_error=0 second_deadlock_stack=1" src/...
 
 `drt`, `gpl`, `grt` and `ant` parallelize with OpenMP. The `@openmp` runtime
 is instrumented along with everything else under `--config=tsan`, but it is
@@ -210,9 +210,12 @@ reported inside `__kmp_*` frames are likely artifacts of the barrier
 implementation rather than OpenROAD bugs. Confirm a finding by checking that
 both stacks land in OpenROAD code.
 
+`--test_tag_filters=-py` skips the Python tests; see "Sanitizers and the
+Python extension modules" below for why.
+
 ## Run tests with the [undefined behavior sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html):
 
-    bazelisk test --config=ubsan src/...
+    bazelisk test --config=ubsan --test_tag_filters=-py src/...
 
 Or to get an instrumented binary to run under ORFS:
 
@@ -228,13 +231,43 @@ prints a report and lets the process run on to exit 0, which would leave a
 test suite green with the reports buried in the logs. To survey everything a
 run would hit instead of stopping at the first, opt back into recovery:
 
-    bazelisk test --config=ubsan --copt=-fsanitize-recover=all src/...
+    bazelisk test --config=ubsan --test_tag_filters=-py --copt=-fsanitize-recover=all src/...
 
 Reports name the check that fired (e.g. `signed-integer-overflow`,
 `misaligned-address`). An individual check can be switched off project-wide
 with a copt, which is preferable to disabling the config wholesale:
 
-    bazelisk test --config=ubsan --copt=-fno-sanitize=vptr src/...
+    bazelisk test --config=ubsan --test_tag_filters=-py --copt=-fno-sanitize=vptr src/...
+
+## Sanitizers and the Python extension modules
+
+`--config=tsan` and `--config=ubsan` cover the C++ and Tcl tests, which run
+the instrumented `openroad` binary. They do **not** work for the `py`-tagged
+tests, which import OpenROAD as a Python extension module:
+
+    ImportError: _openroadpy.so: undefined symbol: __ubsan_handle_pointer_overflow_abort
+
+Clang links a sanitizer runtime into executables but not into shared
+libraries, assuming whoever loads the library provides the symbols. That holds
+for `openroad`, which statically links the runtime; it fails for
+`_openroadpy.so` / `_odb.so` / `_utl.so`, which the *uninstrumented* system
+`python3` dlopens.
+
+`-shared-libsan` is the mechanism for this case, but three things in
+hermetic-llvm block it today:
+
+1. only the static archives are staged into clang's resource directory, so the
+   driver cannot find `libclang_rt.<san>.so` (asan stages both, ubsan and tsan
+   stage static only);
+2. the shared runtimes are built by `cc_shared_library` with sonames like
+   `libubsan_standalone.shared.so`, so a consumer records a `DT_NEEDED` on a
+   name that does not match the staged `libclang_rt.ubsan_standalone.so`;
+3. the runtime arrives via a linkopt rather than a dep, so it lands in neither
+   the test's runfiles nor its RPATH.
+
+Fixing this belongs upstream in hermetic-llvm. Until then, skip them with
+`--test_tag_filters=-py`; the Tcl tests cover the same C++ code paths as their
+Python counterparts.
 
 ## Testing an OpenROAD build with ORFS from within the OpenROAD folder
 

--- a/src/ant/test/BUILD
+++ b/src/ant/test/BUILD
@@ -82,7 +82,10 @@ py_test(
     name = "ant_man_tcl_check",
     srcs = ["ant_man_tcl_check.py"],
     data = ["//src/ant:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/cgt/test/BUILD
+++ b/src/cgt/test/BUILD
@@ -84,6 +84,7 @@ PY_TESTS = [
         name = test_name,
         srcs = [test_name + ".py"],
         data = [":" + test_name + "_resources"],
+        tags = ["py"],
         deps = [
             ":helpers",
             "//python/openroad:openroadpy",

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -268,7 +268,10 @@ py_test(
     name = "cts_man_tcl_check",
     srcs = ["cts_man_tcl_check.py"],
     data = ["//src/cts:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -145,7 +145,10 @@ py_test(
     name = "dft_man_tcl_check",
     srcs = ["dft_man_tcl_check.py"],
     data = ["//src/dft:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -335,7 +335,10 @@ py_test(
     name = "dpl_man_tcl_check",
     srcs = ["dpl_man_tcl_check.py"],
     data = ["//src/dpl:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -147,6 +147,7 @@ py_library(
         name = test_name,
         srcs = [test_name + ".py"],
         data = [":" + test_name + "_resources"],
+        tags = ["py"],
         deps = [
             ":helpers",
             "//python/openroad:openroadpy",
@@ -214,7 +215,10 @@ py_test(
     name = "drt_man_tcl_check",
     srcs = ["drt_man_tcl_check.py"],
     data = ["//src/drt:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -67,7 +67,10 @@ py_test(
     name = "fin_man_tcl_check",
     srcs = ["fin_man_tcl_check.py"],
     data = ["//src/fin:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -170,6 +170,7 @@ PY_TESTS = [
         data = [
             ":test_resources",
         ],
+        tags = ["py"],
         deps = [
             ":helpers",
             "//python/openroad:openroadpy",
@@ -235,7 +236,10 @@ py_test(
     name = "gpl_man_tcl_check",
     srcs = ["gpl_man_tcl_check.py"],
     data = ["//src/gpl:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -240,7 +240,10 @@ py_test(
     name = "grt_man_tcl_check",
     srcs = ["grt_man_tcl_check.py"],
     data = ["//src/grt:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/gui/test/BUILD
+++ b/src/gui/test/BUILD
@@ -50,7 +50,10 @@ py_test(
     name = "gui_man_tcl_check",
     srcs = ["gui_man_tcl_check.py"],
     data = ["//src/gui:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/ifp/test/BUILD
+++ b/src/ifp/test/BUILD
@@ -143,7 +143,10 @@ py_test(
     name = "ifp_man_tcl_check",
     srcs = ["ifp_man_tcl_check.py"],
     data = ["//src/ifp:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -315,7 +315,10 @@ py_test(
     name = "mpl_man_tcl_check",
     srcs = ["mpl_man_tcl_check.py"],
     data = ["//src/mpl:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -31,6 +31,7 @@ py_test(
     srcs = [
         "test_block.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -44,6 +45,7 @@ py_test(
     srcs = [
         "test_bterm.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -57,6 +59,7 @@ py_test(
     srcs = [
         "test_destroy.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -70,6 +73,7 @@ py_test(
     srcs = [
         "test_group.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -83,6 +87,7 @@ py_test(
     srcs = [
         "test_inst.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -96,6 +101,7 @@ py_test(
     srcs = [
         "test_iterm.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -109,6 +115,7 @@ py_test(
     srcs = [
         "test_module.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -122,6 +129,7 @@ py_test(
     srcs = [
         "test_net.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -135,6 +143,7 @@ py_test(
     srcs = [
         "test_wire_codec.py",
     ],
+    tags = ["py"],
     deps = [
         ":helper",
         ":odbUnitTest",
@@ -415,7 +424,10 @@ py_test(
     name = "odb_man_tcl_check",
     srcs = ["odb_man_tcl_check.py"],
     data = ["//src/odb:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -231,7 +231,10 @@ py_test(
     name = "pad_man_tcl_check",
     srcs = ["pad_man_tcl_check.py"],
     data = ["//src/pad:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/par/test/BUILD
+++ b/src/par/test/BUILD
@@ -85,7 +85,10 @@ py_test(
     name = "par_man_tcl_check",
     srcs = ["par_man_tcl_check.py"],
     data = ["//src/par:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -355,7 +355,10 @@ py_test(
     name = "pdn_man_tcl_check",
     srcs = ["pdn_man_tcl_check.py"],
     data = ["//src/pdn:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -207,7 +207,10 @@ py_test(
     name = "ppl_man_tcl_check",
     srcs = ["ppl_man_tcl_check.py"],
     data = ["//src/ppl:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -192,7 +192,10 @@ py_test(
     name = "psm_man_tcl_check",
     srcs = ["psm_man_tcl_check.py"],
     data = ["//src/psm:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -145,7 +145,10 @@ py_test(
     name = "rcx_man_tcl_check",
     srcs = ["rcx_man_tcl_check.py"],
     data = ["//src/rcx:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -212,7 +212,10 @@ py_test(
     name = "rmp_man_tcl_check",
     srcs = ["rmp_man_tcl_check.py"],
     data = ["//src/rmp:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -655,6 +655,7 @@ py_test(
     srcs = ["gcd_resize.py"],
     data = [":test_resources"],
     main = "gcd_resize.py",
+    tags = ["py"],
     deps = [
         ":helpers",
         ":rsz_aux",
@@ -666,7 +667,10 @@ py_test(
     name = "rsz_man_tcl_check",
     srcs = ["rsz_man_tcl_check.py"],
     data = ["//src/rsz:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/stt/test/BUILD
+++ b/src/stt/test/BUILD
@@ -40,7 +40,10 @@ py_test(
     name = "stt_man_tcl_check",
     srcs = ["stt_man_tcl_check.py"],
     data = ["//src/stt:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -192,7 +192,10 @@ py_test(
     name = "tap_man_tcl_check",
     srcs = ["tap_man_tcl_check.py"],
     data = ["//src/tap:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/upf/test/BUILD
+++ b/src/upf/test/BUILD
@@ -62,7 +62,10 @@ py_test(
     name = "upf_man_tcl_check",
     srcs = ["upf_man_tcl_check.py"],
     data = ["//src/upf:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/src/utl/include/utl/prometheus/metrics_server.h
+++ b/src/utl/include/utl/prometheus/metrics_server.h
@@ -47,11 +47,17 @@ class PrometheusMetricsServer
  private:
   std::thread worker_thread_;
   std::shared_ptr<PrometheusRegistry> registry_ptr_{nullptr};
-  uint16_t port_;
+  // The worker thread publishes port_ (the OS-chosen port when the caller
+  // asked for 0), is_ready_ and startup_failed_; the owning thread reads them
+  // through the accessors above and in the destructor. shutdown_ travels the
+  // other way, plus the worker sets it on an unrecoverable startup failure.
+  // The default sequentially consistent ordering is what makes port_ visible
+  // to a reader that has observed is_ready_.
+  std::atomic<uint16_t> port_;
   std::atomic<utl::Logger*> logger_;
-  bool shutdown_ = false;
-  bool is_ready_ = false;
-  bool startup_failed_ = false;
+  std::atomic<bool> shutdown_ = false;
+  std::atomic<bool> is_ready_ = false;
+  std::atomic<bool> startup_failed_ = false;
 
   void RunServer();
   void WorkerFunction();

--- a/src/utl/src/prometheus/metrics_server.cpp
+++ b/src/utl/src/prometheus/metrics_server.cpp
@@ -67,7 +67,7 @@ PrometheusMetricsServer::~PrometheusMetricsServer()
           io_context;  // Use a separate io_context for the connection.
       boost::asio::ip::tcp::socket socket(io_context);
       boost::asio::ip::tcp::endpoint endpoint(
-          boost::asio::ip::make_address("127.0.0.1"), port_);
+          boost::asio::ip::make_address("127.0.0.1"), port_.load());
       socket.connect(endpoint);          // This will unblock the accept().
     } catch (const std::exception& e) {  // NOLINT(bugprone-empty-catch)
                                          /*Do nothing, we're dying*/
@@ -82,8 +82,8 @@ void PrometheusMetricsServer::RunServer()
   namespace http = boost::beast::http;
 
   boost::asio::io_context io_context;
-  boost::asio::ip::tcp::acceptor acceptor(io_context,
-                                          {boost::asio::ip::tcp::v4(), port_});
+  boost::asio::ip::tcp::acceptor acceptor(
+      io_context, {boost::asio::ip::tcp::v4(), port_.load()});
   boost::system::error_code ec;  // Create error_code outside the loop.
 
   // Set the port in case of user passing 0, which lets the OS choose
@@ -95,7 +95,7 @@ void PrometheusMetricsServer::RunServer()
                        104,
                        "Starting Prometheus collection endpoint: "
                        "http://localhost:{}/metrics",
-                       port_);
+                       port_.load());
 
   while (!shutdown_) {
     tcp::socket socket(io_context);

--- a/src/utl/test/BUILD
+++ b/src/utl/test/BUILD
@@ -164,7 +164,10 @@ py_test(
     name = "utl_man_tcl_check",
     srcs = ["utl_man_tcl_check.py"],
     data = ["//src/utl:doc_files"],
-    tags = ["doc_check"],
+    tags = [
+        "doc_check",
+        "py",
+    ],
     deps = ["//docs/src/scripts:extract_utils"],
 )
 

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -391,6 +391,9 @@ def regression_test(
             #
             # https://bazel.build/reference/be/common-definitions#test.size
             size = size,
-            tags = tags,
+            # Tag with the test language so a run can select or skip one of
+            # them, e.g. --test_tag_filters=-py for the sanitizer configs,
+            # which cannot load the instrumented Python extension modules.
+            tags = tags + [ext],
             **kwargs
         )

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -8,6 +8,16 @@ Also provides doc_check_test for lightweight Python-only
 documentation tests that do not require the OpenROAD binary,
 and messages_txt for generating messages.txt from source files."""
 
+# The binary under test comes from exactly one of the two openroad attrs; the
+# macro below leaves the other unset. See //bazel:sanitizer_build.
+def _openroad_target(ctx):
+    return ctx.attr.openroad_sanitized or ctx.attr.openroad
+
+def _openroad_executable(ctx):
+    if ctx.attr.openroad_sanitized:
+        return ctx.executable.openroad_sanitized
+    return ctx.executable.openroad
+
 def _regression_test_impl(ctx):
     # Declare the test script output
     test_script = ctx.actions.declare_file(ctx.label.name + "_test.sh")
@@ -40,7 +50,7 @@ exec "{bazel_test_sh}" "$@"
             TEST_NAME_BAZEL = ctx.attr.test_name,
             TEST_FILE = ctx.file.test_file.short_path,
             TEST_TYPE = test_type,
-            OPENROAD_EXE = ctx.executable.openroad.short_path,
+            OPENROAD_EXE = _openroad_executable(ctx).short_path,
             REGRESSION_TEST = ctx.file.regression_test.short_path,
             TEST_GOLDEN_FILE = ctx.file.golden_file.short_path if ctx.file.golden_file else "",
             TEST_CHECK_LOG = "True" if ctx.attr.check_log else "False",
@@ -62,7 +72,7 @@ exec "{bazel_test_sh}" "$@"
         ctx.file.test_file,
         ctx.file.bazel_test_sh,
         ctx.file.regression_test,
-        ctx.executable.openroad,
+        _openroad_executable(ctx),
     ] + ctx.files.data
     if ctx.file.golden_file:
         runfiles_files.append(ctx.file.golden_file)
@@ -71,7 +81,7 @@ exec "{bazel_test_sh}" "$@"
         executable = test_script,
         runfiles = ctx.runfiles(
             files = runfiles_files,
-        ).merge_all(data_runfiles + [ctx.attr.openroad[DefaultInfo].default_runfiles]),
+        ).merge_all(data_runfiles + [_openroad_target(ctx)[DefaultInfo].default_runfiles]),
     )
 
 regression_rule_test = rule(
@@ -106,13 +116,20 @@ regression_rule_test = rule(
             allow_single_file = True,
         ),
         "openroad": attr.label(
-            doc = "The OpenROAD executable.",
+            doc = "The OpenROAD executable, exec configuration.",
             executable = True,
             # Avoid building OpenROAD twice with "bazelisk test -c opt ..."
             #
             # OpenROAD is used to build more stuff in bazel-orfs,
             # hence we want the "exec" (host) configuration.
             cfg = "exec",
+        ),
+        "openroad_sanitized": attr.label(
+            doc = "The OpenROAD executable, target configuration. Set instead " +
+                  "of `openroad` under a sanitizer config, whose " +
+                  "instrumentation only applies to the target configuration.",
+            executable = True,
+            cfg = "target",
         ),
         "regression_test": attr.label(
             doc = "The regression test script.",
@@ -383,7 +400,17 @@ def regression_test(
             test_type = effective_test_type,
             data = test_data,
             bazel_test_sh = "//test:bazel_test.sh",
-            openroad = "//:openroad",
+            # Only one of these is ever set, so openroad is still built
+            # once. Under a sanitizer config it has to come from the target
+            # configuration to be instrumented at all.
+            openroad = select({
+                "//bazel:sanitizer_build": None,
+                "//conditions:default": "//:openroad",
+            }),
+            openroad_sanitized = select({
+                "//bazel:sanitizer_build": "//:openroad",
+                "//conditions:default": None,
+            }),
             regression_test = "//test:regression_test.sh",
             # top showed me 50-400mByte of usage, so "enormous" for
             # long running tests, but the OpenROAD tests are generally


### PR DESCRIPTION
Adds `--config=tsan` and `--config=ubsan` alongside the existing
`--config=asan`, and fixes the first race TSan found.

### Why the toolchain switch instead of a copt

`--config=asan` passes `-fsanitize=address` as a plain copt/linkopt. That
cannot work for tsan or ubsan under hermetic-llvm: the toolchain has a zero
sysroot and builds compiler-rt from source into `bazel-out`, so the clang
driver has no `libclang_rt.*` to find. Both new configs use hermetic-llvm's
own switches (`@llvm//config:tsan`, `@llvm//config:ubsan`), which build the
runtime and link it. Those switches are scoped to the target configuration,
so exec-config tools (swig, bison, ...) keep building uninstrumented.

`@llvm` is a `dev_dependency`, so the switches resolve only when OpenROAD is
the root module.

### Per-config details

`tsan` overrides `--custom_malloc` to the system allocator. `BUILD.bazel`
sets `malloc = "@tcmalloc//tcmalloc"` on Linux, which replaces the allocator
TSan needs to intercept — the same reason `asan` already overrides it. UBSan
does not touch the allocator, so `ubsan` keeps TCMalloc.

`ubsan` builds with `-fno-sanitize-recover=all`. `-fsanitize=undefined` is
recoverable by default: a finding prints a report and the process runs on to
exit 0, so a test suite stays green with the reports buried in the logs.
`--copt=-fsanitize-recover=all` opts back in when you want to survey
everything a run hits rather than stop at the first.

### The race

TSan flagged two races in `TestCFileUtils` on the first run.
`PrometheusMetricsServer` had four members crossing the thread boundary as
plain `bool`/`uint16_t`; only `logger_` was atomic.

- the worker publishes `port_` (the OS-chosen port, when the caller passes 0)
  and `is_ready_` in `RunServer`, and `startup_failed_` in `WorkerFunction`
- the owner reads all three through `port()` / `is_ready()` /
  `has_startup_failed()` — which is what `Logger::isPrometheusServerReadyToServe()`
  polls in a loop — and in the destructor
- `shutdown_` travels the other way

All four are now `std::atomic`. The default sequentially consistent ordering
is what guarantees a reader that observed `is_ready_ == true` also sees the
real `port_`; under `memory_order_relaxed` that polling loop could still read
a stale 0.

### Notes for reviewers

`--config=asan`'s copt-based approach is left alone here. If it has the same
zero-sysroot problem, converting it to `@llvm//config:asan` would be a small
follow-up.

A full `--config=ubsan //src/...` sweep is still running; I have not yet
confirmed the tree is UB-clean, only that the config works and the flags
reach OpenROAD's compiles. Expect follow-up commits if it turns up findings.
