### PR TITLE
psm: expand pin vias into per-layer boxes in the short check

### DIFF
--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -646,6 +646,21 @@ IRSolver::LayerPolygons IRSolver::getMasterTerms(odb::dbMTerm* mterm) const
           odb::geom::toPolygonSet(pin->getPolygon()));
     }
     for (odb::dbBox* pin : mpin->getGeometry(false)) {
+      if (pin->isVia()) {
+        // a via has no layer of its own, expand it into the boxes it
+        // holds on each layer
+        std::vector<odb::dbShape> via_boxes;
+        pin->getViaBoxes(via_boxes);
+        for (const odb::dbShape& via_box : via_boxes) {
+          odb::dbTechLayer* layer = via_box.getTechLayer();
+          if (layer == nullptr) {
+            // via box
+            continue;
+          }
+          terms[layer].insert(odb::geom::toPolygonSet(via_box.getBox()));
+        }
+        continue;
+      }
       terms[pin->getTechLayer()].insert(odb::geom::toPolygonSet(pin->getBox()));
     }
   }
@@ -694,6 +709,24 @@ IRSolver::LayerPolygons IRSolver::getMasterObstructions(
             odb::geom::toPolygonSet(geom->getPolygon()) + 1);
       }
       for (odb::dbBox* geom : mpin->getGeometry(false)) {
+        if (geom->isVia()) {
+          // a via has no layer of its own, expand it into the boxes it
+          // holds on each layer so its enclosures come out of the
+          // obstructions too
+          std::vector<odb::dbShape> via_boxes;
+          geom->getViaBoxes(via_boxes);
+          for (const odb::dbShape& via_box : via_boxes) {
+            odb::dbTechLayer* layer = via_box.getTechLayer();
+            if (layer == nullptr) {
+              // via box
+              continue;
+            }
+            odb::Rect pin;
+            via_box.getBox().bloat(1, pin);
+            pins[layer].insert(odb::geom::toPolygonSet(pin));
+          }
+          continue;
+        }
         odb::Rect pin;
         geom->getBox().bloat(1, pin);
         pins[geom->getTechLayer()].insert(odb::geom::toPolygonSet(pin));

--- a/src/psm/test/check_power_grid_short_obstructions.def
+++ b/src/psm/test/check_power_grid_short_obstructions.def
@@ -13,6 +13,9 @@
 #   metal1 OBS of macro obs5       dbMaster       x = 7.700um - 8.200um
 # and the VDD metal2 strap at x = 6.000um is overlapped by:
 #   metal2 OBS of macro obs2       dbMaster       y = 4.100um - 4.400um
+# and the VDD metal2 strap at x = 7.500um is overlapped by:
+#   the metal2 box of the via pin
+#   X of macro sig1                dbITerm        y = 3.680um - 4.020um
 #
 # The remaining objects are controls and must never be reported:
 #   metal1 blockage clear of VDD          x = 2.000um - 2.300um, y = 3.2um
@@ -20,6 +23,9 @@
 #   metal1 EXCEPTPGNET blockage           x = 4.800um - 5.100um
 #   PLACEMENT blockage over the rail      x = 5.300um - 5.600um
 #   macro obs3, placed clear of the grid
+#   macro pv1, whose VDD pin sits on the rail and runs up to metal3
+#   through pin vias under a blanket metal2 OBS: the via enclosures are
+#   pin metal of the net under test, not a short
 #
 # The obstruction of obs4 covers its own two pins, which are checked as
 # iterms of their own, so it is reported as the three strips left after
@@ -49,7 +55,7 @@ VIAS 2 ;
       + RECT via2 ( -70 -70 ) ( 70 70 )
       + RECT metal3 ( -170 -170 ) ( 170 170 ) ;
 END VIAS
-COMPONENTS 13 ;
+COMPONENTS 15 ;
     - u1 INV_X1 + PLACED ( 0 2800 ) N ;
     - u2 INV_X1 + PLACED ( 760 2800 ) N ;
     - u3 INV_X1 + PLACED ( 1520 2800 ) N ;
@@ -63,6 +69,8 @@ COMPONENTS 13 ;
     - obs3 OBS_BLOCK + PLACED ( 700 10000 ) N ;
     - obs4 OBS_PIN_BLOCK + PLACED ( 12600 4800 ) N ;
     - obs5 OBS_OVERHANG + PLACED ( 15400 4800 ) N ;
+    - pv1 PIN_VIA_BLOCK + PLACED ( 4700 5030 ) N ;
+    - sig1 SIG_VIA_BLOCK + PLACED ( 14200 6900 ) N ;
 END COMPONENTS
 BLOCKAGES 6 ;
     - LAYER metal1 RECT ( 4000 5500 ) ( 4600 5900 ) ;

--- a/src/psm/test/check_power_grid_short_obstructions.ok
+++ b/src/psm/test/check_power_grid_short_obstructions.ok
@@ -1,8 +1,8 @@
 [INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
-[INFO ODB-0227] LEF file: short_obs.lef, created 3 library cells
+[INFO ODB-0227] LEF file: short_obs.lef, created 2 vias, 5 library cells
 [INFO ODB-0128] Design: short_obstructions
-[INFO ODB-0131]     Created 13 components and 34 component-terminals.
-[INFO ODB-0132]     Created 2 special nets and 16 connections.
+[INFO ODB-0131]     Created 15 components and 36 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 17 connections.
 [WARNING PSM-0043] Shorted shape on net VDD to instance obs1 at (3.500um, 2.715um) - (4.500um, 2.885um), layer: metal1.
 [WARNING PSM-0043] Shorted shape on net VDD to instance obs2 at (5.915um, 4.100um) - (6.085um, 4.400um), layer: metal2.
 [WARNING PSM-0043] Shorted shape on net VDD to terminal obs4/A (net unconnected) at (6.500um, 2.715um) - (6.700um, 2.885um), layer: metal1.
@@ -11,6 +11,7 @@
 [WARNING PSM-0043] Shorted shape on net VDD to instance obs4 at (6.700um, 2.715um) - (6.899um, 2.885um), layer: metal1.
 [WARNING PSM-0043] Shorted shape on net VDD to instance obs4 at (7.101um, 2.715um) - (7.300um, 2.885um), layer: metal1.
 [WARNING PSM-0043] Shorted shape on net VDD to instance obs5 at (7.700um, 2.715um) - (8.200um, 2.885um), layer: metal1.
+[WARNING PSM-0043] Shorted shape on net VDD to terminal sig1/X (net unconnected) at (7.415um, 3.680um) - (7.585um, 4.020um), layer: metal2.
 [WARNING PSM-0043] Shorted shape on net VDD to obstruction at (2.000um, 2.750um) - (2.300um, 2.885um), layer: metal1.
 [WARNING PSM-0043] Shorted shape on net VDD to obstruction of u6 at (0.450um, 2.750um) - (0.490um, 2.950um), layer: metal1.
 [WARNING PSM-0043] Shorted shape on net VDD to obstruction of u6 at (0.490um, 2.750um) - (0.650um, 2.885um), layer: metal1.

--- a/src/psm/test/short_obs.lef
+++ b/src/psm/test/short_obs.lef
@@ -65,3 +65,69 @@ MACRO OBS_OVERHANG
       RECT 0 0.2 1.0 0.5 ;
   END
 END OBS_OVERHANG
+
+# Vias for the pin geometry of the two macros below, the shape of the pin
+# via stacks write_abstract_lef leaves in a block's power pins.
+VIA PV_via1
+  LAYER metal1 ;
+    RECT -0.17 -0.17 0.17 0.17 ;
+  LAYER via1 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal2 ;
+    RECT -0.17 -0.17 0.17 0.17 ;
+END PV_via1
+
+VIA PV_via2
+  LAYER metal2 ;
+    RECT -0.17 -0.17 0.17 0.17 ;
+  LAYER via2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal3 ;
+    RECT -0.17 -0.17 0.17 0.17 ;
+END PV_via2
+
+# Macro whose power pin carries a via stack from its metal1 rail up to a
+# metal3 strap, under a blanket metal2 obstruction, the way an abstract of
+# a block covers its internal grid.  The metal2 enclosures of the pin vias
+# are pin metal, so they have to come out of the obstruction like the pin
+# rects do and must never be reported against the pin's own net.
+MACRO PIN_VIA_BLOCK
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  FOREIGN PIN_VIA_BLOCK 0 0 ;
+  SIZE 1.0 BY 1.0 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 0.2 1.0 0.5 ;
+      LAYER metal3 ;
+        RECT 0.3 0.7 0.7 0.9 ;
+      VIA 0.5 0.35 PV_via1 ;
+      VIA 0.5 0.8 PV_via2 ;
+    END
+  END VDD
+  OBS
+    LAYER metal2 ;
+      RECT 0 0 1.0 1.0 ;
+  END
+END PIN_VIA_BLOCK
+
+# Macro whose signal pin is a single via, so the pin holds metal on two
+# layers but no rect of its own.  Placed with the via's metal2 enclosure
+# over a VDD strap it must be reported on metal2, which only happens if
+# the via is expanded into per-layer boxes when the terminal is checked.
+MACRO SIG_VIA_BLOCK
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  FOREIGN SIG_VIA_BLOCK 0 0 ;
+  SIZE 1.0 BY 1.0 ;
+  PIN X
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      VIA 0.4 0.4 PV_via2 ;
+    END
+  END X
+END SIG_VIA_BLOCK


### PR DESCRIPTION
## Summary
`check_power_grid` reports false shorts of a power net to a macro's own pin vias, seen on ORFS gf180/uart-blocks: abstract-LEF power pins carry pin VIAs, and their intermediate-layer enclosures were flagged against the macro's blanket OBS.

`getMasterTerms()` and `getMasterObstructions()` keyed pin geometry by `dbBox::getTechLayer()`, which is null for vias. So via enclosures were never subtracted from the master OBS (false positive on the pin's own net), and via-only pins on other nets were silently skipped (missed real shorts).

Fix: expand pin vias into per-layer boxes with `getViaBoxes()`, the same way `checkShortBPinBox` already does.

## Type of Change
- Bug fix

## Impact
- `check_power_grid` / `analyze_power_grid` no longer report a macro's own pin-via enclosures as shorts (unblocks ORFS gf180/uart-blocks final_report).
- Via-only pins on other nets are now checked per layer, so real shorts there are reported instead of silently missed.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

Extended `check_power_grid_short_obstructions` with both cases: a power pin via stack under a blanket OBS (must not report) and a via-only signal pin over a VDD strap (must report). Verified on the ORFS uart-blocks `final_report` reproducer: 210 PSM-0043 + PSM-0069 before, clean after. Full psm suite: 54/54.

## Related Issues
Fallout from #11296.
