### PR TITLE
dst: stop and join the io_context thread in TestBalancer

### DIFF
--- a/src/dst/test/BUILD
+++ b/src/dst/test/BUILD
@@ -34,6 +34,7 @@ cc_test(
         "//src/utl",
         "@boost.asio",
         "@boost.bind",
+        "@boost.scope_exit",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ] + select({

--- a/src/dst/test/cpp/TestBalancer.cc
+++ b/src/dst/test/cpp/TestBalancer.cc
@@ -7,6 +7,7 @@
 #include "LoadBalancer.h"
 #include "boost/asio.hpp"
 #include "boost/bind/bind.hpp"
+#include "boost/scope_exit.hpp"
 #include "boost/thread/thread.hpp"
 #include "dst/BroadcastJobDescription.h"
 #include "dst/Distributed.h"
@@ -78,6 +79,16 @@ TEST(test_suite, test_balancer)
 
     // Checking if balancer is up and responding
     boost::thread t(boost::bind(&asio::io_context::run, &service));
+
+    // boost::thread's destructor detaches, so without this the thread keeps
+    // running io_context::run() on `service` after it has been destroyed at
+    // scope exit. The guard also covers the catch blocks below, which unwind
+    // while the thread is still live.
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+      service.stop();
+      t.join();
+    };
     JobMessage msg(JobMessage::JobType::kBalancer);
     JobMessage result;
     EXPECT_TRUE(dist->sendJob(msg, local_ip.c_str(), balancer_port, result));


### PR DESCRIPTION
Found by a `--config=tsan` run (the config itself is #3744, this is
independent of it).

`TestBalancer` runs `service`, a stack `asio::io_context`, on a
`boost::thread` and never joins it:

    asio::io_context service;                                        // :58
    boost::thread t(boost::bind(&asio::io_context::run, &service));  // :79

`boost::thread`'s destructor detaches, so at scope exit the thread keeps
executing `io_context::run()` while `service` is destroyed underneath it. TSan
reports it three ways: the main thread writing in `scheduler::shutdown()`
against the worker reading in `do_run_one()`, plus two `operator delete` races
as asio frees the `epoll_reactor` out from under the running thread.

Stop the service and join the thread with `BOOST_SCOPE_EXIT_ALL`, matching the
idiom already used in `gpl/src/timingBase.cpp`. The guard rather than a plain
call at the end of the block is deliberate: the `catch` blocks below
`GTEST_SKIP` on socket permission errors, and they unwind while the thread is
still live.

Note the test binds hardcoded ports 5555-5559, so it cannot run concurrently
with itself. To reproduce or verify, serialize the runs:

    bazelisk test --config=tsan --runs_per_test=5 --local_test_jobs=1 \
        //src/dst/test:dst_balancer_test

Clean 5/5 with the fix, and `//src/dst/...` passes in a normal build.

There is a related note at `src/dst/test/BUILD:46` saying CMake builds
`TestDistributed` but does not register it because the case is "still
race-prone", so this module may have more of the same waiting.
