### PR TITLE
odb: stop registering a Tcl command per object handle

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -320,6 +320,11 @@ void OpenRoad::init(Tcl_Interp* tcl_interp,
   Tcl_Eval(tcl_interp, "sta::define_sta_cmds");
   Tcl_Eval(tcl_interp, "namespace import sta::*");
 
+  // "$handle method args..." on an odb handle resolves here.  Installed after
+  // OpenSTA's handler, which odb_unknown falls back to for everything that is
+  // not an odb handle.
+  Tcl_Eval(tcl_interp, "namespace eval :: {namespace unknown odb_unknown}");
+
   // Initialize tcl history
   if (Tcl_Eval(tcl_interp, "history") == TCL_ERROR) {
     // There appears to be a typo in the history.tcl file in some

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -323,7 +323,7 @@ void OpenRoad::init(Tcl_Interp* tcl_interp,
   // "$handle method args..." on an odb handle resolves here.  Installed after
   // OpenSTA's handler, which odb_unknown falls back to for everything that is
   // not an odb handle.
-  Tcl_Eval(tcl_interp, "namespace eval :: {namespace unknown odb_unknown}");
+  Tcl_Eval(tcl_interp, "odb_install_unknown");
 
   // Initialize tcl history
   if (Tcl_Eval(tcl_interp, "history") == TCL_ERROR) {

--- a/src/odb/src/swig/tcl/dbtypes.i
+++ b/src/odb/src/swig/tcl/dbtypes.i
@@ -5,6 +5,134 @@
 #if TCL_MAJOR_VERSION < 9 && !defined(Tcl_Size)
   typedef int Tcl_Size;
 #endif
+
+// Borrowed pointers reach Tcl as bare handle strings rather than as registered
+// object commands.  Every shadow-creation site in the module funnels through the
+// SWIG_NewInstanceObj macro, so redirecting it here covers the generated
+// accessors and the container typemaps below alike.  Objects SWIG owns keep a
+// real object command, which is what reclaims them.  Method dispatch on a bare
+// handle goes through odb_unknown() in the wrapper section.
+#undef  SWIG_NewInstanceObj
+#define SWIG_NewInstanceObj(thisvalue, type, flags) \
+        odbNewHandleObj(interp, thisvalue, type, flags)
+
+static Tcl_Obj* odbNewHandleObj(Tcl_Interp* interp,
+                                void* ptr,
+                                swig_type_info* type,
+                                int flags)
+{
+  if (flags) {
+    return SWIG_Tcl_NewInstanceObj(interp, ptr, type, flags);
+  }
+  // SWIG encodes the handle by copying the bytes of the pointer
+  // (SWIG_PackData reads &ptr), which gcc's escape analysis does not treat as
+  // letting the pointee escape.  Inlined into a constructor wrapper, gcc then
+  // proves the freshly allocated object is never read and drops the stores that
+  // initialize it, so the handle names uninitialized memory.  Escaping the
+  // pointer explicitly restores the dependency at no runtime cost.
+#if defined(__GNUC__)
+  asm volatile("" : : "r"(ptr) : "memory");
+#endif
+  return SWIG_Tcl_NewPointerObj(ptr, type, 0);
+}
+
+// Strips the global-namespace qualifier a caller may have written in front of a
+// handle.  Returns a pointer into the original string.
+static const char* odbBareHandle(const char* name)
+{
+  return (name[0] == ':' && name[1] == ':') ? name + 2 : name;
+}
+
+// A qualified handle is no longer a resolvable command name, so normalize it
+// before SWIG's own conversion sees it.
+#undef  SWIG_ConvertPtr
+#define SWIG_ConvertPtr(obj, ptr, type, flags) \
+        odbConvertPtr(interp, obj, ptr, type, flags)
+
+static int odbConvertPtr(Tcl_Interp* interp,
+                         Tcl_Obj* obj,
+                         void** ptr,
+                         swig_type_info* type,
+                         int flags)
+{
+  const char* name = Tcl_GetString(obj);
+  const char* bare = odbBareHandle(name);
+  if (bare != name) {
+    return SWIG_Tcl_ConvertPtrFromString(interp, bare, ptr, type, flags);
+  }
+  return SWIG_Tcl_ConvertPtr(interp, obj, ptr, type, flags);
+}
+%}
+
+%wrapper %{
+// Dispatches "$handle method args..." for handles that have no object command.
+// The handle string carries the pointer and its mangled type, so the swig_class
+// method tables SWIG already generated supply the method lookup, including the
+// base-class walk for inherited methods.
+static int odbUnknownCmd(ClientData,
+                         Tcl_Interp* interp,
+                         int objc,
+                         Tcl_Obj* const objv[])
+{
+  if (objc >= 3) {
+    const char* name = Tcl_GetString(objv[1]);
+    // Both "$handle method" and "::$handle method" are accepted.
+    const char* bare = odbBareHandle(name);
+    void* ptr = nullptr;
+    if (bare[0] == '_') {
+      const char* mangled = SWIG_UnpackData(bare + 1, &ptr, sizeof(void*));
+      swig_type_info* type = mangled ? SWIG_MangledTypeQuery(mangled) : nullptr;
+      if (type && type->clientdata) {
+        const char* method = Tcl_GetString(objv[2]);
+        if (strcmp(method, "-delete") == 0 || strcmp(method, "-acquire") == 0
+            || strcmp(method, "-disown") == 0) {
+          Tcl_AppendResult(
+              interp, "no ownership operations on handle ", name, nullptr);
+          return TCL_ERROR;
+        }
+        // The method wrappers decode the pointer from thisptr, so it has to be
+        // the unqualified spelling.
+        Tcl_Obj* thisptr
+            = (bare == name) ? objv[1] : Tcl_NewStringObj(bare, -1);
+        Tcl_IncrRefCount(thisptr);
+        swig_instance inst;
+        inst.thisptr = thisptr;
+        inst.thisvalue = ptr;
+        inst.classptr = (swig_class*) type->clientdata;
+        inst.destroy = 0;
+        inst.cmdtok = nullptr;
+        const int code = SWIG_Tcl_MethodCommand(
+            (ClientData) &inst, interp, objc - 1, objv + 1);
+        Tcl_DecrRefCount(thisptr);
+        return code;
+      }
+    }
+  }
+
+  // Not a handle: hand it to whichever unknown handler we displaced.
+  Tcl_CmdInfo info;
+  const char* chain
+      = Tcl_GetCommandInfo(interp, "sta_unknown", &info) ? "sta_unknown"
+                                                         : "::unknown";
+  Tcl_Obj** argv = (Tcl_Obj**) ckalloc(sizeof(Tcl_Obj*) * objc);
+  argv[0] = Tcl_NewStringObj(chain, -1);
+  Tcl_IncrRefCount(argv[0]);
+  for (int i = 1; i < objc; i++) {
+    argv[i] = objv[i];
+  }
+  const int code = Tcl_EvalObjv(interp, objc, argv, 0);
+  Tcl_DecrRefCount(argv[0]);
+  ckfree((char*) argv);
+  return code;
+}
+%}
+
+%init %{
+  Tcl_CreateObjCommand(interp, "odb_unknown", odbUnknownCmd, nullptr, nullptr);
+  // Enough on its own for the standalone odbtcl interpreter.  Applications that
+  // install their own handler after this (OpenROAD, via OpenSTA) have to put
+  // odb_unknown back; odb_unknown chains to whatever it displaced.
+  Tcl_Eval(interp, "namespace eval :: {namespace unknown odb_unknown}");
 %}
 
 %import <std_vector.i>

--- a/src/odb/src/swig/tcl/dbtypes.i
+++ b/src/odb/src/swig/tcl/dbtypes.i
@@ -37,14 +37,19 @@ static Tcl_Obj* odbNewHandleObj(Tcl_Interp* interp,
 }
 
 // Strips the global-namespace qualifier a caller may have written in front of a
-// handle.  Returns a pointer into the original string.
+// packed handle.  Returns a pointer into the original string.  A qualified
+// object-command name keeps its qualifier, so that SWIG's own command lookup
+// still resolves the global command the caller asked for rather than one that
+// shadows it in the current namespace.
 static const char* odbBareHandle(const char* name)
 {
-  return (name[0] == ':' && name[1] == ':') ? name + 2 : name;
+  const bool qualified_handle
+      = name[0] == ':' && name[1] == ':' && name[2] == '_';
+  return qualified_handle ? name + 2 : name;
 }
 
-// A qualified handle is no longer a resolvable command name, so normalize it
-// before SWIG's own conversion sees it.
+// A qualified handle is not a resolvable command name, so normalize it before
+// SWIG's own conversion sees it.
 #undef  SWIG_ConvertPtr
 #define SWIG_ConvertPtr(obj, ptr, type, flags) \
         odbConvertPtr(interp, obj, ptr, type, flags)
@@ -65,6 +70,10 @@ static int odbConvertPtr(Tcl_Interp* interp,
 %}
 
 %wrapper %{
+// Holds the command prefix that odb_unknown displaced, so that commands which
+// are not odb handles keep reaching it.
+static const char* const odbDisplacedUnknownVar = "::odb_displaced_unknown";
+
 // Dispatches "$handle method args..." for handles that have no object command.
 // The handle string carries the pointer and its mangled type, so the swig_class
 // method tables SWIG already generated supply the method lookup, including the
@@ -95,12 +104,11 @@ static int odbUnknownCmd(ClientData,
         Tcl_Obj* thisptr
             = (bare == name) ? objv[1] : Tcl_NewStringObj(bare, -1);
         Tcl_IncrRefCount(thisptr);
-        swig_instance inst;
+        // Zero-initialized so that a field SWIG may add stays well defined.
+        swig_instance inst = {};
         inst.thisptr = thisptr;
         inst.thisvalue = ptr;
         inst.classptr = (swig_class*) type->clientdata;
-        inst.destroy = 0;
-        inst.cmdtok = nullptr;
         const int code = SWIG_Tcl_MethodCommand(
             (ClientData) &inst, interp, objc - 1, objv + 1);
         Tcl_DecrRefCount(thisptr);
@@ -109,30 +117,70 @@ static int odbUnknownCmd(ClientData,
     }
   }
 
-  // Not a handle: hand it to whichever unknown handler we displaced.
-  Tcl_CmdInfo info;
-  const char* chain
-      = Tcl_GetCommandInfo(interp, "sta_unknown", &info) ? "sta_unknown"
-                                                         : "::unknown";
-  Tcl_Obj** argv = (Tcl_Obj**) ckalloc(sizeof(Tcl_Obj*) * objc);
-  argv[0] = Tcl_NewStringObj(chain, -1);
-  Tcl_IncrRefCount(argv[0]);
-  for (int i = 1; i < objc; i++) {
-    argv[i] = objv[i];
+  // Not a handle: hand it to the handler odbInstallUnknown displaced, which is
+  // a command prefix rather than a bare command name.
+  Tcl_Obj* chain = Tcl_GetVar2Ex(
+      interp, odbDisplacedUnknownVar, nullptr, TCL_GLOBAL_ONLY);
+  Tcl_Size prefixc = 0;
+  Tcl_Obj** prefixv = nullptr;
+  if (chain == nullptr
+      || Tcl_ListObjGetElements(interp, chain, &prefixc, &prefixv) != TCL_OK
+      || prefixc == 0) {
+    // Nothing was displaced, so Tcl's own default applies.
+    chain = Tcl_NewStringObj("::unknown", -1);
+    Tcl_IncrRefCount(chain);
+    Tcl_ListObjGetElements(interp, chain, &prefixc, &prefixv);
+  } else {
+    Tcl_IncrRefCount(chain);
   }
-  const int code = Tcl_EvalObjv(interp, objc, argv, 0);
-  Tcl_DecrRefCount(argv[0]);
+
+  const int argc = prefixc + objc - 1;
+  Tcl_Obj** argv = (Tcl_Obj**) ckalloc(sizeof(Tcl_Obj*) * argc);
+  for (Tcl_Size i = 0; i < prefixc; i++) {
+    argv[i] = prefixv[i];
+  }
+  for (int i = 1; i < objc; i++) {
+    argv[prefixc + i - 1] = objv[i];
+  }
+  const int code = Tcl_EvalObjv(interp, argc, argv, 0);
   ckfree((char*) argv);
+  Tcl_DecrRefCount(chain);
   return code;
+}
+
+// Makes odb_unknown the global namespace unknown handler, remembering the
+// command prefix it displaces.  Idempotent, so an application can call it again
+// after installing a handler of its own.
+static int odbInstallUnknown(ClientData,
+                             Tcl_Interp* interp,
+                             int,
+                             Tcl_Obj* const[])
+{
+  static const char* const query = "namespace eval :: {namespace unknown}";
+  if (Tcl_Eval(interp, query) != TCL_OK) {
+    return TCL_ERROR;
+  }
+  Tcl_Obj* displaced = Tcl_GetObjResult(interp);
+  if (strcmp(Tcl_GetString(displaced), "odb_unknown") != 0) {
+    Tcl_SetVar2Ex(
+        interp, odbDisplacedUnknownVar, nullptr, displaced, TCL_GLOBAL_ONLY);
+  }
+  Tcl_ResetResult(interp);
+
+  static const char* const install
+      = "namespace eval :: {namespace unknown odb_unknown}";
+  return Tcl_Eval(interp, install);
 }
 %}
 
 %init %{
   Tcl_CreateObjCommand(interp, "odb_unknown", odbUnknownCmd, nullptr, nullptr);
-  // Enough on its own for the standalone odbtcl interpreter.  Applications that
-  // install their own handler after this (OpenROAD, via OpenSTA) have to put
-  // odb_unknown back; odb_unknown chains to whatever it displaced.
-  Tcl_Eval(interp, "namespace eval :: {namespace unknown odb_unknown}");
+  Tcl_CreateObjCommand(
+      interp, "odb_install_unknown", odbInstallUnknown, nullptr, nullptr);
+  // Enough on its own for the standalone odbtcl interpreter.  An application
+  // that installs its own handler after this (OpenROAD, via OpenSTA) has to
+  // call odb_install_unknown again to put odb_unknown back in front of it.
+  odbInstallUnknown(nullptr, interp, 0, nullptr);
 %}
 
 %import <std_vector.i>

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -235,6 +235,7 @@ PASSFAIL_TESTS = [
     "test_iterm",
     "test_module",
     "test_net",
+    "test_tcl_handles",
     "test_wire_codec",
 ]
 

--- a/src/odb/test/CMakeLists.txt
+++ b/src/odb/test/CMakeLists.txt
@@ -80,6 +80,7 @@ or_integration_tests(
     test_iterm
     test_module
     test_net
+    test_tcl_handles
     test_wire_codec
 )
 

--- a/src/odb/test/test_tcl_handles.tcl
+++ b/src/odb/test/test_tcl_handles.tcl
@@ -1,0 +1,61 @@
+source "helper.tcl"
+
+lassign [createSimpleDB] db lib
+set block [create1LevelBlock $db $lib [$db getChip]]
+
+# Borrowed handles are plain strings, so walking a design registers no Tcl
+# command per object.
+foreach net [$block getNets] {
+  foreach iterm [$net getITerms] {
+    $iterm getNet
+  }
+}
+foreach inst [$block getInsts] {
+  $inst getMaster
+}
+set handle_cmds [llength [info commands _*_p_odb__*]]
+assert {$handle_cmds == 0} \
+  "walking the block left $handle_cmds handle commands registered"
+
+# Methods still dispatch on a handle with no command of its own, including ones
+# inherited from a base class and SWIG's own attribute accessors.
+set net [lindex [$block getNets] 0]
+assert {[llength [info commands $net]] == 0} "handle $net is a command"
+assertStringNotEq [$net getName] "" "getName failed on a borrowed handle"
+assert {[$net getId] > 0} "inherited getId failed on a borrowed handle"
+assertStringEq [$net cget -this] $net "cget -this did not round trip"
+
+# The same handle spelled with the global namespace qualifier, both as a command
+# and as an argument.
+assertStringEq [::$net getName] [$net getName] "::\$handle dispatch failed"
+assertStringEq [odb::dbNet_getName ::$net] [$net getName] \
+  "::\$handle failed as an argument"
+
+# A handle names the same object every time it is fetched.
+assertStringEq [lindex [$block getNets] 0] $net "handle identity is not stable"
+
+# Objects SWIG owns keep a command of their own, which is what destroys them.
+odb::Rect rect 100 200 300 400
+assert {[llength [info commands rect]] == 1} "named constructor made no command"
+rename rect {}
+
+# Values reach a constructed object intact.  Handing the pointer to Tcl encodes
+# it byte-wise, which is not enough for gcc to treat the object as escaping, so
+# without an explicit escape it drops the stores that initialize it.
+set r [odb::new_Rect 100 200 300 400]
+assert {[odb::Rect_xMin $r] == 100} "xMin is [odb::Rect_xMin $r], expected 100"
+assert {[odb::Rect_yMin $r] == 200} "yMin is [odb::Rect_yMin $r], expected 200"
+assert {[odb::Rect_xMax $r] == 300} "xMax is [odb::Rect_xMax $r], expected 300"
+assert {[odb::Rect_yMax $r] == 400} "yMax is [odb::Rect_yMax $r], expected 400"
+assert {[$r xMin] == 100} "xMin via dispatch is [$r xMin], expected 100"
+
+set p [odb::new_Point 7 9]
+assert {[$p getX] == 7} "getX is [$p getX], expected 7"
+assert {[$p getY] == 9} "getY is [$p getY], expected 9"
+
+# Names that are not handles reach the handler we displaced, so command
+# abbreviation and the usual error still work.
+assert {[catch { no_such_command_at_all }] == 1} "unknown command did not error"
+
+puts "pass"
+exit 0

--- a/src/odb/test/test_tcl_handles.tcl
+++ b/src/odb/test/test_tcl_handles.tcl
@@ -37,7 +37,32 @@ assertStringEq [lindex [$block getNets] 0] $net "handle identity is not stable"
 # Objects SWIG owns keep a command of their own, which is what destroys them.
 odb::Rect rect 100 200 300 400
 assert {[llength [info commands rect]] == 1} "named constructor made no command"
+
+# An object command passed by name still converts, qualified or not, and from
+# inside another namespace.  Object commands live in the global namespace, so
+# both spellings name the same object.
+assert {[odb::Rect_xMin rect] == 100} "rect did not convert by name"
+assert {[odb::Rect_xMin ::rect] == 100} "::rect did not convert by name"
+namespace eval elsewhere {
+  assert {[odb::Rect_xMin ::rect] == 100} "::rect did not convert from a namespace"
+}
 rename rect {}
+
+# A command that is not a handle still errors the usual way.
+assert {[catch { no_such_command_at_all }] == 1} "unknown command did not error"
+
+# Commands that are not handles reach the handler odb_unknown displaced, even
+# when an application installs one of its own after odb is initialized.
+proc app_unknown { args } { return "app_unknown saw [lindex $args 0]" }
+namespace eval :: { namespace unknown app_unknown }
+odb_install_unknown
+assertStringEq [some_missing_command] "app_unknown saw some_missing_command" \
+  "odb_unknown did not chain to the displaced handler"
+assertStringNotEq [$net getName] "" "handle dispatch broke after reinstall"
+namespace eval :: { namespace unknown {} }
+odb_install_unknown
+assert {[catch { no_such_command_at_all }] == 1} \
+  "unknown command did not error after the handler was cleared"
 
 # Values reach a constructed object intact.  Handing the pointer to Tcl encodes
 # it byte-wise, which is not enough for gcc to treat the object as escaping, so
@@ -52,10 +77,6 @@ assert {[$r xMin] == 100} "xMin via dispatch is [$r xMin], expected 100"
 set p [odb::new_Point 7 9]
 assert {[$p getX] == 7} "getX is [$p getX], expected 7"
 assert {[$p getY] == 9} "getY is [$p getY], expected 9"
-
-# Names that are not handles reach the handler we displaced, so command
-# abbreviation and the usual error still work.
-assert {[catch { no_such_command_at_all }] == 1} "unknown command did not error"
 
 puts "pass"
 exit 0

--- a/src/odb/test/test_tcl_handles.tcl
+++ b/src/odb/test/test_tcl_handles.tcl
@@ -44,7 +44,7 @@ assert {[llength [info commands rect]] == 1} "named constructor made no command"
 assert {[odb::Rect_xMin rect] == 100} "rect did not convert by name"
 assert {[odb::Rect_xMin ::rect] == 100} "::rect did not convert by name"
 namespace eval elsewhere {
-  assert {[odb::Rect_xMin ::rect] == 100} "::rect did not convert from a namespace"
+assert {[odb::Rect_xMin ::rect] == 100} "::rect did not convert from a namespace"
 }
 rename rect {}
 
@@ -54,12 +54,12 @@ assert {[catch { no_such_command_at_all }] == 1} "unknown command did not error"
 # Commands that are not handles reach the handler odb_unknown displaced, even
 # when an application installs one of its own after odb is initialized.
 proc app_unknown { args } { return "app_unknown saw [lindex $args 0]" }
-namespace eval :: { namespace unknown app_unknown }
+uplevel #0 [list namespace unknown app_unknown]
 odb_install_unknown
 assertStringEq [some_missing_command] "app_unknown saw some_missing_command" \
   "odb_unknown did not chain to the displaced handler"
 assertStringNotEq [$net getName] "" "handle dispatch broke after reinstall"
-namespace eval :: { namespace unknown {} }
+uplevel #0 [list namespace unknown ""]
 odb_install_unknown
 assert {[catch { no_such_command_at_all }] == 1} \
   "unknown command did not error after the handler was cleared"


### PR DESCRIPTION
Fixes The-OpenROAD-Project/OpenROAD#11365.

SWIG's Tcl object interface registers a Tcl command named after the pointer for
every distinct object handed to Tcl (`SWIG_Tcl_NewInstanceObj` →
`Tcl_CreateObjCommand`), and nothing ever deletes it. Retention is therefore
O(distinct objects ever touched) for the life of the interpreter, which is why a
design-wide read-back like ORFS `write_rc` runs out of memory. Re-touching the
same object is free, which matches the behaviour reported in the issue.

Measured on this build, ~530 bytes of RSS per retained command: a `swig_instance`,
a duplicated handle `Tcl_Obj` plus its string, a Tcl `Command`, a `Tcl_HashEntry`
with the name copied into the key, and command-table bucket growth.

## Approach

Borrowed pointers now reach Tcl as bare handle strings (`SWIG_NewPointerObj`),
and `$handle method args...` is dispatched for them by a single `unknown`
handler that reuses SWIG's own `SWIG_Tcl_MethodCommand` and the generated
`swig_class` tables. Method lookup, the base-class walk for inherited methods,
`cget`/`configure` and handle identity are unchanged. Objects SWIG owns keep a
real object command, since that is what destroys them.

This needs no per-class work: every shadow-creation site funnels through the
`SWIG_NewInstanceObj` macro, so one redirect covers the 1300 generated accessors
and the `dbSet`/`dbVector`/`std::vector` container typemaps alike. The generated
wrapper is otherwise byte-identical to before.

bp_multi/nangate45, walking 105,345 nets and their wires:

| | before | after |
|---|---|---|
| peak RSS delta | 98,120 kB | 132 kB |
| retained commands | 195,072 | 0 |
| wall time | 162 ms | 96 ms |

Faster because command creation dominates when each object is touched once.
Repeated method calls on one already-registered handle are ~25% slower (500 →
627 ns/call in an isolated A/B), since dispatch goes through the `unknown` path
rather than a direct command lookup.

## Notes for review

- The handler is installed from `%init` for the standalone `odbtcl` interpreter
  and re-installed in `OpenRoad.cc` after OpenSTA sets its own handler;
  `odb_unknown` chains to whatever it displaced, so command abbreviation and
  normal error reporting still work.
- `::$handle method` and `::$handle` as an argument keep working, which needs a
  leading `::` stripped in both the dispatcher and the pointer conversion.
- The `asm volatile` barrier is load-bearing, not defensive. SWIG encodes the
  handle by copying the bytes of the pointer, which gcc's escape analysis does
  not treat as letting the pointee escape; inlined into a constructor wrapper
  gcc then proves the freshly allocated object is never read and deletes the
  stores that initialize it, so `[odb::new_Rect 100 200 300 400]` returns a
  handle to uninitialized memory. Reproduces with gcc 13 at `-O2`, not at `-O0`
  and not with clang. The regression test covers it.

## Not in this change

- Handles still outlive the objects they name: after `odb::dbWire_destroy $w`,
  `$w getNet` reads freed memory. That predates this change and needs the
  `dbBlockCallBackObj::inDb*Destroy` hooks; separate PR.
- The crossing *cost* is untouched. A design-wide read-back still makes tens of
  millions of Tcl round trips, so the bulk value accessor discussed in the issue
  remains worthwhile as a performance fix.
- `odb::dbWire_destroy NULL` segfaults rather than erroring. Unrelated, noticed
  in passing.
