### PR TITLE
build(Build.sh): stamp the git version into Bazel installs

### DIFF
--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -146,6 +146,9 @@ To embed the real git version (e.g. `26Q1-1486-g6fe48208e4`), use `--config=rele
     bazelisk build --config=release :openroad
     ./bazel-bin/openroad -version
 
+`etc/Build.sh` always passes `--config=release`, so installs made through it
+(including ORFS `build_openroad.sh`) carry the real version.
+
 ## Platforms
 
 https://bazel.build/extending/platforms

--- a/etc/Build.sh
+++ b/etc/Build.sh
@@ -392,7 +392,11 @@ if [[ "$useBazel" == "yes" ]]; then
     if command -v bazelisk &> /dev/null; then
         bazel_cmd="bazelisk"
     fi
-    bazelArgs=("--jobs=${numThreads}")
+    # Build.sh is the install path (ORFS, Docker, packaging). Plain
+    # `bazel build` embeds the "bazel-nostamp" placeholder so dev builds stay
+    # cacheable; --config=release turns on --stamp so `openroad -version`
+    # reports the same `git describe` string the CMake build always did.
+    bazelArgs=("--jobs=${numThreads}" "--config=release")
     if [[ "$bazelLto" == "yes" ]]; then
         bazelArgs+=("--config=opt")
     fi


### PR DESCRIPTION
Build.sh switched its default from CMake to Bazel. The CMake path ran git describe on every configure, so an installed openroad reported a version such as 26Q3-1994-g983a118338. The Bazel path calls bazel build and bazel run //:install with no --stamp, and the OpenRoadVersion genrule then writes the "bazel-nostamp" placeholder. Every install made through Build.sh, including the ORFS build_openroad.sh wrapper, lost the version string.

Pass --config=release from Build.sh. That config sets --stamp, so the workspace status script runs git describe and the header carries the real version. Plain bazel build keeps the placeholder, so developer caches stay valid across commits.