### PR TITLE
fin: honor fill obstructions in density fill

### DIFF
--- a/src/fin/src/DensityFill.cpp
+++ b/src/fin/src/DensityFill.cpp
@@ -248,7 +248,7 @@ static void insertShape(const dbShape& shape,
 }
 
 // Build a polygon set out of all the non-fill shape on the given layer
-// including wires, special wires, and instances' pins & OBS
+// including wires, special wires, fill obstructions, and instances' pins & OBS
 static Polygon90Set orNonFills(dbBlock* block, dbTechLayer* layer)
 {
   Polygon90Set non_fill;  // The result
@@ -292,6 +292,15 @@ static Polygon90Set orNonFills(dbBlock* block, dbTechLayer* layer)
   for (auto inst : block->getInsts()) {
     for (insts.begin(inst, dbInstShapeItr::ALL); insts.next(shape);) {
       insertShape(shape, non_fill, layer);
+    }
+  }
+
+  // Get shapes from fill obstructions
+  for (auto obstruction : block->getObstructions()) {
+    auto* box = obstruction->getBBox();
+    if (obstruction->isFillObstruction() && box->getTechLayer() == layer) {
+      non_fill.insert(
+          makeRect(box->xMin(), box->yMin(), box->xMax(), box->yMax()));
     }
   }
 

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -11,7 +11,11 @@ COMPULSORY_TESTS = [
     "gcd_fill",
 ]
 
-ALL_TESTS = COMPULSORY_TESTS
+PASSFAIL_TESTS = [
+    "density_fill_obstruction",
+]
+
+ALL_TESTS = COMPULSORY_TESTS + PASSFAIL_TESTS
 
 filegroup(
     name = "regression_resources",
@@ -56,6 +60,8 @@ filegroup(
 [
     regression_test(
         name = test_name,
+        check_log = False if test_name in PASSFAIL_TESTS else True,
+        check_passfail = True if test_name in PASSFAIL_TESTS else False,
         data = [":" + test_name + "_resources"],
         tags = [] if test_name in COMPULSORY_TESTS else ["manual"],
         visibility = ["//visibility:public"],

--- a/src/fin/test/CMakeLists.txt
+++ b/src/fin/test/CMakeLists.txt
@@ -2,5 +2,7 @@ or_integration_tests(
   "fin"
   TESTS
     gcd_fill
+  PASSFAIL_TESTS
+    density_fill_obstruction
 )
 

--- a/src/fin/test/density_fill_obstruction.tcl
+++ b/src/fin/test/density_fill_obstruction.tcl
@@ -6,10 +6,12 @@ proc count_fill_overlaps { block layer region } {
   foreach fill [$block getFills] {
     if { [$fill getTechLayer] == $layer } {
       set rect [$fill getRect]
-      if { [$rect xMin] < [$region xMax]
+      if {
+        [$rect xMin] < [$region xMax]
         && [$rect xMax] > [$region xMin]
         && [$rect yMin] < [$region yMax]
-        && [$rect yMax] > [$region yMin] } {
+        && [$rect yMax] > [$region yMin]
+      } {
         incr count
       }
     }

--- a/src/fin/test/density_fill_obstruction.tcl
+++ b/src/fin/test/density_fill_obstruction.tcl
@@ -1,0 +1,45 @@
+# Check that density fill honors only obstructions marked for fills.
+source "helpers.tcl"
+
+proc count_fill_overlaps { block layer region } {
+  set count 0
+  foreach fill [$block getFills] {
+    if { [$fill getTechLayer] == $layer } {
+      set rect [$fill getRect]
+      if { [$rect xMin] < [$region xMax]
+        && [$rect xMax] > [$region xMin]
+        && [$rect yMin] < [$region yMax]
+        && [$rect yMax] > [$region yMin] } {
+        incr count
+      }
+    }
+  }
+  return $count
+}
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_def gcd_prefill.def
+
+set block [ord::get_db_block]
+set layer [[ord::get_db_tech] findLayer met2]
+
+set obstruction [create_obstruction -layer met2 -region {258 10 263 18} -fill]
+set fill_obstruction [$obstruction getBBox]
+
+set obstruction [create_obstruction -layer met2 -region {258 30 263 38}]
+set routing_obstruction [$obstruction getBBox]
+
+density_fill -rules fill.json
+
+set fill_overlaps [count_fill_overlaps $block $layer $fill_obstruction]
+if { $fill_overlaps != 0 } {
+  error "$fill_overlaps fills overlap a fill obstruction"
+}
+
+set routing_overlaps [count_fill_overlaps $block $layer $routing_obstruction]
+if { $routing_overlaps == 0 } {
+  error "routing obstruction unexpectedly blocks fills"
+}
+
+puts "pass"


### PR DESCRIPTION
## Summary
Honor block-level fill obstructions when constructing density-fill exclusion regions. The root cause was that orNonFills() included routed wires, special wires, and instance shapes, but omitted dbBlock obstructions.

Only obstructions marked by dbObstruction::isFillObstruction() are excluded. Ordinary routing obstructions remain fillable, matching the issue discussion.

## Type of Change
- Bug fix

## Impact
Density fill now avoids LEF/DEF obstructions marked + FILLS on the target layer. Existing behavior for routing-only obstructions and the public API remains unchanged.

## Verification
- [ ] I have verified that the local build succeeds (./etc/Build.sh). Not run; targeted Bazel builds completed successfully.
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

Tests:
- //:fmt_tcl_test
- //src/fin/test:density_fill_obstruction-tcl_test
- //src/fin/test:gcd_fill-tcl_test
- //src/fin/test:gcd_fill-py_test

The regression test verifies zero fill overlaps for a fill obstruction and permits overlap with a plain routing obstruction.

## Related Issues
Fixes #11285