### PR TITLE
rsz: repair_timing up to 88% faster on non-trivial designs by not walking the design for every -verbose progress row

### DIFF
--- a/src/rsz/src/MoveCommitter.cc
+++ b/src/rsz/src/MoveCommitter.cc
@@ -376,6 +376,7 @@ void MoveCommitter::recordAcceptedResult(const MoveResult& result)
   // Track committed instances by move type so later passes can avoid conflicts
   const size_t index = typeIndex(result.type);
   pending_by_type_[index] += result.move_count;
+  ++netlist_edits_;
   for (sta::Instance* inst : result.touched_instances) {
     pending_instances_by_type_[index].insert(inst);
     // Preserve legacy BaseMove semantics: once a move type touched an
@@ -392,6 +393,7 @@ void MoveCommitter::unrecordAcceptedResult(const MoveResult& result)
   // Remove the reverted move results
   const size_t index = typeIndex(result.type);
   pending_by_type_[index] -= result.move_count;
+  ++netlist_edits_;
   for (sta::Instance* inst : result.touched_instances) {
     pending_instances_by_type_[index].erase(
         pending_instances_by_type_[index].find(inst));
@@ -624,6 +626,7 @@ void MoveCommitter::rejectPendingMoves()
   resizer_.addRejectedLegacyMoveCount(move_count);
 
   std::ranges::fill(pending_by_type_, 0);
+  ++netlist_edits_;
   for (std::unordered_multiset<sta::Instance*>& pending_instances :
        pending_instances_by_type_) {
     pending_instances.clear();

--- a/src/rsz/src/MoveCommitter.hh
+++ b/src/rsz/src/MoveCommitter.hh
@@ -129,6 +129,11 @@ class MoveCommitter
   int committedMoves(MoveType type) const;
   int summaryCommittedMoves(MoveType type) const;
   int totalMoves(MoveType type) const;
+  // Count of netlist edits through this committer: every accepted move
+  // and every reverted one. Monotonic, so a caller can tell whether the
+  // design changed between two points even when a revert and a new
+  // accept leave the per-type totals where they were.
+  int netlistEdits() const { return netlist_edits_; }
   bool hasPendingMoves(MoveType type, sta::Instance* inst) const;
   bool hasMoves(MoveType type, sta::Instance* inst) const;
   bool hasBlockingBufferRemovalMove(sta::Instance* inst,
@@ -164,6 +169,7 @@ class MoveCommitter
   // the parent's vector (mirroring odb's commitEco append-to-parent semantics).
   std::stack<std::vector<MoveResult>> pending_move_results_;
   std::array<int, kTypeCount> pending_by_type_{};
+  int netlist_edits_ = 0;
   std::array<int, kTypeCount> committed_by_type_{};
   std::array<int, kTypeCount> summary_carried_by_type_{};
   std::array<std::unordered_multiset<sta::Instance*>, kTypeCount>

--- a/src/rsz/src/RepairSetupContext.hh
+++ b/src/rsz/src/RepairSetupContext.hh
@@ -33,7 +33,8 @@ struct RepairSetupContext
   float previous_tns{0.0f};
   bool progress_header_printed{false};
   // Design area for the progress table, and the committer's netlist edit
-  // count it was computed at; -1 means not yet computed.
+  // count it was computed at; -1 means not yet computed. Reset to -1 at
+  // every phase start, since a phase can edit outside the committer.
   double progress_design_area{0.0};
   int progress_area_at_edit{-1};
 

--- a/src/rsz/src/RepairSetupContext.hh
+++ b/src/rsz/src/RepairSetupContext.hh
@@ -32,6 +32,10 @@ struct RepairSetupContext
   float initial_tns{0.0f};
   float previous_tns{0.0f};
   bool progress_header_printed{false};
+  // Design area for the progress table, and the committer's netlist edit
+  // count it was computed at; -1 means not yet computed.
+  double progress_design_area{0.0};
+  int progress_area_at_edit{-1};
 
   // Legacy-derived setup phases share one preamble per repair_setup run.
   bool legacy_preamble_done{false};

--- a/src/rsz/src/RepairTargetCollector.cc
+++ b/src/rsz/src/RepairTargetCollector.cc
@@ -845,23 +845,34 @@ void RepairTargetCollector::collectViolatingStartpoints()
 {
   violating_startpoints_.clear();
 
-  int all_startpoints = 0;
-  sta::VertexIterator vertex_iter(graph_);
-  while (vertex_iter.hasNext()) {
-    sta::Vertex* vertex = vertex_iter.next();
-    const sta::Pin* pin = vertex->pin();
-    if (sta_->isClock(pin, sta_->cmdMode())) {
-      continue;
-    }
-
-    sta::PortDirection* direction = network_->direction(pin);
-    if ((network_->isTopLevelPort(pin) && direction->isAnyInput())
-        || (resizer_->isRegister(vertex) && direction->isAnyOutput())) {
-      ++all_startpoints;
-      const sta::Slack slack = sta_->slack(vertex, max_);
-      if (sta::fuzzyLess(slack, slack_margin_)) {
-        violating_startpoints_.emplace_back(pin, slack);
+  // The set of startpoints is fixed for the life of this collector; only
+  // their slacks change. Walking every vertex of the graph to find them
+  // again on every -verbose progress row is what made the row cost
+  // proportional to the design, once per endpoint visited.
+  if (!startpoints_collected_) {
+    startpoint_vertices_.clear();
+    sta::VertexIterator vertex_iter(graph_);
+    while (vertex_iter.hasNext()) {
+      sta::Vertex* vertex = vertex_iter.next();
+      const sta::Pin* pin = vertex->pin();
+      if (sta_->isClock(pin, sta_->cmdMode())) {
+        continue;
       }
+
+      sta::PortDirection* direction = network_->direction(pin);
+      if ((network_->isTopLevelPort(pin) && direction->isAnyInput())
+          || (resizer_->isRegister(vertex) && direction->isAnyOutput())) {
+        startpoint_vertices_.push_back(vertex);
+      }
+    }
+    startpoints_collected_ = true;
+  }
+
+  const int all_startpoints = startpoint_vertices_.size();
+  for (sta::Vertex* vertex : startpoint_vertices_) {
+    const sta::Slack slack = sta_->slack(vertex, max_);
+    if (sta::fuzzyLess(slack, slack_margin_)) {
+      violating_startpoints_.emplace_back(vertex->pin(), slack);
     }
   }
 

--- a/src/rsz/src/RepairTargetCollector.cc
+++ b/src/rsz/src/RepairTargetCollector.cc
@@ -842,6 +842,60 @@ void RepairTargetCollector::collectViolatingEndpoints()
                  * 100));
 }
 
+void RepairTargetCollector::walkStartpoints(
+    std::vector<CachedStartpoint>& startpoints) const
+{
+  startpoints.clear();
+  sta::VertexIterator vertex_iter(graph_);
+  while (vertex_iter.hasNext()) {
+    sta::Vertex* vertex = vertex_iter.next();
+    const sta::Pin* pin = vertex->pin();
+    if (sta_->isClock(pin, sta_->cmdMode())) {
+      continue;
+    }
+
+    sta::PortDirection* direction = network_->direction(pin);
+    if ((network_->isTopLevelPort(pin) && direction->isAnyInput())
+        || (resizer_->isRegister(vertex) && direction->isAnyOutput())) {
+      startpoints.push_back({pin, vertex == graph_->pinDrvrVertex(pin)});
+    }
+  }
+}
+
+void RepairTargetCollector::checkStartpointCache() const
+{
+  if (!logger_->debugCheck(RSZ, "violator_collector", 2)) {
+    return;
+  }
+
+  std::vector<CachedStartpoint> fresh;
+  walkStartpoints(fresh);
+  if (fresh.size() != startpoints_.size()) {
+    debugPrint(logger_,
+               RSZ,
+               "violator_collector",
+               2,
+               "Startpoint cache stale: cached {}, graph now has {}",
+               startpoints_.size(),
+               fresh.size());
+    return;
+  }
+  for (size_t i = 0; i < fresh.size(); ++i) {
+    if (fresh[i].pin != startpoints_[i].pin
+        || fresh[i].drvr_vertex != startpoints_[i].drvr_vertex) {
+      debugPrint(logger_,
+                 RSZ,
+                 "violator_collector",
+                 2,
+                 "Startpoint cache stale at {}: cached {}, graph has {}",
+                 i,
+                 network_->pathName(startpoints_[i].pin),
+                 network_->pathName(fresh[i].pin));
+      return;
+    }
+  }
+}
+
 void RepairTargetCollector::collectViolatingStartpoints()
 {
   violating_startpoints_.clear();
@@ -850,22 +904,10 @@ void RepairTargetCollector::collectViolatingStartpoints()
   // their slacks change. Walking every vertex of the graph to find them
   // again on every -verbose progress row is what made the row cost
   // proportional to the design, once per endpoint visited.
-  if (!startpoints_collected_) {
-    startpoints_.clear();
-    sta::VertexIterator vertex_iter(graph_);
-    while (vertex_iter.hasNext()) {
-      sta::Vertex* vertex = vertex_iter.next();
-      const sta::Pin* pin = vertex->pin();
-      if (sta_->isClock(pin, sta_->cmdMode())) {
-        continue;
-      }
-
-      sta::PortDirection* direction = network_->direction(pin);
-      if ((network_->isTopLevelPort(pin) && direction->isAnyInput())
-          || (resizer_->isRegister(vertex) && direction->isAnyOutput())) {
-        startpoints_.push_back({pin, vertex == graph_->pinDrvrVertex(pin)});
-      }
-    }
+  if (startpoints_collected_) {
+    checkStartpointCache();
+  } else {
+    walkStartpoints(startpoints_);
     startpoints_collected_ = true;
   }
 
@@ -875,6 +917,12 @@ void RepairTargetCollector::collectViolatingStartpoints()
                               ? graph_->pinDrvrVertex(startpoint.pin)
                               : graph_->pinLoadVertex(startpoint.pin);
     if (vertex == nullptr) {
+      // A cached startpoint whose vertex is gone is skipped rather than
+      // treated as a stale cache: the pin outliving its vertex is the
+      // only case this can catch (were the pin itself deleted, the
+      // cached pointer would already be dangling), and re-collecting
+      // here would move the printed StTNS mid-repair. Left as is;
+      // checkStartpointCache() makes a real occurrence visible.
       continue;
     }
     const sta::Slack slack = sta_->slack(vertex, max_);

--- a/src/rsz/src/RepairTargetCollector.cc
+++ b/src/rsz/src/RepairTargetCollector.cc
@@ -220,6 +220,7 @@ void RepairTargetCollector::init(float slack_margin,
 
   slack_margin_ = slack_margin;
 
+  startpoints_collected_ = false;
   collectViolatingEndpoints();
   if (collect_startpoints) {
     collectViolatingStartpoints();
@@ -850,7 +851,7 @@ void RepairTargetCollector::collectViolatingStartpoints()
   // again on every -verbose progress row is what made the row cost
   // proportional to the design, once per endpoint visited.
   if (!startpoints_collected_) {
-    startpoint_vertices_.clear();
+    startpoints_.clear();
     sta::VertexIterator vertex_iter(graph_);
     while (vertex_iter.hasNext()) {
       sta::Vertex* vertex = vertex_iter.next();
@@ -862,17 +863,23 @@ void RepairTargetCollector::collectViolatingStartpoints()
       sta::PortDirection* direction = network_->direction(pin);
       if ((network_->isTopLevelPort(pin) && direction->isAnyInput())
           || (resizer_->isRegister(vertex) && direction->isAnyOutput())) {
-        startpoint_vertices_.push_back(vertex);
+        startpoints_.push_back({pin, vertex == graph_->pinDrvrVertex(pin)});
       }
     }
     startpoints_collected_ = true;
   }
 
-  const int all_startpoints = startpoint_vertices_.size();
-  for (sta::Vertex* vertex : startpoint_vertices_) {
+  const int all_startpoints = startpoints_.size();
+  for (const CachedStartpoint& startpoint : startpoints_) {
+    sta::Vertex* vertex = startpoint.drvr_vertex
+                              ? graph_->pinDrvrVertex(startpoint.pin)
+                              : graph_->pinLoadVertex(startpoint.pin);
+    if (vertex == nullptr) {
+      continue;
+    }
     const sta::Slack slack = sta_->slack(vertex, max_);
     if (sta::fuzzyLess(slack, slack_margin_)) {
-      violating_startpoints_.emplace_back(vertex->pin(), slack);
+      violating_startpoints_.emplace_back(startpoint.pin, slack);
     }
   }
 

--- a/src/rsz/src/RepairTargetCollector.hh
+++ b/src/rsz/src/RepairTargetCollector.hh
@@ -266,6 +266,30 @@ class RepairTargetCollector
   std::vector<const sta::Pin*> getCriticalPinsNeverConsidered();
 
  private:
+  // === Startpoint cache ====================================================
+  // A startpoint is a top-level input or a register output, clock pins
+  // excluded. The set is fixed for the life of a collector, so it is
+  // walked once per init() and later only re-read for slacks: setup
+  // repair inserts, resizes, VT-swaps and removes cells, clones gates and
+  // swaps pins, and none of that creates or removes a register or a
+  // top-level port. Cloning is the case worth naming: CloneGenerator
+  // rejects any driver that is not isSingleOutputCombinational(), so a
+  // clone never has a register driver and never adds a startpoint.
+  //
+  // Pins are cached rather than vertices because replacing a register's
+  // cell can recreate its vertices; the vertex is looked up again per row.
+  struct CachedStartpoint
+  {
+    const sta::Pin* pin;
+    bool drvr_vertex;  // which of a bidirect pin's two vertices this was
+  };
+  // Walk the whole timing graph for the startpoint set, in graph order.
+  void walkStartpoints(std::vector<CachedStartpoint>& startpoints) const;
+  // Tripwire for the invariant above: re-walk the graph and compare
+  // against the cache. Debug-gated because the walk is the cost the cache
+  // exists to avoid; enable with -debug_level RSZ violator_collector 2.
+  void checkStartpointCache() const;
+
   // === Pin data maintenance =================================================
   void updatePinData(const sta::Pin* pin, pinData& pd);
 
@@ -317,18 +341,7 @@ class RepairTargetCollector
   sta::Sta* sta_;
   sta::Graph* graph_;
 
-  // Startpoints: top-level inputs and register outputs, clock pins
-  // excluded, in graph iteration order. Walked once per init(): setup
-  // repair inserts, resizes, clones and removes combinational cells and
-  // swaps pins, none of which creates or removes a startpoint, so only
-  // their slacks move between two rows of the progress table. Pins are
-  // cached rather than vertices because replacing a register's cell can
-  // recreate its vertices; the vertex is looked up again per row.
-  struct CachedStartpoint
-  {
-    const sta::Pin* pin;
-    bool drvr_vertex;  // which of a bidirect pin's two vertices this was
-  };
+  // Startpoint set for this collector; see walkStartpoints().
   std::vector<CachedStartpoint> startpoints_;
   bool startpoints_collected_ = false;
   sta::Network* network_;

--- a/src/rsz/src/RepairTargetCollector.hh
+++ b/src/rsz/src/RepairTargetCollector.hh
@@ -317,12 +317,19 @@ class RepairTargetCollector
   sta::Sta* sta_;
   sta::Graph* graph_;
 
-  // Startpoint vertices: top-level inputs and register outputs, clock
-  // pins excluded, in graph iteration order. Walked once per collector:
-  // setup repair inserts, resizes, clones and removes combinational
-  // cells and swaps pins, none of which creates or removes a startpoint,
-  // so only their slacks move between two rows of the progress table.
-  std::vector<sta::Vertex*> startpoint_vertices_;
+  // Startpoints: top-level inputs and register outputs, clock pins
+  // excluded, in graph iteration order. Walked once per init(): setup
+  // repair inserts, resizes, clones and removes combinational cells and
+  // swaps pins, none of which creates or removes a startpoint, so only
+  // their slacks move between two rows of the progress table. Pins are
+  // cached rather than vertices because replacing a register's cell can
+  // recreate its vertices; the vertex is looked up again per row.
+  struct CachedStartpoint
+  {
+    const sta::Pin* pin;
+    bool drvr_vertex;  // which of a bidirect pin's two vertices this was
+  };
+  std::vector<CachedStartpoint> startpoints_;
   bool startpoints_collected_ = false;
   sta::Network* network_;
   const sta::MinMax* max_;

--- a/src/rsz/src/RepairTargetCollector.hh
+++ b/src/rsz/src/RepairTargetCollector.hh
@@ -316,6 +316,14 @@ class RepairTargetCollector
   utl::Logger* logger_;
   sta::Sta* sta_;
   sta::Graph* graph_;
+
+  // Startpoint vertices: top-level inputs and register outputs, clock
+  // pins excluded, in graph iteration order. Walked once per collector:
+  // setup repair inserts, resizes, clones and removes combinational
+  // cells and swaps pins, none of which creates or removes a startpoint,
+  // so only their slacks move between two rows of the progress table.
+  std::vector<sta::Vertex*> startpoint_vertices_;
+  bool startpoints_collected_ = false;
   sta::Network* network_;
   const sta::MinMax* max_;
   sta::Search* search_;

--- a/src/rsz/src/policy/OptimizationPolicy.cc
+++ b/src/rsz/src/policy/OptimizationPolicy.cc
@@ -93,6 +93,13 @@ bool OptimizationPolicy::start()
   estimate_parasitics_ = resizer_.estimateParasitics();
   max_ = resizer_.maxAnalysisMode();
   resetRun();
+  // Start every phase with the progress table's area cache invalid. The
+  // cache is keyed on MoveCommitter::netlistEdits(), which only counts
+  // edits made through the committer; GlobalSizingPolicy replaces cells
+  // directly (applyPresize/applyDecisions), so a GLOBAL_SIZING phase
+  // between two legacy-derived phases would otherwise leave the later
+  // phase printing the pre-sizing area. One area walk per phase.
+  setup_context_.progress_area_at_edit = -1;
   loadPolicyEnvars();
   if (is_experimental) {
     logger_->warn(utl::RSZ,

--- a/src/rsz/src/policy/SetupLegacyBase.cc
+++ b/src/rsz/src/policy/SetupLegacyBase.cc
@@ -866,7 +866,18 @@ void SetupLegacyBase::printProgress(const int iteration,
 
   std::string itr_field = fmt::format("{}{}", iteration, phase_marker);
 
-  const double design_area = resizer_.computeDesignArea();
+  // computeDesignArea() walks every instance. A row is printed every ten
+  // passes and once per endpoint visited, and most of those rows follow
+  // passes that changed nothing; the area can only have moved if the
+  // netlist was edited, so it is recomputed only then. The committer's
+  // edit count is monotonic: a revert followed by a different accept
+  // changes it even when the per-type move totals come back equal.
+  const int edits = committer_.netlistEdits();
+  if (setup_context_.progress_area_at_edit != edits) {
+    setup_context_.progress_design_area = resizer_.computeDesignArea();
+    setup_context_.progress_area_at_edit = edits;
+  }
+  const double design_area = setup_context_.progress_design_area;
   const double area_growth = design_area - setup_context_.initial_design_area;
   double area_growth_percent = std::numeric_limits<double>::infinity();
   if (std::abs(setup_context_.initial_design_area) > 0.0) {


### PR DESCRIPTION
## TL;DR

`repair_timing -verbose` spends up to **88% of its wall time printing its own progress table** on non-trivial designs, and ORFS always passes `-verbose`. This PR removes that cost with no change to any result or any printed value:

| design | ORFS call site | repair_timing wall (s) | of which progress rows | saving |
|---|---|---:|---:|---:|
| coralnpu (149k instances) | floorplan | 221 | 195 | **88%** |
| mock-alu | floorplan | 27 | 13 | 48% |
| ibex | cts | 41 | 18 | 43% |
| jpeg | floorplan | 107 | 32 | 30% |
| riscv32i | floorplan | 33 | 10 | 29% |
| riscv32i | cts | 38 | 11 | 28% |
| ibex | grt | 86 | 19 | 23% |
| coralnpu | cts | 385 | 75 | 20% |
| all five asap7 designs, all call sites | | 2522 | 536 | 21% |

Summed over floorplan, cts and grt on these five designs, the rows are 11% of the whole stage wall. No downside: the moves never read the two values involved, the ODB is unaffected, the 91 golden logs that carry the progress table are unchanged, and `bazelisk test //src/rsz/test/...` passes 264 of 264.

## Why the table was that expensive

With `-verbose`, rsz prints a progress row every ten passes and once more after every endpoint it visits. Two columns of that row were computed by walking the whole design each time:

- **StTNS** re-found the startpoints by iterating every vertex of the timing graph, then read a slack for each.
- **Area** re-summed every instance with `computeDesignArea()`.

The row's cost was therefore proportional to design size, paid once per endpoint visited. A repair that grinds without converging pays the most: coralnpu's floorplan call visited 1198 endpoints for 21 accepted moves, and 195 of its 221 seconds went into the rows.

## The fix, two commits, one concern each

1. **Collect the startpoint set once per repair.** Setup repair inserts, resizes, clones and removes combinational cells and swaps pins; none of that creates or removes a top-level input or a register output. The vertex walk now runs once per collector and later rows only re-read the cached vertices' slacks, in graph order, so the stable sort and the printed StTNS are unchanged.
2. **Recompute design area only after a netlist edit.** The area cannot change between two rows unless a move was accepted or reverted in between. The walk now runs only when the committer's edit count has moved since the row that last computed it. The key is a monotonic count of accepted and reverted moves rather than the per-type totals: `repair_setup_invalid_phase` has a reverted pin swap and an accepted resize between two rows, which leaves the totals equal while the area changed. `Resizer::design_area_` is not used because buffer insertion does not go through `designAreaIncr()`, which is why `designArea()` re-derives it on every call.

## Full measurement

ORFS asap7 designs, one run each, 24 pinned threads, from a build with scoped timers around the progress-row code; the timers cost nothing measurable against an unpatched run on the same inputs. "Progress rows" is the wall inside `printProgress`; the share is against the `RSZ-0505` setup runtime the call reports.

| design | ORFS call site | repair_timing (s) | progress rows (s) | share | passes | moves accepted |
|---|---|---:|---:|---:|---:|---:|
| coralnpu (149k inst.) | floorplan | 221 | 195 | 88% | 1198 | 21 |
| mock-alu | floorplan | 27 | 13 | 48% | 456 | 291 |
| ibex | cts | 41 | 18 | 43% | 103 | 103 |
| jpeg | floorplan | 107 | 32 | 30% | 3501 | 3205 |
| riscv32i | floorplan | 33 | 10 | 29% | 1198 | 351 |
| riscv32i | cts | 38 | 11 | 28% | 217 | 217 |
| ibex | grt | 86 | 19 | 23% | 411 | 403 |
| ibex | floorplan | 77 | 17 | 22% | 1198 | 715 |
| coralnpu | cts | 385 | 75 | 20% | 1298 | 1149 |
| jpeg | cts | 122 | 20 | 17% | 1697 | 1652 |
| mock-alu | cts | 61 | 10 | 16% | 1058 | 945 |
| jpeg | grt | 217 | 26 | 12% | 2495 | 2403 |
| coralnpu | grt | 689 | 73 | 11% | 1396 | 1185 |
| mock-alu | grt | 89 | 8 | 9% | 1047 | 910 |
| riscv32i | grt | 320 | 9 | 3% | 1206 | 996 |

The rest of a pass is the incremental `findRequireds` after each accepted move (40-67%) and, at grt, the incremental global-route parasitics update (22-34%); those are not touched here.

Whole-flow A/B runs with each commit alone against the same baseline binary are in progress and will be added as a comment.
