### PR TITLE
rcx: drop two unused extMain members

### DIFF
--- a/src/grt/src/cugr/src/geo.h
+++ b/src/grt/src/cugr/src/geo.h
@@ -108,7 +108,12 @@ class IntervalT
 
   // Getters
   int center() const { return (high_ + low_) / 2; }
-  int range() const { return high_ - low_; }
+  // An empty interval still holds the set() sentinel (low = INT_MAX,
+  // high = INT_MIN), where high_ - low_ overflows. A net whose pins yield no
+  // access points leaves its bounding box in that state, and GRNet's sort
+  // comparator asks it for hp(). Report no extent instead, matching the
+  // isValid() guard unionWith() already uses.
+  int range() const { return isValid() ? high_ - low_ : 0; }
 
   // Update
   // update() is always safe, fastUpdate() assumes existing values

--- a/src/pdn/src/techlayer.cpp
+++ b/src/pdn/src/techlayer.cpp
@@ -260,6 +260,14 @@ odb::Rect TechLayer::adjustToMinArea(
     return rect;
   }
 
+  // Shape::getMinimumRect() returns the mergeInit() sentinel when a shape has
+  // no bterm, iterm or via to merge, and dx()/dy()/area() overflow on it. The
+  // caller already skips an inverted rect when correcting the adjusted shape,
+  // so there is nothing to adjust here either.
+  if (rect.isInverted()) {
+    return rect;
+  }
+
   // make sure minimum area is honored
   const double area = min_area;
 

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1864,12 +1864,12 @@ class extMain
   uint32_t* _ccContextLength = nullptr;
   //  uint32_t* _ccContextLength= nullptr;
 
-  bool _skip_via_wires;
+  bool _skip_via_wires = false;
   float _version;                           // dkf: 06242024
   int _metal_flag_22;                       // dkf: 06242024
   uint32_t _wire_extracted_progress_count;  // dkf: 06242024
 
-  bool _v2;  // new flow dkf: 10302023
+  bool _v2 = false;  // new flow dkf: 10302023
 
   void skip_via_wires(bool v) { _skip_via_wires = v; };
   void printUpdateCoup(uint32_t netId1,
@@ -2702,13 +2702,13 @@ class extMain
   char* _origSpefFilePrefix = nullptr;
   char* _newSpefFilePrefix = nullptr;
   uint32_t _bufSpefCnt;
-  bool _incrNoBackSlash;
+  bool _incrNoBackSlash = false;
   uint32_t _cornerCnt = 0;
   uint32_t _extDbCnt;
 
   int _remote;
-  bool _extracted;
-  bool _allNet;
+  bool _extracted = false;
+  bool _allNet = false;
 
   bool _getBandWire = false;
   bool _printBandInfo = false;
@@ -2734,9 +2734,9 @@ class extMain
   bool _gndcModify = false;
 
   float _netGndcCalibFactor;
-  bool _netGndcCalibration;
+  bool _netGndcCalibration = false;
 
-  bool _useDbSdb;
+  bool _useDbSdb = false;
 
   Array1D<int>* _nodeTable = nullptr;   // junction id -> cap node id
   Array1D<int>* _btermTable = nullptr;  // bterm id -> cap node id
@@ -2792,7 +2792,7 @@ class extMain
   odb::dbExtControl* _prevControl = nullptr;
 
   bool _foreign = false;
-  bool _rsegCoord;
+  bool _rsegCoord = false;
   bool _diagFlow = false;
 
   std::vector<uint32_t> _rsegJid;
@@ -2816,10 +2816,10 @@ class extMain
   double _maxResTable[64][64];
 
  public:
-  bool _lef_res;
+  bool _lef_res = false;
   std::string _tmpLenStats;
   int _last_node_xy[2];
-  bool _wireInfra;
+  bool _wireInfra = false;
   odb::Rect _extMaxRect;
 
   // ----------------------------------------- 060623

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2702,7 +2702,6 @@ class extMain
   char* _origSpefFilePrefix = nullptr;
   char* _newSpefFilePrefix = nullptr;
   uint32_t _bufSpefCnt;
-  bool _incrNoBackSlash = false;
   uint32_t _cornerCnt = 0;
   uint32_t _extDbCnt;
 
@@ -2819,7 +2818,6 @@ class extMain
   bool _lef_res = false;
   std::string _tmpLenStats;
   int _last_node_xy[2];
-  bool _wireInfra = false;
   odb::Rect _extMaxRect;
 
   // ----------------------------------------- 060623


### PR DESCRIPTION
**Depends on #3747** -- based on that branch, because it touches the same two
lines. Review or merge it first; this diff is the two-line deletion on top.

`_incrNoBackSlash` and `_wireInfra` each appear exactly once in the whole
repository, in their own declaration in `extMain`:

    src/rcx/include/rcx/extRCap.h:2705:  bool _incrNoBackSlash = false;
    src/rcx/include/rcx/extRCap.h:2822:  bool _wireInfra = false;

Nothing reads or writes either one. No accessor, no SWIG binding, no Tcl or
Python reference.

They surfaced during the ubsan work: `extMain` leaves its bool members
uninitialized, and #3747 initialized all ten of them rather than only the
three UBSan happened to report, to keep that change a pure UB fix. These two
are dead either way, so drop them.

### One thing worth a reviewer's judgement

The two are not equivalent. `_incrNoBackSlash` is `private`, so removing it is
mechanical. `_wireInfra` is `public` in a header exported via
`src/rcx/BUILD:88`, which makes it nominally API surface. It sits in a block of
internal state that merely happens to be public --

    public:
      bool _lef_res = false;
      std::string _tmpLenStats;
      int _last_node_xy[2];
      bool _wireInfra = false;
      odb::Rect _extMaxRect;

-- rather than a curated interface, and it is a bare bool with no semantics
attached, so an out-of-tree consumer referencing it is far-fetched. Say so if
you would rather keep the public one.

### Verification

`//src/rcx/...`: 19/19 pass. `bazelisk build //src/... //:openroad`: clean --
worth running since the header is exported and other modules include it.
