### PR TITLE
rcx,pdn,grt: fix the undefined behavior ubsan reports

### DIFF
--- a/src/grt/src/cugr/src/geo.h
+++ b/src/grt/src/cugr/src/geo.h
@@ -108,7 +108,12 @@ class IntervalT
 
   // Getters
   int center() const { return (high_ + low_) / 2; }
-  int range() const { return high_ - low_; }
+  // An empty interval still holds the set() sentinel (low = INT_MAX,
+  // high = INT_MIN), where high_ - low_ overflows. A net whose pins yield no
+  // access points leaves its bounding box in that state, and GRNet's sort
+  // comparator asks it for hp(). Report no extent instead, matching the
+  // isValid() guard unionWith() already uses.
+  int range() const { return isValid() ? high_ - low_ : 0; }
 
   // Update
   // update() is always safe, fastUpdate() assumes existing values

--- a/src/pdn/src/techlayer.cpp
+++ b/src/pdn/src/techlayer.cpp
@@ -260,6 +260,14 @@ odb::Rect TechLayer::adjustToMinArea(
     return rect;
   }
 
+  // Shape::getMinimumRect() returns the mergeInit() sentinel when a shape has
+  // no bterm, iterm or via to merge, and dx()/dy()/area() overflow on it. The
+  // caller already skips an inverted rect when correcting the adjusted shape,
+  // so there is nothing to adjust here either.
+  if (rect.isInverted()) {
+    return rect;
+  }
+
   // make sure minimum area is honored
   const double area = min_area;
 

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1864,12 +1864,12 @@ class extMain
   uint32_t* _ccContextLength = nullptr;
   //  uint32_t* _ccContextLength= nullptr;
 
-  bool _skip_via_wires;
+  bool _skip_via_wires = false;
   float _version;                           // dkf: 06242024
   int _metal_flag_22;                       // dkf: 06242024
   uint32_t _wire_extracted_progress_count;  // dkf: 06242024
 
-  bool _v2;  // new flow dkf: 10302023
+  bool _v2 = false;  // new flow dkf: 10302023
 
   void skip_via_wires(bool v) { _skip_via_wires = v; };
   void printUpdateCoup(uint32_t netId1,
@@ -2702,13 +2702,13 @@ class extMain
   char* _origSpefFilePrefix = nullptr;
   char* _newSpefFilePrefix = nullptr;
   uint32_t _bufSpefCnt;
-  bool _incrNoBackSlash;
+  bool _incrNoBackSlash = false;
   uint32_t _cornerCnt = 0;
   uint32_t _extDbCnt;
 
   int _remote;
-  bool _extracted;
-  bool _allNet;
+  bool _extracted = false;
+  bool _allNet = false;
 
   bool _getBandWire = false;
   bool _printBandInfo = false;
@@ -2734,9 +2734,9 @@ class extMain
   bool _gndcModify = false;
 
   float _netGndcCalibFactor;
-  bool _netGndcCalibration;
+  bool _netGndcCalibration = false;
 
-  bool _useDbSdb;
+  bool _useDbSdb = false;
 
   Array1D<int>* _nodeTable = nullptr;   // junction id -> cap node id
   Array1D<int>* _btermTable = nullptr;  // bterm id -> cap node id
@@ -2792,7 +2792,7 @@ class extMain
   odb::dbExtControl* _prevControl = nullptr;
 
   bool _foreign = false;
-  bool _rsegCoord;
+  bool _rsegCoord = false;
   bool _diagFlow = false;
 
   std::vector<uint32_t> _rsegJid;
@@ -2816,10 +2816,10 @@ class extMain
   double _maxResTable[64][64];
 
  public:
-  bool _lef_res;
+  bool _lef_res = false;
   std::string _tmpLenStats;
   int _last_node_xy[2];
-  bool _wireInfra;
+  bool _wireInfra = false;
   odb::Rect _extMaxRect;
 
   // ----------------------------------------- 060623


### PR DESCRIPTION
The follow-up to #11371, which added `--config=ubsan`. That sweep reported UB
in 11 tests across three modules; these are those fixes. Three unrelated
causes.

### rcx -- uninitialized bools, 8 tests

    netRC.cpp:1575: load of value 7, which is not a valid value for type 'bool'
    netRC.cpp:1576: load of value 210, which is not a valid value for type 'bool'

`extMain`'s constructor sets only `_modelTable`, leaving **ten** bool members
uninitialized, and reading a `bool` holding anything but 0 or 1 is undefined.
`_rsegCoord`'s garbage also reaches a call argument at `netRC.cpp:2224`.

UBSan only reports the members a given test path happens to read, so all ten
are initialized rather than the three that showed up. `false` is clearly the
intended default: `_foreign`, declared right beside `_rsegCoord`, already had
it -- which is why line 1574 never reported while 1575-76 did -- and
`grids.h:682` and `extSpef.h:364` already default their own `_v2` and
`_extracted` the same way.

`_incrNoBackSlash` and `_wireInfra` are never read or written anywhere in
`src/rcx`. They are initialized here rather than deleted, to keep this a UB
fix; worth removing separately.

### pdn -- dx() on an inverted rect, 2 tests

    geom.h:373: signed integer overflow: -2147483648 - 2147483647

`Shape::getMinimumRect()` starts from `mergeInit()` and merges bterms, iterms
and vias, so a shape with none of them returns the sentinel
(`xlo_ = INT_MAX`, `xhi_ = INT_MIN`). `TechLayer::adjustToMinArea()` then calls
`dx()` on it -- and `area()` too, since that is `dx() * (int64) dy()`.

Fixed by returning the rect untouched, rather than by changing
`odb::Rect::dx()`, which is used throughout OpenROAD and should not take a
branch or change semantics for this. `PdnGen.cc:231` and `:258` already skip an
inverted rect when correcting the adjusted shape, so this only moves a check
that already exists earlier.

### grt -- range() on an empty interval, 1 test

    geo.h:111: signed integer overflow: -2147483648 - 2147483647

`GRNet::bounding_box_` is only fed from `pin_access_points_`, so a net whose
pins yield no access points keeps `IntervalT`'s empty sentinel, and the sort
comparator in `CUGR::sortNetIndices` asks it for `hp()`.

An empty bounding box is a legitimate state, so `range()` now reports no extent
for one, guarded by the same `isValid()` that `unionWith()` already uses. That
covers `width()`, `height()`, `hp()` and `area()` in one place.

### Verification

`bazelisk test --config=ubsan --test_tag_filters=-py //src/...`: **3958 pass,
24 fail**, down from 36. **No first-party UB remains** -- every one of the 24
is third-party reached through a header inlined into our translation units:

| Origin | Tests |
| --- | --- |
| `boost.geometry` `strategies/cartesian/intersection.hpp:139` | 16, in `pad` |
| `boost.geometry` `arithmetic/determinant.hpp:44` | 3, in `pad` |
| `coin-or-lemon` `lemon/network_simplex.h:383` | 5, in `cts` |

Those are documented in `docs/user/Bazel.md` and need an
`-fsanitize-ignorelist` declared as a compile action input, which belongs in
the toolchain rather than `.bazelrc`.

`//src/rcx/... //src/pdn/... //src/grt/...` in a normal build: **352/352 pass**,
so no golden or QoR change. That was the risk worth checking, since all three
fixes change code paths that were previously undefined.
