### PR TITLE
Coverity bazel build

### DIFF
--- a/etc/BUILD
+++ b/etc/BUILD
@@ -23,8 +23,16 @@ exports_files(
 test_suite(
     name = "all_tests",
     tests = [
+        ":code_coverage_test",
         ":test_whittle",
     ],
+)
+
+py_test(
+    name = "code_coverage_test",
+    size = "small",
+    srcs = ["code_coverage_test.py"],
+    data = ["CodeCoverage.sh"],
 )
 
 py_test(

--- a/etc/CodeCoverage.sh
+++ b/etc/CodeCoverage.sh
@@ -77,7 +77,9 @@ _coverity() {
     percent=$(sed -nE \
         's/.*Emitted.*compilation units.*\(([0-9]+)%\).*/\1/p' \
         "${log_file}" | tail -n 1)
-    if [[ ${percent} -lt 85  ]]; then
+    # An empty match means the capture summary is missing; treat it as 0%.
+    percent="${percent:-0}"
+    if [[ ${percent} -lt 85 ]]; then
         echo "Coverity requires more than 85% of compilation coverage. Only got ${percent}%."
         exit 1
     fi

--- a/etc/CodeCoverage.sh
+++ b/etc/CodeCoverage.sh
@@ -6,7 +6,7 @@ cd "$(dirname $(readlink -f $0))/../"
 
 _help() {
     cat <<EOF
-usage: $0 [dynamic]
+usage: $0 [dynamic|test]
        $0 static <TOKEN>
        $0 static-bazel <TOKEN>
 
@@ -127,6 +127,9 @@ target="${1:-dynamic}"
 case "${target}" in
     dynamic )
         _lcov
+        ;;
+    test )
+        bazelisk test //etc:code_coverage_test
         ;;
     static | static-bazel )
         if [[ $# -ne 2 ]]; then

--- a/etc/CodeCoverage.sh
+++ b/etc/CodeCoverage.sh
@@ -8,6 +8,7 @@ _help() {
     cat <<EOF
 usage: $0 [dynamic]
        $0 static <TOKEN>
+       $0 static-bazel <TOKEN>
 
 EOF
     exit "${1:-1}"
@@ -41,7 +42,7 @@ _lcov() {
 
 }
 
-_coverity() {
+_coverity_cmake() {
     cmakeOptions=""
     if [[ -f "/etc/openroad_deps_prefixes.txt" ]]; then
         cmakeOptions="$(cat "/etc/openroad_deps_prefixes.txt")"
@@ -51,12 +52,33 @@ _coverity() {
     # Coverity fails to process abc code due to -fpermissive flag.
     cmake --build build -j $(nproc) --target abc
     cov-build --dir cov-int cmake --build build -j $(nproc)
+}
+
+_coverity_bazel() {
+    # Coverity captures compiler invocations, so cached or sandboxed Bazel
+    # actions can make the capture incomplete. Clear the local action cache,
+    # disable the persistent action caches, and execute spawns locally.
+    bazelisk clean
+    cov-build --dir cov-int --bazel bazelisk build \
+        --spawn_strategy=local \
+        --remote_cache= \
+        --disk_cache= \
+        --noremote_accept_cached \
+        --noremote_upload_local_results \
+        --jobs=$(nproc) \
+        --//:platform=cli \
+        -- //:openroad
+}
+
+_coverity() {
+    "$1"
     log_file=cov-int/build-log.txt
-    regex='Emitted.*compilation units.*\(\d+%\)'
     # get compilation coverage percentage
-    percent=$(grep -Poi "${regex}" ${log_file} | grep -Po '\d+' | tail -n 1)
+    percent=$(sed -nE \
+        's/.*Emitted.*compilation units.*\(([0-9]+)%\).*/\1/p' \
+        "${log_file}" | tail -n 1)
     if [[ ${percent} -lt 85  ]]; then
-        echo "Coverity requires more than 85% of compilation coverage. Only got ${percentage}%."
+        echo "Coverity requires more than 85% of compilation coverage. Only got ${percent}%."
         exit 1
     fi
 
@@ -106,7 +128,7 @@ case "${target}" in
     dynamic )
         _lcov
         ;;
-    static )
+    static | static-bazel )
         if [[ $# -ne 2 ]]; then
             if [[ $# -lt 2 ]]; then
                 echo -n "Too few arguments. "
@@ -118,7 +140,11 @@ case "${target}" in
             _help
         fi
         token="${2}"
-        _coverity
+        if [[ ${target} == "static-bazel" ]]; then
+            _coverity _coverity_bazel
+        else
+            _coverity _coverity_cmake
+        fi
         ;;
     *)
         echo "invalid argument: ${1}" >&2

--- a/etc/code_coverage_test.py
+++ b/etc/code_coverage_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class CodeCoverageTest(unittest.TestCase):
+    def test_static_bazel_uses_uncached_local_capture(self):
+        result, archive_exists, commands = self._run("static-bazel")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(archive_exists)
+        self.assertIn("bazelisk clean", commands)
+        self.assertIn("cov-build --dir cov-int --bazel bazelisk build", commands)
+        self.assertIn("--spawn_strategy=local", commands)
+        self.assertIn("--remote_cache= --disk_cache=", commands)
+        self.assertIn("--noremote_accept_cached", commands)
+        self.assertIn("--noremote_upload_local_results", commands)
+        self.assertIn("--//:platform=cli -- //:openroad", commands)
+        self.assertNotIn("cmake ", commands)
+
+    def test_static_keeps_the_cmake_capture(self):
+        result, archive_exists, commands = self._run("static")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(archive_exists)
+        self.assertIn("cmake -B build .", commands)
+        self.assertIn("cmake --build build", commands)
+        self.assertIn("cov-build --dir cov-int cmake --build build", commands)
+        self.assertNotIn("bazelisk", commands)
+
+    def _run(self, mode):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            etc = root / "repo" / "etc"
+            fake_bin = root / "bin"
+            etc.mkdir(parents=True)
+            fake_bin.mkdir()
+
+            script = etc / "CodeCoverage.sh"
+            shutil.copy2(Path(__file__).with_name("CodeCoverage.sh"), script)
+
+            command_log = root / "commands.log"
+            self._write_executable(
+                fake_bin / "bazelisk",
+                '#!/bin/sh\nprintf "bazelisk %s\\n" "$*" >> "$COMMAND_LOG"\n',
+            )
+            self._write_executable(
+                fake_bin / "cmake",
+                '#!/bin/sh\nprintf "cmake %s\\n" "$*" >> "$COMMAND_LOG"\n',
+            )
+            self._write_executable(
+                fake_bin / "cov-build",
+                """#!/bin/sh
+printf 'cov-build %s\n' "$*" >> "$COMMAND_LOG"
+mkdir -p cov-int
+printf 'Emitted 100 compilation units (100%%)\n' > cov-int/build-log.txt
+""",
+            )
+            self._write_executable(
+                fake_bin / "git",
+                '#!/bin/sh\nprintf "0123456789abcdef\\n"\n',
+            )
+
+            env = os.environ.copy()
+            env["COMMAND_LOG"] = str(command_log)
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            env["SKIP_COVERITY_UPLOAD"] = "1"
+
+            result = subprocess.run(
+                [script, mode, "unused-test-token"],
+                cwd=root / "repo",
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            commands = command_log.read_text()
+            archive = root / "repo" / "openroad.tgz"
+            return result, archive.is_file(), commands
+
+    @staticmethod
+    def _write_executable(path, content):
+        path.write_text(content)
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/code_coverage_test.py
+++ b/etc/code_coverage_test.py
@@ -34,7 +34,23 @@ class CodeCoverageTest(unittest.TestCase):
         self.assertIn("cov-build --dir cov-int cmake --build build", commands)
         self.assertNotIn("bazelisk", commands)
 
-    def _run(self, mode):
+    def test_static_fails_when_capture_percentage_is_missing(self):
+        result, archive_exists, _ = self._run("static", build_log="no summary\n")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(archive_exists)
+        self.assertIn("Only got 0%", result.stdout)
+
+    def test_static_fails_when_capture_percentage_is_low(self):
+        result, archive_exists, _ = self._run(
+            "static", build_log="Emitted 84 compilation units (84%)\n"
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(archive_exists)
+        self.assertIn("Only got 84%", result.stdout)
+
+    def _run(self, mode, build_log="Emitted 100 compilation units (100%)\n"):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             etc = root / "repo" / "etc"
@@ -59,9 +75,11 @@ class CodeCoverageTest(unittest.TestCase):
                 """#!/bin/sh
 printf 'cov-build %s\n' "$*" >> "$COMMAND_LOG"
 mkdir -p cov-int
-printf 'Emitted 100 compilation units (100%%)\n' > cov-int/build-log.txt
+cat "$BUILD_LOG_SOURCE" > cov-int/build-log.txt
 """,
             )
+            build_log_source = root / "build-log.txt"
+            build_log_source.write_text(build_log)
             self._write_executable(
                 fake_bin / "git",
                 '#!/bin/sh\nprintf "0123456789abcdef\\n"\n',
@@ -69,6 +87,7 @@ printf 'Emitted 100 compilation units (100%%)\n' > cov-int/build-log.txt
 
             env = os.environ.copy()
             env["COMMAND_LOG"] = str(command_log)
+            env["BUILD_LOG_SOURCE"] = str(build_log_source)
             env["PATH"] = f"{fake_bin}:{env['PATH']}"
             env["SKIP_COVERITY_UPLOAD"] = "1"
 


### PR DESCRIPTION
## Summary

Added a `static-bazel` mode to `etc/CodeCoverage.sh`.

It runs Coverity with:

```sh
cov-build --bazel bazelisk build //:openroad
```

The mode clears local Bazel outputs, disables action caches, forces local execution, preserves the 85% capture gate, and keeps the existing archive and upload flow.

Added regression tests for both Bazel and CMake modes.

## Type of Change

- New feature
- Refactoring

## Impact

OpenROAD can now run Coverity analysis against its Bazel build while keeping the existing CMake mode for compatibility.

## Verification

- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues

I will follow up with a PR to enable the new test in CI.